### PR TITLE
fix(chat): normalize typography scale

### DIFF
--- a/apps/web/e2e/typed-mentions.spec.ts
+++ b/apps/web/e2e/typed-mentions.spec.ts
@@ -105,6 +105,9 @@ test("Codex @ autocomplete groups agents and files, then sends selected agent me
   await expect(popup).toHaveClass(/composer-autocomplete-surface/);
   await expect(popup).toHaveCSS("position", "fixed");
   await expect(popup).toHaveAttribute("data-composer-autocomplete", "true");
+  await popup.evaluate(async (element) => {
+    await Promise.all(element.getAnimations().map((animation) => animation.finished));
+  });
   const [mentionBox, composerBox] = await Promise.all([
     popup.boundingBox(),
     page.getByTestId("composer-surface").boundingBox(),

--- a/apps/web/src/components/chat/AttachmentPreview.tsx
+++ b/apps/web/src/components/chat/AttachmentPreview.tsx
@@ -144,7 +144,7 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
                     <FileText size={18} className="shrink-0 text-primary" />
                     <span className="truncate text-xs font-medium text-foreground">Page context</span>
                   </div>
-                  <span className="block max-w-[120px] truncate pl-[26px] text-[10px] leading-tight text-muted-foreground">
+                  <span className="block max-w-[120px] truncate pl-[26px] text-xs leading-tight text-muted-foreground">
                     {spill ? spill.line : "No image"}
                   </span>
                   {removeButton(att.name, att.id)}
@@ -186,7 +186,7 @@ export function AttachmentPreview({ attachments, onRemove }: AttachmentPreviewPr
                 >
                   {spill ? (
                     <span
-                      className="absolute bottom-0.5 left-0.5 right-0.5 z-10 truncate rounded bg-background/85 px-0.5 text-center text-[8px] font-medium text-foreground/90 shadow-sm"
+                      className="absolute bottom-0.5 left-0.5 right-0.5 z-10 truncate rounded bg-background/85 px-0.5 text-center text-xs font-medium text-foreground/90 shadow-sm"
                       title={spill.title}
                     >
                       + spill file

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -105,7 +105,7 @@ function EmptyState({ onPromptSelect }: EmptyStateProps) {
             className="flex flex-col items-start gap-0.5 rounded-lg border border-border/40 bg-muted/20 px-3 py-2.5 text-left transition-colors hover:border-border/70 hover:bg-muted/40"
           >
             <span className="text-xs font-medium text-foreground/80">{ep.label}</span>
-            <span className="text-[11px] text-muted-foreground/60">{ep.description}</span>
+            <span className="text-xs text-muted-foreground/60">{ep.description}</span>
           </button>
         ))}
       </div>
@@ -166,7 +166,7 @@ function NewThreadWelcome({
               className="group h-auto min-h-24 flex-col items-start justify-between rounded-xl border-border/70 bg-transparent px-4 py-3.5 text-left shadow-none hover:border-primary/35 hover:bg-accent/45"
             >
               <Icon size={15} className="text-primary transition-transform duration-200 group-hover:-translate-y-0.5 motion-reduce:transform-none" aria-hidden />
-              <span className="max-w-32 text-wrap text-[13px] font-medium leading-5 text-foreground/90">
+              <span className="max-w-32 text-wrap text-sm font-medium leading-5 text-foreground/90">
                 {label}
               </span>
             </Button>
@@ -226,7 +226,7 @@ function ThreadPreparingShell({
                   <button
                     type="button"
                     onClick={() => useWorkspaceStore.getState().setActiveThread(thread.parent_thread_id!)}
-                    className="flex shrink-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-[11px] font-medium text-primary/80 transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
+                    className="flex shrink-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs font-medium text-primary/80 transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
                   >
                     <GitFork size={10} />
                     <span>Forked</span>
@@ -557,7 +557,7 @@ export function ChatView() {
                   <button
                     type="button"
                     onClick={() => setActiveThread(activeThread.parent_thread_id!)}
-                    className="flex items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-[11px] font-medium text-primary/80 transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
+                    className="flex items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs font-medium text-primary/80 transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
                   >
                     <GitFork size={10} />
                     <span>Forked</span>

--- a/apps/web/src/components/chat/ChecksPopover.tsx
+++ b/apps/web/src/components/chat/ChecksPopover.tsx
@@ -229,7 +229,7 @@ function RunRow({ run }: { run: CheckRun }) {
           className={cn("shrink-0", visual.iconClassName)}
         />
       ) : null}
-      <span className="min-w-0 flex-1 truncate text-[13px] text-foreground">
+      <span className="min-w-0 flex-1 truncate text-sm text-foreground">
         {run.name}
       </span>
       <span className={cn("shrink-0 text-xs", visual.labelClassName)}>

--- a/apps/web/src/components/chat/CliErrorBanner.tsx
+++ b/apps/web/src/components/chat/CliErrorBanner.tsx
@@ -82,7 +82,7 @@ export function CliErrorBanner({ error, onDismiss, onOpenSettings }: CliErrorBan
           {/* Install command */}
           {installCmd && (
             <div className="flex items-center gap-2">
-              <code className="flex-1 rounded bg-muted/60 px-2.5 py-1 font-mono text-[11px] text-foreground/80 border border-border/40">
+              <code className="flex-1 rounded bg-muted/60 px-2.5 py-1 font-mono text-xs text-foreground/80 border border-border/40">
                 {installCmd}
               </code>
               <button
@@ -102,7 +102,7 @@ export function CliErrorBanner({ error, onDismiss, onOpenSettings }: CliErrorBan
 
           {/* Settings hint */}
           {settingsHint && (
-            <p className="text-[11px] text-muted-foreground/70">
+            <p className="text-xs text-muted-foreground/70">
               {settingsHint.replace(/(?:in |at )?Settings > [^.\n]+\.?/, "").trim()}{" "}
               <button
                 type="button"

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -72,7 +72,7 @@ import { useTaskStore, type TaskItem } from "@/stores/taskStore";
 import { usePlanStore } from "@/stores/planStore";
 
 const NEW_THREAD_CONTEXT_CONTROL_CLASS =
-  "h-[28px] gap-[6px] rounded-md px-[10px] text-[12px] font-medium leading-none";
+  "h-[28px] gap-[6px] rounded-md px-[10px] text-xs font-medium leading-none";
 import { useDiffStore } from "@/stores/diffStore";
 import {
   hideRightPanelAdaptive,
@@ -350,7 +350,7 @@ function ComposerOptionsMenu({
       </PopoverTrigger>
       <PopoverContent align="start" sideOffset={8} className="w-60 p-2">
         {/* Mode */}
-        <div className="px-1.5 pt-1 pb-1.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+        <div className="px-1.5 pt-1 pb-1.5 text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
           Mode
         </div>
         <div className="mb-2 flex rounded-md bg-muted/40 p-0.5">
@@ -387,7 +387,7 @@ function ComposerOptionsMenu({
         </div>
 
         {/* Permissions */}
-        <div className="px-1.5 pt-1 pb-1.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+        <div className="px-1.5 pt-1 pb-1.5 text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
           Permissions
         </div>
         {permissionLocked ? (
@@ -449,7 +449,7 @@ function ComposerOptionsMenu({
               <ListChecks size={13} className={panelVisible ? "text-primary" : "text-muted-foreground"} />
               Plan panel
             </span>
-            <span className={cn("text-[10px] font-medium uppercase tracking-[0.1em]", panelVisible ? "text-primary" : "text-muted-foreground/60")}>
+            <span className={cn("text-xs font-medium uppercase tracking-[0.1em]", panelVisible ? "text-primary" : "text-muted-foreground/60")}>
               {panelVisible ? "On" : "Off"}
             </span>
           </Button>
@@ -2853,7 +2853,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
           {activeWorkspace ? (
             <>
               <div
-                className="inline-flex h-[28px] min-w-0 shrink items-center gap-[6px] rounded-md pl-[10px] text-[12px] font-medium leading-none text-foreground/90"
+                className="inline-flex h-[28px] min-w-0 shrink items-center gap-[6px] rounded-md pl-[10px] text-xs font-medium leading-none text-foreground/90"
               >
                 <Folder size={14} className="shrink-0 text-muted-foreground" aria-hidden />
                 <span className="max-w-40 truncate" title={activeWorkspace.path}>
@@ -3003,7 +3003,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             out for editing. Cancel returns it to its original slot. */}
         {editingFromQueue && (
           <div className="flex items-center justify-between gap-2 border-b border-primary/20 bg-primary/5 px-3 py-1.5">
-            <span className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-primary/85">
+            <span className="font-mono text-xs uppercase tracking-[0.18em] text-primary/85">
               Editing
               <span className="ml-1.5 tabular-nums text-primary/55">
                 {String(editingFromQueue.originalIndex + 1).padStart(2, "0")}
@@ -3151,7 +3151,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                   ? "Fast mode"
                   : "Context window";
 
-            const sectionHeaderClass = "px-3 pt-1.5 pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none";
+            const sectionHeaderClass = "px-3 pt-1.5 pb-1 text-xs font-medium uppercase tracking-wider text-muted-foreground/60 select-none";
             const itemClass = (active: boolean) => cn(
               "flex w-full items-center justify-between rounded px-3 py-1.5 text-xs",
               active
@@ -3186,7 +3186,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
                         {activeChipLabel && (
                           <span
                             data-testid="composer-1m-badge"
-                            className="rounded-sm bg-foreground/5 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-foreground/80 ring-1 ring-inset ring-foreground/10 tabular-nums"
+                            className="rounded-sm bg-foreground/5 px-1 py-px text-xs font-medium uppercase tracking-wide text-foreground/80 ring-1 ring-inset ring-foreground/10 tabular-nums"
                           >
                             {activeChipLabel}
                           </span>
@@ -3493,7 +3493,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
       {/* Queued-send hint: shown while the child thread handoff is still generating */}
       {queuedSend && (
-        <p className="px-1 pt-1 text-[10px] text-muted-foreground/60">
+        <p className="px-1 pt-1 text-xs text-muted-foreground/60">
           queued · sends when handoff lands
         </p>
       )}
@@ -3510,7 +3510,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         {showComposerStatusBar && <div className="min-h-0">
           <div className="flex items-center justify-between px-1 pt-1.5">
             {!isGitRepo && isNewThread ? (
-              <span className="flex h-6 items-center rounded-md px-1.5 py-0.5 text-[10px] text-muted-foreground/40">
+              <span className="flex h-6 items-center rounded-md px-1.5 py-0.5 text-xs text-muted-foreground/40">
                 Not a git repo
               </span>
             ) : (

--- a/apps/web/src/components/chat/ComposerBranchBar.tsx
+++ b/apps/web/src/components/chat/ComposerBranchBar.tsx
@@ -21,7 +21,7 @@ export function ComposerBranchBar({ branchFromMessageId, branchFromMessageConten
     <div className="flex items-start gap-2 px-3 py-2 animate-fade-up-in">
       <span className="shrink-0 text-sm text-primary/70 leading-none mt-0.5" aria-hidden="true">↳</span>
       <div className="min-w-0 flex-1">
-        <p className="text-[11px] font-medium text-muted-foreground/60 leading-none mb-0.5">Forking from</p>
+        <p className="text-xs font-medium text-muted-foreground/60 leading-none mb-0.5">Forking from</p>
         {branchFromMessageContent && (
           <p className="text-xs text-muted-foreground/50 truncate italic">
             {branchFromMessageContent.slice(0, 120)}{branchFromMessageContent.length > 120 ? "…" : ""}

--- a/apps/web/src/components/chat/ComposerQueueList.tsx
+++ b/apps/web/src/components/chat/ComposerQueueList.tsx
@@ -113,7 +113,7 @@ export function ComposerQueueList({
       {/* Header strip: small-caps mono, quiet, dev-tool feel.
           Continue is primary (only when idle); Clear all is quiet on the side. */}
       <header className="flex items-center justify-between border-b border-border/40 px-3 py-1.5">
-        <span className="font-mono text-[10.5px] uppercase tracking-[0.18em] text-muted-foreground/70">
+        <span className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground/70">
           Queued
         </span>
         <div className="flex items-center gap-1.5">
@@ -122,7 +122,7 @@ export function ComposerQueueList({
               type="button"
               onClick={onResume}
               aria-label="Send next queued message"
-              className="flex items-center gap-1 rounded-sm bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.16em] text-primary transition-colors hover:bg-primary/20"
+              className="flex items-center gap-1 rounded-sm bg-primary/10 px-1.5 py-0.5 font-mono text-xs uppercase tracking-[0.16em] text-primary transition-colors hover:bg-primary/20"
             >
               <Play size={9} strokeWidth={1.75} />
               Continue
@@ -132,7 +132,7 @@ export function ComposerQueueList({
             type="button"
             onClick={() => clearQueue(threadId)}
             aria-label="Clear all queued messages"
-            className="flex items-center gap-1 rounded-sm px-1 py-0.5 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground/50 transition-colors hover:bg-destructive/8 hover:text-destructive"
+            className="flex items-center gap-1 rounded-sm px-1 py-0.5 font-mono text-xs uppercase tracking-[0.16em] text-muted-foreground/50 transition-colors hover:bg-destructive/8 hover:text-destructive"
           >
             <Trash2 size={9} strokeWidth={1.75} />
             Clear all
@@ -262,13 +262,13 @@ const QueueRow = memo(function QueueRow({
         <PreviewAnnotationBundleChip
           bundle={msg.previewAnnotations}
           testId="queue-annotation-bundle"
-          className="shrink-0 rounded-md px-1.5 py-0.5 text-[11px]"
+          className="shrink-0 rounded-md px-1.5 py-0.5 text-xs"
         />
       ) : null}
 
       {hasAttachments && (
         <span
-          className="flex shrink-0 items-center gap-0.5 font-mono text-[10px] tabular-nums text-muted-foreground/55"
+          className="flex shrink-0 items-center gap-0.5 font-mono text-xs tabular-nums text-muted-foreground/55"
           aria-label={`${msg.attachments.length} attachment${msg.attachments.length === 1 ? "" : "s"}`}
         >
           <Paperclip size={9} strokeWidth={1.75} />

--- a/apps/web/src/components/chat/ComposerReplyBar.tsx
+++ b/apps/web/src/components/chat/ComposerReplyBar.tsx
@@ -19,7 +19,7 @@ export function ComposerReplyBar({ sourceRole, previewText, onDismiss }: Compose
     <div className="flex items-start gap-2 px-3 py-2 animate-fade-up-in">
       <Reply className="mt-0.5 size-3.5 shrink-0 text-primary/70 scale-x-[-1]" />
       <div className="min-w-0 flex-1 border-l-2 border-primary/40 pl-2">
-        <p className="text-[11px] font-medium text-muted-foreground/60 leading-none mb-0.5">
+        <p className="text-xs font-medium text-muted-foreground/60 leading-none mb-0.5">
           Replying to {sourceRole}
         </p>
         <p className="text-xs text-muted-foreground/50 truncate italic">

--- a/apps/web/src/components/chat/ContextTracker.tsx
+++ b/apps/web/src/components/chat/ContextTracker.tsx
@@ -108,7 +108,7 @@ export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, 
             <span
               className={cn(
                 "absolute inset-0 flex items-center justify-center",
-                "text-[7px] font-semibold leading-none select-none",
+                "text-xs font-semibold leading-none select-none",
                 text,
               )}
             >
@@ -119,12 +119,12 @@ export function ContextTracker({ tokensIn, contextWindow, totalProcessedTokens, 
       />
       <TooltipContent side="top" sideOffset={6}>
         <div className="flex flex-col gap-1">
-          <span className="text-[10px] font-semibold tracking-widest uppercase opacity-50">
+          <span className="text-xs font-semibold tracking-widest uppercase opacity-50">
             Context Window
           </span>
           <span className="text-xs font-medium">{tooltipLine}</span>
           {totalProcessedTokens != null && totalProcessedTokens > tokensIn && (
-            <span className="text-[10px] text-muted-foreground">
+            <span className="text-xs text-muted-foreground">
               Total processed: {abbrev(totalProcessedTokens)} tokens
             </span>
           )}

--- a/apps/web/src/components/chat/CopilotAgentSelector.tsx
+++ b/apps/web/src/components/chat/CopilotAgentSelector.tsx
@@ -72,7 +72,7 @@ function AgentItem({
       </span>
       <span className="flex flex-col gap-0.5">
         <span className="font-medium leading-none">{agent.displayName}</span>
-        <span className="text-[11px] leading-snug text-muted-foreground">
+        <span className="text-xs leading-snug text-muted-foreground">
           {agent.description}
         </span>
       </span>
@@ -83,7 +83,7 @@ function AgentItem({
 /** Section label rendered as all-caps category header with a separator line. */
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <DropdownMenuLabel className="px-2 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+    <DropdownMenuLabel className="px-2 pb-1 pt-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground/60">
       {children}
     </DropdownMenuLabel>
   );

--- a/apps/web/src/components/chat/DiffViewer.tsx
+++ b/apps/web/src/components/chat/DiffViewer.tsx
@@ -68,12 +68,12 @@ export function DiffViewer({ snapshotId, filePath, changeType = "modified" }: Di
         <ChevronRight className={`h-3 w-3 shrink-0 transition-transform ${expanded ? "rotate-90" : ""}`} />
         <FileText className="h-3 w-3 shrink-0" />
         <span className="truncate font-mono">{filePath}</span>
-        <span className="ml-auto text-[10px] opacity-60">{changeLabel}</span>
-        {loading && <span className="text-[10px]">Loading...</span>}
+        <span className="ml-auto text-xs opacity-60">{changeLabel}</span>
+        {loading && <span className="text-xs">Loading...</span>}
       </button>
 
       {expanded && diff !== null && changeType !== "binary" && (
-        <div className="max-h-[500px] overflow-auto text-[11px] font-mono leading-relaxed">
+        <div className="max-h-[500px] overflow-auto text-xs font-mono leading-relaxed">
           {visibleLines.map((line, i) => (
             <div
               key={i}

--- a/apps/web/src/components/chat/HookActivitySection.tsx
+++ b/apps/web/src/components/chat/HookActivitySection.tsx
@@ -30,10 +30,10 @@ export function HookActivitySection({ hooks }: { hooks: readonly HookExecution[]
                 expanded && "rotate-90",
               )}
             />
-            <span className="font-mono text-[10.5px] tracking-[0.18em] uppercase text-muted-foreground/60">
+            <span className="font-mono text-xs tracking-[0.18em] uppercase text-muted-foreground/60">
               Hooks
             </span>
-            <span className="font-mono text-[10.5px] tabular-nums text-muted-foreground/40">
+            <span className="font-mono text-xs tabular-nums text-muted-foreground/40">
               {hooks.length}
             </span>
             <StatusDot hasError={hasError} hasRunning={hasRunning} />
@@ -93,12 +93,12 @@ function HookRowContent({ hook, hasOutput, detailOpen }: { hook: HookExecution; 
           </span>
         )}
         {hook.status === "completed" && hook.exitCode != null && hook.exitCode !== 0 && (
-          <span className="font-mono text-[10px] px-1 rounded bg-diff-remove-strong/15 text-diff-remove-strong">
+          <span className="font-mono text-xs px-1 rounded bg-diff-remove-strong/15 text-diff-remove-strong">
             exit {hook.exitCode}
           </span>
         )}
         {hook.didBlock && (
-          <span className="font-mono text-[10px] tracking-[0.12em] uppercase text-diff-remove-strong">
+          <span className="font-mono text-xs tracking-[0.12em] uppercase text-diff-remove-strong">
             blocked
           </span>
         )}

--- a/apps/web/src/components/chat/ImageAttachmentLightbox.tsx
+++ b/apps/web/src/components/chat/ImageAttachmentLightbox.tsx
@@ -303,13 +303,13 @@ export const ImageAttachmentLightbox = memo(function ImageAttachmentLightbox({
 
                       <div className="flex w-full min-w-0 flex-col items-center gap-1 border-t border-white/[0.08] pt-3 text-center">
                         <p
-                          className="line-clamp-2 max-w-full min-w-0 break-words px-1 text-[13px] font-medium leading-snug tracking-tight text-white/[0.94]"
+                          className="line-clamp-2 max-w-full min-w-0 break-words px-1 text-sm font-medium leading-snug tracking-tight text-white/[0.94]"
                           title={rawTitle.trim() ? rawTitle : undefined}
                         >
                           {displayTitle}
                         </p>
                         {carousel ? (
-                          <p className="text-[11px] tabular-nums tracking-wide text-white/48">
+                          <p className="text-xs tabular-nums tracking-wide text-white/48">
                             {safeIndex + 1} / {items.length}
                           </p>
                         ) : null}

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -120,7 +120,7 @@ function GoalReceipt({
     <span
       data-testid="goal-receipt"
       className={cn(
-        "inline-flex items-center gap-1.5 font-mono text-[11px] font-medium uppercase tracking-[0.18em]",
+        "inline-flex items-center gap-1.5 font-mono text-xs font-medium uppercase tracking-[0.18em]",
         tone === "muted" ? "text-muted-foreground" : "text-primary",
         className,
       )}
@@ -157,12 +157,12 @@ function GoalPill({ label, condition, hint }: { label: string; condition?: strin
   const [expanded, setExpanded] = useState(false);
 
   const labelEl = (
-    <span className="font-mono text-[10.5px] uppercase tracking-[0.2em] text-primary">
+    <span className="font-mono text-xs uppercase tracking-[0.2em] text-primary">
       {label}
     </span>
   );
   const hintEl = hint ? (
-    <span className="shrink-0 font-mono text-[9.5px] uppercase tracking-[0.18em] text-muted-foreground/70">
+    <span className="shrink-0 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground/70">
       {hint}
     </span>
   ) : null;
@@ -443,7 +443,7 @@ function QuoteBlock({
       onClick={onClick}
       className="mb-1.5 w-full cursor-pointer rounded-md border-l-2 border-primary/40 bg-muted/30 px-2.5 py-1.5 text-left transition-colors hover:bg-muted/50 select-none"
     >
-      <p className="text-[10px] font-semibold text-primary/60 leading-none mb-0.5">{label}</p>
+      <p className="text-xs font-semibold text-primary/60 leading-none mb-0.5">{label}</p>
       <p className="text-xs text-muted-foreground/60 truncate italic">{displayText}</p>
     </button>
   );
@@ -676,7 +676,7 @@ export const MessageBubble = memo(function MessageBubble({
               {onBranch && <BranchButton onClick={() => onBranch(message.id)} />}
               {userDisplayText.trim() && <CopyButton content={userDisplayText} />}
             </div>
-            <div className="flex items-center gap-2 font-mono text-[10px] tabular-nums text-muted-foreground/55">
+            <div className="flex items-center gap-2 font-mono text-xs tabular-nums text-muted-foreground/55">
               {userGoal && <GoalReceipt label="Sent as goal" tone="muted" />}
               <span>{formattedTime}</span>
             </div>
@@ -794,7 +794,7 @@ export const MessageBubble = memo(function MessageBubble({
         {assistantActionsVisible && onBranch && <BranchButton onClick={() => onBranch(message.id)} />}
         {assistantActionsVisible && textContent.trim() && <CopyButton content={textContent} />}
         {assistantActionsVisible && (message.model || message.tokens_used != null || message.cost_usd != null || formattedTime) && (
-          <span className="ml-auto font-mono text-[10px] tabular-nums text-muted-foreground/55 transition-colors group-hover/msg:text-muted-foreground/80">
+          <span className="ml-auto font-mono text-xs tabular-nums text-muted-foreground/55 transition-colors group-hover/msg:text-muted-foreground/80">
             {[
               modelDisplayLabel,
               message.tokens_used != null ? `${message.tokens_used.toLocaleString()} tok` : null,

--- a/apps/web/src/components/chat/ModelSelector.tsx
+++ b/apps/web/src/components/chat/ModelSelector.tsx
@@ -370,7 +370,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
                   className="flex min-w-0 flex-1 cursor-not-allowed items-center gap-2 rounded px-2 py-1.5 text-xs text-muted-foreground/60"
                 >
                   <span className="flex-1 truncate text-left">{m.label}</span>
-                  <span className="text-[10px] tabular-nums shrink-0">Ended {endDate}</span>
+                  <span className="text-xs tabular-nums shrink-0">Ended {endDate}</span>
                 </button>
               }
             />
@@ -414,17 +414,17 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
         >
           <span className="flex-1 truncate text-left">{m.label}</span>
           {ctxLabel && (
-            <span className="text-[10px] text-muted-foreground/60 tabular-nums shrink-0">
+            <span className="text-xs text-muted-foreground/60 tabular-nums shrink-0">
               {ctxLabel}
             </span>
           )}
           {m.multiplier != null && (
-            <span className="text-[10px] text-muted-foreground/60 tabular-nums shrink-0">
+            <span className="text-xs text-muted-foreground/60 tabular-nums shrink-0">
               {m.multiplier}x
             </span>
           )}
           {m.availableUntil && (
-            <span className="text-[10px] text-muted-foreground/60 tabular-nums shrink-0">
+            <span className="text-xs text-muted-foreground/60 tabular-nums shrink-0">
               Until {new Date(`${m.availableUntil}T00:00:00`).toLocaleDateString(undefined, { day: "numeric", month: "short" })}
             </span>
           )}
@@ -453,7 +453,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
       return (
       <div key={label}>
         <div
-          className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none"
+          className="px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground/60 select-none"
           id={headingId}
         >
           {label}
@@ -483,7 +483,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
       }
       return (
         <div className="space-y-0.5">
-          <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
+          <div className="px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
             Favorites
           </div>
           {favoritesFiltered.map((entry) => renderFavoriteRow(entry))}
@@ -510,7 +510,7 @@ export function ModelSelector({ selectedModelId, selectedProviderId, onSelect, l
         ) : (
           <>
             {showProviderTitle && (
-              <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
+              <div className="px-3 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground/60 select-none">
                 {p.name}
               </div>
             )}

--- a/apps/web/src/components/chat/NewThreadProjectPicker.tsx
+++ b/apps/web/src/components/chat/NewThreadProjectPicker.tsx
@@ -47,7 +47,7 @@ export function NewThreadProjectPicker({
               size="sm"
               data-testid="new-thread-project-picker"
               aria-expanded={open}
-              className="h-[28px] gap-[6px] rounded-md px-[10px] text-[12px] font-medium leading-none text-foreground/90 hover:bg-accent/70"
+              className="h-[28px] gap-[6px] rounded-md px-[10px] text-xs font-medium leading-none text-foreground/90 hover:bg-accent/70"
             >
               <Folder size={14} className="size-3.5 text-muted-foreground" aria-hidden />
               Choose project
@@ -73,7 +73,7 @@ export function NewThreadProjectPicker({
                   beginNewThread(workspace.id);
                   setOpen(false);
                 }}
-                className="gap-2.5 px-2 py-1.5 text-[13px]"
+                className="gap-2.5 px-2 py-1.5 text-sm"
               >
                 <Folder size={13} className="text-muted-foreground" aria-hidden />
                 <span className="truncate">{workspace.name}</span>
@@ -87,7 +87,7 @@ export function NewThreadProjectPicker({
             variant="ghost"
             size="sm"
             onClick={handleAddProject}
-            className="h-8 w-full justify-start gap-2 px-2 text-[13px] font-normal"
+            className="h-8 w-full justify-start gap-2 px-2 text-sm font-normal"
           >
             <Plus size={13} className="text-muted-foreground" aria-hidden />
             New project

--- a/apps/web/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/web/src/components/chat/PermissionRequestCard.tsx
@@ -127,7 +127,7 @@ export function PermissionRequestCard({
       {/* Input preview */}
       <pre
         className={cn(
-          "text-[0.7rem] leading-relaxed text-muted-foreground/80",
+          "text-xs leading-relaxed text-muted-foreground/80",
           "bg-muted/30 rounded px-2 py-1.5",
           "max-h-[120px] overflow-y-auto scrollbar-on-hover",
           "whitespace-pre-wrap break-all font-mono",
@@ -179,7 +179,7 @@ export function PermissionRequestCard({
                 <Zap size={12} className="text-amber-500 shrink-0" />
                 <div className="flex flex-col">
                   <span className="text-xs font-medium">Allow once</span>
-                  <span className="text-[10px] text-muted-foreground">Prompt again next time</span>
+                  <span className="text-xs text-muted-foreground">Prompt again next time</span>
                 </div>
                 {allowMode === "allow" && <Check size={11} className="ml-auto text-primary" />}
               </DropdownMenuItem>
@@ -191,7 +191,7 @@ export function PermissionRequestCard({
                 <Clock size={12} className="text-blue-400 shrink-0" />
                 <div className="flex flex-col">
                   <span className="text-xs font-medium">Allow in session</span>
-                  <span className="text-[10px] text-muted-foreground">Skip prompts this session</span>
+                  <span className="text-xs text-muted-foreground">Skip prompts this session</span>
                 </div>
                 {allowMode === "allow-session" && <Check size={11} className="ml-auto text-primary" />}
               </DropdownMenuItem>

--- a/apps/web/src/components/chat/PlanQuestionWizard.tsx
+++ b/apps/web/src/components/chat/PlanQuestionWizard.tsx
@@ -273,13 +273,13 @@ export function PlanQuestionWizard({ threadId }: PlanQuestionWizardProps) {
                 onClick={() => setActiveQuestionIndex(threadId, i)}
                 className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent/50"
               >
-                <span className="font-mono text-[10px] tabular-nums tracking-[0.12em] text-muted-foreground/45">
+                <span className="font-mono text-xs tabular-nums tracking-[0.12em] text-muted-foreground/45">
                   {formatStep(i + 1, displayQuestions.length)}
                 </span>
                 <span className="flex-1 truncate text-xs text-muted-foreground/60">
                   {prev.question}
                 </span>
-                <span className="flex-shrink-0 max-w-[140px] truncate text-[11.5px] font-medium text-muted-foreground">
+                <span className="flex-shrink-0 max-w-[140px] truncate text-xs font-medium text-muted-foreground">
                   {answerLabel}
                 </span>
                 <span className="text-xs text-[oklch(0.48_0.14_145)]" aria-hidden="true">
@@ -294,11 +294,11 @@ export function PlanQuestionWizard({ threadId }: PlanQuestionWizardProps) {
 
       {/* Mono header: step counter + category + step dots */}
       <div className="animate-wizard-header flex items-center gap-2 mb-2">
-        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground/45">
+        <span className="font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground/45">
           <span className="tabular-nums">{formatStep(displayActiveIndex + 1, displayQuestions.length)}</span>
         </span>
-        <span className="font-mono text-[8px] text-muted-foreground/25" aria-hidden="true">/</span>
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-primary/65">
+        <span className="font-mono text-xs text-muted-foreground/25" aria-hidden="true">/</span>
+        <span className="font-mono text-xs uppercase tracking-[0.14em] text-primary/65">
           {q.category.toLowerCase()}
         </span>
         <div className="ml-auto flex items-center gap-1">
@@ -320,7 +320,7 @@ export function PlanQuestionWizard({ threadId }: PlanQuestionWizardProps) {
       <p
         key={displayActiveIndex}
         className={cn(
-          "text-[14.5px] font-medium text-foreground leading-snug mb-3 max-w-[62ch]",
+          "text-sm font-medium text-foreground leading-snug mb-3 max-w-[62ch]",
           slideDirection === "forward"
             ? "animate-wizard-question-forward"
             : "animate-wizard-question-back",
@@ -369,7 +369,7 @@ export function PlanQuestionWizard({ threadId }: PlanQuestionWizardProps) {
       </div>
 
       {/* Nav row */}
-      <div className="animate-wizard-nav flex items-center justify-between font-mono text-[11px] tracking-wide">
+      <div className="animate-wizard-nav flex items-center justify-between font-mono text-xs tracking-wide">
         <div className="flex items-center gap-4 text-muted-foreground/55">
           <button
             type="button"
@@ -427,7 +427,7 @@ export function PlanQuestionWizard({ threadId }: PlanQuestionWizardProps) {
           className={cn(
             "absolute right-5 bottom-12 z-10",
             "rounded-sm border border-border/40 bg-card/95 backdrop-blur-sm",
-            "px-3 py-2 font-mono text-[10px] leading-relaxed text-muted-foreground/80",
+            "px-3 py-2 font-mono text-xs leading-relaxed text-muted-foreground/80",
             "shadow-sm animate-wizard-legend",
           )}
         >

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -268,13 +268,13 @@ function CommandRow({
       {/* Name + description */}
       <span className="flex min-w-0 flex-1 flex-col">
         <span className={cn(
-          "truncate text-[13px] font-medium leading-4",
+          "truncate text-sm font-medium leading-4",
           tone === "dark" ? "text-neutral-50" : "text-foreground",
         )}>
           /{cmd.name}
         </span>
         <span className={cn(
-          "truncate text-[11px] leading-4",
+          "truncate text-xs leading-4",
           tone === "dark" ? "text-neutral-400" : "text-muted-foreground",
         )}>
           {cmd.description}

--- a/apps/web/src/components/chat/StickyUserMessage.tsx
+++ b/apps/web/src/components/chat/StickyUserMessage.tsx
@@ -152,7 +152,7 @@ export function StickyUserMessage({
                 </span>
                 <span
                   aria-hidden
-                  className="mt-1 inline-flex items-center gap-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+                  className="mt-1 inline-flex items-center gap-0.5 font-mono text-xs uppercase tracking-[0.14em] text-muted-foreground"
                 >
                   <ChevronDown
                     size={11}

--- a/apps/web/src/components/chat/TerminalStatusIndicator.tsx
+++ b/apps/web/src/components/chat/TerminalStatusIndicator.tsx
@@ -24,7 +24,7 @@ export function TerminalStatusIndicator() {
       type="button"
       aria-label="Toggle terminal"
       onClick={togglePanel}
-      className="flex cursor-pointer items-center gap-1.5 text-[11px] hover:opacity-80"
+      className="flex cursor-pointer items-center gap-1.5 text-xs hover:opacity-80"
     >
       <Spinner size={12} className="text-muted-foreground" style={SLOW_SPIN_STYLE} />
       <span className="flex items-center gap-1.5 text-muted-foreground font-medium">

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1307,7 +1307,7 @@ function ThreadOverviewPrActiveRow({
       status.label ? (
         <span
           data-testid="thread-overview-pr-status"
-          className="ml-6 inline-flex h-6 items-center rounded-md px-2 text-[11px] text-muted-foreground"
+          className="ml-6 inline-flex h-6 items-center rounded-md px-2 text-xs text-muted-foreground"
         >
           {status.label}
         </span>

--- a/apps/web/src/components/chat/UsagePopover.tsx
+++ b/apps/web/src/components/chat/UsagePopover.tsx
@@ -120,7 +120,7 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
             <div>
               <div className="text-sm font-medium capitalize">{providerId}</div>
               {activeThread?.model && (
-                <div className="text-[10px] text-muted-foreground">
+                <div className="text-xs text-muted-foreground">
                   {activeThread.model}
                   {contextEntry?.costMultiplier != null && ` · ${contextEntry.costMultiplier}×`}
                 </div>
@@ -136,7 +136,7 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
           {/* Quota section */}
           {categories.length > 0 ? (
             <div className="space-y-2">
-              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+              <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground/60">
                 Quota
               </div>
               {categories.map((cat) => (
@@ -173,7 +173,7 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
           {/* Context window section */}
           {hasContext && (
             <div className="space-y-1 border-t border-border pt-2">
-              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+              <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground/60">
                 Context window
               </div>
               <div className="flex items-center justify-between text-xs">
@@ -192,29 +192,29 @@ export function UsagePopover({ threadId, children, onOpenChange, side = "top", a
           {/* Last turn section */}
           {hasTurn ? (
             <div className="space-y-2 border-t border-border pt-2">
-              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+              <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground/60">
                 Last turn
               </div>
               <div className="grid grid-cols-2 gap-1.5">
                 <div className="rounded bg-muted/40 px-2 py-1.5">
-                  <div className="text-[9px] text-muted-foreground">in</div>
+                  <div className="text-xs text-muted-foreground">in</div>
                   <div className="text-xs text-foreground/80">{formatTokens(tokensIn)}</div>
                 </div>
                 <div className="rounded bg-muted/40 px-2 py-1.5">
-                  <div className="text-[9px] text-muted-foreground">out</div>
+                  <div className="text-xs text-muted-foreground">out</div>
                   <div className="text-xs text-foreground/80">
                     {formatTokens(tokensOut)}
                   </div>
                 </div>
                 {contextEntry?.cacheReadTokens != null && (
                   <div className="rounded bg-muted/40 px-2 py-1.5">
-                    <div className="text-[9px] text-muted-foreground">cache read</div>
+                    <div className="text-xs text-muted-foreground">cache read</div>
                     <div className="text-xs text-foreground/80">{formatTokens(contextEntry.cacheReadTokens)}</div>
                   </div>
                 )}
                 {contextEntry?.cacheWriteTokens != null && (
                   <div className="rounded bg-muted/40 px-2 py-1.5">
-                    <div className="text-[9px] text-muted-foreground">cache write</div>
+                    <div className="text-xs text-muted-foreground">cache write</div>
                     <div className="text-xs text-foreground/80">{formatTokens(contextEntry.cacheWriteTokens)}</div>
                   </div>
                 )}

--- a/apps/web/src/components/chat/narrative/ActiveToolRow.tsx
+++ b/apps/web/src/components/chat/narrative/ActiveToolRow.tsx
@@ -27,7 +27,7 @@ export function ActiveToolRow({ toolCall }: ActiveToolRowProps) {
   const detail = extractToolInputDetail(toolCall);
 
   return (
-    <div className={`${NARRATIVE_TOOL_ROW} px-2 py-1 text-[0.8125rem]`}>
+    <div className={`${NARRATIVE_TOOL_ROW} px-2 py-1 text-sm`}>
       <Icon className="w-3.5 h-3.5 shrink-0 text-muted-foreground/60" />
       <span className="font-medium text-foreground shrink-0">{label}</span>
       <span className={narrativeToolDetailClass("sm")} title={detail}>

--- a/apps/web/src/components/chat/narrative/HookRow.tsx
+++ b/apps/web/src/components/chat/narrative/HookRow.tsx
@@ -81,11 +81,11 @@ export function HookRow({ hook }: HookRowProps) {
           </span>
         )}
         badge={isRunning ? (
-          <span className="font-mono text-[0.625rem] font-medium px-1.5 py-px rounded-sm bg-primary/15 text-primary shrink-0">
+          <span className="font-mono text-xs font-medium px-1.5 py-px rounded-sm bg-primary/15 text-primary shrink-0">
             running
           </span>
         ) : isBlocked ? (
-          <span className="font-mono text-[0.625rem] font-medium px-1.5 py-px rounded-sm bg-[var(--diff-remove)]/15 text-[var(--diff-remove)] shrink-0">
+          <span className="font-mono text-xs font-medium px-1.5 py-px rounded-sm bg-[var(--diff-remove)]/15 text-[var(--diff-remove)] shrink-0">
             blocked
           </span>
         ) : undefined}
@@ -98,14 +98,14 @@ export function HookRow({ hook }: HookRowProps) {
 
         {/* Trigger label */}
         {hook.toolName && (
-          <span className="min-w-0 truncate font-mono text-[0.6875rem] text-muted-foreground/50">
+          <span className="min-w-0 truncate font-mono text-xs text-muted-foreground/50">
             on {hook.toolName}
           </span>
         )}
 
         {/* Duration or elapsed timer - hide for sub-5ms instant hooks */}
         {(isRunning || (hook.durationMs != null && hook.durationMs >= 5)) && (
-          <span className="font-mono text-[0.6875rem] tabular-nums text-muted-foreground/50 shrink-0">
+          <span className="font-mono text-xs tabular-nums text-muted-foreground/50 shrink-0">
             {isRunning ? `${elapsedSeconds}s` : formatDuration(hook.durationMs!)}
           </span>
         )}

--- a/apps/web/src/components/chat/narrative/SubagentRow.tsx
+++ b/apps/web/src/components/chat/narrative/SubagentRow.tsx
@@ -44,7 +44,7 @@ function DelegationTags({ tags }: DelegationTagsProps) {
       {tags.map((tag) => (
         <span
           key={tag}
-          className="font-mono text-[0.625rem] font-medium px-1 py-px rounded-sm bg-muted-foreground/12 text-muted-foreground/70"
+          className="font-mono text-xs font-medium px-1 py-px rounded-sm bg-muted-foreground/12 text-muted-foreground/70"
         >
           {tag}
         </span>
@@ -76,7 +76,7 @@ export function SubagentRow({ toolCall, children, hooks, allToolCalls, depth = 0
   if (!hasChildren && !finalOutput) {
     return (
       <div
-        className="flex w-full min-w-0 max-w-full items-center gap-1.5 overflow-hidden px-2 py-1 text-[0.8125rem]"
+        className="flex w-full min-w-0 max-w-full items-center gap-1.5 overflow-hidden px-2 py-1 text-sm"
         data-testid="subagent-flat-row"
       >
         <StackedLayersIcon
@@ -93,7 +93,7 @@ export function SubagentRow({ toolCall, children, hooks, allToolCalls, depth = 0
         </span>
         <DelegationTags tags={delegationTags} />
         {isErrored && (
-          <span className="font-mono text-[0.625rem] font-medium px-1 py-px rounded-sm bg-[var(--diff-remove)]/15 text-[var(--diff-remove)] shrink-0">
+          <span className="font-mono text-xs font-medium px-1 py-px rounded-sm bg-[var(--diff-remove)]/15 text-[var(--diff-remove)] shrink-0">
             errored
           </span>
         )}
@@ -179,7 +179,7 @@ function ExpandableSubagentRow({
           userToggledRef.current = true;
           setOpen((o) => !o);
         }}
-        className={`${NARRATIVE_TOOL_ROW} w-full px-2 py-1 text-left rounded-md hover:bg-muted/30 transition-colors duration-100 text-[0.8125rem]`}
+        className={`${NARRATIVE_TOOL_ROW} w-full px-2 py-1 text-left rounded-md hover:bg-muted/30 transition-colors duration-100 text-sm`}
         aria-expanded={open}
       >
         <StackedLayersIcon
@@ -199,13 +199,13 @@ function ExpandableSubagentRow({
         <DelegationTags tags={delegationTags} />
 
         {metaText && (
-          <span className="font-mono text-[0.6875rem] text-muted-foreground/50 shrink-0">
+          <span className="font-mono text-xs text-muted-foreground/50 shrink-0">
             {!isRunning ? `· ${metaText}` : metaText}
           </span>
         )}
 
         {isErrored && (
-          <span className="font-mono text-[0.625rem] font-medium px-1 py-px rounded-sm bg-[var(--diff-remove)]/15 text-[var(--diff-remove)] shrink-0">
+          <span className="font-mono text-xs font-medium px-1 py-px rounded-sm bg-[var(--diff-remove)]/15 text-[var(--diff-remove)] shrink-0">
             errored
           </span>
         )}
@@ -260,7 +260,7 @@ function ExpandableSubagentRow({
             const detail = extractToolInputDetail(tc);
 
             return (
-              <li key={tc.id} className={`${NARRATIVE_TOOL_ROW} py-px text-[0.8125rem]`}>
+              <li key={tc.id} className={`${NARRATIVE_TOOL_ROW} py-px text-sm`}>
                 <Icon className={`w-3 h-3 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground/50"}`} />
                 <span className={`shrink-0 ${isActive ? "text-foreground" : "text-muted-foreground/70"}`}>{label}</span>
                 <span className={narrativeToolDetailClass("sm")} title={detail}>
@@ -279,7 +279,7 @@ function ExpandableSubagentRow({
           <button
             type="button"
             onClick={() => setShowAll((o) => !o)}
-            className="flex items-center gap-1 pl-7 pb-1 text-[0.6875rem] text-muted-foreground/40 hover:text-muted-foreground/60 transition-colors"
+            className="flex items-center gap-1 pl-7 pb-1 text-xs text-muted-foreground/40 hover:text-muted-foreground/60 transition-colors"
           >
             <ChevronDown className={`h-2.5 w-2.5 shrink-0 transition-transform duration-150 ${showAll ? "rotate-180" : ""}`} />
             {showAll ? "Show less" : `Show all ${children.length}`}

--- a/apps/web/src/components/chat/narrative/ToolOutputTruncationNotice.tsx
+++ b/apps/web/src/components/chat/narrative/ToolOutputTruncationNotice.tsx
@@ -18,7 +18,7 @@ export function ToolOutputTruncationNotice({ toolCall }: ToolOutputTruncationNot
 
   return (
     <div
-      className="max-w-full text-[0.6875rem] font-mono text-muted-foreground/65 truncate"
+      className="max-w-full text-xs font-mono text-muted-foreground/65 truncate"
       title={toolCall.outputArtifactPath}
       aria-label={`Output truncated${total}${saved}`}
     >

--- a/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
+++ b/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
@@ -105,7 +105,7 @@ function StatusBadge({ status }: StatusBadgeProps) {
   };
   return (
     <span
-      className={`font-mono text-[0.625rem] font-medium px-1.5 py-px rounded-sm ${styles[status]}`}
+      className={`font-mono text-xs font-medium px-1.5 py-px rounded-sm ${styles[status]}`}
     >
       {status}
     </span>

--- a/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
@@ -60,6 +60,8 @@ describe("narrative tool row layout classes", () => {
     const row = detail.parentElement;
     expect(row?.className).toContain("min-w-0");
     expect(row?.className).toContain("overflow-hidden");
+    expect(row?.className).toContain("text-sm");
+    expect(detail.className).toContain("text-sm");
     expect(detail.className).toContain("truncate");
     expect(detail.className).toContain("overflow-wrap");
   });
@@ -102,6 +104,22 @@ describe("narrative tool row layout classes", () => {
     fireEvent.click(screen.getByRole("button"));
     expect(container.querySelector(".lucide-terminal")).toBeTruthy();
     expect(screen.getByText("Ran command")).toBeTruthy();
+  });
+
+  it("ToolSummaryLine renders cancelled status at the mono-data text size", () => {
+    const group: ToolGroup = {
+      calls: [makeBashCall()],
+    };
+
+    render(
+      <div className={COLUMN_CLASS}>
+        <ToolSummaryLine group={group} hasError={false} hasCancelled />
+      </div>,
+    );
+
+    for (const badge of screen.getAllByText("cancelled")) {
+      expect(badge).toHaveClass("text-xs");
+    }
   });
 
   it("ToolSummaryLine shows truncation metadata for bounded output", () => {

--- a/apps/web/src/components/chat/narrative/narrative-layout.ts
+++ b/apps/web/src/components/chat/narrative/narrative-layout.ts
@@ -19,6 +19,6 @@ export function narrativeToolDetailClass(size: "sm" | "md"): string {
   const tone =
     size === "md"
       ? "text-sm text-muted-foreground/80"
-      : "text-[0.6875rem] text-muted-foreground/50";
+      : "text-sm text-muted-foreground/50";
   return `font-mono ${tone} truncate flex-1 min-w-0 [overflow-wrap:anywhere]`;
 }

--- a/apps/web/src/components/chat/plan-questions/AcceptRecommended.tsx
+++ b/apps/web/src/components/chat/plan-questions/AcceptRecommended.tsx
@@ -57,7 +57,7 @@ export function AcceptRecommended({
       disabled={disabled}
       data-testid={testId}
       className={cn(
-        "inline-flex items-center gap-1.5 text-[11px] font-mono",
+        "inline-flex items-center gap-1.5 text-xs font-mono",
         "text-primary/65 hover:text-primary",
         "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:text-primary/65",
         "transition-colors duration-150 ease-out",

--- a/apps/web/src/components/chat/plan-questions/AnsweredSummary.tsx
+++ b/apps/web/src/components/chat/plan-questions/AnsweredSummary.tsx
@@ -78,7 +78,7 @@ export function AnsweredSummary({ content, messageId }: AnsweredSummaryProps) {
             open && "rotate-90",
           )}
         />
-        <span className="font-mono text-[10px] uppercase tracking-widest">
+        <span className="font-mono text-xs uppercase tracking-widest">
           {questions.length} plan question{questions.length !== 1 ? "s" : ""} answered
         </span>
       </CollapsibleTrigger>
@@ -86,7 +86,7 @@ export function AnsweredSummary({ content, messageId }: AnsweredSummaryProps) {
       <CollapsibleContent className="ml-4.5 space-y-2 data-[state=open]:animate-fade-up-in">
         {questions.map((q) => (
           <div key={q.id} className="text-xs">
-            <span className="text-[10px] font-medium uppercase tracking-widest text-muted-foreground/30">
+            <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground/30">
               {q.category}
             </span>
             <p className="text-muted-foreground/60 mt-0.5">{q.question}</p>
@@ -95,7 +95,7 @@ export function AnsweredSummary({ content, messageId }: AnsweredSummaryProps) {
                 <span
                   key={o.id}
                   className={cn(
-                    "inline-block text-[10px] px-1.5 py-0.5 rounded border",
+                    "inline-block text-xs px-1.5 py-0.5 rounded border",
                     o.recommended
                       ? "border-primary/20 text-primary/50 bg-primary/5"
                       : "border-border/30 text-muted-foreground/35",

--- a/apps/web/src/components/chat/plan-questions/OptionTile.tsx
+++ b/apps/web/src/components/chat/plan-questions/OptionTile.tsx
@@ -73,7 +73,7 @@ export function OptionTile({
         <span
           aria-hidden="true"
           className={cn(
-            "font-mono text-[10px] leading-none w-2.5 flex-shrink-0",
+            "font-mono text-xs leading-none w-2.5 flex-shrink-0",
             "transition-[opacity,transform] duration-200 ease-out",
             selected
               ? "opacity-100 translate-x-0 text-primary"
@@ -96,7 +96,7 @@ export function OptionTile({
               {option.title}
             </span>
             {isRecommended && (
-              <span className="text-[10px] font-mono uppercase tracking-wider text-primary/65 leading-none">
+              <span className="text-xs font-mono uppercase tracking-wider text-primary/65 leading-none">
                 · recommended
               </span>
             )}

--- a/apps/web/src/components/chat/tool-renderers/AgentRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/AgentRenderer.tsx
@@ -18,7 +18,7 @@ export function AgentRenderer({ toolCall, isActive }: ToolRendererProps) {
     >
       <div className="space-y-1.5">
         {prompt && (
-          <pre className="rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
+          <pre className="rounded bg-muted/30 p-2 text-xs leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
             {prompt}
           </pre>
         )}
@@ -32,7 +32,7 @@ export function AgentRenderer({ toolCall, isActive }: ToolRendererProps) {
               {showResult ? "Hide result" : "Show result"}
             </button>
             {showResult && (
-              <pre className="mt-1 max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
+              <pre className="mt-1 max-h-64 overflow-auto rounded bg-muted/30 p-2 text-xs leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
                 {toolCall.output}
               </pre>
             )}

--- a/apps/web/src/components/chat/tool-renderers/BashRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/BashRenderer.tsx
@@ -25,14 +25,14 @@ export function BashRenderer({ toolCall, isActive }: ToolRendererProps) {
       isActive={isActive}
     >
       <div className="space-y-1.5">
-        <pre className="rounded bg-zinc-900 px-2.5 py-1.5 text-[11px] leading-relaxed text-zinc-300 font-mono overflow-x-auto">
+        <pre className="rounded bg-zinc-900 px-2.5 py-1.5 text-xs leading-relaxed text-zinc-300 font-mono overflow-x-auto">
           <span className="select-none text-zinc-500">$ </span>{command}
         </pre>
 
         {outputLines.length > 0 && (
           <div>
             <pre
-              className={`max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono ${
+              className={`max-h-64 overflow-auto rounded bg-muted/30 p-2 text-xs leading-relaxed text-muted-foreground font-mono ${
                 toolCall.isError ? "border-l-2 border-red-500/70" : ""
               }`}
             >

--- a/apps/web/src/components/chat/tool-renderers/EditRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/EditRenderer.tsx
@@ -23,7 +23,7 @@ export const EditRenderer = memo(function EditRenderer({ toolCall, isActive }: T
       defaultExpanded
     >
       {lines.length > 0 && (
-        <div className="rounded border border-border/30 overflow-hidden font-mono text-[11px] leading-relaxed">
+        <div className="rounded border border-border/30 overflow-hidden font-mono text-xs leading-relaxed">
           {lines.map((line, i) => (
             <div
               key={i}

--- a/apps/web/src/components/chat/tool-renderers/GenericRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/GenericRenderer.tsx
@@ -34,11 +34,11 @@ export function GenericRenderer({ toolCall, isActive }: ToolRendererProps) {
       isActive={isActive}
     >
       <div className="space-y-1.5">
-        <pre className="max-h-48 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono">
+        <pre className="max-h-48 overflow-auto rounded bg-muted/30 p-2 text-xs leading-relaxed text-muted-foreground font-mono">
           {JSON.stringify(toolCall.toolInput, null, 2)}
         </pre>
         {toolCall.output && (
-          <pre className="max-h-48 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
+          <pre className="max-h-48 overflow-auto rounded bg-muted/30 p-2 text-xs leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
             {toolCall.output}
           </pre>
         )}

--- a/apps/web/src/components/chat/tool-renderers/GrepRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/GrepRenderer.tsx
@@ -28,7 +28,7 @@ export function GrepRenderer({ toolCall, isActive }: ToolRendererProps) {
           {visible.map((line, i) => (
             <div key={i} className="flex items-center gap-1.5 text-xs text-muted-foreground">
               <File size={12} className="shrink-0 opacity-60" />
-              <span className="truncate font-mono text-[11px]">{line}</span>
+              <span className="truncate font-mono text-xs">{line}</span>
             </div>
           ))}
           <ShowMoreButton

--- a/apps/web/src/components/chat/tool-renderers/ReadRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/ReadRenderer.tsx
@@ -22,7 +22,7 @@ export function ReadRenderer({ toolCall, isActive }: ToolRendererProps) {
     >
       {lines.length > 0 && (
         <div>
-          <pre className="max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono">
+          <pre className="max-h-64 overflow-auto rounded bg-muted/30 p-2 text-xs leading-relaxed text-muted-foreground font-mono">
             {visible.join("\n")}
           </pre>
           <ShowMoreButton

--- a/apps/web/src/components/chat/tool-renderers/WebRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/WebRenderer.tsx
@@ -22,7 +22,7 @@ export function WebRenderer({ toolCall, isActive }: ToolRendererProps) {
     >
       {lines.length > 0 && lines[0].trim() && (
         <div>
-          <pre className="max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
+          <pre className="max-h-64 overflow-auto rounded bg-muted/30 p-2 text-xs leading-relaxed text-muted-foreground font-mono whitespace-pre-wrap">
             {visible.join("\n")}
           </pre>
           <ShowMoreButton

--- a/apps/web/src/components/chat/tool-renderers/WriteRenderer.tsx
+++ b/apps/web/src/components/chat/tool-renderers/WriteRenderer.tsx
@@ -31,7 +31,7 @@ export function WriteRenderer({ toolCall, isActive }: ToolRendererProps) {
     >
       {lines.length > 0 && (
         <div>
-          <pre className="max-h-64 overflow-auto rounded bg-muted/30 p-2 text-[11px] leading-relaxed text-muted-foreground font-mono">
+          <pre className="max-h-64 overflow-auto rounded bg-muted/30 p-2 text-xs leading-relaxed text-muted-foreground font-mono">
             {visible.join("\n")}
           </pre>
           <ShowMoreButton


### PR DESCRIPTION
## What
Normalize chat text to Mcode's 12px and 14px typography roles.

## Why
Some chat components used arbitrary rem sizes. With a 62.5% root font size, 0.625rem and 0.8125rem rendered at 6.25px and 8.125px, making status badges and command details difficult to read.

## Key Changes
- Use 14px text for primary narrative rows and command details.
- Use 12px text for status badges and supporting metadata.
- Keep the intentional empty-state typography.
- Add regression coverage for active command rows and cancelled badges.
- Wait for the mention popup animation before measuring its anchored position.

## Verification
- `bun run verify`
- Focused Vitest suite: 22 tests passed.
- Live Playwright verification: 2 tests passed.
- Typed-mentions E2E: 10 repeated runs passed.
