### PR TITLE
docs: propose hybrid memory broker

### DIFF
--- a/docs/research/2026-07-17-provider-memory-capabilities.md
+++ b/docs/research/2026-07-17-provider-memory-capabilities.md
@@ -1,0 +1,98 @@
+# Provider Memory Capabilities
+
+**Research date:** 2026-07-17
+
+## Scope
+
+This note compares persistent context in Claude Code, Codex, Gemini CLI, GitHub Copilot CLI, Cursor Agent, and OpenCode. It separates four mechanisms:
+
+- **Learned memory:** the provider derives reusable facts or preferences from prior work.
+- **Persistent instructions:** a person maintains files such as `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`.
+- **Session history:** a provider resumes or forks an existing conversation.
+- **Mcode memory:** context owned by Mcode and passed across provider boundaries.
+
+The sources expose no common memory API or shared data model. Mcode should therefore treat native memory as a provider capability, not as a portable record.
+
+## Capability matrix
+
+| Provider | Learned memory | Persistent instructions | User review and removal | Documented integration surface |
+| --- | --- | --- | --- | --- |
+| Claude Code | Auto memory, enabled by default in supported versions | `CLAUDE.md`, `CLAUDE.local.md`, and `.claude/rules/` | Plain Markdown; `/memory` opens files and toggles auto memory | Settings, environment variables, CLI, and local files; no structured memory API is documented |
+| Codex | Two-stage extraction and consolidation from eligible rollouts | `AGENTS.md` hierarchy | Local artifacts can be inspected; app-server can disable memory per thread or reset all memory | Experimental app-server methods plus config and local files; no per-memory CRUD API is documented |
+| Gemini CLI | Explicit `save_memory` plus experimental Auto Memory | `GEMINI.md` hierarchy, configurable filenames | Auto Memory holds patches and skill drafts in an inbox until approval | Local files, settings, slash commands, and tools; Auto Memory support must be verified for the hosting surface |
+| GitHub Copilot | Repository facts and user preferences | Copilot instruction files and `AGENTS.md` support vary by surface | GitHub settings list and delete entries; administrators can export or delete preferences | Provider-managed service and settings UI; no memory CRUD API for Copilot CLI or SDK is documented |
+| Cursor | Project-scoped memories generated from chat | `.cursor/rules`, `AGENTS.md`, and `CLAUDE.md` in Cursor CLI | Background memories require approval and are managed in Cursor Settings | Cursor Settings for memories; Cursor CLI documents rules and session resume, but no memory API or CLI command |
+| OpenCode | No learned-memory feature found in current official documentation | Project and global `AGENTS.md`, optional instruction paths, and `CLAUDE.md` fallbacks | Files are edited through normal source control or filesystem workflows | Config files, CLI session commands, HTTP server, and SDK session methods; no memory endpoint is documented |
+
+## Claude Code
+
+Claude Code distinguishes user-authored instructions from agent-authored auto memory. `CLAUDE.md` files carry instructions into every session, while auto memory stores patterns derived from corrections and work. Auto memory requires Claude Code 2.1.59 or later and is enabled by default. `/memory`, `autoMemoryEnabled`, and `CLAUDE_CODE_DISABLE_AUTO_MEMORY` control it. [`--bare` skips instruction discovery and auto memory](https://code.claude.com/docs/en/cli-reference).
+
+Auto memory is machine-local under `~/.claude/projects/<project>/memory/`; worktrees of one repository share a directory. The first 200 lines or 25 KB of `MEMORY.md` load at conversation start, and topic files load on demand. Users can inspect, edit, or delete these files. Anthropic does not document source citations, expiry, branch validation, candidate approval, or an external memory API. [Claude Code memory documentation](https://code.claude.com/docs/en/memory)
+
+Mcode can report whether auto memory is enabled and link to its folder, but should not rewrite Claude's notes without explicit user action. `CLAUDE.md` and resumed history must remain separate context sources.
+
+## Codex
+
+Codex runs a local, two-stage pipeline for eligible root sessions. Phase 1 extracts memories from recent idle rollouts, redacts secrets, and writes to the local state database. Phase 2 selects a bounded set using age, use, and retention settings, then consolidates artifacts under `~/.codex/memories`. A git baseline records changes between consolidations. [Codex memory pipeline](https://github.com/openai/codex/blob/main/codex-rs/memories/README.md)
+
+Codex exposes experimental app-server controls. `thread/memoryMode/set` changes a thread's future eligibility. `memory/reset` clears artifacts and memory-stage rows while preserving thread eligibility. Memory citations contain file paths, line ranges, notes, and contributing thread IDs. There is no individual-memory CRUD or approval operation. [Codex app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md) and [memory citation schema](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/typescript/v2/MemoryCitation.ts)
+
+`memories.generate_memories` controls contribution, while `memories.use_memories` controls injection. Other settings bound rollout age, idle time, startup work, retained inputs, and unused-memory age. These controls need version gating. [Codex configuration schema](https://github.com/openai/codex/blob/main/codex-rs/core/config.schema.json)
+
+Mcode can show thread eligibility, surface native citations, and offer a clearly destructive global reset. Per-item review needs a future Codex contract.
+
+## Gemini CLI
+
+Gemini CLI has three persistent-context layers. Hierarchical `GEMINI.md` instructions load from user, workspace, and just-in-time directory scopes. `save_memory` persists a requested fact to Markdown. `/memory show` displays combined context and `/memory reload` rescans it. File names can include `AGENTS.md`. [Gemini context files](https://geminicli.com/docs/cli/gemini-md/) and [memory files](https://geminicli.com/docs/tools/memory/)
+
+Experimental Auto Memory is off by default. It scans eligible local transcripts, then places memory patches or skill drafts in a project inbox without editing active memory. `/memory inbox` supports inspection, application, promotion, dismissal, and deletion. Selected transcript content may reach the configured model during extraction. No post-approval staleness validation is documented. [Gemini Auto Memory](https://geminicli.com/docs/cli/auto-memory/)
+
+The hosting surface matters. An official-repository issue records that Auto Memory was not started for ACP sessions even when enabled. Mcode must test its exact adapter rather than assume TUI parity. [Gemini CLI issue 25624](https://github.com/google-gemini/gemini-cli/issues/25624)
+
+Mcode can display active instruction files and link to the inbox when available. It should not apply candidates automatically.
+
+## GitHub Copilot
+
+Copilot Memory is a provider-managed public preview. It learns repository facts and user preferences from user-initiated activity. Repository facts carry code citations and are revalidated against the current branch. Preferences remain tied to the user and billing entity. Unused entries are deleted after 28 days, with reset on successful validation and use. Copilot CLI applies both types. [About Copilot Memory](https://docs.github.com/en/copilot/concepts/agents/copilot-memory)
+
+GitHub settings let users enable the feature and inspect or delete entries. Administrators have additional deletion and export controls. No documented CLI flag, SDK method, or public API manages individual memories for a session. [Managing Copilot Memory](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/copilot-memory/manage-for-yourself)
+
+Copilot CLI reads repository, path-specific, agent, and personal instructions separately; `--no-custom-instructions` skips them. [Copilot CLI customization](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/comparing-cli-features)
+
+Mcode should present Copilot memory as opaque and provider-managed, without scraping GitHub settings or claiming unavailable citations.
+
+## Cursor
+
+Cursor describes memories as project-scoped rules generated from chat. A sidecar model can propose memories in the background, and those proposals require approval before saving. The agent can also create a memory through a tool call when the user asks it to remember something or when it identifies useful context. Users manage saved memories in Cursor Settings under Rules. The documentation does not publish the storage location, expiry policy, provenance schema, or external API. [Cursor Memories](https://docs.cursor.com/en/context/memories)
+
+Cursor CLI documents a separate rules system. It loads `.cursor/rules` and root `AGENTS.md` or `CLAUDE.md`, and it can resume a prior thread with `--resume`. Its command and parameter references do not document memory inspection, approval, or suppression. [Cursor CLI usage](https://docs.cursor.com/en/cli/using) and [Cursor CLI parameters](https://docs.cursor.com/en/cli/reference/parameters)
+
+Mcode should not assume IDE memories are present in Cursor CLI sessions. Until Cursor publishes a CLI contract, Mcode can expose instruction files and resumed-session status, while labelling native memories as unavailable or externally managed.
+
+## OpenCode
+
+OpenCode's current documentation describes persistent instructions, not learned memory. Project `AGENTS.md` files are intended for source control; `~/.config/opencode/AGENTS.md` supplies personal global rules. OpenCode can fall back to project and global `CLAUDE.md`, and `opencode.json` can add local globs or remote instruction URLs. The first matching project and global rule files win, while configured instruction files are combined with them. [OpenCode rules](https://opencode.ai/docs/rules/)
+
+OpenCode persists sessions separately. CLI flags continue or fork sessions, `opencode session list` enumerates them, and exports produce session JSON. The HTTP server and SDK expose session creation, retrieval, update, deletion, abort, and child-session operations. None of the current rules, CLI, SDK, or tools references documents learned-memory extraction or a memory management endpoint. [OpenCode CLI](https://opencode.ai/docs/cli/) and [OpenCode SDK](https://opencode.ai/docs/sdk/)
+
+Mcode should treat OpenCode instruction files and resumed sessions as distinct context sources. Calling either one “memory” would hide an important capability gap.
+
+## Implications for a hybrid Mcode memory broker
+
+1. **Keep provider memory provider-owned.** Mcode should not import native memories into its database or silently rewrite their files. The native stores have different scopes, review rules, retention policies, and ownership models.
+2. **Model context sources, not a universal memory record.** A thread receipt should identify provider-native memory, checked-in instructions, resumed history, and Mcode-approved cross-provider notes separately.
+3. **Use a capability handshake.** Each adapter should report whether it can detect use, control contribution, control recall, expose citations, open a management surface, or reset data. Unsupported means unavailable, not a best-effort guess.
+4. **Version-gate native controls.** Codex app-server methods are the strongest integration seam but remain experimental. Gemini Auto Memory depends on its host surface. Cursor and Copilot have no documented memory API for Mcode to call.
+5. **Reserve Mcode memory for explicit cross-provider continuity.** A candidate should require human approval, retain its source thread and provider, show the evidence used to derive it, declare its workspace scope, and record every later injection.
+6. **Prefer checked-in instructions for shared rules.** `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, repository documentation, and ADRs are reviewable by a team and should outrank learned context.
+7. **Prevent double injection.** Before a turn, Mcode should show which native and Mcode-owned sources will be active. A user must be able to disable Mcode notes without altering the provider's own store, and vice versa where the provider supports it.
+
+## Exploration still required
+
+- Capture protocol traces for each Mcode adapter to confirm which memory state or citations are observable in practice.
+- Test Codex versions across the supported range for `thread/memoryMode/set`, `memory/reset`, and citation delivery.
+- Verify Gemini Auto Memory behavior through the exact integration Mcode intends to host.
+- Confirm whether Cursor Agent CLI consumes IDE-approved memories; current official CLI documentation does not say.
+- Confirm whether the Copilot SDK exposes memory state indirectly in session context or events; current public documentation does not define such a contract.
+- Define how Mcode deduplicates an approved cross-provider note when the selected provider may already know the same fact.

--- a/docs/specs/2026-07-17-reviewable-local-memory.md
+++ b/docs/specs/2026-07-17-reviewable-local-memory.md
@@ -1,0 +1,155 @@
+# Hybrid Memory Broker
+
+**Date:** 2026-07-17
+**Status:** Proposal
+**Tracking issue:** [#875](https://github.com/Mzeey-Empire/mcode/issues/875)
+**Research:** [Provider memory capability research](../research/2026-07-17-provider-memory-capabilities.md)
+**Origin:** [Codex app feature audit PR #861](https://github.com/Mzeey-Empire/mcode/pull/861)
+
+## Problem
+
+Mcode can move a Thread between Providers through a Handoff, but each Provider may also load its own memories, instructions, and session context. Those sources have different scopes and controls.
+
+Another automatic memory system could inject stale or conflicting guidance. Users need explicit facts and preferences that cross Providers without becoming hidden context.
+
+## Product outcome
+
+Add a hybrid memory broker that keeps Provider memory provider-owned and adds local, reviewable Mcode portable memory. Mcode discloses Provider memory without importing it. Portable memory crosses Providers only after user acceptance.
+
+## Source model
+
+Mcode presents two distinct sources:
+
+1. **Provider memory** is owned by its Provider. Mcode never reads, copies, edits, merges, or exports it without a documented Provider API.
+2. **Portable memory** is owned by Mcode. It contains user-approved statements with Mcode provenance and may be supplied to any compatible Provider selected for the Thread.
+
+Mcode reports Provider memory as active only when runtime evidence proves it. Documentation may support “available, status unknown,” never an active claim.
+
+## Native capability handshake
+
+Each Provider adapter reports version-gated capabilities for detecting use, controlling recall or contribution, exposing citations, opening management, and resetting data. Each is supported, unavailable, or unknown. Runtime state remains separate.
+
+Native controls require live verification and retain Provider terminology and confirmations. Destructive reset remains Provider-specific.
+
+## Portable-memory lifecycle
+
+Portable memories are never learned silently. A user creates a candidate by:
+
+- saving a selected user statement, assistant result, or verified command;
+- entering a statement directly; or
+- explicitly requesting suggestions from an eligible part of a completed Thread.
+
+Suggestions use the current Provider in an identified, bounded side-channel and enter review. Manual creation remains available.
+
+Each candidate records class, scope, source Turn, evidence, creation Provider, and review rule. Acceptance creates an immutable revision. Editing creates another revision.
+
+## Memory classes and scopes
+
+| Class | Example | Default scope | Review trigger |
+| --- | --- | --- | --- |
+| Preference | Preferred verification style | User | User changes it |
+| Project fact | Runtime ports come from the runtime manifest | Workspace | Cited source changes |
+| Verified command | Command that started the local runtime | Workspace | Command fails or source changes |
+| Temporary observation | Current migration is blocked | Thread | Required expiry |
+
+Scopes are Thread, Workspace, and User. A Provider restriction limits delivery without granting access to native memory.
+
+## Turn contract
+
+Before dispatch, the broker resolves accepted revisions by scope, staleness, exclusions, Thread settings, conflicts, and byte budget. The envelope is immutable for the logical Turn and every retry.
+
+The Turn request carries the envelope separately. Each adapter reports its documented delivery mode. Without one, portable memory is unavailable.
+
+Mcode persists one Turn context receipt containing:
+
+- the user message and Provider identity;
+- each portable memory ID and immutable revision;
+- a hash of the rendered envelope;
+- the delivery mode and dispatch state;
+- exclusions and reasons;
+- runtime disclosure and citations available for Provider memory; and
+- references to known instructions, resumed history, and Handoff context.
+
+Only portable memory stores exact revisions. Other sources receive observable references, hashes, or unknown markers. Provider memory is never copied.
+
+## Precedence and conflicts
+
+Current instructions and checked-in guidance remain authoritative. Portable memory cannot grant permissions, approve tools, install Hooks, change settings, or weaken sandbox rules.
+
+Source changes make related memory stale. Conflicting portable memories are excluded for review rather than sent to the model. Mcode cannot enforce precedence over opaque Provider memory, and the UI states that limitation.
+
+## Provider switching and Handoffs
+
+Portable memories resolve independently for the destination Provider's next Turn. Handoffs omit them. A switch preview shows what can cross and warns that Provider memory stays behind.
+
+Returning may reactivate native memory. Mcode records only its portable envelope.
+
+## User experience
+
+The composer shows included portable-memory count and Provider-memory disclosure. Its inspector reveals text, scope, source, revision, exclusions, and one-Turn controls.
+
+Settings owns every record state. Revision, Provider, scope, and time use monospace. Actions have keyboard paths; Filament Amber marks selection or the primary action.
+
+Each Thread has **Use portable memories**, off by default. Suggestions remain explicit. Provider switching and Turn receipts link to the same inspector.
+
+## Security, privacy, and bounds
+
+- Portable-memory storage and review state stay in Mcode's local data directory.
+- Secret-shaped candidates fail closed before storage. Rejected text does not enter logs, analytics, exports, or Provider context.
+- Memory content is untrusted data. It cannot affect permissions or tool approval.
+- Each statement is capped at 2 KiB and each evidence excerpt at 8 KiB.
+- A Turn may receive at most 16 portable revisions and 12 KiB of rendered portable context.
+- Candidate and rejected queues are bounded; accepted records are never evicted automatically.
+- Export includes portable records and receipts only. Provider-owned memory is excluded.
+- Deleting a source Thread removes candidates and asks whether linked accepted memories should be deleted or kept with unavailable provenance.
+
+## Acceptance criteria
+
+1. Provider memory and Mcode portable memory appear as separate named sources.
+2. Mcode never imports or represents the contents of Provider memory without a documented integration contract.
+3. Every Provider reports native capabilities separately; active status and controls require runtime evidence.
+4. No portable candidate is created without an explicit user action.
+5. No candidate reaches another Thread or Provider before user acceptance.
+6. Every accepted memory has immutable revision, class, scope, source, evidence, reviewer action, and review trigger.
+7. Users can create, inspect, edit, accept, reject, exclude, mark stale, delete, and export portable memories.
+8. **Use portable memories** is off by default and can be changed per Thread.
+9. The exact resolved envelope is fixed before dispatch and reused on automatic retry.
+10. Every dispatched Turn has a source-separated context receipt with exact portable revisions and only observable references for other sources.
+11. Checked-in guidance and the current prompt outrank portable memory.
+12. Conflicting or stale portable memories are excluded before Provider dispatch.
+13. Provider switching previews portable continuity and warns that native memory does not cross.
+14. Portable memory is resolved separately from the Handoff document.
+15. Secret-shaped candidates fail closed and leave no recoverable text in normal application data.
+16. Context, record size, queue length, suggestion work, and storage are bounded.
+17. The complete workflow is keyboard accessible and remains usable in narrow and wide layouts.
+
+## Verification protocol
+
+The primary seam is a completed Turn against a recording Provider adapter and real local database. The Provider request and persisted receipt must describe the same immutable envelope.
+
+- Unit-test lifecycle transitions, revisioning, scope matching, stale-source detection, conflict exclusion, secret rejection, and byte budgets.
+- Contract-test each Provider adapter's portable-context delivery and native-memory disclosure.
+- Integration-test explicit save, explicit suggestions, review, one-Turn exclusion, automatic retry, Provider switching, export, and deletion.
+- Verify that retries reuse the original revisions even if memory changes while the first attempt is in flight.
+- Verify that a Handoff omits portable memory and the destination Turn resolves it once.
+- Verify that an opaque Provider never produces a false “active memory” status.
+- Inspect the composer, review queue, Turn receipt, and switch preview live in both themes and at narrow and wide widths.
+- Run `bun run verify` after the live checks.
+
+## Non-goals
+
+- Replacing or synchronizing Provider-native memory.
+- Reading private Provider files or cloud memory stores.
+- Automatically accepting model-generated memories.
+- Background transcript mining.
+- Cloud sync, shared team memory, organization policy, or account-level administration.
+- Replacing `AGENTS.md`, `CLAUDE.md`, Provider rules, `CONTEXT.md`, ADRs, Skills, Hooks, or Handoffs.
+- Guaranteeing precedence over context injected internally by a Provider.
+
+## Repository anchors
+
+- Provider and Turn contracts
+- Agent orchestration and retry
+- Thread settings and Provider-switch Handoffs
+- Local data repositories and schema
+- Composer, Settings, and narrative timeline


### PR DESCRIPTION
## What

Proposes a research-backed hybrid memory broker that keeps Provider memory provider-owned and adds explicit, reviewable Mcode portable memory for cross-Provider continuity.

## Why

Claude, Codex, Copilot, Cursor, Gemini, and OpenCode expose different memory, instruction, and session capabilities. Mcode needs accurate capability disclosure and a local continuity layer without importing or imitating opaque Provider memory.

## Key Changes

- Maps current Provider memory capabilities and remaining protocol checks against primary sources.
- Defines version-gated native-memory detection, controls, citations, management, and reset capabilities.
- Requires explicit portable-memory creation, human review, immutable revisions, provenance, staleness, conflict handling, and bounded injection.
- Defines a source-separated Turn context receipt for portable memory, Provider memory, instructions, resumed history, and Handoff.
- Keeps portable memory separate from Handoff documents and previews continuity during Provider switching.

Planning issue: #875

Related research: #861

## Visual reference

![OpenAI Memories documentation reference](https://raw.githubusercontent.com/Mzeey-Empire/mcode/refs/heads/docs/codex-app-feature-audit/docs/design/codex-app-feature-research/memory-doc.png)

Source: [OpenAI Memories](https://learn.chatgpt.com/docs/customization/memories). OpenAI does not publish an in-product memory screenshot on this page, so this PR uses its official reference image.
