### PR TITLE
fix(chat): improve command execution display

### DIFF
--- a/apps/server/src/services/__tests__/narrative-store.test.ts
+++ b/apps/server/src/services/__tests__/narrative-store.test.ts
@@ -296,6 +296,24 @@ describe("NarrativeStore write seam (server-side traps)", () => {
       expect(calls).toHaveLength(1);
       expect(calls[0]._rawToolInput).toEqual({ command: "echo hi" });
     });
+
+    it("persists Codex commands beyond the old 200-character JSON summary", () => {
+      const command = `pwsh -Command \"${"Write-Output long-command;".repeat(20)}\"`;
+      seedAssistantMessage("m1", "done", 1);
+      store.beginTurn(THREAD);
+      store.resetTurnCounters(THREAD);
+      store.bufferToolCall(THREAD, {
+        toolCallId: "cmd-1",
+        toolName: "command_execution",
+        toolInput: { command },
+      });
+
+      store.persistNarrative(THREAD, "m1", "done", "completed");
+
+      const [record] = new ToolCallRecordRepo(db).listByMessage("m1");
+      expect(command.length).toBeGreaterThan(200);
+      expect(record.input_summary).toBe(command);
+    });
   });
 
   describe("Classification precedence + is_final_response safety net", () => {

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -93,6 +93,9 @@ export interface PersistNarrativeResult {
   toolCallCount: number;
 }
 
+/** Bounds persisted shell commands while retaining enough text for readable expansion. */
+const MAX_PERSISTED_COMMAND_CHARS = 4096;
+
 @injectable()
 export class NarrativeStore {
   /** Per-thread buffer of tool calls accumulated during the current turn. */
@@ -686,7 +689,10 @@ export class NarrativeStore {
       case "Write":
         return String(input.file_path ?? input.filePath ?? "");
       case "Bash":
-        return String(input.command ?? "").slice(0, 200);
+      case "Shell":
+      case "Terminal":
+      case "command_execution":
+        return String(input.command ?? "").slice(0, MAX_PERSISTED_COMMAND_CHARS);
       case "Grep":
       case "Glob":
         return String(input.pattern ?? "");

--- a/apps/web/e2e/tool-output-truncation.spec.ts
+++ b/apps/web/e2e/tool-output-truncation.spec.ts
@@ -141,7 +141,7 @@ async function dispatchAgentEvent(page: Page, event: unknown) {
 }
 
 async function expectTruncationNotice(page: Page, total: string) {
-  const summary = page.getByRole("button", { name: /Ran 1 command/ });
+  const summary = page.getByRole("button", { name: /Ran command/ });
   if (await summary.getAttribute("aria-expanded") !== "true") {
     await summary.click();
   }

--- a/apps/web/src/components/chat/narrative/ActiveToolRow.tsx
+++ b/apps/web/src/components/chat/narrative/ActiveToolRow.tsx
@@ -4,10 +4,12 @@ import {
   TOOL_PHASE_LABELS,
   DEFAULT_ICON,
   resolveToolName,
+  isShellTool,
 } from "../tool-renderers/constants";
 import type { ToolCall } from "@/transport/types";
 import { extractToolInputDetail } from "./tool-detail";
 import { NARRATIVE_TOOL_ROW, narrativeToolDetailClass } from "./narrative-layout";
+import { CommandExecutionCard } from "./CommandExecutionCard";
 
 interface ActiveToolRowProps {
   toolCall: ToolCall;
@@ -18,6 +20,10 @@ interface ActiveToolRowProps {
  * No background tint - the spinning icon alone signals activity.
  */
 export function ActiveToolRow({ toolCall }: ActiveToolRowProps) {
+  if (isShellTool(toolCall.toolName)) {
+    return <CommandExecutionCard toolCall={toolCall} isActive />;
+  }
+
   const canonicalName = resolveToolName(toolCall.toolName);
   const Icon = TOOL_ICONS[canonicalName] ?? DEFAULT_ICON;
   const label =

--- a/apps/web/src/components/chat/narrative/CommandExecutionCard.tsx
+++ b/apps/web/src/components/chat/narrative/CommandExecutionCard.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { ChevronRight, Terminal } from "lucide-react";
+import { AnimatedCollapsible } from "@/components/ui/animated-collapsible";
+import type { ToolCall } from "@/transport/types";
+import { ToolOutputTruncationNotice } from "./ToolOutputTruncationNotice";
+
+interface CommandExecutionCardProps {
+  /** Shell tool call rendered by the card. */
+  toolCall: ToolCall;
+  /** Whether the command is still running. */
+  isActive?: boolean;
+}
+
+/**
+ * Extracts a shell command from live input or its persisted summary.
+ * Older Codex records stored `command_execution` inputs as JSON summaries,
+ * so the persisted boundary is normalized before it reaches the UI.
+ */
+function extractCommand(toolCall: ToolCall): string {
+  const direct = toolCall.toolInput.command;
+  if (typeof direct === "string" && direct.trim().length > 0) return direct;
+
+  const summary = toolCall.toolInput._summary ?? toolCall.toolInput.summary;
+  if (typeof summary !== "string") return "";
+
+  const trimmed = summary.trim();
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        "command" in parsed &&
+        typeof parsed.command === "string"
+      ) {
+        return parsed.command;
+      }
+    } catch {
+      // Truncated legacy JSON is normalized by the bounded decoder below.
+    }
+  }
+
+  const legacyPrefix = '{"command":"';
+  if (trimmed.startsWith(legacyPrefix)) {
+    const escapedCommand = trimmed
+      .slice(legacyPrefix.length)
+      .replace(/"}$/, "");
+    const escapedSlash = "\u0000";
+    return escapedCommand
+      .replace(/\\\\/g, escapedSlash)
+      .replace(/\\"/g, '"')
+      .replace(/\\n/g, "\n")
+      .replace(/\\r/g, "\r")
+      .replace(/\\t/g, "\t")
+      .replace(/\\\//g, "/")
+      .split(escapedSlash)
+      .join("\\");
+  }
+
+  return summary;
+}
+
+/** Renders one shell invocation as a compact, expandable terminal surface. */
+export function CommandExecutionCard({
+  toolCall,
+  isActive = false,
+}: CommandExecutionCardProps) {
+  const [open, setOpen] = useState(false);
+  const command = extractCommand(toolCall);
+  const preview = command.replace(/\s+/g, " ").trim() || "Command unavailable";
+  const output = toolCall.output ?? "";
+  const isCancelled = !isActive && !toolCall.isComplete && !toolCall.isError;
+
+  return (
+    <div className="min-w-0 max-w-full overflow-hidden rounded-md bg-[var(--code-bg)] ring-1 ring-inset ring-border/45">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className="flex min-h-8 w-full min-w-0 items-center gap-2 px-2 py-1.5 text-left transition-colors duration-150 hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring motion-reduce:transition-none"
+        aria-expanded={open}
+      >
+        <Terminal
+          className={`h-3.5 w-3.5 shrink-0 ${
+            toolCall.isError
+              ? "text-[var(--diff-remove)]"
+              : isActive
+                ? "text-primary"
+                : "text-muted-foreground/70"
+          }`}
+        />
+        <span className="shrink-0 text-xs font-medium text-foreground/75">
+          {isActive ? "Running command" : "Ran command"}
+        </span>
+        {!open && (
+          <span
+            className="min-w-0 flex-1 truncate font-mono text-xs font-normal text-muted-foreground/70"
+            title={command || undefined}
+          >
+            {preview}
+          </span>
+        )}
+        {open && <span className="min-w-0 flex-1" />}
+        {toolCall.isError && (
+          <span className="shrink-0 rounded-sm bg-[var(--diff-remove)]/15 px-1.5 py-px font-mono text-xs font-medium leading-4 text-[var(--diff-remove)]">
+            errored
+          </span>
+        )}
+        {isCancelled && (
+          <span className="shrink-0 rounded-sm bg-muted-foreground/18 px-1.5 py-px font-mono text-xs font-medium leading-4 text-muted-foreground">
+            cancelled
+          </span>
+        )}
+        <ChevronRight
+          className={`h-3 w-3 shrink-0 text-muted-foreground/45 transition-transform duration-150 motion-reduce:transition-none ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+      </button>
+
+      <AnimatedCollapsible open={open}>
+        <div className="border-t border-border/45">
+          <div className="min-w-0 px-3 py-2.5 font-mono text-xs font-normal leading-5">
+            <div className="flex min-w-0 items-start gap-2">
+              <span aria-hidden="true" className="select-none text-primary/75">
+                &gt;
+              </span>
+              <code className="min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-xs font-normal leading-5 text-foreground/85 [overflow-wrap:anywhere]">
+                {command || "Command unavailable"}
+              </code>
+            </div>
+
+            {toolCall.outputTruncated === true && (
+              <div className="mt-1">
+                <ToolOutputTruncationNotice toolCall={toolCall} />
+              </div>
+            )}
+
+            {output.length > 0 && (
+              <pre
+                className={`mt-1 max-h-64 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono text-xs font-normal leading-5 [overflow-wrap:anywhere] ${
+                  toolCall.isError
+                    ? "text-[var(--diff-remove)]"
+                    : "text-foreground/75"
+                }`}
+              >
+                {output}
+              </pre>
+            )}
+          </div>
+        </div>
+      </AnimatedCollapsible>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/narrative/ToolOutputTruncationNotice.tsx
+++ b/apps/web/src/components/chat/narrative/ToolOutputTruncationNotice.tsx
@@ -18,7 +18,7 @@ export function ToolOutputTruncationNotice({ toolCall }: ToolOutputTruncationNot
 
   return (
     <div
-      className="max-w-full text-xs font-mono text-muted-foreground/65 truncate"
+      className="max-w-full truncate font-mono text-xs font-normal leading-5 text-muted-foreground/65"
       title={toolCall.outputArtifactPath}
       aria-label={`Output truncated${total}${saved}`}
     >

--- a/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
+++ b/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
@@ -15,6 +15,7 @@ import type { ToolGroup } from "./types";
 import { extractToolInputDetail } from "./tool-detail";
 import { NARRATIVE_TOOL_ROW, narrativeToolDetailClass } from "./narrative-layout";
 import { ToolOutputTruncationNotice } from "./ToolOutputTruncationNotice";
+import { CommandExecutionCard } from "./CommandExecutionCard";
 
 interface ToolSummaryLineProps {
   /** The group of consecutive tool calls to summarize. */
@@ -127,6 +128,19 @@ export function ToolSummaryLine({
 }: ToolSummaryLineProps) {
   const [open, setOpen] = useState(false);
 
+  if (
+    group.calls.length > 0 &&
+    group.calls.every((call) => isShellTool(call.toolName))
+  ) {
+    return (
+      <div className="flex min-w-0 max-w-full flex-col gap-1 py-0.5">
+        {group.calls.map((toolCall) => (
+          <CommandExecutionCard key={toolCall.id} toolCall={toolCall} />
+        ))}
+      </div>
+    );
+  }
+
   const firstCall = group.calls[0];
   const LeadingIcon = firstCall
     ? (TOOL_ICONS[resolveToolName(firstCall.toolName)] ?? DEFAULT_ICON)
@@ -164,6 +178,14 @@ export function ToolSummaryLine({
             const detail = extractToolInputDetail(tc);
             const status = getCallStatus(tc);
 
+            if (isShellTool(tc.toolName)) {
+              return (
+                <li key={tc.id} className="min-w-0 max-w-full py-0.5">
+                  <CommandExecutionCard toolCall={tc} />
+                </li>
+              );
+            }
+
             return (
               <li key={tc.id} className="flex min-w-0 max-w-full flex-col gap-0.5">
                 {/* Row: icon + label + detail + badge */}
@@ -179,15 +201,6 @@ export function ToolSummaryLine({
                 </div>
 
                 {/* Inline content blocks */}
-                {tc.isComplete && !tc.isError && isShellTool(tc.toolName) && tc.output && (
-                  <div className="flex min-w-0 max-w-full flex-col gap-1">
-                    <ToolOutputTruncationNotice toolCall={tc} />
-                    <pre className="max-w-full text-sm font-mono rounded px-2 py-1 bg-[var(--code-bg)] text-foreground/80 overflow-x-auto whitespace-pre-wrap break-words max-h-40">
-                      {tc.output}
-                    </pre>
-                  </div>
-                )}
-
                 {tc.isError && tc.output && (
                   <div className="flex min-w-0 max-w-full flex-col gap-1">
                     <ToolOutputTruncationNotice toolCall={tc} />

--- a/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
@@ -49,39 +49,52 @@ describe("resolveToolName", () => {
 });
 
 describe("narrative tool row layout classes", () => {
-  it("ActiveToolRow applies constrained flex row and title tooltip on detail", () => {
-    render(
+  it("ActiveToolRow renders shell commands as expandable terminal cards", () => {
+    const { container } = render(
       <div className={COLUMN_CLASS}>
         <ActiveToolRow toolCall={makeBashCall()} />
       </div>,
     );
 
-    const detail = screen.getByTitle(LONG_SHELL_COMMAND);
-    const row = detail.parentElement;
-    expect(row?.className).toContain("min-w-0");
-    expect(row?.className).toContain("overflow-hidden");
-    expect(row?.className).toContain("text-sm");
-    expect(detail.className).toContain("text-sm");
-    expect(detail.className).toContain("truncate");
-    expect(detail.className).toContain("overflow-wrap");
+    const button = screen.getByRole("button", { name: /Running command/ });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTitle(LONG_SHELL_COMMAND)).toHaveClass("truncate");
+
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    const command = container.querySelector("code");
+    expect(command?.textContent).toBe(LONG_SHELL_COMMAND);
+    expect(command?.className).toContain("whitespace-pre-wrap");
+    expect(command?.className).toContain("overflow-wrap");
   });
 
-  it("ToolSummaryLine expanded rows use constrained flex layout", () => {
+  it("ToolSummaryLine gives a completed shell command its own disclosure", () => {
     const group: ToolGroup = {
-      calls: [makeBashCall({ id: "tc-1", isComplete: true })],
+      calls: [
+        makeBashCall({
+          id: "tc-1",
+          isComplete: true,
+          output: "command output",
+        }),
+      ],
     };
 
-    render(
+    const { container } = render(
       <div className={COLUMN_CLASS}>
         <ToolSummaryLine group={group} hasError={false} hasCancelled={false} />
       </div>,
     );
 
-    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    const button = screen.getByRole("button", { name: /Ran command/ });
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+    fireEvent.click(button);
 
-    const detail = screen.getByTitle(LONG_SHELL_COMMAND);
-    expect(detail.className).toContain("truncate");
-    expect(detail.closest("li")?.className).toContain("min-w-0");
+    expect(container.querySelector("code")?.textContent).toBe(LONG_SHELL_COMMAND);
+    expect(screen.queryByText("Output")).toBeNull();
+    expect(screen.getByText("command output")).toBeTruthy();
+    expect(container.querySelector("code")?.className).toContain("text-xs");
+    expect(container.querySelector("pre")?.className).toContain("text-xs");
   });
 
   it("ToolSummaryLine maps command_execution to terminal icon via Bash alias", () => {
@@ -101,7 +114,7 @@ describe("narrative tool row layout classes", () => {
       </div>,
     );
 
-    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByRole("button", { name: /Ran command/ }));
     expect(container.querySelector(".lucide-terminal")).toBeTruthy();
     expect(screen.getByText("Ran command")).toBeTruthy();
   });
@@ -120,6 +133,51 @@ describe("narrative tool row layout classes", () => {
     for (const badge of screen.getAllByText("cancelled")) {
       expect(badge).toHaveClass("text-xs");
     }
+  });
+
+  it("normalizes older persisted Codex command summaries before display", () => {
+    const group: ToolGroup = {
+      calls: [
+        makeBashCall({
+          id: "tc-persisted",
+          toolName: "command_execution",
+          toolInput: { _summary: JSON.stringify({ command: LONG_SHELL_COMMAND }) },
+          isComplete: true,
+        }),
+      ],
+    };
+
+    const { container } = render(
+      <ToolSummaryLine group={group} hasError={false} hasCancelled={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Ran command/ }));
+    expect(container.querySelector("code")?.textContent).toBe(LONG_SHELL_COMMAND);
+    expect(container.textContent).not.toContain('{"command"');
+  });
+
+  it("normalizes truncated legacy Codex summaries without escaped path syntax", () => {
+    const legacySummary = JSON.stringify({ command: LONG_SHELL_COMMAND }).slice(0, 80);
+    const group: ToolGroup = {
+      calls: [
+        makeBashCall({
+          id: "tc-truncated-summary",
+          toolName: "command_execution",
+          toolInput: { _summary: legacySummary },
+          isComplete: true,
+        }),
+      ],
+    };
+
+    const { container } = render(
+      <ToolSummaryLine group={group} hasError={false} hasCancelled={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Ran command/ }));
+    const command = container.querySelector("code")?.textContent ?? "";
+    expect(command).toMatch(/^cd "C:\\Users\\cjnwo/);
+    expect(command).not.toContain("\\\\Users");
+    expect(command).not.toContain('{"command"');
   });
 
   it("ToolSummaryLine shows truncation metadata for bounded output", () => {
@@ -142,9 +200,11 @@ describe("narrative tool row layout classes", () => {
       </div>,
     );
 
-    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByRole("button", { name: /Ran command/ }));
 
-    expect(screen.getByText(/Output truncated/).textContent).toContain("300 KB total");
-    expect(screen.getByText(/Output truncated/).textContent).toContain("full output saved");
+    const notice = screen.getByText(/Output truncated/);
+    expect(notice.textContent).toContain("300 KB total");
+    expect(notice.textContent).toContain("full output saved");
+    expect(notice.className).toContain("text-xs");
   });
 });


### PR DESCRIPTION
## What

Render shell tool calls as compact, expandable terminal cards in the chat narrative.

## Why

Expanded command output repeated the command, mixed text sizes, and displayed the transcript inside a generic details layout. Persisted Codex commands could also be reduced to a short JSON summary.

## Key Changes

- Give active and completed shell calls their own command disclosure.
- Present the prompt, command, truncation notice, and output as one monospace transcript.
- Persist up to 4,096 command characters and normalize older JSON-escaped summaries when rendered.
- Cover active, completed, cancelled, truncated, legacy, and persisted command states.

## Verification

- Command-card component tests: 10 passed.
- Narrative persistence tests: 20 passed.
- Full-app Playwright checks: 2 passed, including persisted reload.
- Monorepo typecheck: 5 packages passed.
- `git diff --check`: passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786891365&installation_id=129163861&pr_number=870&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F870&signature=5c492933e54f370a209c84f32ec32529c6c164861223fd4ac5e112ed2985e4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added expandable terminal-style cards for shell commands in active and completed tool activity.
  - Displays command previews, full commands, execution status, errors, cancellations, and output.
  - Supports output truncation notices with access to saved full output.

- **Bug Fixes**
  - Preserves longer command inputs without prematurely truncating persisted summaries.
  - Improves display of legacy and persisted command summaries, including escaped paths and JSON-wrapped formats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->