### PR TITLE
perf(web): make thread switching progressive

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -494,10 +494,10 @@ the user typed.
 The routing rule for server-pushed events: a client declares which threads
 it is watching, and an event carrying a thread id is delivered only to
 clients subscribed to that thread. Events without a thread id remain
-broadcast to every client. A window watching one thread never receives
-another thread's streaming traffic; on a thread switch the client
-resubscribes and hydration covers the gap. Payload validation at this seam
-has two adapters: validating (dev, logs schema drift) and pass-through
+broadcast to every client. A window's bounded watch set contains its selected
+thread and any threads with running agents, which keeps their live layers warm
+during a switch. Unrelated idle threads remain excluded. Payload validation at
+this seam has two adapters: validating (dev, logs schema drift) and pass-through
 (production). (Epic #649, slices #656/#657.)
 
 ### Grace period

--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import {
   interceptZustandStores,
   mockWebSocketServer,
@@ -65,6 +65,33 @@ function message(threadId: string, id: string, role: "user" | "assistant", conte
     attachments: null,
     tool_call_count: 0,
   };
+}
+
+async function readThreadRecord(page: Page, threadId: string) {
+  return page.evaluate((targetThreadId) => {
+    type StoreHandle = { getState: () => Record<string, unknown> };
+    type RecordProbe = {
+      loading?: boolean;
+      messages?: Array<{ id: string; sequence: number }>;
+      toolCalls?: Array<{ id: string }>;
+      goal?: { objective?: string } | null;
+    };
+    const stores = (window as unknown as { __mcodeStores?: StoreHandle[] }).__mcodeStores ?? [];
+    const store = stores.find((candidate) => {
+      const state = candidate.getState();
+      return "handleAgentEvent" in state && "records" in state;
+    });
+    const state = store?.getState();
+    const record = (state?.records as Map<string, RecordProbe> | undefined)?.get(targetThreadId);
+    return {
+      currentThreadId: state?.currentThreadId ?? null,
+      loading: record?.loading ?? null,
+      messageIds: record?.messages?.map((entry) => entry.id) ?? [],
+      messageSequences: record?.messages?.map((entry) => entry.sequence) ?? [],
+      toolCallIds: record?.toolCalls?.map((entry) => entry.id) ?? [],
+      goalObjective: record?.goal?.objective ?? null,
+    };
+  }, threadId);
 }
 
 test("thread switch cache miss hydrates messages and narrative through conversation.page", async ({ page }) => {
@@ -188,6 +215,7 @@ test("rapid reselection paints the tail before auxiliary thread data resolves", 
     thread("thread-b", "Thread B"),
   ];
 
+  await interceptZustandStores(page);
   await mockWebSocketServer(page, {
     "workspace.list": [workspace],
     "thread.list": threads,
@@ -217,7 +245,21 @@ test("rapid reselection paints the tail before auxiliary thread data resolves", 
     "thread.goal.get": (params) => {
       const input = params as { threadId: string };
       const result = {
-        goal: null,
+        goal: input.threadId === "thread-a"
+          ? {
+              threadId: "thread-a",
+              objective: "Alpha reselection settled",
+              status: "active",
+              tokenBudget: null,
+              tokensUsed: 0,
+              timeUsedSeconds: 0,
+              createdAt: 1,
+              updatedAt: 1,
+              providerId: "codex",
+              source: "codex",
+              controls: { canInspect: true, canClear: true },
+            }
+          : null,
         authoritative: false,
         source: "codex-cache",
         reason: "not-materialized",
@@ -247,9 +289,17 @@ test("rapid reselection paints the tail before auxiliary thread data resolves", 
   expect(typeof resolveSnapshots).toBe("function");
   expect(typeof resolveGoal).toBe("function");
 
+  resolveThreadB();
   resolveSnapshots();
   resolveGoal();
-  resolveThreadB();
+  await expect.poll(() => readThreadRecord(page, "thread-a")).toEqual({
+    currentThreadId: "thread-a",
+    loading: false,
+    messageIds: ["thread-a-tail"],
+    messageSequences: [12],
+    toolCallIds: [],
+    goalObjective: "Alpha reselection settled",
+  });
   await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread A");
   await expect(page.getByText("Alpha tail after reselection", { exact: true })).toBeVisible();
   await expect(page.getByText("Beta tail", { exact: true })).not.toBeVisible();
@@ -279,6 +329,7 @@ test("thread switch paints the latest turn before older history finishes", async
     );
   });
 
+  await interceptZustandStores(page);
   await mockWebSocketServer(page, {
     "workspace.list": [workspace],
     "thread.list": threads,
@@ -344,6 +395,14 @@ test("thread switch paints the latest turn before older history finishes", async
   const scrollContainer = page.locator("[data-testid=message-list] > div").first();
   const tailScrollHeight = await scrollContainer.evaluate((element) => element.scrollHeight);
   resolveOlderHistory?.();
+  await expect.poll(() => readThreadRecord(page, "thread-b")).toEqual({
+    currentThreadId: "thread-b",
+    loading: false,
+    messageIds: threadBMessages.slice(20).map((entry) => entry.id),
+    messageSequences: Array.from({ length: 100 }, (_, index) => index + 21),
+    toolCallIds: [],
+    goalObjective: null,
+  });
   await expect.poll(() => scrollContainer.evaluate((element) => element.scrollHeight))
     .toBeGreaterThan(tailScrollHeight);
   await expect(page.getByText("Latest beta response", { exact: true })).toBeVisible();
@@ -371,6 +430,7 @@ test("thread switch shows a running agent before persisted history refreshes", a
     message("thread-a", "thread-a-assistant", "assistant", "Alpha response", 2),
   ];
 
+  await interceptZustandStores(page);
   const controller = await mockWebSocketServer(page, {
     "workspace.list": [workspace],
     "thread.list": threads,
@@ -426,5 +486,13 @@ test("thread switch shows a running agent before persisted history refreshes", a
   expect(typeof resolveThreadBHistory).toBe("function");
 
   resolveThreadBHistory?.();
+  await expect.poll(() => readThreadRecord(page, "thread-b")).toEqual({
+    currentThreadId: "thread-b",
+    loading: false,
+    messageIds: [],
+    messageSequences: [],
+    toolCallIds: ["thread-b-live-tool"],
+    goalObjective: null,
+  });
   await expect(page.getByRole("button", { name: "Running command echo live-switch" })).toBeVisible();
 });

--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -176,3 +176,172 @@ test("thread switch cache miss hydrates messages and narrative through conversat
   expect(calls.filter((call) => call.method === "conversation.page" && (call.params as { threadId?: string }).threadId === "thread-b")).toHaveLength(1);
   expect(calls.filter((call) => call.method === "message.list" || call.method === "turn.load" || call.method === "narrative.list")).toHaveLength(0);
 });
+
+test("thread switch paints the latest turn before older history finishes", async ({ page }) => {
+  test.setTimeout(90_000);
+  const calls: RpcCall[] = [];
+  let resolveTail: (() => void) | undefined;
+  let resolveOlderHistory: (() => void) | undefined;
+  const threads = [
+    thread("thread-a", "Thread A"),
+    thread("thread-b", "Thread B"),
+  ];
+  const threadAMessages = [
+    message("thread-a", "thread-a-user", "user", "Alpha request", 1),
+    message("thread-a", "thread-a-assistant", "assistant", "Alpha response", 2),
+  ];
+  const threadBMessages = Array.from({ length: 120 }, (_, index) => {
+    const sequence = index + 1;
+    return message(
+      "thread-b",
+      `thread-b-${sequence}`,
+      sequence % 2 === 0 ? "assistant" : "user",
+      sequence === 120 ? "Latest beta response" : `Beta message ${sequence}`,
+      sequence,
+    );
+  });
+
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": threads,
+    "conversation.page": (params) => {
+      const input = params as { threadId: string; limit: number; before?: number };
+      calls.push({ method: "conversation.page", params: input });
+      const source = input.threadId === "thread-b" ? threadBMessages : threadAMessages;
+      const eligible = input.before == null
+        ? source
+        : source.filter((entry) => entry.sequence < input.before!);
+      const messages = eligible.slice(-input.limit);
+      const result = {
+        messages,
+        hasMore: eligible.length > messages.length,
+        answeredPlanMessageIds: [],
+        narrativeByMessage: {},
+      };
+      if (input.threadId !== "thread-b") return result;
+      return new Promise((resolve) => {
+        const release = () => resolve(result);
+        if (input.before == null) resolveTail = release;
+        else resolveOlderHistory = release;
+      });
+    },
+  });
+
+  await page.goto("/");
+  await page.getByRole("group", { name: "Conversation Page Workspace project" }).click();
+  await page.waitForSelector("[data-testid='thread-item']");
+  const threadItems = page.locator("[data-testid='thread-item']");
+  await threadItems.nth(0).click();
+  await expect(page.locator("[data-testid=message-list]")).toContainText("Alpha response");
+
+  const loadingObserved = page.evaluate(() => new Promise<boolean>((resolve) => {
+    if (document.querySelector("[data-testid='conversation-loading']")) {
+      resolve(true);
+      return;
+    }
+    const observer = new MutationObserver(() => {
+      if (!document.querySelector("[data-testid='conversation-loading']")) return;
+      observer.disconnect();
+      resolve(true);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    setTimeout(() => {
+      observer.disconnect();
+      resolve(false);
+    }, 1000);
+  }));
+  await threadItems.nth(1).click();
+  expect(await loadingObserved).toBe(true);
+  await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread B");
+  await expect.poll(() => typeof resolveTail).toBe("function");
+  resolveTail?.();
+  await expect(page.getByText("Latest beta response", { exact: true })).toBeVisible();
+
+  await expect.poll(() => calls.filter((call) =>
+    call.method === "conversation.page"
+    && (call.params as { threadId?: string }).threadId === "thread-b").length,
+  { timeout: 3000 }).toBe(2);
+  expect(typeof resolveOlderHistory).toBe("function");
+  await expect(page.getByText("Latest beta response", { exact: true })).toBeVisible();
+  resolveOlderHistory?.();
+
+  const threadBCalls = calls.filter((call) =>
+    call.method === "conversation.page"
+    && (call.params as { threadId?: string }).threadId === "thread-b");
+  expect(threadBCalls).toHaveLength(2);
+  expect(threadBCalls.map((call) => call.params)).toEqual([
+    { threadId: "thread-b", limit: 12 },
+    { threadId: "thread-b", limit: 88, before: 109 },
+  ]);
+});
+
+test("thread switch shows a running agent before persisted history refreshes", async ({ page }) => {
+  test.setTimeout(90_000);
+  const calls: RpcCall[] = [];
+  let resolveThreadBHistory: (() => void) | undefined;
+  const threads = [
+    thread("thread-a", "Thread A"),
+    { ...thread("thread-b", "Thread B"), status: "active" as const },
+  ];
+  const threadAMessages = [
+    message("thread-a", "thread-a-user", "user", "Alpha request", 1),
+    message("thread-a", "thread-a-assistant", "assistant", "Alpha response", 2),
+  ];
+
+  const controller = await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": threads,
+    "agent.listRunning": ["thread-b"],
+    "push.subscribeThread": (params) => {
+      calls.push({ method: "push.subscribeThread", params });
+      return undefined;
+    },
+    "conversation.page": (params) => {
+      const input = params as { threadId: string; limit: number; before?: number };
+      calls.push({ method: "conversation.page", params: input });
+      if (input.threadId === "thread-a") {
+        return {
+          messages: threadAMessages,
+          hasMore: false,
+          answeredPlanMessageIds: [],
+          narrativeByMessage: {},
+        };
+      }
+      return new Promise((resolve) => {
+        resolveThreadBHistory = () => resolve({
+          messages: [],
+          hasMore: false,
+          answeredPlanMessageIds: [],
+          narrativeByMessage: {},
+        });
+      });
+    },
+  });
+
+  await page.goto("/");
+  await page.getByRole("group", { name: "Conversation Page Workspace project" }).click();
+  await page.waitForSelector("[data-testid='thread-item']");
+  const threadItems = page.locator("[data-testid='thread-item']");
+  await threadItems.nth(0).click();
+  await expect(page.locator("[data-testid=message-list]")).toContainText("Alpha response");
+
+  await expect.poll(() => calls.some((call) =>
+    call.method === "push.subscribeThread"
+    && (call.params as { threadId?: string }).threadId === "thread-b"),
+  ).toBe(true);
+  await controller.sendPush("agent.event", {
+    type: "toolUse",
+    threadId: "thread-b",
+    toolCallId: "thread-b-live-tool",
+    toolName: "Bash",
+    toolInput: { command: "echo live-switch" },
+  });
+
+  await threadItems.nth(1).click();
+  await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread B");
+  await expect(page.getByText("Running a command...", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("echo live-switch", { exact: true })).toBeVisible();
+  expect(typeof resolveThreadBHistory).toBe("function");
+
+  resolveThreadBHistory?.();
+});

--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -250,6 +250,9 @@ test("rapid reselection paints the tail before auxiliary thread data resolves", 
   resolveSnapshots();
   resolveGoal();
   resolveThreadB();
+  await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread A");
+  await expect(page.getByText("Alpha tail after reselection", { exact: true })).toBeVisible();
+  await expect(page.getByText("Beta tail", { exact: true })).not.toBeVisible();
 });
 
 test("thread switch paints the latest turn before older history finishes", async ({ page }) => {
@@ -338,7 +341,12 @@ test("thread switch paints the latest turn before older history finishes", async
   { timeout: 3000 }).toBe(2);
   expect(typeof resolveOlderHistory).toBe("function");
   await expect(page.getByText("Latest beta response", { exact: true })).toBeVisible();
+  const scrollContainer = page.locator("[data-testid=message-list] > div").first();
+  const tailScrollHeight = await scrollContainer.evaluate((element) => element.scrollHeight);
   resolveOlderHistory?.();
+  await expect.poll(() => scrollContainer.evaluate((element) => element.scrollHeight))
+    .toBeGreaterThan(tailScrollHeight);
+  await expect(page.getByText("Latest beta response", { exact: true })).toBeVisible();
 
   const threadBCalls = calls.filter((call) =>
     call.method === "conversation.page"
@@ -418,4 +426,5 @@ test("thread switch shows a running agent before persisted history refreshes", a
   expect(typeof resolveThreadBHistory).toBe("function");
 
   resolveThreadBHistory?.();
+  await expect(page.getByRole("button", { name: "Running command echo live-switch" })).toBeVisible();
 });

--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -414,8 +414,7 @@ test("thread switch shows a running agent before persisted history refreshes", a
 
   await threadItems.nth(1).click();
   await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread B");
-  await expect(page.getByText("Running a command...", { exact: true }).first()).toBeVisible();
-  await expect(page.getByText("echo live-switch", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Running command echo live-switch" })).toBeVisible();
   expect(typeof resolveThreadBHistory).toBe("function");
 
   resolveThreadBHistory?.();

--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -405,7 +405,6 @@ test("thread switch paints the latest turn before older history finishes", async
   });
   await expect.poll(() => scrollContainer.evaluate((element) => element.scrollHeight))
     .toBeGreaterThan(tailScrollHeight);
-  await expect(page.getByText("Latest beta response", { exact: true })).toBeVisible();
 
   const threadBCalls = calls.filter((call) =>
     call.method === "conversation.page"

--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -177,6 +177,81 @@ test("thread switch cache miss hydrates messages and narrative through conversat
   expect(calls.filter((call) => call.method === "message.list" || call.method === "turn.load" || call.method === "narrative.list")).toHaveLength(0);
 });
 
+test("rapid reselection paints the tail before auxiliary thread data resolves", async ({ page }) => {
+  test.setTimeout(90_000);
+  let resolveThreadA!: () => void;
+  let resolveThreadB!: () => void;
+  let resolveSnapshots!: () => void;
+  let resolveGoal!: () => void;
+  const threads = [
+    thread("thread-a", "Thread A"),
+    thread("thread-b", "Thread B"),
+  ];
+
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": threads,
+    "conversation.page": (params) => {
+      const input = params as { threadId: string };
+      const result = {
+        messages: input.threadId === "thread-a"
+          ? [message("thread-a", "thread-a-tail", "assistant", "Alpha tail after reselection", 12)]
+          : [message("thread-b", "thread-b-tail", "assistant", "Beta tail", 12)],
+        hasMore: false,
+        answeredPlanMessageIds: [],
+        narrativeByMessage: {},
+      };
+      return new Promise((resolve) => {
+        const release = () => resolve(result);
+        if (input.threadId === "thread-a") resolveThreadA = release;
+        else resolveThreadB = release;
+      });
+    },
+    "snapshot.listByThread": (params) => {
+      const input = params as { threadId: string };
+      if (input.threadId !== "thread-a") return [];
+      return new Promise((resolve) => {
+        resolveSnapshots = () => resolve([]);
+      });
+    },
+    "thread.goal.get": (params) => {
+      const input = params as { threadId: string };
+      const result = {
+        goal: null,
+        authoritative: false,
+        source: "codex-cache",
+        reason: "not-materialized",
+      };
+      if (input.threadId !== "thread-a") return result;
+      return new Promise((resolve) => {
+        resolveGoal = () => resolve(result);
+      });
+    },
+  });
+
+  await page.goto("/");
+  await page.getByRole("group", { name: "Conversation Page Workspace project" }).click();
+  await page.waitForSelector("[data-testid='thread-item']");
+  const threadItems = page.locator("[data-testid='thread-item']");
+
+  await threadItems.nth(0).click();
+  await expect.poll(() => typeof resolveThreadA).toBe("function");
+  await threadItems.nth(1).click();
+  await expect.poll(() => typeof resolveThreadB).toBe("function");
+  await threadItems.nth(0).click();
+
+  await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread A");
+  await expect(page.locator("[data-testid=conversation-loading]")).toBeVisible();
+  resolveThreadA();
+  await expect(page.getByText("Alpha tail after reselection", { exact: true })).toBeVisible();
+  expect(typeof resolveSnapshots).toBe("function");
+  expect(typeof resolveGoal).toBe("function");
+
+  resolveSnapshots();
+  resolveGoal();
+  resolveThreadB();
+});
+
 test("thread switch paints the latest turn before older history finishes", async ({ page }) => {
   test.setTimeout(90_000);
   const calls: RpcCall[] = [];

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -363,7 +363,7 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     await waitFor(() => {
       expect(chatViewTransportMock.subscribeThread).toHaveBeenCalledTimes(5);
     }, { timeout: 3000 });
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await new Promise((resolve) => setTimeout(resolve, 1700));
     expect(chatViewTransportMock.subscribeThread).toHaveBeenCalledTimes(5);
   });
 

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Thread } from "@/transport/types";
@@ -6,8 +6,9 @@ import type { Thread } from "@/transport/types";
 // Store mocks must be declared before importing the component under test.
 
 /** Holds the store snapshot backing both the hook selector and `getState()` (real Zustand API). */
-const { chatViewWorkspaceMockRef, chatViewTransportMock } = vi.hoisted(() => ({
+const { chatViewWorkspaceMockRef, chatViewThreadMockRef, chatViewTransportMock } = vi.hoisted(() => ({
   chatViewWorkspaceMockRef: { current: null as Record<string, unknown> | null },
+  chatViewThreadMockRef: { current: null as Record<string, unknown> | null },
   chatViewTransportMock: {
     subscribeThread: vi.fn(),
     unsubscribeThread: vi.fn(),
@@ -36,16 +37,17 @@ vi.mock("@/stores/workspaceStore", () => ({
 }));
 
 vi.mock("@/stores/threadStore", () => ({
-  useThreadStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({
-      records: new Map(),
-      currentThreadId: null,
-      runningThreadIds: new Set(),
-      loadMessages: vi.fn(),
-      clearMessages: vi.fn(),
-      setForkMode: vi.fn(),
-      sendMessage: vi.fn(),
-    }),
+  useThreadStore: vi.fn((selector: (s: unknown) => unknown) => {
+    if (!chatViewThreadMockRef.current) {
+      throw new Error("ChatView tests: set chatViewThreadMockRef before render");
+    }
+    return selector(chatViewThreadMockRef.current);
+  }),
+}));
+
+vi.mock("@/stores/connectionStore", () => ({
+  useConnectionStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ status: "connected" }),
   ),
 }));
 
@@ -185,6 +187,22 @@ function setupWorkspaceMock(state: ReturnType<typeof defaultWorkspaceState>) {
   );
 }
 
+/** Produces the thread-store fields consumed by ChatView. */
+function defaultThreadState(overrides: Partial<{
+  currentThreadId: string | null;
+  runningThreadIds: Set<string>;
+}> = {}) {
+  return {
+    records: new Map(),
+    currentThreadId: overrides.currentThreadId ?? "thread-1",
+    runningThreadIds: overrides.runningThreadIds ?? new Set<string>(),
+    loadMessages: vi.fn(),
+    clearMessages: vi.fn(),
+    setForkMode: vi.fn(),
+    sendMessage: vi.fn(),
+  };
+}
+
 describe("ChatView - Thread Title Double-Click Rename", () => {
   beforeEach(() => {
     chatViewTransportMock.subscribeThread.mockResolvedValue(undefined);
@@ -192,6 +210,7 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     chatViewTransportMock.subscribeThread.mockClear();
     chatViewTransportMock.unsubscribeThread.mockClear();
     setupWorkspaceMock(defaultWorkspaceState());
+    chatViewThreadMockRef.current = defaultThreadState();
   });
 
   it("renders thread title as static span by default", () => {
@@ -280,5 +299,46 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
 
     // Edit mode should be closed
     expect(screen.queryByTestId("chat-header-title-input")).not.toBeInTheDocument();
+  });
+
+  it("swaps the thread shell before persisted history resolves", () => {
+    chatViewThreadMockRef.current = defaultThreadState({ currentThreadId: "thread-2" });
+
+    render(<ChatView />);
+
+    expect(screen.getByTestId("chat-header-title")).toHaveTextContent("My Thread");
+    expect(screen.getByTestId("conversation-loading")).toBeVisible();
+    expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
+  });
+
+  it("keeps running threads subscribed while another thread is selected", async () => {
+    const thread1 = makeThread({ id: "thread-1", title: "Thread 1" });
+    const thread2 = makeThread({ id: "thread-2", title: "Thread 2", status: "active" });
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread1.id,
+      threads: [thread1, thread2],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread1.id,
+      runningThreadIds: new Set([thread2.id]),
+    });
+
+    const { rerender } = render(<ChatView />);
+
+    await waitFor(() => {
+      expect(chatViewTransportMock.subscribeThread).toHaveBeenCalledWith(thread1.id);
+      expect(chatViewTransportMock.subscribeThread).toHaveBeenCalledWith(thread2.id);
+    });
+
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread1.id,
+      runningThreadIds: new Set(),
+    });
+    rerender(<ChatView />);
+
+    await waitFor(() => {
+      expect(chatViewTransportMock.unsubscribeThread).toHaveBeenCalledWith(thread2.id);
+    });
+    expect(chatViewTransportMock.unsubscribeThread).not.toHaveBeenCalledWith(thread1.id);
   });
 });

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -341,4 +341,58 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     });
     expect(chatViewTransportMock.unsubscribeThread).not.toHaveBeenCalledWith(thread1.id);
   });
+
+  it("retries a rejected thread subscription", async () => {
+    chatViewTransportMock.subscribeThread
+      .mockRejectedValueOnce(new Error("temporary subscribe failure"))
+      .mockResolvedValue(undefined);
+
+    render(<ChatView />);
+
+    await waitFor(() => {
+      expect(chatViewTransportMock.subscribeThread).toHaveBeenCalledTimes(2);
+      expect(chatViewTransportMock.subscribeThread).toHaveBeenLastCalledWith("thread-1");
+    }, { timeout: 3000 });
+  });
+
+  it("stops retrying a rejected thread subscription after the retry limit", async () => {
+    chatViewTransportMock.subscribeThread.mockRejectedValue(new Error("persistent subscribe failure"));
+
+    render(<ChatView />);
+
+    await waitFor(() => {
+      expect(chatViewTransportMock.subscribeThread).toHaveBeenCalledTimes(5);
+    }, { timeout: 3000 });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(chatViewTransportMock.subscribeThread).toHaveBeenCalledTimes(5);
+  });
+
+  it("retries a rejected thread unsubscription", async () => {
+    const thread1 = makeThread({ id: "thread-1", title: "Thread 1" });
+    const thread2 = makeThread({ id: "thread-2", title: "Thread 2" });
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread1.id,
+      threads: [thread1, thread2],
+    }));
+
+    const { rerender } = render(<ChatView />);
+    await waitFor(() => {
+      expect(chatViewTransportMock.subscribeThread).toHaveBeenCalledWith(thread1.id);
+    });
+
+    chatViewTransportMock.unsubscribeThread
+      .mockRejectedValueOnce(new Error("temporary unsubscribe failure"))
+      .mockResolvedValue(undefined);
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread2.id,
+      threads: [thread1, thread2],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({ currentThreadId: thread2.id });
+    rerender(<ChatView />);
+
+    await waitFor(() => {
+      expect(chatViewTransportMock.unsubscribeThread).toHaveBeenCalledTimes(2);
+      expect(chatViewTransportMock.unsubscribeThread).toHaveBeenLastCalledWith(thread1.id);
+    }, { timeout: 3000 });
+  });
 });

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -13,6 +13,7 @@ import { useComposerDraftStore } from "@/stores/composerDraftStore";
 import { useOverviewStore } from "@/stores/overviewStore";
 import { Badge } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { MessageList } from "./MessageList";
 import { Composer } from "./Composer";
@@ -276,13 +277,13 @@ function ConversationLoadingState() {
     >
       <div className={`${PRIMARY_CONTENT_RAIL_CLASS} w-full space-y-5 motion-safe:animate-pulse`}>
         <div className="ml-auto space-y-2">
-          <div className="ml-auto h-3 w-2/5 rounded bg-muted/55" />
-          <div className="ml-auto h-3 w-3/5 rounded bg-muted/40" />
+          <Skeleton className="ml-auto h-3 w-2/5 rounded bg-muted/55" />
+          <Skeleton className="ml-auto h-3 w-3/5 rounded bg-muted/40" />
         </div>
         <div className="space-y-2">
-          <div className="h-3 w-1/4 rounded bg-muted/55" />
-          <div className="h-3 w-4/5 rounded bg-muted/40" />
-          <div className="h-3 w-3/5 rounded bg-muted/40" />
+          <Skeleton className="h-3 w-1/4 rounded bg-muted/55" />
+          <Skeleton className="h-3 w-4/5 rounded bg-muted/40" />
+          <Skeleton className="h-3 w-3/5 rounded bg-muted/40" />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -265,6 +265,11 @@ function ThreadPreparingShell({
   );
 }
 const CACHE_PRESSURE_BYTES = 20 * 1024 * 1024; // 20 MB
+const THREAD_SUBSCRIPTION_RETRY_BASE_MS = 100;
+const THREAD_SUBSCRIPTION_RETRY_MAX_MS = 1_600;
+const THREAD_SUBSCRIPTION_MAX_RETRIES = 4;
+
+type ThreadSubscriptionAction = "subscribe" | "unsubscribe";
 
 /** Keeps the conversation surface occupied while the latest persisted tail loads. */
 function ConversationLoadingState() {
@@ -459,38 +464,141 @@ export function ChatView() {
   }, [connectionStatus]);
 
   const prevThreadIdRef = useRef<string | null>(null);
-  const subscribedThreadIdsRef = useRef<Set<string>>(new Set());
+  const confirmedThreadIdsRef = useRef<Set<string>>(new Set());
+  const desiredThreadIdsRef = useRef<Set<string>>(new Set());
+  const pendingThreadChangesRef = useRef<Map<string, symbol>>(new Map());
   const previousSubscriptionStatusRef = useRef<typeof connectionStatus | null>(null);
+  const subscriptionEpochRef = useRef(0);
+  const subscriptionRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const subscriptionRetryAttemptRef = useRef(0);
+  const subscriptionRetryExhaustedRef = useRef(false);
+  const subscriptionTargetSignatureRef = useRef("");
+  const subscriptionMountedRef = useRef(true);
+  const [subscriptionReconcileVersion, setSubscriptionReconcileVersion] = useState(0);
 
   useEffect(() => {
     const desired = new Set(runningThreadIds);
     if (activeThreadId) desired.add(activeThreadId);
+    desiredThreadIdsRef.current = desired;
 
-    const previous = subscribedThreadIdsRef.current;
+    const targetSignature = `${connectionStatus}:${Array.from(desired).sort().join("\u0000")}`;
+    if (subscriptionTargetSignatureRef.current !== targetSignature) {
+      subscriptionTargetSignatureRef.current = targetSignature;
+      subscriptionRetryAttemptRef.current = 0;
+      subscriptionRetryExhaustedRef.current = false;
+      if (subscriptionRetryTimerRef.current !== null) {
+        clearTimeout(subscriptionRetryTimerRef.current);
+        subscriptionRetryTimerRef.current = null;
+      }
+    }
+
     const reconnected = connectionStatus === "connected"
       && previousSubscriptionStatusRef.current !== "connected";
-    if (connectionStatus === "connected") {
-      for (const threadId of desired) {
-        if (reconnected || !previous.has(threadId)) {
-          void getTransport().subscribeThread(threadId).catch(() => {});
-        }
-      }
-      for (const threadId of previous) {
-        if (!desired.has(threadId)) {
-          void getTransport().unsubscribeThread(threadId).catch(() => {});
-        }
-      }
+    const disconnected = connectionStatus !== "connected"
+      && previousSubscriptionStatusRef.current === "connected";
+    if (reconnected || disconnected) {
+      subscriptionEpochRef.current += 1;
+      confirmedThreadIdsRef.current.clear();
+      pendingThreadChangesRef.current.clear();
     }
-
-    subscribedThreadIdsRef.current = desired;
     previousSubscriptionStatusRef.current = connectionStatus;
-  }, [activeThreadId, connectionStatus, runningThreadIds]);
 
-  useEffect(() => () => {
-    for (const threadId of subscribedThreadIdsRef.current) {
-      void getTransport().unsubscribeThread(threadId).catch(() => {});
+    if (connectionStatus !== "connected" || subscriptionRetryExhaustedRef.current) return;
+
+    const epoch = subscriptionEpochRef.current;
+    const operations: Promise<boolean>[] = [];
+    const startChange = (threadId: string, action: ThreadSubscriptionAction) => {
+      const change = Symbol();
+      pendingThreadChangesRef.current.set(threadId, change);
+      const request = action === "subscribe"
+        ? getTransport().subscribeThread(threadId)
+        : getTransport().unsubscribeThread(threadId);
+
+      operations.push(request.then(() => {
+        if (subscriptionEpochRef.current !== epoch) return true;
+        if (action === "subscribe") confirmedThreadIdsRef.current.add(threadId);
+        else confirmedThreadIdsRef.current.delete(threadId);
+        return true;
+      }, () => false).finally(() => {
+        if (pendingThreadChangesRef.current.get(threadId) === change) {
+          pendingThreadChangesRef.current.delete(threadId);
+        }
+      }));
+    };
+
+    for (const threadId of desired) {
+      if (!confirmedThreadIdsRef.current.has(threadId)
+        && !pendingThreadChangesRef.current.has(threadId)) {
+        startChange(threadId, "subscribe");
+      }
     }
-    subscribedThreadIdsRef.current.clear();
+    for (const threadId of confirmedThreadIdsRef.current) {
+      if (!desired.has(threadId) && !pendingThreadChangesRef.current.has(threadId)) {
+        startChange(threadId, "unsubscribe");
+      }
+    }
+
+    if (operations.length === 0) return;
+
+    void Promise.all(operations).then((results) => {
+      if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
+      if (subscriptionTargetSignatureRef.current !== targetSignature) {
+        setSubscriptionReconcileVersion((version) => version + 1);
+        return;
+      }
+
+      if (results.every(Boolean)) {
+        subscriptionRetryAttemptRef.current = 0;
+        subscriptionRetryExhaustedRef.current = false;
+        const confirmed = confirmedThreadIdsRef.current;
+        const latestDesired = desiredThreadIdsRef.current;
+        const needsReconcile = confirmed.size !== latestDesired.size
+          || Array.from(confirmed).some((threadId) => !latestDesired.has(threadId));
+        if (needsReconcile) {
+          setSubscriptionReconcileVersion((version) => version + 1);
+        }
+        return;
+      }
+
+      if (subscriptionRetryAttemptRef.current >= THREAD_SUBSCRIPTION_MAX_RETRIES) {
+        subscriptionRetryExhaustedRef.current = true;
+        return;
+      }
+
+      const delay = Math.min(
+        THREAD_SUBSCRIPTION_RETRY_BASE_MS * (2 ** subscriptionRetryAttemptRef.current),
+        THREAD_SUBSCRIPTION_RETRY_MAX_MS,
+      );
+      subscriptionRetryAttemptRef.current += 1;
+      subscriptionRetryTimerRef.current = setTimeout(() => {
+        subscriptionRetryTimerRef.current = null;
+        if (subscriptionMountedRef.current) {
+          setSubscriptionReconcileVersion((version) => version + 1);
+        }
+      }, delay);
+    });
+  }, [activeThreadId, connectionStatus, runningThreadIds, subscriptionReconcileVersion]);
+
+  useEffect(() => {
+    subscriptionMountedRef.current = true;
+    return () => {
+      subscriptionMountedRef.current = false;
+      subscriptionEpochRef.current += 1;
+      if (subscriptionRetryTimerRef.current !== null) {
+        clearTimeout(subscriptionRetryTimerRef.current);
+        subscriptionRetryTimerRef.current = null;
+      }
+      const threadIds = new Set([
+        ...confirmedThreadIdsRef.current,
+        ...desiredThreadIdsRef.current,
+      ]);
+      for (const threadId of threadIds) {
+        void getTransport().unsubscribeThread(threadId).catch(() => {});
+      }
+      confirmedThreadIdsRef.current.clear();
+      desiredThreadIdsRef.current.clear();
+      pendingThreadChangesRef.current.clear();
+    };
   }, []);
 
   useLayoutEffect(() => {

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import { Bug, GitFork, Hammer, SearchCode, ScanSearch } from "lucide-react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import {
@@ -34,6 +34,7 @@ import { overviewResponsivePaddingRight } from "@/lib/composer-layout";
 import { Button } from "@/components/ui/button";
 import { McodeLogo } from "@/components/brand/McodeLogo";
 import { NewThreadProjectPicker } from "./NewThreadProjectPicker";
+import { PRIMARY_CONTENT_RAIL_CLASS } from "@/lib/layout-rails";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
 const ENTRY_POINTS = [
@@ -264,6 +265,30 @@ function ThreadPreparingShell({
 }
 const CACHE_PRESSURE_BYTES = 20 * 1024 * 1024; // 20 MB
 
+/** Keeps the conversation surface occupied while the latest persisted tail loads. */
+function ConversationLoadingState() {
+  return (
+    <div
+      data-testid="conversation-loading"
+      role="status"
+      aria-label="Loading conversation"
+      className="flex h-full items-end px-4 pb-6 sm:px-8"
+    >
+      <div className={`${PRIMARY_CONTENT_RAIL_CLASS} w-full space-y-5 motion-safe:animate-pulse`}>
+        <div className="ml-auto space-y-2">
+          <div className="ml-auto h-3 w-2/5 rounded bg-muted/55" />
+          <div className="ml-auto h-3 w-3/5 rounded bg-muted/40" />
+        </div>
+        <div className="space-y-2">
+          <div className="h-3 w-1/4 rounded bg-muted/55" />
+          <div className="h-3 w-4/5 rounded bg-muted/40" />
+          <div className="h-3 w-3/5 rounded bg-muted/40" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /** Renders the main chat UI for sending and receiving messages within a thread. */
 export function ChatView() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
@@ -279,7 +304,9 @@ export function ChatView() {
   const loadMessages = useThreadStore((s) => s.loadMessages);
   const clearMessages = useThreadStore((s) => s.clearMessages);
   const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
+  const hydratedThreadId = useThreadStore((s) => s.currentThreadId);
   const messageCount = useActiveThreadRecord((r) => r.messages.length);
+  const historyLoading = useActiveThreadRecord((r) => r.loading);
   const setPendingPrefill = useComposerDraftStore((s) => s.setPendingPrefill);
 
   const isAgentRunning = activeThreadId ? runningThreadIds.has(activeThreadId) : false;
@@ -431,16 +458,41 @@ export function ChatView() {
   }, [connectionStatus]);
 
   const prevThreadIdRef = useRef<string | null>(null);
+  const subscribedThreadIdsRef = useRef<Set<string>>(new Set());
+  const previousSubscriptionStatusRef = useRef<typeof connectionStatus | null>(null);
 
   useEffect(() => {
-    if (!activeThreadId) return;
-    void getTransport().subscribeThread(activeThreadId).catch(() => {});
-    return () => {
-      void getTransport().unsubscribeThread(activeThreadId).catch(() => {});
-    };
-  }, [activeThreadId]);
+    const desired = new Set(runningThreadIds);
+    if (activeThreadId) desired.add(activeThreadId);
 
-  useEffect(() => {
+    const previous = subscribedThreadIdsRef.current;
+    const reconnected = connectionStatus === "connected"
+      && previousSubscriptionStatusRef.current !== "connected";
+    if (connectionStatus === "connected") {
+      for (const threadId of desired) {
+        if (reconnected || !previous.has(threadId)) {
+          void getTransport().subscribeThread(threadId).catch(() => {});
+        }
+      }
+      for (const threadId of previous) {
+        if (!desired.has(threadId)) {
+          void getTransport().unsubscribeThread(threadId).catch(() => {});
+        }
+      }
+    }
+
+    subscribedThreadIdsRef.current = desired;
+    previousSubscriptionStatusRef.current = connectionStatus;
+  }, [activeThreadId, connectionStatus, runningThreadIds]);
+
+  useEffect(() => () => {
+    for (const threadId of subscribedThreadIdsRef.current) {
+      void getTransport().unsubscribeThread(threadId).catch(() => {});
+    }
+    subscribedThreadIdsRef.current.clear();
+  }, []);
+
+  useLayoutEffect(() => {
     if (!activeThreadId) {
       clearMessages();
     } else {
@@ -527,7 +579,8 @@ export function ChatView() {
   }
 
   const hasMessages = messageCount > 0;
-  const showEmptyState = !hasMessages && !isAgentRunning;
+  const conversationLoading = hydratedThreadId !== activeThreadId || historyLoading;
+  const showEmptyState = !hasMessages && !isAgentRunning && !conversationLoading;
 
   return (
     <div ref={chatPaneRef} className="flex h-full flex-col bg-background" data-testid="chat-view">
@@ -608,7 +661,9 @@ export function ChatView() {
         className="animate-fade-up-in flex-1 min-h-0 transition-[padding] duration-200"
         style={{ paddingRight: overviewPaddingRight }}
       >
-        {showEmptyState ? (
+        {conversationLoading && !hasMessages && !isAgentRunning ? (
+          <ConversationLoadingState />
+        ) : showEmptyState ? (
           <div className="flex h-full items-center justify-center">
             <EmptyState onPromptSelect={setPendingPrefill} />
           </div>

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -4,6 +4,7 @@ import { ArrowDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useShallow } from "zustand/shallow";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -690,18 +691,19 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   );
 
   /**
-   * Pins the scroll element to the list tail and reveals only after the inner
-   * list height has been stable for {@link TAIL_SETTLE_STABLE_FRAMES} consecutive
-   * frames (or {@link TAIL_SETTLE_MAX_FRAMES} hard cap, whichever comes first).
+   * Pins the scroll element to the list tail. Cache-miss navigation may reveal
+   * after two frames while the same loop continues settling later row measurements;
+   * other callers reveal after the inner height stabilizes or reaches the hard cap.
    *
    * Why a settle loop: TanStack Virtual measures rows after mount via its
    * internal ResizeObserver. On long threads the estimated total size can be
    * significantly less than the measured total. A single (or few) `scrollTop =
    * scrollHeight` snap revealed before measurements complete leaves the user
    * sitting *above* the real tail. ResizeObserver-based pinning fires too late
-   * to fix the perceived first paint. Hiding the list (opacity: 0) until both
-   * `scrollHeight` and `virtualizer.getTotalSize()` stop changing means the
-   * very first thing the user sees is already at the true bottom.
+   * to fix the perceived first paint. The loop keeps snapping until
+   * `scrollHeight` and `virtualizer.getTotalSize()` stop changing. Regular
+   * positioning stays hidden during that work; cache-miss navigation reveals
+   * the anchored tail early while the same loop continues below the viewport.
    *
    * @param options.measureFirst - Re-measures and anchors the virtualizer to the tail.
    * @param options.revealEarly - Reveals the anchored tail after two frames while
@@ -1202,9 +1204,9 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       {handoffStatus === "generating" && messages.filter((m) => m.role !== "system").length <= 1 && (
         <div className="px-4 py-4 sm:px-8">
           <div className={cn(PRIMARY_CONTENT_RAIL_CLASS, "space-y-2")}>
-            <div className="h-3.5 w-3/4 animate-pulse rounded bg-muted" />
-            <div className="h-3.5 w-1/2 animate-pulse rounded bg-muted" />
-            <div className="h-3.5 w-2/3 animate-pulse rounded bg-muted" />
+            <Skeleton className="h-3.5 w-3/4 animate-pulse rounded" />
+            <Skeleton className="h-3.5 w-1/2 animate-pulse rounded" />
+            <Skeleton className="h-3.5 w-2/3 animate-pulse rounded" />
           </div>
         </div>
       )}

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -703,13 +703,14 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
    * `scrollHeight` and `virtualizer.getTotalSize()` stop changing means the
    * very first thing the user sees is already at the true bottom.
    *
-   * @param options.measureFirst - When true, runs `virtualizer.measure()` and
-   *   `scrollToIndex(n-1, end, auto)` to anchor the virtualizer to the tail
-   *   before rows finish measuring. Used on cache-miss completion and first
-   *   open. Cache-hit switches omit this so the cached measurement state stays
-   *   warm and we land exactly where the cache says the tail is.
+   * @param options.measureFirst - Re-measures and anchors the virtualizer to the tail.
+   * @param options.revealEarly - Reveals the anchored tail after two frames while
+   *   the pin loop continues to absorb later row measurements.
    */
-  const positionAtBottom = useCallback((options?: { measureFirst?: boolean }) => {
+  const positionAtBottom = useCallback((options?: {
+    measureFirst?: boolean;
+    revealEarly?: boolean;
+  }) => {
     beginSuppressPassiveAutoBottomScroll();
     const settleGen = ++tailSettleGenRef.current;
     pinListTailRef.current = true;
@@ -733,6 +734,16 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     // Synchronous first snap so non-rAF environments (jsdom in unit tests)
     // still see scrollTop applied before the rAF-based settle loop runs.
     snap();
+
+    if (options?.revealEarly) {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (tailSettleGenRef.current !== settleGen) return;
+          snap();
+          setIsPositioned(true);
+        });
+      });
+    }
 
     let lastScrollHeight = -1;
     let lastTotalSize = -1;
@@ -923,7 +934,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       // also hits this branch. Pin the tail here so it tracks the same path as a
       // cache-hit switch (lazy markdown and measured row heights included).
       pendingScrollRestoreRef.current = null;
-      positionAtBottom({ measureFirst: true });
+      positionAtBottom({ measureFirst: true, revealEarly: true });
     }
   }, [activeThreadId, loading, virtualizer, positionAtBottom, items.length]);
 

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,16 @@
+import type { HTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+/** Renders a shared muted placeholder surface for loading layouts. */
+function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
@@ -367,4 +367,42 @@ describe("AuxiliaryHydrator", () => {
       "turn-1": ["src/a.ts"],
     });
   });
+
+  it("discarded file-change snapshots after the expected load epoch changed", async () => {
+    let resolveSnapshots!: (value: Array<{
+      message_id: string;
+      files_changed: string[];
+      thread_id: string;
+      created_at: string;
+    }>) => void;
+    records = patchThreadRecord(records, THREAD_ID, { loadEpoch: 4 });
+    (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveSnapshots = resolve;
+      }),
+    );
+
+    const aux = createAux({
+      getWorkspaceThread: () => createMockThread({ id: THREAD_ID, has_file_changes: true }),
+    });
+    aux.hydrate(THREAD_ID, {
+      freshnessTtlMs: HYDRATION_TTL_MS,
+      force: true,
+      commitFileChangesToStore: true,
+      expectedLoadEpoch: 4,
+    });
+    records = patchThreadRecord(records, THREAD_ID, { loadEpoch: 5 });
+
+    resolveSnapshots([{
+      message_id: "turn-stale",
+      files_changed: ["src/stale.ts"],
+      thread_id: THREAD_ID,
+      created_at: "2026-01-01T00:00:00Z",
+    }]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getCachedRecord(THREAD_ID)?.persistedFilesChanged).toEqual({});
+    expect(getThreadRecord(records, THREAD_ID).persistedFilesChanged).toEqual({});
+  });
 });

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -24,6 +24,7 @@ import {
 import { createEmptyThreadRecord, patchThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 import {
   createThreadHydrator,
+  BACKGROUND_PREFETCH_LIMIT,
   HYDRATION_TTL_MS,
   MESSAGE_FETCH_SIZE,
   type ThreadHydrator,
@@ -174,6 +175,63 @@ describe("ThreadHydrator", () => {
     expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
   });
 
+  it("commits the latest tail before prefetching earlier history", async () => {
+    const history = Array.from({ length: 100 }, (_, index) => createMockMessage({
+      id: `a-${index + 1}`,
+      thread_id: THREAD_A,
+      content: `message ${index + 1}`,
+      sequence: index + 1,
+    }));
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_threadId: string, limit: number, before?: number) => {
+        const eligible = before == null
+          ? history
+          : history.filter((entry) => entry.sequence < before);
+        const messages = eligible.slice(-limit);
+        return {
+          messages,
+          hasMore: eligible.length > messages.length,
+          narrativeByMessage: {},
+        };
+      },
+    );
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(mockTransport.loadConversationPage).toHaveBeenNthCalledWith(1, THREAD_A, 12);
+    expect(getTestActiveMessages()).toEqual(history.slice(88));
+
+    await vi.waitFor(() => {
+      expect(mockTransport.loadConversationPage).toHaveBeenNthCalledWith(2, THREAD_A, 88, 89);
+      expect(getTestActiveMessages()).toEqual(history);
+    });
+  });
+
+  it("resumes earlier-history hydration when a cached tail is reopened", async () => {
+    const history = Array.from({ length: 100 }, (_, index) => createMockMessage({
+      id: `cached-a-${index + 1}`,
+      thread_id: THREAD_A,
+      sequence: index + 1,
+    }));
+    cacheRecord(THREAD_A, {
+      ...makeCachedRecord(history.slice(88)),
+      hasMoreMessages: true,
+    });
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: history.slice(0, 88),
+      hasMore: false,
+      narrativeByMessage: {},
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(getTestActiveMessages()).toEqual(history.slice(88));
+    await vi.waitFor(() => {
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, 88, 89);
+      expect(getTestActiveMessages()).toEqual(history);
+    });
+  });
+
   it("preserves an existing open goal when lookup returns non-authoritative null", async () => {
     const goal = makeGoal();
     resetThreadStoreForTests({
@@ -281,6 +339,49 @@ describe("ThreadHydrator", () => {
     await hydrator.hydrate(THREAD_A, "active");
 
     expect(getTestThreadStreaming(THREAD_A)).toBe("partial...");
+    expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
+  });
+
+  it("activates a running resident layer before its history refresh resolves", async () => {
+    let resolvePage!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_B,
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map<string, ThreadRecord>([[
+        THREAD_A,
+        {
+          ...createEmptyThreadRecord(),
+          messages: [msgA],
+          streaming: "current activity",
+          toolCalls: [
+            { id: "tc1", toolName: "bash", toolInput: {}, output: null, isError: false, isComplete: false },
+          ],
+        },
+      ]]),
+    });
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+
+    const hydration = hydrator.hydrate(THREAD_A, "active");
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_A);
+    expect(readActiveThreadField((record) => record.loading)).toBe(false);
+    expect(getTestActiveMessages()).toEqual([msgA]);
+    expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
+    expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, BACKGROUND_PREFETCH_LIMIT);
+
+    resolvePage({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
+    await hydration;
+
+    expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
   });
 

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -747,6 +747,57 @@ describe("ThreadHydrator", () => {
     expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
   });
 
+  it("keeps a resident layer visible while reusing an in-flight background prefetch", async () => {
+    const resident = createMockMessage({
+      id: "resident-a",
+      thread_id: THREAD_A,
+      content: "resident message",
+      sequence: 1,
+    });
+    const refreshed = createMockMessage({
+      id: "refreshed-a",
+      thread_id: THREAD_A,
+      content: "refreshed message",
+      sequence: 2,
+    });
+    let resolvePage!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_B,
+      records: new Map<string, ThreadRecord>([
+        [THREAD_A, { ...createEmptyThreadRecord(), messages: [resident] }],
+        [THREAD_B, { ...createEmptyThreadRecord(), messages: [msgB] }],
+      ]),
+    });
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+
+    const background = hydrator.hydrate(THREAD_A, "background");
+    await vi.waitFor(() => {
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+    });
+
+    const active = hydrator.hydrate(THREAD_A, "active");
+    await Promise.resolve();
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_A);
+    expect(getTestActiveMessages()).toEqual([resident]);
+    expect(readActiveThreadField((record) => record.loading)).toBe(false);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+
+    resolvePage({ messages: [refreshed], hasMore: false, narrativeByMessage: {} });
+    await Promise.all([background, active]);
+
+    expect(getTestActiveMessages()).toEqual([refreshed]);
+    expect(getCachedRecord(THREAD_A)?.messages).toEqual([refreshed]);
+  });
+
   it("bumps load epoch on each hydrate so stale pagination is discarded", async () => {
     resetThreadStoreForTests({
       records: new Map<string, ThreadRecord>([

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -34,7 +34,7 @@ import { shallowEqualBy } from "@/lib/shallowEqualBy";
 import { coerceTaskStatus } from "@/stores/taskStore";
 import { getTransport } from "@/transport";
 import { PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
-import type { GoalState } from "@mcode/contracts";
+import type { GoalLookupResult, GoalState, TurnSnapshot } from "@mcode/contracts";
 
 vi.mock("@/transport", async () => ({
   ...(await vi.importActual("@/transport")),
@@ -439,6 +439,215 @@ describe("ThreadHydrator", () => {
 
     expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
     expect(getTestActiveMessages()).toEqual([msgB]);
+  });
+
+  it("reselects an in-flight thread immediately during A to B to A navigation", async () => {
+    const resolvers = new Map<string, (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void>();
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      (threadId: string) => new Promise((resolve) => {
+        resolvers.set(threadId, resolve);
+      }),
+    );
+
+    const loadA = hydrator.hydrate(THREAD_A, "active");
+    const loadB = hydrator.hydrate(THREAD_B, "active");
+    const reselectA = hydrator.hydrate(THREAD_A, "active");
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_A);
+    expect(readActiveThreadField((record) => record.loading)).toBe(true);
+
+    resolvers.get(THREAD_A)?.({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
+    resolvers.get(THREAD_B)?.({ messages: [msgB], hasMore: false, narrativeByMessage: {} });
+    await Promise.all([loadA, loadB, reselectA]);
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_A);
+    expect(getTestActiveMessages()).toEqual([msgA]);
+    expect(readActiveThreadField((record) => record.loading)).toBe(false);
+  });
+
+  it("keeps the final in-flight selection during A to B to A to B navigation", async () => {
+    const resolvers = new Map<string, (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void>();
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      (threadId: string) => new Promise((resolve) => {
+        resolvers.set(threadId, resolve);
+      }),
+    );
+
+    const loads = [
+      hydrator.hydrate(THREAD_A, "active"),
+      hydrator.hydrate(THREAD_B, "active"),
+      hydrator.hydrate(THREAD_A, "active"),
+      hydrator.hydrate(THREAD_B, "active"),
+    ];
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
+
+    resolvers.get(THREAD_A)?.({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
+    resolvers.get(THREAD_B)?.({ messages: [msgB], hasMore: false, narrativeByMessage: {} });
+    await Promise.all(loads);
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
+    expect(getTestActiveMessages()).toEqual([msgB]);
+    expect(readActiveThreadField((record) => record.loading)).toBe(false);
+  });
+
+  it("commits the conversation tail without waiting for snapshots or goal lookup", async () => {
+    let resolveSnapshots!: (value: TurnSnapshot[]) => void;
+    let resolveGoal!: (value: GoalLookupResult) => void;
+    useWorkspaceStore.setState({
+      threads: [
+        createMockThread({ id: THREAD_A, has_file_changes: true }),
+        createMockThread({ id: THREAD_B, has_file_changes: false }),
+      ],
+    });
+    (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveSnapshots = resolve;
+      }),
+    );
+    (mockTransport.getThreadGoal as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveGoal = resolve;
+      }),
+    );
+
+    const hydration = hydrator.hydrate(THREAD_A, "active");
+
+    await vi.waitFor(() => {
+      expect(getTestActiveMessages()).toEqual([msgA]);
+      expect(readActiveThreadField((record) => record.loading)).toBe(false);
+    });
+
+    const goal = makeGoal();
+    resolveSnapshots([{
+      message_id: msgA.id,
+      files_changed: ["src/a.ts"],
+      thread_id: THREAD_A,
+      created_at: "2026-01-01T00:00:00Z",
+    } as TurnSnapshot]);
+    resolveGoal({
+      goal,
+      authoritative: false,
+      source: "codex-cache",
+      reason: "not-materialized",
+    });
+    await hydration;
+    await vi.waitFor(() => {
+      expect(readActiveThreadField((record) => record.goal)).toEqual(goal);
+      expect(readActiveThreadField((record) => record.persistedFilesChanged)).toEqual({
+        [msgA.id]: ["src/a.ts"],
+      });
+    });
+  });
+
+  it("discards deferred snapshot and goal results after their load epoch is replaced", async () => {
+    let resolveSnapshots!: (value: TurnSnapshot[]) => void;
+    let resolveGoal!: (value: GoalLookupResult) => void;
+    useWorkspaceStore.setState({
+      threads: [
+        createMockThread({ id: THREAD_A, has_file_changes: true }),
+        createMockThread({ id: THREAD_B, has_file_changes: false }),
+      ],
+    });
+    (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveSnapshots = resolve;
+      }),
+    );
+    (mockTransport.getThreadGoal as ReturnType<typeof vi.fn>).mockImplementation(
+      (threadId: string) => threadId === THREAD_A
+        ? new Promise((resolve) => {
+            resolveGoal = resolve;
+          })
+        : Promise.resolve({
+            goal: null,
+            authoritative: false,
+            source: "codex-cache",
+            reason: "not-materialized",
+          }),
+    );
+
+    await hydrator.hydrate(THREAD_A, "active");
+    await hydrator.hydrate(THREAD_B, "active");
+
+    resolveSnapshots([{
+      message_id: msgA.id,
+      files_changed: ["src/stale.ts"],
+      thread_id: THREAD_A,
+      created_at: "2026-01-01T00:00:00Z",
+    } as TurnSnapshot]);
+    resolveGoal({
+      goal: makeGoal(),
+      authoritative: false,
+      source: "codex-cache",
+      reason: "not-materialized",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
+    expect(useThreadStore.getState().records.get(THREAD_A)?.goal).toBeNull();
+    expect(useThreadStore.getState().records.get(THREAD_A)?.persistedFilesChanged).toEqual({});
+  });
+
+  it("coalesces repeated cached older-history requests by thread and cursor", async () => {
+    const tailA = Array.from({ length: 12 }, (_, index) => createMockMessage({
+      id: `tail-a-${index + 89}`,
+      thread_id: THREAD_A,
+      sequence: index + 89,
+    }));
+    const tailB = Array.from({ length: 12 }, (_, index) => createMockMessage({
+      id: `tail-b-${index + 89}`,
+      thread_id: THREAD_B,
+      sequence: index + 89,
+    }));
+    cacheRecord(THREAD_A, { ...makeCachedRecord(tailA), hasMoreMessages: true });
+    cacheRecord(THREAD_B, { ...makeCachedRecord(tailB), hasMoreMessages: true });
+    const resolvers = new Map<string, (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void>();
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      (threadId: string) => new Promise((resolve) => {
+        resolvers.set(threadId, resolve);
+      }),
+    );
+
+    for (let index = 0; index < 20; index++) {
+      await hydrator.hydrate(index % 2 === 0 ? THREAD_A : THREAD_B, "active");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(2);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, 88, 89);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_B, 88, 89);
+
+    const earlierA = createMockMessage({
+      id: "earlier-a-88",
+      thread_id: THREAD_A,
+      sequence: 88,
+    });
+    const earlierB = createMockMessage({
+      id: "earlier-b-88",
+      thread_id: THREAD_B,
+      sequence: 88,
+    });
+    resolvers.get(THREAD_A)?.({ messages: [earlierA], hasMore: false, narrativeByMessage: {} });
+    resolvers.get(THREAD_B)?.({ messages: [earlierB], hasMore: false, narrativeByMessage: {} });
+
+    await vi.waitFor(() => {
+      expect(getTestActiveMessages()).toEqual([earlierB, ...tailB]);
+    });
+    expect(getCachedRecord(THREAD_A)?.messages).toEqual(tailA);
   });
 
   it("background mode populates cache without touching the live store", async () => {

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -21,6 +21,10 @@ export interface AuxiliaryHydratorOptions {
   force?: boolean;
   /** When true, merges file-change data into the live store if this thread is current. */
   commitFileChangesToStore?: boolean;
+  /** Load epoch that may receive a deferred file-change result. */
+  expectedLoadEpoch?: number;
+  /** Skips snapshots when the caller already owns that request. */
+  skipFileChangeSnapshots?: boolean;
 }
 
 /** Collaborators injected into {@link AuxiliaryHydrator}. */
@@ -66,7 +70,13 @@ export class AuxiliaryHydrator {
     this.hydratePermissions(threadId);
     this.hydrateTasks(threadId);
     this.hydratePlans(threadId);
-    this.hydrateFileChangeSnapshots(threadId, opts.commitFileChangesToStore ?? false);
+    if (!opts.skipFileChangeSnapshots) {
+      this.hydrateFileChangeSnapshots(
+        threadId,
+        opts.commitFileChangesToStore ?? false,
+        opts.expectedLoadEpoch,
+      );
+    }
   }
 
   private transport(): ThreadHydratorTransport {
@@ -157,7 +167,11 @@ export class AuxiliaryHydrator {
    * Fetch file-change snapshots when the thread has changes but the cache entry
    * lacks file-change data (e.g. after a background prefetch).
    */
-  private hydrateFileChangeSnapshots(threadId: string, commitToStore: boolean): void {
+  private hydrateFileChangeSnapshots(
+    threadId: string,
+    commitToStore: boolean,
+    expectedLoadEpoch?: number,
+  ): void {
     const threadRecord = this.deps.getWorkspaceThread(threadId);
     if (!threadRecord?.has_file_changes) return;
 
@@ -169,6 +183,13 @@ export class AuxiliaryHydrator {
       .listSnapshots(threadId)
       .then((snapshots) => {
         if (snapshots.length === 0) return;
+
+        const state = this.deps.getState();
+        const record = getThreadRecord(state.records, threadId);
+        if (expectedLoadEpoch != null && (
+          state.currentThreadId !== threadId
+          || record.loadEpoch !== expectedLoadEpoch
+        )) return;
 
         const latestCached = getCachedRecord(threadId);
         if (!latestCached) return;
@@ -192,6 +213,7 @@ export class AuxiliaryHydrator {
         setState((state: ThreadHydratorWriteState) => {
           if (state.currentThreadId !== threadId) return {};
           const rec = getThreadRecord(state.records, threadId);
+          if (expectedLoadEpoch != null && rec.loadEpoch !== expectedLoadEpoch) return {};
           return {
             records: patchThreadRecord(state.records, threadId, {
               persistedFilesChanged: {

--- a/apps/web/src/lib/thread-hydrator/index.ts
+++ b/apps/web/src/lib/thread-hydrator/index.ts
@@ -5,6 +5,7 @@ export {
   getThreadHydrator,
   __resetThreadHydratorForTests,
   MESSAGE_FETCH_SIZE,
+  HISTORY_PREFETCH_SIZE,
   HYDRATION_TTL_MS,
   BACKGROUND_PREFETCH_LIMIT,
 } from "./thread-hydrator";

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -22,8 +22,11 @@ import type {
 import { snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
 
-/** Initial message fetch size per thread. */
-export const MESSAGE_FETCH_SIZE = 100;
+/** Latest messages fetched before the selected thread first paints. */
+export const MESSAGE_FETCH_SIZE = 12;
+
+/** Earlier messages filled in after the latest tail has painted. */
+export const HISTORY_PREFETCH_SIZE = 88;
 
 /** Auxiliary side-effect refresh TTL (permissions, tasks, plans). */
 export const HYDRATION_TTL_MS = 2000;
@@ -39,6 +42,7 @@ export class ThreadHydrator {
   private readonly auxiliaryHydrator: AuxiliaryHydrator;
   private readonly activeHydrates = new Map<string, Promise<void>>();
   private readonly backgroundHydrates = new Map<string, Promise<void>>();
+  private readonly historyHydrates = new Map<string, Promise<void>>();
 
   constructor(private readonly deps: ThreadHydratorDeps) {
     this.auxiliaryHydrator = new AuxiliaryHydrator({
@@ -145,13 +149,27 @@ export class ThreadHydrator {
       return;
     }
 
+    const resident = this.deps.getState().records.get(threadId);
+    const hasResidentLayer = resident != null && (
+      resident.messages.length > 0
+      || resident.streaming.length > 0
+      || resident.toolCalls.length > 0
+      || resident.thoughtSegments.length > 0
+      || resident.hooks.length > 0
+      || this.deps.getState().runningThreadIds.has(threadId)
+    );
+
     const inFlight = this.activeHydrates.get(threadId);
     if (inFlight) {
       await inFlight;
       return;
     }
 
-    const hydrate = this.fetchActiveReusingBackground(threadId, opts).finally(() => {
+    if (hasResidentLayer) {
+      this.activateResidentLayer(threadId);
+    }
+
+    const hydrate = this.fetchActiveReusingBackground(threadId, opts, hasResidentLayer).finally(() => {
       if (this.activeHydrates.get(threadId) === hydrate) {
         this.activeHydrates.delete(threadId);
       }
@@ -164,6 +182,7 @@ export class ThreadHydrator {
   private async fetchActiveReusingBackground(
     threadId: string,
     opts?: ThreadHydratorOptions,
+    hasResidentLayer = false,
   ): Promise<void> {
     const background = this.backgroundHydrates.get(threadId);
     if (background) {
@@ -182,7 +201,30 @@ export class ThreadHydrator {
       return;
     }
 
-    await this.fetchAndCommit(threadId, opts);
+    await this.fetchAndCommit(threadId, opts, hasResidentLayer
+      ? {
+          skipPrepare: true,
+          fetchLimit: BACKGROUND_PREFETCH_LIMIT,
+          prefetchEarlierHistory: false,
+        }
+      : undefined);
+  }
+
+  /** Makes a retained thread record visible while its persisted history refreshes. */
+  private activateResidentLayer(threadId: string): void {
+    this.deps.setState((state: ThreadHydratorWriteState) => {
+      const current = getThreadRecord(state.records, threadId);
+      return {
+        records: patchThreadRecord(state.records, threadId, {
+          loading: false,
+          error: null,
+          isLoadingMore: false,
+          loadEpoch: current.loadEpoch + 1,
+          settings: this.deps.getWorkspaceThreadSettings(threadId),
+        }),
+        currentThreadId: threadId,
+      };
+    });
   }
 
   /** Restore cached data to the active store and refresh auxiliary data. */
@@ -199,6 +241,9 @@ export class ThreadHydrator {
       force: opts?.force,
       commitFileChangesToStore: true,
     });
+    if (cached.hasMoreMessages && cached.messages.length < BACKGROUND_PREFETCH_LIMIT) {
+      this.scheduleEarlierHistoryHydration(threadId, cached);
+    }
   }
 
   /**
@@ -333,7 +378,11 @@ export class ThreadHydrator {
   private async fetchAndCommit(
     threadId: string,
     opts?: ThreadHydratorOptions,
-    commitOpts?: { skipPrepare?: boolean },
+    commitOpts?: {
+      skipPrepare?: boolean;
+      fetchLimit?: number;
+      prefetchEarlierHistory?: boolean;
+    },
   ): Promise<void> {
     const { getState, setState } = this.deps;
 
@@ -347,7 +396,10 @@ export class ThreadHydrator {
 
       const goalLookupPromise = this.transport().getThreadGoal(threadId).catch(() => null);
       const [pageResult, snapshots, goalLookup] = await Promise.all([
-        this.transport().loadConversationPage(threadId, MESSAGE_FETCH_SIZE),
+        this.transport().loadConversationPage(
+          threadId,
+          commitOpts?.fetchLimit ?? MESSAGE_FETCH_SIZE,
+        ),
         shouldFetchSnapshots
           ? this.transport().listSnapshots(threadId).catch(() => [] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>)
           : Promise.resolve([] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>),
@@ -394,6 +446,9 @@ export class ThreadHydrator {
       if (goalLookup) {
         this.applyGoalLookup(threadId, goalLookup);
       }
+      if (commitOpts?.prefetchEarlierHistory !== false) {
+        this.scheduleEarlierHistoryHydration(threadId, pageResult);
+      }
     } catch (e) {
       if (getState().currentThreadId === threadId) {
         setState((state: ThreadHydratorWriteState) => ({
@@ -404,6 +459,83 @@ export class ThreadHydrator {
         }));
       }
       evictCachedRecord(threadId);
+    }
+  }
+
+  /** Defers older history until the browser has had a chance to paint the tail. */
+  private scheduleEarlierHistoryHydration(
+    threadId: string,
+    page: Pick<ThreadRecord, "messages"> & { hasMore?: boolean; hasMoreMessages?: boolean },
+  ): void {
+    if (!(page.hasMore ?? page.hasMoreMessages) || page.messages.length === 0) return;
+    const before = page.messages[0].sequence;
+    const epoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
+    const hydrateKey = `${threadId}:${epoch}`;
+    setTimeout(() => {
+      const state = this.deps.getState();
+      if (state.currentThreadId !== threadId) return;
+      if (getThreadRecord(state.records, threadId).loadEpoch !== epoch) return;
+      if (this.historyHydrates.has(hydrateKey)) return;
+      const hydrate = this.hydrateEarlierHistory(threadId, before, epoch).finally(() => {
+        if (this.historyHydrates.get(hydrateKey) === hydrate) {
+          this.historyHydrates.delete(hydrateKey);
+        }
+      });
+      this.historyHydrates.set(hydrateKey, hydrate);
+    }, 0);
+  }
+
+  /** Prepends the rest of the warm history window without blocking the tail. */
+  private async hydrateEarlierHistory(
+    threadId: string,
+    before: number,
+    expectedEpoch: number,
+  ): Promise<void> {
+    try {
+      const page = await this.transport().loadConversationPage(
+        threadId,
+        HISTORY_PREFETCH_SIZE,
+        before,
+      );
+      const state = this.deps.getState();
+      const current = getThreadRecord(state.records, threadId);
+      if (state.currentThreadId !== threadId || current.loadEpoch !== expectedEpoch) return;
+
+      const currentIds = new Set(current.messages.map((message) => message.id));
+      const earlierMessages = page.messages.filter((message) => !currentIds.has(message.id));
+      const persistedToolCallCounts = { ...current.persistedToolCallCounts };
+      for (const message of earlierMessages) {
+        if (message.tool_call_count && message.tool_call_count > 0) {
+          persistedToolCallCounts[message.id] = message.tool_call_count;
+        }
+      }
+      const messages = [...earlierMessages, ...current.messages];
+
+      this.deps.setState((latest: ThreadHydratorWriteState) => {
+        const record = getThreadRecord(latest.records, threadId);
+        if (latest.currentThreadId !== threadId || record.loadEpoch !== expectedEpoch) {
+          return {};
+        }
+        return {
+          records: patchThreadRecord(latest.records, threadId, {
+            messages,
+            oldestLoadedSequence: messages[0]?.sequence ?? record.oldestLoadedSequence,
+            hasMoreMessages: page.hasMore,
+            persistedToolCallCounts,
+            narrativeByMessage: {
+              ...page.narrativeByMessage,
+              ...record.narrativeByMessage,
+            },
+            answeredPlanMessageIds: new Set([
+              ...record.answeredPlanMessageIds,
+              ...(page.answeredPlanMessageIds ?? []),
+            ]),
+          }),
+        };
+      });
+      cacheRecord(threadId, getThreadRecord(this.deps.getState().records, threadId));
+    } catch {
+      // The visible tail is complete; older history remains available on scroll.
     }
   }
 

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -19,8 +19,13 @@ import type {
   ThreadHydratorTransport,
   ThreadHydratorWriteState,
 } from "./types";
-import { snapshotBuilder } from "./snapshot-builder";
+import { SnapshotBuilder, snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
+
+interface HistoryHydrate {
+  expectedEpoch: number;
+  promise: Promise<void>;
+}
 
 /** Latest messages fetched before the selected thread first paints. */
 export const MESSAGE_FETCH_SIZE = 12;
@@ -42,7 +47,7 @@ export class ThreadHydrator {
   private readonly auxiliaryHydrator: AuxiliaryHydrator;
   private readonly activeHydrates = new Map<string, Promise<void>>();
   private readonly backgroundHydrates = new Map<string, Promise<void>>();
-  private readonly historyHydrates = new Map<string, Promise<void>>();
+  private readonly historyHydrates = new Map<string, HistoryHydrate>();
 
   constructor(private readonly deps: ThreadHydratorDeps) {
     this.auxiliaryHydrator = new AuxiliaryHydrator({
@@ -161,7 +166,13 @@ export class ThreadHydrator {
 
     const inFlight = this.activeHydrates.get(threadId);
     if (inFlight) {
+      this.selectInFlightLayer(threadId, hasResidentLayer);
       await inFlight;
+      const state = this.deps.getState();
+      const current = getThreadRecord(state.records, threadId);
+      if (state.currentThreadId === threadId && current.loading && !hasCachedRecord(threadId)) {
+        await this.hydrateActive(threadId, opts);
+      }
       return;
     }
 
@@ -227,6 +238,18 @@ export class ThreadHydrator {
     });
   }
 
+  /** Makes an already-loading thread current without invalidating its request epoch. */
+  private selectInFlightLayer(threadId: string, hasResidentLayer: boolean): void {
+    this.deps.setState((state: ThreadHydratorWriteState) => ({
+      records: patchThreadRecord(state.records, threadId, {
+        loading: !hasResidentLayer,
+        error: null,
+        settings: this.deps.getWorkspaceThreadSettings(threadId),
+      }),
+      currentThreadId: threadId,
+    }));
+  }
+
   /** Restore cached data to the active store and refresh auxiliary data. */
   private restoreCachedActive(
     threadId: string,
@@ -235,11 +258,13 @@ export class ThreadHydrator {
     restoreOpts?: { bumpLoadEpoch?: boolean },
   ): void {
     this.restoreFromCache(threadId, cached, restoreOpts);
-    void this.refreshThreadGoal(threadId);
+    const expectedEpoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
+    void this.refreshThreadGoal(threadId, expectedEpoch);
     this.auxiliaryHydrator.hydrate(threadId, {
       freshnessTtlMs: HYDRATION_TTL_MS,
       force: opts?.force,
       commitFileChangesToStore: true,
+      expectedLoadEpoch: expectedEpoch,
     });
     if (cached.hasMoreMessages && cached.messages.length < BACKGROUND_PREFETCH_LIMIT) {
       this.scheduleEarlierHistoryHydration(threadId, cached);
@@ -295,9 +320,21 @@ export class ThreadHydrator {
   }
 
   /** Apply lookup result semantics to the live record and record cache. */
-  private applyGoalLookup(threadId: string, lookup: GoalLookupResult): void {
+  private applyGoalLookup(
+    threadId: string,
+    lookup: GoalLookupResult,
+    expectedEpoch?: number,
+  ): void {
+    let applied = false;
     this.deps.setState((state: ThreadHydratorWriteState) => {
       const current = getThreadRecord(state.records, threadId);
+      if (expectedEpoch != null && (
+        state.currentThreadId !== threadId
+        || current.loadEpoch !== expectedEpoch
+      )) {
+        return {};
+      }
+      applied = true;
       const goal = resolveGoalLookupGoal(lookup, current.goal);
       return {
         records: patchThreadRecord(state.records, threadId, { goal }),
@@ -305,16 +342,40 @@ export class ThreadHydrator {
     });
 
     const cached = getCachedRecord(threadId);
-    if (!cached) return;
+    if (!cached || !applied) return;
     const goal = resolveGoalLookupGoal(lookup, cached.goal);
     cacheRecord(threadId, { ...cached, goal });
   }
 
+  /** Merges file-change snapshots only into the load that requested them. */
+  private applySnapshots(
+    threadId: string,
+    snapshots: Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>,
+    expectedEpoch: number,
+  ): void {
+    const fileChanges = SnapshotBuilder.deriveFileChanges(snapshots);
+    let applied = false;
+    this.deps.setState((state: ThreadHydratorWriteState) => {
+      const current = getThreadRecord(state.records, threadId);
+      if (state.currentThreadId !== threadId || current.loadEpoch !== expectedEpoch) {
+        return {};
+      }
+      applied = true;
+      return {
+        records: patchThreadRecord(state.records, threadId, fileChanges),
+      };
+    });
+
+    const cached = getCachedRecord(threadId);
+    if (!cached || !applied) return;
+    cacheRecord(threadId, { ...cached, ...fileChanges });
+  }
+
   /** Refresh one thread's active goal without blocking main hydration. */
-  private async refreshThreadGoal(threadId: string): Promise<void> {
+  private async refreshThreadGoal(threadId: string, expectedEpoch: number): Promise<void> {
     try {
       const lookup = await this.transport().getThreadGoal(threadId);
-      this.applyGoalLookup(threadId, lookup);
+      this.applyGoalLookup(threadId, lookup, expectedEpoch);
     } catch {
       // Best-effort hydration: message load remains the authoritative error surface.
     }
@@ -389,30 +450,31 @@ export class ThreadHydrator {
     if (!commitOpts?.skipPrepare) {
       this.prepareActiveLoad(threadId);
     }
+    const expectedEpoch = getThreadRecord(getState().records, threadId).loadEpoch;
 
     try {
       const workspaceThread = this.deps.getWorkspaceThread(threadId);
       const shouldFetchSnapshots = workspaceThread?.has_file_changes !== false;
 
       const goalLookupPromise = this.transport().getThreadGoal(threadId).catch(() => null);
-      const [pageResult, snapshots, goalLookup] = await Promise.all([
-        this.transport().loadConversationPage(
-          threadId,
-          commitOpts?.fetchLimit ?? MESSAGE_FETCH_SIZE,
-        ),
-        shouldFetchSnapshots
-          ? this.transport().listSnapshots(threadId).catch(() => [] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>)
-          : Promise.resolve([] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>),
-        goalLookupPromise,
-      ]);
+      const snapshotsPromise = shouldFetchSnapshots
+        ? this.transport().listSnapshots(threadId).catch(() => [] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>)
+        : Promise.resolve([] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>);
+      const pageResult = await this.transport().loadConversationPage(
+        threadId,
+        commitOpts?.fetchLimit ?? MESSAGE_FETCH_SIZE,
+      );
 
-      if (getState().currentThreadId !== threadId) return;
+      const stateAtCommit = getState();
+      if (
+        stateAtCommit.currentThreadId !== threadId
+        || getThreadRecord(stateAtCommit.records, threadId).loadEpoch !== expectedEpoch
+      ) return;
 
       const patch = snapshotBuilder.build({
         messages: pageResult.messages,
         hasMore: pageResult.hasMore,
         answeredPlanMessageIds: pageResult.answeredPlanMessageIds,
-        snapshots,
       });
 
       setState((state: ThreadHydratorWriteState) => ({
@@ -429,6 +491,8 @@ export class ThreadHydrator {
         freshnessTtlMs: HYDRATION_TTL_MS,
         force: opts?.force ?? true,
         commitFileChangesToStore: true,
+        expectedLoadEpoch: expectedEpoch,
+        skipFileChangeSnapshots: true,
       });
 
       const committed = getThreadRecord(getState().records, threadId);
@@ -443,9 +507,12 @@ export class ThreadHydrator {
       }
 
       cacheRecord(threadId, getThreadRecord(getState().records, threadId));
-      if (goalLookup) {
-        this.applyGoalLookup(threadId, goalLookup);
-      }
+      void snapshotsPromise.then((snapshots) => {
+        this.applySnapshots(threadId, snapshots, expectedEpoch);
+      });
+      void goalLookupPromise.then((goalLookup) => {
+        if (goalLookup) this.applyGoalLookup(threadId, goalLookup, expectedEpoch);
+      });
       if (commitOpts?.prefetchEarlierHistory !== false) {
         this.scheduleEarlierHistoryHydration(threadId, pageResult);
       }
@@ -470,13 +537,25 @@ export class ThreadHydrator {
     if (!(page.hasMore ?? page.hasMoreMessages) || page.messages.length === 0) return;
     const before = page.messages[0].sequence;
     const epoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
-    const hydrateKey = `${threadId}:${epoch}`;
+    const hydrateKey = `${threadId}:${before}`;
     setTimeout(() => {
       const state = this.deps.getState();
       if (state.currentThreadId !== threadId) return;
       if (getThreadRecord(state.records, threadId).loadEpoch !== epoch) return;
-      if (this.historyHydrates.has(hydrateKey)) return;
-      const hydrate = this.hydrateEarlierHistory(threadId, before, epoch).finally(() => {
+      const existing = this.historyHydrates.get(hydrateKey);
+      if (existing) {
+        existing.expectedEpoch = epoch;
+        return;
+      }
+      const hydrate: HistoryHydrate = {
+        expectedEpoch: epoch,
+        promise: Promise.resolve(),
+      };
+      hydrate.promise = this.hydrateEarlierHistory(
+        threadId,
+        before,
+        () => hydrate.expectedEpoch,
+      ).finally(() => {
         if (this.historyHydrates.get(hydrateKey) === hydrate) {
           this.historyHydrates.delete(hydrateKey);
         }
@@ -489,7 +568,7 @@ export class ThreadHydrator {
   private async hydrateEarlierHistory(
     threadId: string,
     before: number,
-    expectedEpoch: number,
+    getExpectedEpoch: () => number,
   ): Promise<void> {
     try {
       const page = await this.transport().loadConversationPage(
@@ -499,6 +578,7 @@ export class ThreadHydrator {
       );
       const state = this.deps.getState();
       const current = getThreadRecord(state.records, threadId);
+      const expectedEpoch = getExpectedEpoch();
       if (state.currentThreadId !== threadId || current.loadEpoch !== expectedEpoch) return;
 
       const currentIds = new Set(current.messages.map((message) => message.id));
@@ -533,7 +613,11 @@ export class ThreadHydrator {
           }),
         };
       });
-      cacheRecord(threadId, getThreadRecord(this.deps.getState().records, threadId));
+      const latest = this.deps.getState();
+      const latestRecord = getThreadRecord(latest.records, threadId);
+      if (latest.currentThreadId === threadId && latestRecord.loadEpoch === getExpectedEpoch()) {
+        cacheRecord(threadId, latestRecord);
+      }
     } catch {
       // The visible tail is complete; older history remains available on scroll.
     }

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -197,7 +197,9 @@ export class ThreadHydrator {
   ): Promise<void> {
     const background = this.backgroundHydrates.get(threadId);
     if (background) {
-      this.prepareActiveLoad(threadId);
+      if (!hasResidentLayer) {
+        this.prepareActiveLoad(threadId);
+      }
       await background;
 
       if (this.deps.getState().currentThreadId !== threadId) return;

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -35,6 +35,7 @@ import { isGoalStatusNotice } from "@/lib/goal-message";
 import {
   createThreadHydrator,
   registerThreadHydrator,
+  MESSAGE_FETCH_SIZE as HYDRATOR_MESSAGE_FETCH_SIZE,
   type ThreadHydratorWriteState,
 } from "@/lib/thread-hydrator";
 import {
@@ -612,8 +613,8 @@ export const OLDER_PAGE_SIZE = 50;
 /** Maximum messages kept in the in-memory sliding window. */
 export const MESSAGE_WINDOW_SIZE = 200;
 
-/** Initial message fetch size per thread */
-export const MESSAGE_FETCH_SIZE = 100;
+/** Initial message fetch size per thread. */
+export const MESSAGE_FETCH_SIZE = HYDRATOR_MESSAGE_FETCH_SIZE;
 
 const DEFAULT_THREAD_SETTINGS: ThreadSettings = {
   permissionMode: PERMISSION_MODES.FULL,

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -278,10 +278,7 @@ export function createWsTransport(
       // Deferred import avoids a circular dependency at module evaluation time.
       const nowForThreads = Date.now();
       import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        const { activeWorkspaceId, activeThreadId, loadThreads } = useWorkspaceStore.getState();
-        if (activeThreadId) {
-          rpc<void>("push.subscribeThread", { threadId: activeThreadId }).catch(() => {});
-        }
+        const { activeWorkspaceId, loadThreads } = useWorkspaceStore.getState();
         if (!activeWorkspaceId) return;
         const last = lastLoadThreadsAtByWorkspace.get(activeWorkspaceId) ?? 0;
         if (nowForThreads - last <= LOAD_THREADS_RECONNECT_COOLDOWN_MS) return;


### PR DESCRIPTION
## What

Make thread switching show the selected conversation layer and current agent activity before the full history window finishes loading.

## Why

Switches waited for a 100-message history page, and inactive running threads could miss live activity before selection. Rapid switching could also leave a stale loading layer or multiply older-history requests.

## Key Changes

- Load the latest 12 messages first, then fill the earlier 88-message window after the tail paints.
- Keep the selected thread and running-agent threads subscribed so their live layers stay current.
- Guard delayed history, goal, and snapshot results by thread epoch and coalesce repeated history requests.
- Reveal the anchored message tail early while virtualized measurements continue settling.
- Add deterministic rapid-switch, slow-auxiliary, running-agent, pagination, and browser regressions.

## Verification

- `node scripts/agent/verify-tests.mjs --full`: passed typecheck, lint, and all package tests; frontend 264 files and 2,305 tests.
- Focused thread-switch tests: 81 passed.
- Playwright thread-switch flow: 4 passed.
- Real worktree runtime: health 200 and a two-thread browser switch passed.
- `reviewer_qa`: `REVIEW_PASSED` with no findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786895044&installation_id=129163861&pr_number=871&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F871&signature=a26a1bb98e57e721f4aaa3ecc90c967dc4bf3db9a68051775857b74ad3b62d4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread conversations now reveal the pinned tail sooner, with animated skeleton placeholders while history and auxiliary details load in the background.
  * Running threads stay subscribed across thread switches, including command activity controls.
* **Bug Fixes**
  * Prevented outdated conversation, file-change snapshots, and auxiliary results from appearing after rapid navigation or hydration/epoch changes.
  * Improved realtime subscription handling during connection/reconnect scenarios and stabilized cached/older-history pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->