### PR TITLE
feat(diff): add Dev Review comments and worktree files

### DIFF
--- a/apps/web/src/__tests__/MessageBubble.test.tsx
+++ b/apps/web/src/__tests__/MessageBubble.test.tsx
@@ -263,6 +263,9 @@ describe("MessageBubble user messages", () => {
       "src",
       `mcode-attachment://${threadUuid}/shot-1.png`,
     );
+    expect(await findByTestId("preview-annotation-hover-thumbnail")).toHaveClass(
+      "object-contain",
+    );
     expect(document.querySelector('[data-slot="tooltip-arrow"]')).toHaveClass(
       "bg-popover",
       "fill-popover",

--- a/apps/web/src/__tests__/MessageBubble.test.tsx
+++ b/apps/web/src/__tests__/MessageBubble.test.tsx
@@ -93,6 +93,33 @@ function makePreviewAnnotationBundle(): PreviewAnnotationBundle {
   };
 }
 
+function makeCodeCommentBundle(): PreviewAnnotationBundle {
+  return {
+    schemaVersion: 1,
+    annotations: [
+      {
+        kind: "diff",
+        id: "550e8400-e29b-41d4-a716-446655440002",
+        displayNumber: 1,
+        filePath: "apps/web/src/components/chat/Composer.tsx",
+        side: "right",
+        line: 946,
+        lineContent: "const diffAnnotationRows = usePreviewAnnotationStore(...);",
+        note: "Keep this review target attached to the next prompt.",
+      },
+    ],
+  };
+}
+
+function makeMixedFeedbackBundle(): PreviewAnnotationBundle {
+  const preview = makePreviewAnnotationBundle().annotations[0];
+  const comment = makeCodeCommentBundle().annotations[0];
+  return {
+    schemaVersion: 1,
+    annotations: [preview, { ...comment, displayNumber: 2 }],
+  };
+}
+
 describe("MessageBubble user messages", () => {
   it("renders user message through MarkdownContent with variant='user'", async () => {
     const { container } = render(
@@ -246,6 +273,35 @@ describe("MessageBubble user messages", () => {
     expect(queryByText("bundle")).not.toBeInTheDocument();
   });
 
+  it("labels code review feedback as comments", async () => {
+    const user = userEvent.setup();
+    const message: Message = {
+      ...makeMessage(""),
+      previewAnnotations: makeCodeCommentBundle(),
+    };
+
+    const { findByText, getByTestId } = render(<MessageBubble message={message} />);
+
+    expect(getByTestId("sent-preview-annotation-bundle-chip")).toHaveTextContent(
+      "1 comment",
+    );
+    await user.hover(getByTestId("sent-preview-annotation-bundle-chip"));
+    expect(await findByText("Comment")).toBeVisible();
+  });
+
+  it("keeps annotations and comments distinct in mixed feedback", () => {
+    const message: Message = {
+      ...makeMessage(""),
+      previewAnnotations: makeMixedFeedbackBundle(),
+    };
+
+    const { getByTestId } = render(<MessageBubble message={message} />);
+
+    expect(getByTestId("sent-preview-annotation-bundle-chip")).toHaveTextContent(
+      "1 annotation · 1 comment",
+    );
+  });
+
   it("shows each annotation screenshot thumbnail in the chip hover", async () => {
     const user = userEvent.setup();
     const threadUuid = "550e8400-e29b-41d4-a716-446655440000";
@@ -322,6 +378,23 @@ describe("MessageBubble user messages", () => {
     await user.click(getByLabelText("Reply to this message"));
 
     expect(onReply).toHaveBeenCalledWith("msg-1", "[Annotation]", "user");
+  });
+
+  it("uses a comment reply fallback for code-comment-only messages", async () => {
+    const user = userEvent.setup();
+    const onReply = vi.fn();
+    const message: Message = {
+      ...makeMessage(""),
+      previewAnnotations: makeCodeCommentBundle(),
+    };
+
+    const { getByLabelText } = render(
+      <MessageBubble message={message} onReply={onReply} />,
+    );
+
+    await user.click(getByLabelText("Reply to this message"));
+
+    expect(onReply).toHaveBeenCalledWith("msg-1", "[Comment]", "user");
   });
 });
 

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -943,16 +943,17 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const annotationRows = usePreviewAnnotationStore((s) =>
     annotationScopeId ? s.byThread[annotationScopeId] : undefined,
   );
-  const annotationCount = annotationRows?.length ?? 0;
+  const diffAnnotationRows = usePreviewAnnotationStore((s) =>
+    annotationScopeId ? s.diffByThread[annotationScopeId] : undefined,
+  );
+  const annotationCount =
+    (annotationRows?.length ?? 0) + (diffAnnotationRows?.length ?? 0);
   const annotationBundleForDisplay = useMemo(
     () =>
-      annotationRows && annotationRows.length > 0
-        ? {
-            schemaVersion: 1 as const,
-            annotations: annotationRows.map(({ createdAt: _createdAt, ...annotation }) => annotation),
-          }
+      annotationScopeId
+        ? usePreviewAnnotationStore.getState().buildBundle(annotationScopeId)
         : undefined,
-    [annotationRows],
+    [annotationRows, annotationScopeId, diffAnnotationRows],
   );
   const setPreviewDesignModeActive = usePreviewDesignModeStore((s) => s.setActive);
 

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -17,6 +17,7 @@ import { AnsweredSummary } from "./plan-questions/AnsweredSummary";
 import { PLAN_ANSWER_MESSAGE_PREFIX } from "@mcode/contracts";
 import { DeltaBlock } from "./narrative/DeltaBlock";
 import { parseGoalStatusNotice } from "@/lib/goal-message";
+import { composerFeedbackReplyFallback } from "@/lib/composer-feedback";
 import { PreviewAnnotationBundleChip } from "./PreviewAnnotationBundleChip";
 import { useRetriableAttachmentImage } from "./useRetriableAttachmentImage";
 
@@ -662,11 +663,8 @@ export const MessageBubble = memo(function MessageBubble({
                 let fallback = "[Attachment]";
                 if (!userDisplayText.trim()) {
                   const firstAtt = message.attachments?.[0];
-                  if (hasPreviewAnnotations) {
-                    fallback =
-                      message.previewAnnotations?.annotations.length === 1
-                        ? "[Annotation]"
-                        : "[Annotations]";
+                  if (hasPreviewAnnotations && message.previewAnnotations) {
+                    fallback = composerFeedbackReplyFallback(message.previewAnnotations);
                   } else if (firstAtt?.mimeType.startsWith("image/")) fallback = "[Image attachment]";
                   else if (firstAtt?.mimeType === "application/pdf") fallback = "[PDF attachment]";
                   else if (firstAtt) fallback = "[File attachment]";

--- a/apps/web/src/components/chat/PreviewAnnotationBundleChip.tsx
+++ b/apps/web/src/components/chat/PreviewAnnotationBundleChip.tsx
@@ -1,7 +1,10 @@
-import type { PreviewAnnotationBundle, PreviewAnnotationPayload } from "@mcode/contracts";
-import { ImageIcon, MessageCircle, X } from "lucide-react";
+import {
+  isDiffAnnotationPayload,
+  type ComposerAnnotationPayload,
+  type PreviewAnnotationBundle,
+} from "@mcode/contracts";
+import { FileCode2, ImageIcon, MessageCircle, X } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { buildStoredAttachmentImageSrc } from "@/lib/attachment-url";
@@ -14,7 +17,10 @@ function annotationCountLabel(count: number): string {
   return count === 1 ? "1 annotation" : `${count} annotations`;
 }
 
-function annotationTargetLabel(annotation: PreviewAnnotationPayload): string {
+function annotationTargetLabel(annotation: ComposerAnnotationPayload): string {
+  if (isDiffAnnotationPayload(annotation)) {
+    return `${annotation.filePath}:${annotation.line}`;
+  }
   return (
     annotation.targetContext.label?.trim() ||
     annotation.targetContext.selectorHint?.trim() ||
@@ -22,11 +28,10 @@ function annotationTargetLabel(annotation: PreviewAnnotationPayload): string {
   );
 }
 
-function annotationDetail(annotation: PreviewAnnotationPayload): string {
-  const text =
-    annotation.note?.trim() ||
-    annotation.changeSummary?.trim() ||
-    "Visual annotation";
+function annotationDetail(annotation: ComposerAnnotationPayload): string {
+  const text = isDiffAnnotationPayload(annotation)
+    ? annotation.note.trim()
+    : annotation.note?.trim() || annotation.changeSummary?.trim() || "Visual annotation";
   return text.length <= MAX_DETAIL_LENGTH
     ? text
     : `${text.slice(0, MAX_DETAIL_LENGTH - 3).trimEnd()}...`;
@@ -36,7 +41,7 @@ function AnnotationSnapshotThumbnail({ src }: { readonly src: string }) {
   const image = useRetriableAttachmentImage(src);
 
   return (
-    <span className="relative block h-14 overflow-hidden rounded-md border border-border/60 bg-muted/30">
+    <span className="relative block aspect-video w-28 shrink-0 overflow-hidden rounded-md bg-muted/35 ring-1 ring-inset ring-border/60">
       {image.failed ? (
         <span className="flex h-full w-full items-center justify-center text-muted-foreground">
           <ImageIcon size={16} aria-hidden />
@@ -47,7 +52,7 @@ function AnnotationSnapshotThumbnail({ src }: { readonly src: string }) {
             src={image.src}
             alt=""
             className={cn(
-              "h-full w-full object-cover transition-opacity",
+              "h-full w-full object-contain transition-opacity duration-150 motion-reduce:transition-none",
               image.retrying ? "opacity-0" : "opacity-100",
             )}
             loading="lazy"
@@ -102,7 +107,7 @@ export function PreviewAnnotationBundleChip({
             tabIndex={0}
             aria-label={`${label}. Annotation details available.`}
             className={cn(
-              "group relative inline-flex max-w-full items-center gap-2 rounded-lg border border-accent-foreground/10 bg-accent px-2 py-1 text-xs font-medium text-accent-foreground shadow-sm transition-colors hover:border-accent-foreground/15 hover:bg-accent/90 focus-visible:border-accent-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-foreground/20",
+              "group relative inline-flex max-w-full items-center gap-2 rounded-lg bg-accent px-2 py-1 text-xs font-medium text-accent-foreground ring-1 ring-inset ring-accent-foreground/10 transition-colors duration-150 hover:bg-accent/90 hover:ring-accent-foreground/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-foreground/25 motion-reduce:transition-none",
               className,
             )}
           >
@@ -118,7 +123,7 @@ export function PreviewAnnotationBundleChip({
                   event.stopPropagation();
                   onRemove();
                 }}
-                className="pointer-events-none absolute -right-2 -top-2 size-5 rounded-full border border-accent-foreground/10 bg-accent text-accent-foreground/70 opacity-0 shadow-sm transition-opacity hover:bg-accent-foreground/10 hover:text-accent-foreground focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
+                className="pointer-events-none absolute -right-2 -top-2 size-5 rounded-full bg-accent text-accent-foreground/70 opacity-0 ring-1 ring-inset ring-accent-foreground/15 transition-opacity duration-150 hover:bg-accent-foreground/10 hover:text-accent-foreground focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 motion-reduce:transition-none"
               >
                 <X size={12} aria-hidden />
               </Button>
@@ -130,12 +135,12 @@ export function PreviewAnnotationBundleChip({
         side="top"
         align="end"
         sideOffset={8}
-        className="w-[min(22rem,calc(100vw-2rem))] max-w-none items-stretch rounded-xl border border-border/70 bg-popover p-2.5 text-popover-foreground shadow-xl"
+        className="w-[min(32rem,calc(100vw-1.6rem))] max-w-none items-stretch rounded-xl bg-popover p-3 text-popover-foreground ring-1 ring-inset ring-border/70"
         arrowClassName="bg-popover fill-popover"
       >
-        <div className="max-h-72 min-w-0 space-y-2 overflow-y-auto pr-1">
+        <div className="max-h-80 min-w-0 divide-y divide-border/45 overflow-y-auto">
           {bundle.annotations.map((annotation) => {
-            const snapshotSrc = threadId
+            const snapshotSrc = threadId && !isDiffAnnotationPayload(annotation)
               ? buildStoredAttachmentImageSrc(
                   threadId,
                   annotation.snapshot.id,
@@ -145,22 +150,23 @@ export function PreviewAnnotationBundleChip({
             return (
               <div
                 key={annotation.id}
-                className="grid min-w-0 grid-cols-[minmax(0,1fr)_4.5rem] gap-2 border-b border-border/50 pb-2 last:border-b-0 last:pb-0"
+                className="flex min-w-0 items-start gap-3 py-3 first:pt-0 last:pb-0"
               >
-                <div className="min-w-0">
-                  <div className="flex min-w-0 items-center gap-2">
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 items-center gap-2.5">
                     <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/80 text-xs font-semibold tabular-nums text-primary-foreground/90">
                       {annotation.displayNumber}
                     </span>
-                    <Badge
-                      variant="secondary"
-                      size="sm"
-                      className="min-w-0 max-w-full truncate font-mono font-normal text-muted-foreground"
-                    >
+                    {isDiffAnnotationPayload(annotation) ? (
+                      <FileCode2 size={14} className="shrink-0 text-muted-foreground" aria-hidden />
+                    ) : (
+                      <ImageIcon size={14} className="shrink-0 text-muted-foreground" aria-hidden />
+                    )}
+                    <span className="min-w-0 truncate font-mono text-[1.1rem] font-normal text-muted-foreground">
                       {annotationTargetLabel(annotation)}
-                    </Badge>
+                    </span>
                   </div>
-                  <p className="mt-1.5 min-w-0 whitespace-pre-wrap break-words text-xs leading-snug text-popover-foreground">
+                  <p className="mt-2 min-w-0 whitespace-pre-wrap break-words text-xs leading-5 text-popover-foreground">
                     {annotationDetail(annotation)}
                   </p>
                 </div>

--- a/apps/web/src/components/chat/PreviewAnnotationBundleChip.tsx
+++ b/apps/web/src/components/chat/PreviewAnnotationBundleChip.tsx
@@ -8,30 +8,30 @@ import { FileCode2, ImageIcon, MessageCircle, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { buildStoredAttachmentImageSrc } from "@/lib/attachment-url";
+import {
+  composerFeedbackAccessibleLabel,
+  composerFeedbackLabel,
+} from "@/lib/composer-feedback";
 import { cn } from "@/lib/utils";
 import { useRetriableAttachmentImage } from "./useRetriableAttachmentImage";
 
 const MAX_DETAIL_LENGTH = 220;
 
-function annotationCountLabel(count: number): string {
-  return count === 1 ? "1 annotation" : `${count} annotations`;
-}
-
-function annotationTargetLabel(annotation: ComposerAnnotationPayload): string {
-  if (isDiffAnnotationPayload(annotation)) {
-    return `${annotation.filePath}:${annotation.line}`;
+function feedbackTargetLabel(item: ComposerAnnotationPayload): string {
+  if (isDiffAnnotationPayload(item)) {
+    return `${item.filePath}:${item.line}`;
   }
   return (
-    annotation.targetContext.label?.trim() ||
-    annotation.targetContext.selectorHint?.trim() ||
+    item.targetContext.label?.trim() ||
+    item.targetContext.selectorHint?.trim() ||
     "Element"
   );
 }
 
-function annotationDetail(annotation: ComposerAnnotationPayload): string {
-  const text = isDiffAnnotationPayload(annotation)
-    ? annotation.note.trim()
-    : annotation.note?.trim() || annotation.changeSummary?.trim() || "Visual annotation";
+function feedbackDetail(item: ComposerAnnotationPayload): string {
+  const text = isDiffAnnotationPayload(item)
+    ? item.note.trim()
+    : item.note?.trim() || item.changeSummary?.trim() || "Visual annotation";
   return text.length <= MAX_DETAIL_LENGTH
     ? text
     : `${text.slice(0, MAX_DETAIL_LENGTH - 3).trimEnd()}...`;
@@ -71,9 +71,9 @@ function AnnotationSnapshotThumbnail({ src }: { readonly src: string }) {
   );
 }
 
-/** Props for the compact annotation chip shown in composer and transcript surfaces. */
+/** Props for the compact feedback chip shown in composer and transcript surfaces. */
 export interface PreviewAnnotationBundleChipProps {
-  /** Saved Preview annotation payloads to summarize. */
+  /** Saved Preview annotations and code comments to summarize. */
   readonly bundle: PreviewAnnotationBundle;
   /** Thread that owns the persisted annotation screenshots. */
   readonly threadId?: string;
@@ -85,7 +85,7 @@ export interface PreviewAnnotationBundleChipProps {
   readonly testId?: string;
 }
 
-/** Renders a responsive annotation summary chip with hoverable per-annotation details. */
+/** Renders a responsive feedback summary with hoverable item details. */
 export function PreviewAnnotationBundleChip({
   bundle,
   threadId,
@@ -93,10 +93,10 @@ export function PreviewAnnotationBundleChip({
   className,
   testId = "preview-annotation-bundle-chip",
 }: PreviewAnnotationBundleChipProps) {
-  const count = bundle.annotations.length;
-  if (count === 0) return null;
+  if (bundle.annotations.length === 0) return null;
 
-  const label = annotationCountLabel(count);
+  const label = composerFeedbackLabel(bundle);
+  const accessibleLabel = composerFeedbackAccessibleLabel(bundle);
 
   return (
     <Tooltip>
@@ -105,7 +105,7 @@ export function PreviewAnnotationBundleChip({
           <div
             data-testid={testId}
             tabIndex={0}
-            aria-label={`${label}. Annotation details available.`}
+            aria-label={`${accessibleLabel}. Details available.`}
             className={cn(
               "group relative inline-flex max-w-full items-center gap-2 rounded-lg bg-accent px-2 py-1 text-xs font-medium text-accent-foreground ring-1 ring-inset ring-accent-foreground/10 transition-colors duration-150 hover:bg-accent/90 hover:ring-accent-foreground/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-foreground/25 motion-reduce:transition-none",
               className,
@@ -139,35 +139,40 @@ export function PreviewAnnotationBundleChip({
         arrowClassName="bg-popover fill-popover"
       >
         <div className="max-h-80 min-w-0 divide-y divide-border/45 overflow-y-auto">
-          {bundle.annotations.map((annotation) => {
-            const snapshotSrc = threadId && !isDiffAnnotationPayload(annotation)
+          {bundle.annotations.map((item) => {
+            const isComment = isDiffAnnotationPayload(item);
+            const snapshotSrc = threadId && !isComment
               ? buildStoredAttachmentImageSrc(
                   threadId,
-                  annotation.snapshot.id,
-                  annotation.snapshot.mimeType,
+                  item.snapshot.id,
+                  item.snapshot.mimeType,
                 )
               : null;
             return (
               <div
-                key={annotation.id}
+                key={item.id}
                 className="flex min-w-0 items-start gap-3 py-3 first:pt-0 last:pb-0"
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex min-w-0 items-center gap-2.5">
                     <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/80 text-xs font-semibold tabular-nums text-primary-foreground/90">
-                      {annotation.displayNumber}
+                      {item.displayNumber}
                     </span>
-                    {isDiffAnnotationPayload(annotation) ? (
+                    {isComment ? (
                       <FileCode2 size={14} className="shrink-0 text-muted-foreground" aria-hidden />
                     ) : (
                       <ImageIcon size={14} className="shrink-0 text-muted-foreground" aria-hidden />
                     )}
+                    <span className="shrink-0 text-xs font-medium text-popover-foreground">
+                      {isComment ? "Comment" : "Annotation"}
+                    </span>
+                    <span aria-hidden className="text-muted-foreground/45">·</span>
                     <span className="min-w-0 truncate font-mono text-[1.1rem] font-normal text-muted-foreground">
-                      {annotationTargetLabel(annotation)}
+                      {feedbackTargetLabel(item)}
                     </span>
                   </div>
                   <p className="mt-2 min-w-0 whitespace-pre-wrap break-words text-xs leading-5 text-popover-foreground">
-                    {annotationDetail(annotation)}
+                    {feedbackDetail(item)}
                   </p>
                 </div>
                 {snapshotSrc ? <AnnotationSnapshotThumbnail src={snapshotSrc} /> : null}

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -6,6 +6,7 @@ import { Composer } from "../Composer";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import {
   usePreviewAnnotationStore,
+  type SavedDiffAnnotation,
   type SavedPreviewAnnotation,
 } from "@/stores/previewAnnotationStore";
 import { usePreviewDesignModeStore } from "@/stores/previewDesignModeStore";
@@ -274,6 +275,20 @@ function makePreviewAnnotationBundle() {
   };
 }
 
+function makeSavedDiffAnnotation(): SavedDiffAnnotation {
+  return {
+    kind: "diff",
+    id: "550e8400-e29b-41d4-a716-446655440002",
+    displayNumber: 2,
+    filePath: "apps/web/src/components/chat/Composer.tsx",
+    side: "right",
+    line: 946,
+    lineContent: "const diffAnnotationRows = usePreviewAnnotationStore(...);",
+    note: "Keep this review target attached to the next prompt.",
+    createdAt: 1_783_036_800_001,
+  };
+}
+
 describe("Composer checkout confirmation", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -281,7 +296,7 @@ describe("Composer checkout confirmation", () => {
     lastComposerText = "";
     resetThreadStoreForTests({ runningThreadIds: new Set() });
     useQueueStore.setState({ queues: {}, toast: null, editingThreadId: null });
-    usePreviewAnnotationStore.setState({ byThread: {}, drafts: {} });
+    usePreviewAnnotationStore.setState({ byThread: {}, diffByThread: {}, drafts: {} });
     usePreviewDesignModeStore.setState({ modes: {} });
     useWorkspaceStore.setState({
       workspaces: [],
@@ -448,13 +463,16 @@ describe("Composer checkout confirmation", () => {
       byThread: {
         [thread.id]: [makeSavedAnnotation()],
       },
+      diffByThread: {
+        [thread.id]: [makeSavedDiffAnnotation()],
+      },
     });
     (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
     render(<Composer threadId={thread.id} workspaceId="ws-1" />);
 
     expect(screen.getByTestId("composer-annotation-bundle")).toHaveTextContent(
-      "1 annotation",
+      "2 annotations",
     );
     expect(screen.getByTestId("composer-annotation-bundle")).toHaveClass(
       "bg-accent",
@@ -463,7 +481,22 @@ describe("Composer checkout confirmation", () => {
     await userEvent.click(screen.getByLabelText("Send message"));
 
     await waitFor(() => expect(mockTransport.sendMessage).toHaveBeenCalled());
+    const sendCall = (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+    expect(sendCall?.[17]).toMatchObject({
+      schemaVersion: 1,
+      annotations: [
+        { id: "550e8400-e29b-41d4-a716-446655440001" },
+        {
+          kind: "diff",
+          id: "550e8400-e29b-41d4-a716-446655440002",
+          filePath: "apps/web/src/components/chat/Composer.tsx",
+          line: 946,
+          note: "Keep this review target attached to the next prompt.",
+        },
+      ],
+    });
     expect(usePreviewAnnotationStore.getState().byThread[thread.id] ?? []).toEqual([]);
+    expect(usePreviewAnnotationStore.getState().diffByThread[thread.id] ?? []).toEqual([]);
     expect(usePreviewDesignModeStore.getState().modes[thread.id]).toBe(false);
   });
 

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -444,7 +444,7 @@ describe("Composer checkout confirmation", () => {
     );
   });
 
-  it("clears annotations and exits design mode after a successful annotation send", async () => {
+  it("clears annotations and comments after a successful feedback send", async () => {
     const workspace = createMockWorkspace({ id: "ws-1", is_git_repo: true });
     const thread = createMockThread({ id: "thread-1", workspace_id: "ws-1" });
     useWorkspaceStore.setState({
@@ -472,7 +472,7 @@ describe("Composer checkout confirmation", () => {
     render(<Composer threadId={thread.id} workspaceId="ws-1" />);
 
     expect(screen.getByTestId("composer-annotation-bundle")).toHaveTextContent(
-      "2 annotations",
+      "1 annotation · 1 comment",
     );
     expect(screen.getByTestId("composer-annotation-bundle")).toHaveClass(
       "bg-accent",

--- a/apps/web/src/components/diff/DiffAnnotationEditor.tsx
+++ b/apps/web/src/components/diff/DiffAnnotationEditor.tsx
@@ -1,0 +1,108 @@
+import { MessageCircle } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  usePreviewAnnotationStore,
+  type DiffAnnotationInput,
+  type SavedDiffAnnotation,
+} from "@/stores/previewAnnotationStore";
+
+/** Props for the inline editor attached to a local diff line. */
+export interface DiffAnnotationEditorProps {
+  /** Thread that will receive the composer annotation. */
+  readonly threadId: string;
+  /** Line target and source context sent to the agent. */
+  readonly target: Omit<DiffAnnotationInput, "note">;
+  /** Existing annotation when the user is editing a saved line note. */
+  readonly annotation?: SavedDiffAnnotation;
+  /** Closes the inline editor and restores the diff row. */
+  readonly onClose: () => void;
+}
+
+/** Edits one Dev diff comment and adds it to the thread composer bundle. */
+export function DiffAnnotationEditor({
+  threadId,
+  target,
+  annotation,
+  onClose,
+}: DiffAnnotationEditorProps) {
+  const [note, setNote] = useState(annotation?.note ?? "");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const save = (): void => {
+    if (!note.trim()) return;
+    usePreviewAnnotationStore
+      .getState()
+      .saveDiffAnnotation(threadId, { ...target, note }, annotation?.id);
+    onClose();
+  };
+
+  return (
+    <section
+      aria-label={`Comment on ${target.filePath} line ${target.line}`}
+      className="mx-3 my-2 rounded-lg bg-muted/45 p-3 ring-1 ring-inset ring-border/60"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <MessageCircle size={14} className="shrink-0 text-muted-foreground" aria-hidden />
+        <span className="text-xs font-medium text-foreground">Diff comment</span>
+        <span className="ml-auto min-w-0 truncate font-mono text-[1.1rem] tabular-nums text-muted-foreground">
+          {target.filePath}:{target.line}
+        </span>
+      </div>
+      <Textarea
+        ref={textareaRef}
+        aria-label="Diff comment"
+        value={note}
+        maxLength={4_000}
+        placeholder="Request a change"
+        className="mt-2 min-h-20 resize-y bg-background/65 px-3 py-2 text-sm leading-5 shadow-none"
+        onChange={(event) => setNote(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onClose();
+            return;
+          }
+          if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+            event.preventDefault();
+            save();
+          }
+        }}
+      />
+      <div className="mt-2 flex items-center justify-end gap-1.5">
+        {annotation ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="mr-auto text-xs text-destructive"
+            onClick={() => {
+              usePreviewAnnotationStore.getState().deleteAnnotation(threadId, annotation.id);
+              onClose();
+            }}
+          >
+            Remove
+          </Button>
+        ) : null}
+        <Button type="button" variant="ghost" size="xs" className="text-xs" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="xs"
+          className="text-xs"
+          disabled={!note.trim()}
+          onClick={save}
+        >
+          Add to prompt
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/diff/DiffAnnotationEditor.tsx
+++ b/apps/web/src/components/diff/DiffAnnotationEditor.tsx
@@ -49,14 +49,14 @@ export function DiffAnnotationEditor({
     >
       <div className="flex min-w-0 items-center gap-2">
         <MessageCircle size={14} className="shrink-0 text-muted-foreground" aria-hidden />
-        <span className="text-xs font-medium text-foreground">Diff comment</span>
+        <span className="text-xs font-medium text-foreground">Code comment</span>
         <span className="ml-auto min-w-0 truncate font-mono text-[1.1rem] tabular-nums text-muted-foreground">
           {target.filePath}:{target.line}
         </span>
       </div>
       <Textarea
         ref={textareaRef}
-        aria-label="Diff comment"
+        aria-label="Code comment"
         value={note}
         maxLength={4_000}
         placeholder="Request a change"

--- a/apps/web/src/components/diff/DiffContent.tsx
+++ b/apps/web/src/components/diff/DiffContent.tsx
@@ -113,9 +113,17 @@ export function DiffContent() {
         <ScrollArea className="flex-1 min-h-0">
           {lines.length > 0 ? (
             renderMode === "unified" ? (
-              <UnifiedDiff lines={lines} language={language} />
+              <UnifiedDiff
+                lines={lines}
+                filePath={selectedFile.filePath}
+                language={language}
+              />
             ) : (
-              <SideBySideDiff lines={lines} language={language} />
+              <SideBySideDiff
+                lines={lines}
+                filePath={selectedFile.filePath}
+                language={language}
+              />
             )
           ) : (
             <div className="flex items-center justify-center py-10">

--- a/apps/web/src/components/diff/DiffPanel.tsx
+++ b/apps/web/src/components/diff/DiffPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore } from "@/stores/diffStore";
 import { getTransport } from "@/transport";
@@ -7,6 +7,16 @@ import { LastTurnView } from "./LastTurnView";
 import { CumulativeView } from "./CumulativeView";
 import { GitDiffView, type GitView } from "./GitDiffView";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useElementWidth } from "@/hooks/useElementWidth";
+import { WorktreeFilesPane } from "./WorktreeFilesPane";
+
+const FILES_PANEL_MIN_WIDTH = 280;
+const FILES_PANEL_DEFAULT_WIDTH = 320;
+const FILES_PANEL_WIDE_WIDTH = 480;
+const DIFF_VIEWPORT_MIN_WIDTH = 520;
+const DOCKED_FILES_MIN_WIDTH = FILES_PANEL_MIN_WIDTH + DIFF_VIEWPORT_MIN_WIDTH;
+const FLOATING_FILES_PANEL_EDGE_GAP = 48;
+const FLOATING_FILES_PANEL_FLOOR = 220;
 
 /** The threadless git working-tree view ids. */
 const GIT_VIEWS: readonly GitView[] = ["unstaged", "staged", "commit", "branch"];
@@ -23,6 +33,7 @@ function isGitView(mode: string): mode is GitView {
  * (Last turn, Cumulative). Each view renders exactly one diff.
  */
 export function DiffPanel() {
+  const panelRootRef = useRef<HTMLDivElement>(null);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const viewMode = useDiffStore((s) => s.viewMode);
@@ -48,6 +59,83 @@ export function DiffPanel() {
   );
   const setSnapshots = useDiffStore((s) => s.setSnapshots);
   const setSnapshotsLoading = useDiffStore((s) => s.setSnapshotsLoading);
+  const requestReviewFileJump = useDiffStore((s) => s.requestReviewFileJump);
+  const diffScopeId = activeThreadId ?? activeWorkspaceId;
+  const diffRevision = useDiffStore((s) =>
+    diffScopeId ? (s.diffRevisionByScope[diffScopeId] ?? 0) : 0,
+  );
+  const panelWidth = useElementWidth(panelRootRef, diffScopeId ?? undefined);
+  const filesDocked = panelWidth >= DOCKED_FILES_MIN_WIDTH;
+  const [filesVisibilityByScope, setFilesVisibilityByScope] = useState<
+    Record<string, boolean>
+  >({});
+  const filesVisible = diffScopeId
+    ? (filesVisibilityByScope[diffScopeId] ?? filesDocked)
+    : false;
+  const [filesPanelWidth, setFilesPanelWidth] = useState(FILES_PANEL_DEFAULT_WIDTH);
+  const [worktreeFiles, setWorktreeFiles] = useState<string[]>([]);
+  const [worktreeFilesLoading, setWorktreeFilesLoading] = useState(false);
+  const [worktreeFilesError, setWorktreeFilesError] = useState<string | null>(null);
+  const [activeWorktreePath, setActiveWorktreePath] = useState<string | null>(null);
+
+  const setFilesVisible = useCallback(
+    (visible: boolean) => {
+      if (!diffScopeId) return;
+      setFilesVisibilityByScope((current) => ({ ...current, [diffScopeId]: visible }));
+    },
+    [diffScopeId],
+  );
+
+  const getFilesPanelMaxWidth = useCallback(
+    (panel: HTMLDivElement | null): number =>
+      Math.max(
+        FILES_PANEL_MIN_WIDTH,
+        (panel?.parentElement?.clientWidth ?? window.innerWidth) - DIFF_VIEWPORT_MIN_WIDTH,
+      ),
+    [],
+  );
+  const floatingFilesPanelMaxWidth =
+    panelWidth > 0
+      ? Math.max(FLOATING_FILES_PANEL_FLOOR, panelWidth - FLOATING_FILES_PANEL_EDGE_GAP)
+      : FILES_PANEL_DEFAULT_WIDTH;
+  const floatingFilesPanelMinWidth = Math.min(
+    FILES_PANEL_MIN_WIDTH,
+    floatingFilesPanelMaxWidth,
+  );
+  const getFloatingFilesPanelMaxWidth = useCallback(
+    (panel: HTMLDivElement | null): number =>
+      Math.max(
+        floatingFilesPanelMinWidth,
+        (panel?.parentElement?.clientWidth ?? window.innerWidth) -
+          FLOATING_FILES_PANEL_EDGE_GAP,
+      ),
+    [floatingFilesPanelMinWidth],
+  );
+
+  useEffect(() => {
+    setActiveWorktreePath(null);
+    if (!filesVisible || !activeWorkspaceId) return;
+    let cancelled = false;
+    setWorktreeFilesLoading(true);
+    setWorktreeFilesError(null);
+    void getTransport()
+      .listWorkspaceFiles(activeWorkspaceId, activeThreadId ?? undefined)
+      .then((files) => {
+        if (!cancelled) setWorktreeFiles([...files].sort((a, b) => a.localeCompare(b)));
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setWorktreeFiles([]);
+          setWorktreeFilesError("Could not load worktree files.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setWorktreeFilesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeThreadId, activeWorkspaceId, diffRevision, filesVisible]);
 
   useEffect(() => {
     if (!activeThreadId) return;
@@ -96,10 +184,14 @@ export function DiffPanel() {
   }, [activeThreadId, snapshotsPending, panelVisible, panelState, viewMode, setSnapshots]);
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden min-h-0">
-      <DiffToolbar />
+    <div ref={panelRootRef} className="flex flex-1 flex-col overflow-hidden min-h-0">
+      <DiffToolbar
+        filesVisible={filesVisible}
+        onToggleFiles={() => setFilesVisible(!filesVisible)}
+      />
 
-      <ScrollArea className="flex-1 min-h-0">
+      <div className="relative flex min-h-0 flex-1">
+      <ScrollArea className="min-h-0 min-w-0 flex-1">
         {activeThreadId ? (
           // The git working-tree views are additive in a thread: they read the
           // thread's checkout (passed via threadId), alongside the turn views.
@@ -117,6 +209,48 @@ export function DiffPanel() {
           <GitDiffView view={viewMode} workspaceId={activeWorkspaceId} />
         ) : null}
       </ScrollArea>
+      {filesDocked && filesVisible ? (
+        <WorktreeFilesPane
+          files={worktreeFiles}
+          activePath={activeWorktreePath}
+          loading={worktreeFilesLoading}
+          error={worktreeFilesError}
+          width={filesPanelWidth}
+          minWidth={FILES_PANEL_MIN_WIDTH}
+          maxWidth={`calc(100% - ${DIFF_VIEWPORT_MIN_WIDTH}px)`}
+          defaultWidth={FILES_PANEL_DEFAULT_WIDTH}
+          wideWidth={FILES_PANEL_WIDE_WIDTH}
+          getMaxWidth={getFilesPanelMaxWidth}
+          onWidthChange={setFilesPanelWidth}
+          onClose={() => setFilesVisible(false)}
+          onActivate={(path) => {
+            setActiveWorktreePath(path);
+            if (diffScopeId) requestReviewFileJump(diffScopeId, path);
+          }}
+        />
+      ) : null}
+      {!filesDocked && filesVisible ? (
+        <WorktreeFilesPane
+          files={worktreeFiles}
+          activePath={activeWorktreePath}
+          loading={worktreeFilesLoading}
+          error={worktreeFilesError}
+          width={Math.min(filesPanelWidth, floatingFilesPanelMaxWidth)}
+          minWidth={floatingFilesPanelMinWidth}
+          maxWidth={`calc(100% - ${FLOATING_FILES_PANEL_EDGE_GAP}px)`}
+          defaultWidth={FILES_PANEL_DEFAULT_WIDTH}
+          wideWidth={FILES_PANEL_WIDE_WIDTH}
+          getMaxWidth={getFloatingFilesPanelMaxWidth}
+          onWidthChange={setFilesPanelWidth}
+          className="absolute inset-y-0 right-0 z-30 h-full bg-popover ring-1 ring-inset ring-border/60 animate-in slide-in-from-right-2 duration-150 motion-reduce:animate-none"
+          onClose={() => setFilesVisible(false)}
+          onActivate={(path) => {
+            setActiveWorktreePath(path);
+            if (diffScopeId) requestReviewFileJump(diffScopeId, path);
+          }}
+        />
+      ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/diff/DiffToolbar.tsx
+++ b/apps/web/src/components/diff/DiffToolbar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, Files } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -8,6 +8,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { Spinner } from "@/components/ui/spinner";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { getTransport } from "@/transport";
@@ -20,8 +22,16 @@ import { DiffStat } from "./DiffStat";
 
 type CommitAvailability = "loading" | "available" | "empty";
 
+/** Props for the Dev Review toolbar. */
+export interface DiffToolbarProps {
+  /** Whether the full-worktree file navigator is visible. */
+  readonly filesVisible: boolean;
+  /** Toggles the full-worktree file navigator. */
+  readonly onToggleFiles: () => void;
+}
+
 /** Toolbar for the Review tab: dual-scope view switcher + unified/side-by-side toggle. */
-export function DiffToolbar() {
+export function DiffToolbar({ filesVisible, onToggleFiles }: DiffToolbarProps) {
   const viewMode = useDiffStore((s) => s.viewMode);
   const reviewFileCount = useDiffStore((s) => s.reviewFileCount);
   const reviewDiffStat = useDiffStore((s) => s.reviewDiffStat);
@@ -243,6 +253,29 @@ export function DiffToolbar() {
       {/* Commit-or-push + Create-PR (worktree threads only). Wrap / split / jump
           now live on the file-list bar below. */}
       <div className="flex items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={filesVisible ? "Hide worktree files" : "Show worktree files"}
+                aria-pressed={filesVisible}
+                className={cn(
+                  "rounded-md text-muted-foreground",
+                  filesVisible && "bg-muted/60 text-foreground",
+                )}
+                onClick={onToggleFiles}
+              >
+                <Files size={13} aria-hidden />
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom" className="text-xs">
+            {filesVisible ? "Hide worktree files" : "Show worktree files"}
+          </TooltipContent>
+        </Tooltip>
         {activeThread && <ReviewActions thread={activeThread} />}
       </div>
 

--- a/apps/web/src/components/diff/FileEntry.tsx
+++ b/apps/web/src/components/diff/FileEntry.tsx
@@ -412,12 +412,14 @@ export const FileEntry = memo(function FileEntry({
               {renderMode === "unified" ? (
                 <UnifiedDiff
                   lines={visibleLines}
+                  filePath={filePath}
                   language={language}
                   skipLeadingHunkSeparator={leadingHiddenLines > 0}
                 />
               ) : (
                 <SideBySideDiff
                   lines={visibleLines}
+                  filePath={filePath}
                   language={language}
                   skipLeadingHunkSeparator={leadingHiddenLines > 0}
                 />

--- a/apps/web/src/components/diff/FileList.tsx
+++ b/apps/web/src/components/diff/FileList.tsx
@@ -74,6 +74,7 @@ export function FileList({
   const [jumpTarget, setJumpTarget] = useState<{ path: string; token: number } | null>(null);
   const [highlightTarget, setHighlightTarget] = useState<{ path: string; token: number } | null>(null);
   const jumpTokenRef = useRef(0);
+  const handledExternalJumpNonceRef = useRef<number | null>(null);
   const highlightClearRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sortedFiles = useMemo(
     () => [...files].sort((a, b) => a.localeCompare(b)),
@@ -100,6 +101,7 @@ export function FileList({
   const setSnapshots = useDiffStore((s) => s.setSnapshots);
   const setBulkDiffExpand = useDiffStore((s) => s.setBulkDiffExpand);
   const bulkDiffExpand = useDiffStore((s) => s.bulkDiffExpand);
+  const reviewFileJumpRequest = useDiffStore((s) => s.reviewFileJumpRequest);
   // The expand/collapse toggle reflects the last bulk action, falling back to
   // the view's default expand state when none has run yet.
   const allExpanded = bulkDiffExpand?.expand ?? defaultFilesExpanded;
@@ -190,6 +192,14 @@ export function FileList({
   const clearJumpTarget = useCallback((token: number) => {
     setJumpTarget((current) => (current?.token === token ? null : current));
   }, []);
+
+  useEffect(() => {
+    if (!reviewFileJumpRequest || reviewFileJumpRequest.scopeId !== threadId) return;
+    if (handledExternalJumpNonceRef.current === reviewFileJumpRequest.nonce) return;
+    if (!sortedFiles.includes(reviewFileJumpRequest.path)) return;
+    handledExternalJumpNonceRef.current = reviewFileJumpRequest.nonce;
+    jumpToFile(reviewFileJumpRequest.path);
+  }, [jumpToFile, reviewFileJumpRequest, sortedFiles, threadId]);
 
   if (files.length === 0) {
     return (

--- a/apps/web/src/components/diff/SideBySideDiff.tsx
+++ b/apps/web/src/components/diff/SideBySideDiff.tsx
@@ -20,7 +20,7 @@ const EMPTY_DIFF_ANNOTATIONS: readonly SavedDiffAnnotation[] = [];
 /** Props for SideBySideDiff. */
 interface SideBySideDiffProps {
   lines: ParsedDiffLine[];
-  /** Workspace-relative file path used by Dev diff annotations. */
+  /** Workspace-relative file path used by Dev diff comments. */
   filePath?: string;
   /** File language for syntax highlighting (e.g. "typescript"). "text" disables highlighting. */
   language?: string;

--- a/apps/web/src/components/diff/SideBySideDiff.tsx
+++ b/apps/web/src/components/diff/SideBySideDiff.tsx
@@ -1,15 +1,27 @@
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState } from "react";
+import { Plus } from "lucide-react";
 import type { ParsedDiffLine } from "@/lib/diff-parser";
 import { getFirstHunkHeaderIndex } from "@/lib/diff-parser";
 import { useDiffHighlighter } from "@/hooks/useDiffHighlighter";
 import { useShikiTheme } from "@/hooks/useTheme";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import {
+  usePreviewAnnotationStore,
+  type SavedDiffAnnotation,
+} from "@/stores/previewAnnotationStore";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { HunkSeparator } from "./HunkSeparator";
+import { DiffAnnotationEditor } from "./DiffAnnotationEditor";
+
+const EMPTY_DIFF_ANNOTATIONS: readonly SavedDiffAnnotation[] = [];
 
 /** Props for SideBySideDiff. */
 interface SideBySideDiffProps {
   lines: ParsedDiffLine[];
+  /** Workspace-relative file path used by Dev diff annotations. */
+  filePath?: string;
   /** File language for syntax highlighting (e.g. "typescript"). "text" disables highlighting. */
   language?: string;
   /** When true, the first hunk's hidden-line band is omitted (shown on the file header instead). */
@@ -100,29 +112,31 @@ const RIGHT_BG: Record<string, string> = {
   empty: "bg-muted/[0.04]",
 };
 
-const LEFT_GUTTER: Record<string, string> = {
-  remove: "bg-[var(--diff-remove-gutter)]",
-  context: "bg-transparent",
-  header: "bg-transparent",
-  empty: "bg-transparent",
-};
-
-const RIGHT_GUTTER: Record<string, string> = {
-  add: "bg-[var(--diff-add-gutter)]",
-  context: "bg-transparent",
-  header: "bg-transparent",
-  empty: "bg-transparent",
-};
-
 /** Side-by-side diff renderer with syntax highlighting and hunk separator bars. */
 export const SideBySideDiff = memo(function SideBySideDiff({
   lines,
+  filePath,
   language = "text",
   skipLeadingHunkSeparator = false,
 }: SideBySideDiffProps) {
   const rows = useMemo(() => buildRows(lines), [lines]);
   const theme = useShikiTheme();
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const annotations = usePreviewAnnotationStore((s) =>
+    activeThreadId
+      ? (s.diffByThread[activeThreadId] ?? EMPTY_DIFF_ANNOTATIONS)
+      : EMPTY_DIFF_ANNOTATIONS,
+  );
+  const annotationsByTarget = useMemo(
+    () =>
+      new Map(
+        annotations
+          .filter((annotation) => annotation.filePath === filePath)
+          .map((annotation) => [`${annotation.side}:${annotation.line}`, annotation]),
+      ),
+    [annotations, filePath],
+  );
+  const [editingTarget, setEditingTarget] = useState<string | null>(null);
   const lineWrap = useDiffStore((s) =>
     activeThreadId ? s.getLineWrap(activeThreadId) : true,
   );
@@ -148,14 +162,33 @@ export const SideBySideDiff = memo(function SideBySideDiff({
           }
 
           const tokens = row.left.diffIndex !== null ? getLineTokens(row.left.diffIndex) : null;
+          const targetKey = row.left.lineNo === null ? null : `left:${row.left.lineNo}`;
+          const annotation = targetKey ? annotationsByTarget.get(targetKey) : undefined;
+          const editing = targetKey !== null && editingTarget === targetKey;
 
           return (
-            <div key={i} className={`flex items-stretch ${LEFT_BG[row.left.type]}`}>
-              <span className="inline-flex w-10 shrink-0 select-none items-center justify-end pr-2.5 text-[10px] tabular-nums text-muted-foreground">
-                {row.left.lineNo ?? ""}
+            <div key={i}>
+            <div className={cn("group/diff-line relative flex min-h-7 items-stretch", LEFT_BG[row.left.type], editing && "ring-1 ring-inset ring-primary/70")}>
+              {activeThreadId && filePath && row.left.lineNo !== null && row.left.type !== "empty" ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={`${annotation ? "Edit" : "Add"} comment on line ${row.left.lineNo}`}
+                  className={cn(
+                    "pointer-events-none absolute left-0.5 top-0.5 z-10 size-6 rounded-md bg-foreground text-background opacity-0 shadow-none transition-opacity duration-100 hover:bg-foreground hover:text-background group-hover/diff-line:pointer-events-auto group-hover/diff-line:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 motion-reduce:transition-none",
+                    (annotation || editing) && "pointer-events-auto opacity-100",
+                  )}
+                  onClick={() => setEditingTarget(editing ? null : targetKey)}
+                >
+                  {annotation ? <span className="font-mono text-[1rem] font-semibold tabular-nums">{annotation.displayNumber}</span> : <Plus size={16} strokeWidth={2.5} aria-hidden />}
+                </Button>
+              ) : null}
+              <span aria-hidden className="inline-grid w-10 shrink-0 select-none grid-cols-[0.75rem_1fr] items-center bg-page/35 pr-1.5 text-[1rem] tabular-nums text-muted-foreground/70">
+                <span className="text-center">{row.left.type === "remove" ? "−" : ""}</span>
+                <span className="text-right">{row.left.lineNo ?? ""}</span>
               </span>
-              <span className={`w-[2px] shrink-0 ${LEFT_GUTTER[row.left.type]}`} aria-hidden="true" />
-              <span className={`flex-1 pl-3 pr-2 ${lineWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}>
+              <span className={`flex-1 px-2 py-1 leading-5 ${lineWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}>
                 {row.left.type === "remove" && <span className="sr-only">Removed: </span>}
                 {tokens ? (
                   tokens.map((token, j) => (
@@ -178,6 +211,15 @@ export const SideBySideDiff = memo(function SideBySideDiff({
                 )}
               </span>
             </div>
+            {editing && activeThreadId && filePath && row.left.lineNo !== null ? (
+              <DiffAnnotationEditor
+                threadId={activeThreadId}
+                annotation={annotation}
+                target={{ filePath, side: "left", line: row.left.lineNo, lineContent: row.left.content }}
+                onClose={() => setEditingTarget(null)}
+              />
+            ) : null}
+            </div>
           );
         })}
         </div>
@@ -194,14 +236,33 @@ export const SideBySideDiff = memo(function SideBySideDiff({
           }
 
           const tokens = row.right.diffIndex !== null ? getLineTokens(row.right.diffIndex) : null;
+          const targetKey = row.right.lineNo === null ? null : `right:${row.right.lineNo}`;
+          const annotation = targetKey ? annotationsByTarget.get(targetKey) : undefined;
+          const editing = targetKey !== null && editingTarget === targetKey;
 
           return (
-            <div key={i} className={`flex items-stretch ${RIGHT_BG[row.right.type]}`}>
-              <span className="inline-flex w-10 shrink-0 select-none items-center justify-end pr-2.5 text-[10px] tabular-nums text-muted-foreground">
-                {row.right.lineNo ?? ""}
+            <div key={i}>
+            <div className={cn("group/diff-line relative flex min-h-7 items-stretch", RIGHT_BG[row.right.type], editing && "ring-1 ring-inset ring-primary/70")}>
+              {activeThreadId && filePath && row.right.lineNo !== null && row.right.type !== "empty" ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={`${annotation ? "Edit" : "Add"} comment on line ${row.right.lineNo}`}
+                  className={cn(
+                    "pointer-events-none absolute left-0.5 top-0.5 z-10 size-6 rounded-md bg-foreground text-background opacity-0 shadow-none transition-opacity duration-100 hover:bg-foreground hover:text-background group-hover/diff-line:pointer-events-auto group-hover/diff-line:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 motion-reduce:transition-none",
+                    (annotation || editing) && "pointer-events-auto opacity-100",
+                  )}
+                  onClick={() => setEditingTarget(editing ? null : targetKey)}
+                >
+                  {annotation ? <span className="font-mono text-[1rem] font-semibold tabular-nums">{annotation.displayNumber}</span> : <Plus size={16} strokeWidth={2.5} aria-hidden />}
+                </Button>
+              ) : null}
+              <span aria-hidden className="inline-grid w-10 shrink-0 select-none grid-cols-[0.75rem_1fr] items-center bg-page/35 pr-1.5 text-[1rem] tabular-nums text-muted-foreground/70">
+                <span className="text-center">{row.right.type === "add" ? "+" : ""}</span>
+                <span className="text-right">{row.right.lineNo ?? ""}</span>
               </span>
-              <span className={`w-[2px] shrink-0 ${RIGHT_GUTTER[row.right.type]}`} aria-hidden="true" />
-              <span className={`flex-1 pl-3 pr-2 ${lineWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}>
+              <span className={`flex-1 px-2 py-1 leading-5 ${lineWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}>
                 {row.right.type === "add" && <span className="sr-only">Added: </span>}
                 {tokens ? (
                   tokens.map((token, j) => (
@@ -223,6 +284,15 @@ export const SideBySideDiff = memo(function SideBySideDiff({
                   </span>
                 )}
               </span>
+            </div>
+            {editing && activeThreadId && filePath && row.right.lineNo !== null ? (
+              <DiffAnnotationEditor
+                threadId={activeThreadId}
+                annotation={annotation}
+                target={{ filePath, side: "right", line: row.right.lineNo, lineContent: row.right.content }}
+                onClose={() => setEditingTarget(null)}
+              />
+            ) : null}
             </div>
           );
         })}

--- a/apps/web/src/components/diff/SideBySideDiff.tsx
+++ b/apps/web/src/components/diff/SideBySideDiff.tsx
@@ -176,7 +176,7 @@ export const SideBySideDiff = memo(function SideBySideDiff({
                   size="icon-xs"
                   aria-label={`${annotation ? "Edit" : "Add"} comment on line ${row.left.lineNo}`}
                   className={cn(
-                    "pointer-events-none absolute left-0.5 top-0.5 z-10 size-6 rounded-md bg-foreground text-background opacity-0 shadow-none transition-opacity duration-100 hover:bg-foreground hover:text-background group-hover/diff-line:pointer-events-auto group-hover/diff-line:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 motion-reduce:transition-none",
+                    "pointer-events-none absolute left-0.5 top-0.5 z-10 size-6 rounded-md bg-foreground text-background opacity-0 shadow-none transition-opacity duration-100 hover:bg-foreground hover:text-background group-hover/diff-line:pointer-events-auto group-hover/diff-line:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 dark:hover:bg-foreground dark:hover:text-background motion-reduce:transition-none",
                     (annotation || editing) && "pointer-events-auto opacity-100",
                   )}
                   onClick={() => setEditingTarget(editing ? null : targetKey)}
@@ -250,7 +250,7 @@ export const SideBySideDiff = memo(function SideBySideDiff({
                   size="icon-xs"
                   aria-label={`${annotation ? "Edit" : "Add"} comment on line ${row.right.lineNo}`}
                   className={cn(
-                    "pointer-events-none absolute left-0.5 top-0.5 z-10 size-6 rounded-md bg-foreground text-background opacity-0 shadow-none transition-opacity duration-100 hover:bg-foreground hover:text-background group-hover/diff-line:pointer-events-auto group-hover/diff-line:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 motion-reduce:transition-none",
+                    "pointer-events-none absolute left-0.5 top-0.5 z-10 size-6 rounded-md bg-foreground text-background opacity-0 shadow-none transition-opacity duration-100 hover:bg-foreground hover:text-background group-hover/diff-line:pointer-events-auto group-hover/diff-line:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 dark:hover:bg-foreground dark:hover:text-background motion-reduce:transition-none",
                     (annotation || editing) && "pointer-events-auto opacity-100",
                   )}
                   onClick={() => setEditingTarget(editing ? null : targetKey)}

--- a/apps/web/src/components/diff/UnifiedDiff.tsx
+++ b/apps/web/src/components/diff/UnifiedDiff.tsx
@@ -1,15 +1,27 @@
-import { memo } from "react";
+import { memo, useMemo, useState } from "react";
+import { Plus } from "lucide-react";
 import type { ParsedDiffLine } from "@/lib/diff-parser";
 import { getFirstHunkHeaderIndex } from "@/lib/diff-parser";
 import { useDiffHighlighter } from "@/hooks/useDiffHighlighter";
 import { useShikiTheme } from "@/hooks/useTheme";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import {
+  usePreviewAnnotationStore,
+  type SavedDiffAnnotation,
+} from "@/stores/previewAnnotationStore";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { HunkSeparator } from "./HunkSeparator";
+import { DiffAnnotationEditor } from "./DiffAnnotationEditor";
+
+const EMPTY_DIFF_ANNOTATIONS: readonly SavedDiffAnnotation[] = [];
 
 /** Props for UnifiedDiff. */
 interface UnifiedDiffProps {
   lines: ParsedDiffLine[];
+  /** Workspace-relative file path used by Dev diff annotations. */
+  filePath?: string;
   /** File language for syntax highlighting (e.g. "typescript"). "text" disables highlighting. */
   language?: string;
   /** When true, the first hunk's hidden-line band is omitted (shown on the file header instead). */
@@ -23,11 +35,30 @@ interface UnifiedDiffProps {
  */
 export const UnifiedDiff = memo(function UnifiedDiff({
   lines,
+  filePath,
   language = "text",
   skipLeadingHunkSeparator = false,
 }: UnifiedDiffProps) {
   const theme = useShikiTheme();
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const annotations = usePreviewAnnotationStore((s) =>
+    activeThreadId
+      ? (s.diffByThread[activeThreadId] ?? EMPTY_DIFF_ANNOTATIONS)
+      : EMPTY_DIFF_ANNOTATIONS,
+  );
+  const annotationsByTarget = useMemo(
+    () =>
+      new Map(
+        annotations
+          .filter((annotation) => annotation.filePath === filePath)
+          .map((annotation) => [
+            `${annotation.side}:${annotation.line}`,
+            annotation,
+          ]),
+      ),
+    [annotations, filePath],
+  );
+  const [editingTarget, setEditingTarget] = useState<string | null>(null);
   const lineWrap = useDiffStore((s) =>
     activeThreadId ? s.getLineWrap(activeThreadId) : true,
   );
@@ -55,47 +86,89 @@ export const UnifiedDiff = memo(function UnifiedDiff({
             ? "bg-[var(--diff-remove-bg)] hover:bg-[var(--diff-remove-bg-hover)]"
             : "hover:bg-muted/[0.06]";
 
-        // Gutter accent: a 2px tinted strip between line numbers and content.
-        // This replaces the +/- character column — same signal, less noise.
-        const gutterAccent = isAdd
-          ? "bg-[var(--diff-add-gutter)]"
-          : isRemove
-            ? "bg-[var(--diff-remove-gutter)]"
-            : "bg-transparent";
+        const side = isRemove ? "left" : "right";
+        const lineNumber = isRemove ? line.oldLineNo : (line.newLineNo ?? line.oldLineNo);
+        const targetKey = lineNumber === null ? null : `${side}:${lineNumber}`;
+        const annotation = targetKey ? annotationsByTarget.get(targetKey) : undefined;
+        const editing = targetKey !== null && editingTarget === targetKey;
+        const changeMarker = isAdd ? "+" : isRemove ? "−" : "";
 
         return (
-          <div key={i} className={`flex items-stretch ${rowBg}`}>
-            <span className="inline-flex w-10 shrink-0 select-none items-center justify-end pr-2.5 text-[10px] tabular-nums text-muted-foreground">
-              {line.oldLineNo ?? ""}
-            </span>
-            <span className="inline-flex w-10 shrink-0 select-none items-center justify-end pr-2.5 text-[10px] tabular-nums text-muted-foreground">
-              {line.newLineNo ?? ""}
-            </span>
-            <span className={`w-[2px] shrink-0 ${gutterAccent}`} aria-hidden="true" />
-            <span className={`flex-1 pl-3 pr-2 ${lineWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}>
-              {(isAdd || isRemove) && (
-                <span className="sr-only">{isAdd ? "Added: " : "Removed: "}</span>
+          <div key={i}>
+            <div
+              className={cn(
+                "group/diff-line relative flex min-h-7 items-stretch outline-none",
+                rowBg,
+                editing && "ring-1 ring-inset ring-primary/70",
               )}
-              {tokens ? (
-                tokens.map((token, j) => (
-                  <span key={j} style={{ color: token.color }}>
-                    {token.content}
-                  </span>
-                ))
-              ) : (
-                <span
-                  className={
-                    isAdd
-                      ? "text-[var(--diff-add-text)]"
-                      : isRemove
-                        ? "text-[var(--diff-remove-text)]"
-                        : "text-foreground/65"
-                  }
+            >
+              {activeThreadId && filePath && lineNumber !== null ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={`${annotation ? "Edit" : "Add"} comment on line ${lineNumber}`}
+                  className={cn(
+                    "pointer-events-none absolute left-0.5 top-0.5 z-10 size-6 rounded-md bg-foreground text-background opacity-0 shadow-none transition-opacity duration-100 hover:bg-foreground hover:text-background group-hover/diff-line:pointer-events-auto group-hover/diff-line:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 motion-reduce:transition-none",
+                    (annotation || editing) && "pointer-events-auto opacity-100",
+                  )}
+                  onClick={() => setEditingTarget(editing ? null : targetKey)}
                 >
-                  {line.content}
-                </span>
-              )}
-            </span>
+                  {annotation ? (
+                    <span className="font-mono text-[1rem] font-semibold tabular-nums">
+                      {annotation.displayNumber}
+                    </span>
+                  ) : (
+                    <Plus size={16} strokeWidth={2.5} aria-hidden />
+                  )}
+                </Button>
+              ) : null}
+              <span
+                aria-hidden
+                data-testid="dev-diff-gutter"
+                className="inline-grid w-10 shrink-0 select-none grid-cols-[0.75rem_1fr] items-center bg-page/35 pr-1.5 text-[1rem] tabular-nums text-muted-foreground/70"
+              >
+                <span className="text-center text-current">{changeMarker}</span>
+                <span className="text-right">{lineNumber ?? ""}</span>
+              </span>
+              <span className={`flex-1 px-2 py-1 leading-5 ${lineWrap ? "whitespace-pre-wrap break-words" : "whitespace-pre"}`}>
+                {(isAdd || isRemove) && (
+                  <span className="sr-only">{isAdd ? "Added: " : "Removed: "}</span>
+                )}
+                {tokens ? (
+                  tokens.map((token, j) => (
+                    <span key={j} style={{ color: token.color }}>
+                      {token.content}
+                    </span>
+                  ))
+                ) : (
+                  <span
+                    className={
+                      isAdd
+                        ? "text-[var(--diff-add-text)]"
+                        : isRemove
+                          ? "text-[var(--diff-remove-text)]"
+                          : "text-foreground/65"
+                    }
+                  >
+                    {line.content}
+                  </span>
+                )}
+              </span>
+            </div>
+            {editing && activeThreadId && filePath && lineNumber !== null ? (
+              <DiffAnnotationEditor
+                threadId={activeThreadId}
+                annotation={annotation}
+                target={{
+                  filePath,
+                  side,
+                  line: lineNumber,
+                  lineContent: line.content,
+                }}
+                onClose={() => setEditingTarget(null)}
+              />
+            ) : null}
           </div>
         );
       })}

--- a/apps/web/src/components/diff/UnifiedDiff.tsx
+++ b/apps/web/src/components/diff/UnifiedDiff.tsx
@@ -20,7 +20,7 @@ const EMPTY_DIFF_ANNOTATIONS: readonly SavedDiffAnnotation[] = [];
 /** Props for UnifiedDiff. */
 interface UnifiedDiffProps {
   lines: ParsedDiffLine[];
-  /** Workspace-relative file path used by Dev diff annotations. */
+  /** Workspace-relative file path used by Dev diff comments. */
   filePath?: string;
   /** File language for syntax highlighting (e.g. "typescript"). "text" disables highlighting. */
   language?: string;

--- a/apps/web/src/components/diff/UnifiedDiff.tsx
+++ b/apps/web/src/components/diff/UnifiedDiff.tsx
@@ -109,7 +109,7 @@ export const UnifiedDiff = memo(function UnifiedDiff({
                   size="icon-xs"
                   aria-label={`${annotation ? "Edit" : "Add"} comment on line ${lineNumber}`}
                   className={cn(
-                    "pointer-events-none absolute left-0.5 top-0.5 z-10 size-6 rounded-md bg-foreground text-background opacity-0 shadow-none transition-opacity duration-100 hover:bg-foreground hover:text-background group-hover/diff-line:pointer-events-auto group-hover/diff-line:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 motion-reduce:transition-none",
+                    "pointer-events-none absolute left-0.5 top-0.5 z-10 size-6 rounded-md bg-foreground text-background opacity-0 shadow-none transition-opacity duration-100 hover:bg-foreground hover:text-background group-hover/diff-line:pointer-events-auto group-hover/diff-line:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 dark:hover:bg-foreground dark:hover:text-background motion-reduce:transition-none",
                     (annotation || editing) && "pointer-events-auto opacity-100",
                   )}
                   onClick={() => setEditingTarget(editing ? null : targetKey)}

--- a/apps/web/src/components/diff/WorktreeFilesPane.tsx
+++ b/apps/web/src/components/diff/WorktreeFilesPane.tsx
@@ -1,0 +1,119 @@
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import { FilesPanel, type FilesPanelProps } from "@/components/files/FilesPanel";
+import { PullRequestFileTree } from "@/components/pull-requests/PullRequestFileTree";
+import { Input } from "@/components/ui/input";
+
+/** Props for the full-worktree file navigator shown beside a Dev diff. */
+export interface WorktreeFilesPaneProps {
+  readonly files: readonly string[];
+  readonly activePath: string | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly className?: string;
+  readonly onActivate: (path: string) => void;
+  readonly onClose: () => void;
+  readonly width: number;
+  readonly minWidth: number;
+  readonly maxWidth: number | string;
+  readonly defaultWidth: number;
+  readonly wideWidth: number;
+  readonly getMaxWidth: NonNullable<FilesPanelProps["getMaxWidth"]>;
+  readonly onWidthChange: NonNullable<FilesPanelProps["onWidthChange"]>;
+}
+
+/** Renders the active thread's complete tracked and untracked worktree file tree. */
+export function WorktreeFilesPane({
+  files,
+  activePath,
+  loading,
+  error,
+  className,
+  onActivate,
+  onClose,
+  width,
+  minWidth,
+  maxWidth,
+  defaultWidth,
+  wideWidth,
+  getMaxWidth,
+  onWidthChange,
+}: WorktreeFilesPaneProps) {
+  const [search, setSearch] = useState("");
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  const filteredFiles = useMemo(
+    () =>
+      normalizedSearch
+        ? files.filter((file) => file.toLocaleLowerCase().includes(normalizedSearch))
+        : files,
+    [files, normalizedSearch],
+  );
+
+  return (
+    <FilesPanel
+      title="Worktree files"
+      count={files.length}
+      ariaLabel="Worktree files"
+      testId="dev-worktree-files-pane"
+      className={className}
+      onClose={onClose}
+      width={width}
+      minWidth={minWidth}
+      maxWidth={maxWidth}
+      defaultWidth={defaultWidth}
+      wideWidth={wideWidth}
+      getMaxWidth={getMaxWidth}
+      onWidthChange={onWidthChange}
+      controls={
+        <div className="flex h-11 shrink-0 items-center border-b border-border/35 px-2.5">
+          <div className="relative min-w-0 flex-1">
+            <Search
+              size={13}
+              aria-hidden
+              className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground/70"
+            />
+            <Input
+              size="sm"
+              value={search}
+              maxLength={200}
+              aria-label="Search worktree files"
+              placeholder="Filter files"
+              className="h-8 rounded-md bg-background/70 pl-7 font-mono text-xs"
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </div>
+        </div>
+      }
+    >
+      {loading ? (
+        <div className="flex flex-1 items-center justify-center" role="status">
+          <span className="font-mono text-[1.05rem] uppercase tracking-[0.18em] text-muted-foreground/50">
+            Loading files
+          </span>
+        </div>
+      ) : error ? (
+        <p role="alert" className="px-3 py-4 text-xs text-destructive">
+          {error}
+        </p>
+      ) : filteredFiles.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 text-center">
+          <span aria-hidden className="font-mono text-2xl text-muted-foreground/15">
+            ⊘
+          </span>
+          <p className="font-mono text-[1.05rem] uppercase tracking-[0.18em] text-muted-foreground/40">
+            {files.length === 0 ? "No worktree files" : "No matching files"}
+          </p>
+        </div>
+      ) : (
+        <PullRequestFileTree
+          filePaths={filteredFiles}
+          activePath={activePath}
+          searchActive={normalizedSearch.length > 0}
+          className="min-h-0 flex-1"
+          ariaLabel="Worktree files"
+          onActivate={onActivate}
+        />
+      )}
+    </FilesPanel>
+  );
+}

--- a/apps/web/src/components/diff/__tests__/DiffPanel.files.test.tsx
+++ b/apps/web/src/components/diff/__tests__/DiffPanel.files.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDiffStore } from "@/stores/diffStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { DiffPanel } from "../DiffPanel";
+
+let measuredWidth = 900;
+const transport = vi.hoisted(() => ({
+  listWorkspaceFiles: vi.fn().mockResolvedValue(["src/App.tsx", "README.md"]),
+  listSnapshots: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/hooks/useElementWidth", () => ({
+  useElementWidth: () => measuredWidth,
+}));
+
+vi.mock("@/transport", () => ({
+  getTransport: () => transport,
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../DiffToolbar", () => ({
+  DiffToolbar: ({
+    filesVisible,
+    onToggleFiles,
+  }: {
+    filesVisible: boolean;
+    onToggleFiles: () => void;
+  }) => (
+    <button type="button" aria-pressed={filesVisible} onClick={onToggleFiles}>
+      Files
+    </button>
+  ),
+}));
+
+vi.mock("../WorktreeFilesPane", () => ({
+  WorktreeFilesPane: ({ files }: { files: readonly string[] }) => (
+    <aside data-testid="worktree-files">{files.join(",")}</aside>
+  ),
+}));
+
+vi.mock("../LastTurnView", () => ({ LastTurnView: () => <div>Last turn</div> }));
+vi.mock("../CumulativeView", () => ({ CumulativeView: () => <div>Cumulative</div> }));
+vi.mock("../GitDiffView", () => ({ GitDiffView: () => <div>Git diff</div> }));
+
+describe("DiffPanel worktree files", () => {
+  beforeEach(() => {
+    measuredWidth = 900;
+    vi.clearAllMocks();
+    useWorkspaceStore.setState({
+      activeThreadId: "thread-1",
+      activeWorkspaceId: "workspace-1",
+    });
+    useDiffStore.setState({
+      viewMode: "last-turn",
+      snapshotsByThread: { "thread-1": [] },
+      snapshotsLoadingByThread: {},
+      snapshotsPendingByThread: {},
+      diffRevisionByScope: {},
+    });
+  });
+
+  it("opens the full worktree navigator by default when the diff has docked room", async () => {
+    render(<DiffPanel />);
+
+    await waitFor(() =>
+      expect(transport.listWorkspaceFiles).toHaveBeenCalledWith(
+        "workspace-1",
+        "thread-1",
+      ),
+    );
+    expect(screen.getByTestId("worktree-files")).toHaveTextContent(
+      "README.md,src/App.tsx",
+    );
+    expect(screen.getByRole("button", { name: "Files" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("starts closed in a compact diff and opens from the same toggle", async () => {
+    measuredWidth = 640;
+    const user = userEvent.setup();
+    render(<DiffPanel />);
+
+    expect(screen.queryByTestId("worktree-files")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Files" }));
+
+    await waitFor(() => expect(screen.getByTestId("worktree-files")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Files" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+});

--- a/apps/web/src/components/diff/__tests__/UnifiedDiff.test.tsx
+++ b/apps/web/src/components/diff/__tests__/UnifiedDiff.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ParsedDiffLine } from "@/lib/diff-parser";
+import { useDiffStore } from "@/stores/diffStore";
+import { usePreviewAnnotationStore } from "@/stores/previewAnnotationStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { UnifiedDiff } from "../UnifiedDiff";
+
+vi.mock("@/hooks/useDiffHighlighter", () => ({
+  useDiffHighlighter: () => ({ getLineTokens: () => null }),
+}));
+
+vi.mock("@/hooks/useTheme", () => ({
+  useShikiTheme: () => "github-dark",
+}));
+
+const lines: ParsedDiffLine[] = [
+  { type: "remove", content: "const state = oldState;", oldLineNo: 10, newLineNo: null },
+  { type: "add", content: "const state = nextState;", oldLineNo: null, newLineNo: 11 },
+];
+
+describe("UnifiedDiff Dev review", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({ activeThreadId: "thread-1" });
+    useDiffStore.setState({ lineWrapByThread: {} });
+    usePreviewAnnotationStore.setState({
+      byThread: {},
+      diffByThread: {},
+      drafts: {},
+    });
+  });
+
+  it("uses one PR-style gutter per line", () => {
+    render(<UnifiedDiff lines={lines} filePath="src/state.ts" />);
+
+    const gutters = screen.getAllByTestId("dev-diff-gutter");
+    expect(gutters).toHaveLength(2);
+    expect(gutters[0]).toHaveTextContent("−10");
+    expect(gutters[1]).toHaveTextContent("+11");
+  });
+
+  it("adds a line comment to the thread composer annotation bundle", async () => {
+    const user = userEvent.setup();
+    render(<UnifiedDiff lines={lines} filePath="src/state.ts" />);
+
+    await user.click(screen.getByRole("button", { name: "Add comment on line 11" }));
+    await user.type(screen.getByRole("textbox", { name: "Diff comment" }), "Keep this immutable");
+    await user.click(screen.getByRole("button", { name: "Add to prompt" }));
+
+    expect(usePreviewAnnotationStore.getState().buildBundle("thread-1")?.annotations).toMatchObject([
+      {
+        kind: "diff",
+        filePath: "src/state.ts",
+        side: "right",
+        line: 11,
+        lineContent: "const state = nextState;",
+        note: "Keep this immutable",
+      },
+    ]);
+    expect(screen.getByRole("button", { name: "Edit comment on line 11" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/diff/__tests__/UnifiedDiff.test.tsx
+++ b/apps/web/src/components/diff/__tests__/UnifiedDiff.test.tsx
@@ -45,7 +45,7 @@ describe("UnifiedDiff Dev review", () => {
     render(<UnifiedDiff lines={lines} filePath="src/state.ts" />);
 
     await user.click(screen.getByRole("button", { name: "Add comment on line 11" }));
-    await user.type(screen.getByRole("textbox", { name: "Diff comment" }), "Keep this immutable");
+    await user.type(screen.getByRole("textbox", { name: "Code comment" }), "Keep this immutable");
     await user.click(screen.getByRole("button", { name: "Add to prompt" }));
 
     expect(usePreviewAnnotationStore.getState().buildBundle("thread-1")?.annotations).toMatchObject([

--- a/apps/web/src/components/diff/__tests__/UnifiedDiff.test.tsx
+++ b/apps/web/src/components/diff/__tests__/UnifiedDiff.test.tsx
@@ -40,6 +40,15 @@ describe("UnifiedDiff Dev review", () => {
     expect(gutters[1]).toHaveTextContent("+11");
   });
 
+  it("keeps the add-comment control opaque in dark mode hover", () => {
+    render(<UnifiedDiff lines={lines} filePath="src/state.ts" />);
+
+    expect(screen.getByRole("button", { name: "Add comment on line 11" })).toHaveClass(
+      "dark:hover:bg-foreground",
+      "dark:hover:text-background",
+    );
+  });
+
   it("adds a line comment to the thread composer annotation bundle", async () => {
     const user = userEvent.setup();
     render(<UnifiedDiff lines={lines} filePath="src/state.ts" />);

--- a/apps/web/src/components/pull-requests/PullRequestFileTree.tsx
+++ b/apps/web/src/components/pull-requests/PullRequestFileTree.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { ChevronDown, ChevronRight, Folder, FolderOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { FileTypeIcon } from "@/components/ui/file-type-icon";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Tooltip,
@@ -88,8 +89,7 @@ function collectDirectoryIds(
 }
 
 /** Props for the virtual, keyboard-navigable pull request file tree. */
-export interface PullRequestFileTreeProps {
-  files: readonly PullRequestFile[];
+interface FileTreeBaseProps {
   activePath: string | null;
   searchActive?: boolean;
   className?: string;
@@ -97,20 +97,34 @@ export interface PullRequestFileTreeProps {
   onActivate: (path: string) => void;
 }
 
+/** Props for the virtual, keyboard-navigable path tree. */
+export type PullRequestFileTreeProps = FileTreeBaseProps &
+  (
+    | { files: readonly PullRequestFile[]; filePaths?: never }
+    | { files?: never; filePaths: readonly string[] }
+  );
+
 /** Virtual path tree and jump index for the loaded pull request Change stack. */
-export function PullRequestFileTree({
-  files,
-  activePath,
-  searchActive = false,
-  className,
-  ariaLabel = "Pull request changed files",
-  onActivate,
-}: PullRequestFileTreeProps) {
+export function PullRequestFileTree(props: PullRequestFileTreeProps) {
+  const {
+    activePath,
+    searchActive = false,
+    className,
+    ariaLabel = "Pull request changed files",
+    onActivate,
+  } = props;
+  const files = "files" in props && props.files ? props.files : [];
+  const providedFilePaths =
+    "filePaths" in props && props.filePaths ? props.filePaths : undefined;
+  const filePaths = useMemo(
+    () => providedFilePaths ?? files.map((file) => file.path),
+    [files, providedFilePaths],
+  );
   const viewportRef = useRef<HTMLDivElement>(null);
   const rowRefs = useRef(new Map<string, HTMLButtonElement>());
   const tree = useMemo(
-    () => buildPullRequestFileTree(files.map((file) => file.path)),
-    [files],
+    () => buildPullRequestFileTree(filePaths),
+    [filePaths],
   );
   const filesByPath = useMemo(
     () => new Map(files.map((file) => [file.path, file])),
@@ -268,8 +282,7 @@ export function PullRequestFileTree({
   const renderRow = (row: PullRequestFileTreeRow, index: number) => {
     if (row.node.kind === "file") {
       const item = filesByPath.get(row.node.path);
-      if (!item) return null;
-      return (
+      return item ? (
         <PullRequestFileRow
           file={item}
           active={item.path === activePath}
@@ -285,6 +298,37 @@ export function PullRequestFileTree({
           onFocus={() => setFocusedId(row.node.id)}
           onKeyDown={(event) => handleKeyDown(event, row, index)}
         />
+      ) : (
+        <Button
+          type="button"
+          role="treeitem"
+          variant="ghost"
+          size="sm"
+          tabIndex={focusedId === row.node.id ? 0 : -1}
+          aria-label={row.node.path}
+          aria-level={row.depth}
+          aria-posinset={row.positionInSet}
+          aria-setsize={row.setSize}
+          aria-selected={row.node.path === activePath}
+          ref={(node) => {
+            if (node) rowRefs.current.set(row.node.id, node);
+            else rowRefs.current.delete(row.node.id);
+          }}
+          title={row.node.path}
+          className={cn(
+            "mx-1 h-8 w-[calc(100%-0.5rem)] justify-start gap-1.5 rounded-md px-2 font-mono text-xs font-normal",
+            row.node.path === activePath
+              ? "bg-muted/70 text-foreground"
+              : "text-foreground/75 hover:bg-muted/40",
+          )}
+          style={{ paddingLeft: `${Math.max(8, row.depth * 12 - 4)}px` }}
+          onClick={() => onActivate(row.node.path)}
+          onFocus={() => setFocusedId(row.node.id)}
+          onKeyDown={(event) => handleKeyDown(event, row, index)}
+        >
+          <FileTypeIcon filePath={row.node.path} size={14} />
+          <OverflowPathLabel label={row.node.name} path={row.node.path} />
+        </Button>
       );
     }
 

--- a/apps/web/src/components/pull-requests/__tests__/PullRequestFileTree.test.tsx
+++ b/apps/web/src/components/pull-requests/__tests__/PullRequestFileTree.test.tsx
@@ -75,6 +75,25 @@ describe("PullRequestFileTree", () => {
     expect(onActivate).toHaveBeenCalledWith("b.ts");
   });
 
+  it("renders full worktree paths without pull request status metadata", async () => {
+    const onActivate = vi.fn();
+    render(
+      <PullRequestFileTree
+        filePaths={["apps/web/App.tsx", "packages/contracts/index.ts"]}
+        activePath={null}
+        ariaLabel="Worktree files"
+        onActivate={onActivate}
+      />,
+    );
+
+    const app = screen.getByRole("treeitem", { name: "apps/web/App.tsx" });
+    app.focus();
+    await userEvent.keyboard("{Enter}");
+
+    expect(onActivate).toHaveBeenCalledWith("apps/web/App.tsx");
+    expect(app.querySelector("[data-change-type]")).not.toBeInTheDocument();
+  });
+
   it("expands and collapses directories with Right and Left", async () => {
     render(
       <PullRequestFileTree

--- a/apps/web/src/lib/composer-feedback.ts
+++ b/apps/web/src/lib/composer-feedback.ts
@@ -1,0 +1,51 @@
+import {
+  isDiffAnnotationPayload,
+  type PreviewAnnotationBundle,
+} from "@mcode/contracts";
+
+interface ComposerFeedbackCounts {
+  readonly annotations: number;
+  readonly comments: number;
+}
+
+function feedbackCounts(bundle: PreviewAnnotationBundle): ComposerFeedbackCounts {
+  const comments = bundle.annotations.filter(isDiffAnnotationPayload).length;
+  return {
+    annotations: bundle.annotations.length - comments,
+    comments,
+  };
+}
+
+function countLabel(count: number, singular: string): string {
+  return `${count} ${count === 1 ? singular : `${singular}s`}`;
+}
+
+function feedbackCountParts(bundle: PreviewAnnotationBundle): string[] {
+  const counts = feedbackCounts(bundle);
+  return [
+    ...(counts.annotations > 0 ? [countLabel(counts.annotations, "annotation")] : []),
+    ...(counts.comments > 0 ? [countLabel(counts.comments, "comment")] : []),
+  ];
+}
+
+/** Formats the compact count shown for Preview annotations and code comments. */
+export function composerFeedbackLabel(bundle: PreviewAnnotationBundle): string {
+  return feedbackCountParts(bundle).join(" · ");
+}
+
+/** Formats an accessible count without relying on a visual separator. */
+export function composerFeedbackAccessibleLabel(bundle: PreviewAnnotationBundle): string {
+  return feedbackCountParts(bundle).join(" and ");
+}
+
+/** Returns the quoted-message fallback for feedback-only user messages. */
+export function composerFeedbackReplyFallback(bundle: PreviewAnnotationBundle): string {
+  const counts = feedbackCounts(bundle);
+  if (counts.comments === 0) {
+    return counts.annotations === 1 ? "[Annotation]" : "[Annotations]";
+  }
+  if (counts.annotations === 0) {
+    return counts.comments === 1 ? "[Comment]" : "[Comments]";
+  }
+  return "[Annotations and comments]";
+}

--- a/apps/web/src/stores/__tests__/previewAnnotationStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewAnnotationStore.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { isPreviewAnnotationPayload } from "@mcode/contracts";
 import {
   normalizePreviewPageIdentity,
   usePreviewAnnotationStore,
@@ -38,7 +39,7 @@ function draft(overrides: Partial<PreviewDraftAnnotation> = {}): PreviewDraftAnn
 
 describe("previewAnnotationStore", () => {
   beforeEach(() => {
-    usePreviewAnnotationStore.setState({ byThread: {}, drafts: {} });
+    usePreviewAnnotationStore.setState({ byThread: {}, diffByThread: {}, drafts: {} });
   });
 
   it("normalizes fragments, query order, and tracking parameters", () => {
@@ -68,11 +69,42 @@ describe("previewAnnotationStore", () => {
 
     const bundle = usePreviewAnnotationStore.getState().buildBundle("thread-1");
 
-    expect(bundle?.annotations[0]?.note).toBeUndefined();
-    expect(bundle?.annotations[0]?.changeSummary).toContain("background");
-    expect(bundle?.annotations[0]?.proposedChanges).toEqual({
+    const annotation = bundle?.annotations[0];
+    expect(annotation && isPreviewAnnotationPayload(annotation)).toBe(true);
+    if (!annotation || !isPreviewAnnotationPayload(annotation)) return;
+    expect(annotation.note).toBeUndefined();
+    expect(annotation.changeSummary).toContain("background");
+    expect(annotation.proposedChanges).toEqual({
       background: "#fff",
       fontWeight: "700",
     });
+  });
+
+  it("combines preview and diff annotations in creation order", () => {
+    const preview = usePreviewAnnotationStore
+      .getState()
+      .saveAnnotation("thread-1", draft({ note: "Align the button" }));
+    const diff = usePreviewAnnotationStore.getState().saveDiffAnnotation("thread-1", {
+      filePath: "apps/web/src/App.tsx",
+      side: "right",
+      line: 42,
+      lineContent: "return <App />;",
+      note: "Handle the loading state",
+    });
+
+    const bundle = usePreviewAnnotationStore.getState().buildBundle("thread-1");
+
+    expect(preview.displayNumber).toBe(1);
+    expect(diff.displayNumber).toBe(2);
+    expect(bundle?.annotations).toMatchObject([
+      { id: preview.id, displayNumber: 1 },
+      {
+        id: diff.id,
+        kind: "diff",
+        displayNumber: 2,
+        filePath: "apps/web/src/App.tsx",
+        line: 42,
+      },
+    ]);
   });
 });

--- a/apps/web/src/stores/__tests__/previewAnnotationStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewAnnotationStore.test.ts
@@ -80,7 +80,7 @@ describe("previewAnnotationStore", () => {
     });
   });
 
-  it("combines preview and diff annotations in creation order", () => {
+  it("combines Preview annotations and code comments in creation order", () => {
     const preview = usePreviewAnnotationStore
       .getState()
       .saveAnnotation("thread-1", draft({ note: "Align the button" }));

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -313,6 +313,8 @@ interface DiffState {
   reviewDiffStat: { additions: number; deletions: number } | null;
   /** Bulk expand/collapse command for the Review view's file cards; each FileEntry applies it on nonce change. */
   bulkDiffExpand: { expand: boolean; nonce: number } | null;
+  /** File-tree jump request for the active Review scope. */
+  reviewFileJumpRequest: { scopeId: string; path: string; nonce: number } | null;
   /** Per-thread line-wrap preference keyed by thread ID. */
   readonly lineWrapByThread: Record<string, boolean>;
   /** Turn snapshots keyed by thread ID. */
@@ -423,6 +425,8 @@ interface DiffState {
   setReviewDiffStat: (stat: { additions: number; deletions: number } | null) => void;
   /** Expand or collapse every file card in the active Review view. */
   setBulkDiffExpand: (expand: boolean) => void;
+  /** Ask the active Review file list to reveal one changed file. */
+  requestReviewFileJump: (scopeId: string, path: string) => void;
   getLineWrap: (threadId: string) => boolean;
   toggleLineWrap: (threadId: string) => void;
   setSnapshots: (threadId: string, snapshots: TurnSnapshot[]) => void;
@@ -468,6 +472,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   reviewFileCount: null,
   reviewDiffStat: null,
   bulkDiffExpand: null,
+  reviewFileJumpRequest: null,
   lineWrapByThread: {},
   snapshotsByThread: {},
   snapshotsLoadingByThread: {},
@@ -621,6 +626,14 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   setReviewDiffStat: (stat) => set({ reviewDiffStat: stat }),
   setBulkDiffExpand: (expand) =>
     set((s) => ({ bulkDiffExpand: { expand, nonce: (s.bulkDiffExpand?.nonce ?? 0) + 1 } })),
+  requestReviewFileJump: (scopeId, path) =>
+    set((s) => ({
+      reviewFileJumpRequest: {
+        scopeId,
+        path,
+        nonce: (s.reviewFileJumpRequest?.nonce ?? 0) + 1,
+      },
+    })),
   getLineWrap: (threadId) => get().lineWrapByThread[threadId] ?? DEFAULT_LINE_WRAP,
   toggleLineWrap: (threadId) =>
     set((state) => {

--- a/apps/web/src/stores/previewAnnotationStore.ts
+++ b/apps/web/src/stores/previewAnnotationStore.ts
@@ -2,12 +2,14 @@ import { create } from "zustand";
 import type {
   BrowserPreviewBounds,
   BrowserPreviewElementStyle,
+  ComposerAnnotationPayload,
+  DiffAnnotationPayload,
   McodeBrowserCaptureV2,
   PreviewAnnotationBundle,
   PreviewAnnotationPayload,
   PreviewAnnotationVisualProposal,
 } from "@mcode/contracts";
-import { PreviewAnnotationBundleSchema } from "@mcode/contracts";
+import { isDiffAnnotationPayload, PreviewAnnotationBundleSchema } from "@mcode/contracts";
 
 /** Draft data captured from the Preview before it becomes a saved annotation. */
 export interface PreviewDraftAnnotation {
@@ -39,9 +41,31 @@ export interface SavedPreviewAnnotation extends PreviewAnnotationPayload {
   readonly createdAt: number;
 }
 
+/** Saved local diff annotation with stable identity and creation ordering. */
+export interface SavedDiffAnnotation extends DiffAnnotationPayload {
+  /** Stable sort key independent of display number. */
+  readonly createdAt: number;
+}
+
+/** Input captured by a Dev diff line before it becomes a saved annotation. */
+export interface DiffAnnotationInput {
+  /** Workspace-relative file path. */
+  readonly filePath: string;
+  /** Diff side that owns the target line. */
+  readonly side: DiffAnnotationPayload["side"];
+  /** Target line number on that side. */
+  readonly line: number;
+  /** Source line text shown to the agent for context. */
+  readonly lineContent: string;
+  /** User review note. */
+  readonly note: string;
+}
+
 interface PreviewAnnotationStore {
   /** Saved annotation sets keyed by thread id. */
   readonly byThread: Record<string, SavedPreviewAnnotation[]>;
+  /** Saved Dev diff annotations keyed by thread id. */
+  readonly diffByThread: Record<string, SavedDiffAnnotation[]>;
   /** Active unsaved drafts keyed by thread id. */
   readonly drafts: Record<string, PreviewDraftAnnotation | undefined>;
   /** Returns all saved annotations for a thread in creation order. */
@@ -52,6 +76,8 @@ interface PreviewAnnotationStore {
   setDraft(threadId: string, draft: PreviewDraftAnnotation | undefined): void;
   /** Saves a draft or edited annotation into the thread bundle. */
   saveAnnotation(threadId: string, draft: PreviewDraftAnnotation, id?: string): SavedPreviewAnnotation;
+  /** Saves a local diff line comment into the thread bundle. */
+  saveDiffAnnotation(threadId: string, input: DiffAnnotationInput, id?: string): SavedDiffAnnotation;
   /** Deletes one saved annotation by stable id. */
   deleteAnnotation(threadId: string, id: string): void;
   /** Deletes saved annotations for the current page identity only. */
@@ -96,11 +122,22 @@ export function normalizePreviewPageIdentity(rawUrl: string): string {
   }
 }
 
-function renumber(list: readonly SavedPreviewAnnotation[]): SavedPreviewAnnotation[] {
-  return list.map((annotation, index) => ({
-    ...annotation,
-    displayNumber: index + 1,
-  }));
+function renumberAnnotations(
+  preview: readonly SavedPreviewAnnotation[],
+  diff: readonly SavedDiffAnnotation[],
+): { preview: SavedPreviewAnnotation[]; diff: SavedDiffAnnotation[] } {
+  const ordered = [...preview, ...diff].sort((a, b) => a.createdAt - b.createdAt);
+  const numbers = new Map(ordered.map((annotation, index) => [annotation.id, index + 1]));
+  return {
+    preview: preview.map((annotation) => ({
+      ...annotation,
+      displayNumber: numbers.get(annotation.id) ?? annotation.displayNumber,
+    })),
+    diff: diff.map((annotation) => ({
+      ...annotation,
+      displayNumber: numbers.get(annotation.id) ?? annotation.displayNumber,
+    })),
+  };
 }
 
 function visualSummary(proposedChanges: PreviewAnnotationVisualProposal | undefined): string | undefined {
@@ -114,6 +151,7 @@ function visualSummary(proposedChanges: PreviewAnnotationVisualProposal | undefi
 /** Zustand store for thread-scoped Preview annotation sets. */
 export const usePreviewAnnotationStore = create<PreviewAnnotationStore>((set, get) => ({
   byThread: {},
+  diffByThread: {},
   drafts: {},
 
   getThreadAnnotations(threadId) {
@@ -152,34 +190,75 @@ export const usePreviewAnnotationStore = create<PreviewAnnotationStore>((set, ge
       proposedChanges: draft.proposedChanges,
       snapshot: draft.snapshot,
     };
-    const next = id
+    const nextPreview = id
       ? existing.map((row) => (row.id === id ? annotation : row))
       : [...existing, annotation];
-    const sorted = renumber([...next].sort((a, b) => a.createdAt - b.createdAt));
+    const next = renumberAnnotations(nextPreview, get().diffByThread[threadId] ?? []);
     set((state) => ({
-      byThread: { ...state.byThread, [threadId]: sorted },
+      byThread: { ...state.byThread, [threadId]: next.preview },
+      diffByThread: { ...state.diffByThread, [threadId]: next.diff },
       drafts: { ...state.drafts, [threadId]: undefined },
     }));
-    return sorted.find((row) => row.id === annotation.id) ?? annotation;
+    return next.preview.find((row) => row.id === annotation.id) ?? annotation;
+  },
+
+  saveDiffAnnotation(threadId, input, id) {
+    const existing = get().diffByThread[threadId] ?? [];
+    const note = input.note.trim();
+    if (!note) throw new Error("diff annotation note is required");
+    const annotation: SavedDiffAnnotation = {
+      kind: "diff",
+      id: id ?? crypto.randomUUID(),
+      createdAt: id ? (existing.find((row) => row.id === id)?.createdAt ?? Date.now()) : Date.now(),
+      displayNumber: 1,
+      filePath: input.filePath,
+      side: input.side,
+      line: input.line,
+      lineContent: input.lineContent,
+      note,
+    };
+    const nextDiff = id
+      ? existing.map((row) => (row.id === id ? annotation : row))
+      : [...existing, annotation];
+    const next = renumberAnnotations(get().byThread[threadId] ?? [], nextDiff);
+    set((state) => ({
+      byThread: { ...state.byThread, [threadId]: next.preview },
+      diffByThread: { ...state.diffByThread, [threadId]: next.diff },
+    }));
+    return next.diff.find((row) => row.id === annotation.id) ?? annotation;
   },
 
   deleteAnnotation(threadId, id) {
-    const next = renumber((get().byThread[threadId] ?? []).filter((row) => row.id !== id));
-    set((state) => ({ byThread: { ...state.byThread, [threadId]: next } }));
+    const next = renumberAnnotations(
+      (get().byThread[threadId] ?? []).filter((row) => row.id !== id),
+      (get().diffByThread[threadId] ?? []).filter((row) => row.id !== id),
+    );
+    set((state) => ({
+      byThread: { ...state.byThread, [threadId]: next.preview },
+      diffByThread: { ...state.diffByThread, [threadId]: next.diff },
+    }));
   },
 
   discardPage(threadId, pageIdentity) {
-    const next = renumber((get().byThread[threadId] ?? []).filter((row) => row.pageIdentity !== pageIdentity));
-    set((state) => ({ byThread: { ...state.byThread, [threadId]: next } }));
+    const next = renumberAnnotations(
+      (get().byThread[threadId] ?? []).filter((row) => row.pageIdentity !== pageIdentity),
+      get().diffByThread[threadId] ?? [],
+    );
+    set((state) => ({
+      byThread: { ...state.byThread, [threadId]: next.preview },
+      diffByThread: { ...state.diffByThread, [threadId]: next.diff },
+    }));
   },
 
   clearThread(threadId) {
     set((state) => {
       const byThread = { ...state.byThread };
+      const diffByThread = { ...state.diffByThread };
       const drafts = { ...state.drafts };
       delete byThread[threadId];
+      delete diffByThread[threadId];
       delete drafts[threadId];
-      return { byThread, drafts };
+      return { byThread, diffByThread, drafts };
     });
   },
 
@@ -194,25 +273,35 @@ export const usePreviewAnnotationStore = create<PreviewAnnotationStore>((set, ge
       return false;
     }
     const baseCreatedAt = Date.now();
-    const annotations = renumber(
-      parsed.data.annotations.map((annotation, index) => ({
-        ...annotation,
-        createdAt: baseCreatedAt + index,
-      })),
-    );
+    const preview: SavedPreviewAnnotation[] = [];
+    const diff: SavedDiffAnnotation[] = [];
+    parsed.data.annotations.forEach((annotation, index) => {
+      if (isDiffAnnotationPayload(annotation)) {
+        diff.push({ ...annotation, createdAt: baseCreatedAt + index });
+      } else {
+        preview.push({ ...annotation, createdAt: baseCreatedAt + index });
+      }
+    });
+    const annotations = renumberAnnotations(preview, diff);
     set((state) => ({
-      byThread: { ...state.byThread, [threadId]: annotations },
+      byThread: { ...state.byThread, [threadId]: annotations.preview },
+      diffByThread: { ...state.diffByThread, [threadId]: annotations.diff },
       drafts: { ...state.drafts, [threadId]: undefined },
     }));
     return true;
   },
 
   buildBundle(threadId) {
-    const annotations = get().byThread[threadId] ?? [];
+    const annotations: Array<ComposerAnnotationPayload & { createdAt: number }> = [
+      ...(get().byThread[threadId] ?? []),
+      ...(get().diffByThread[threadId] ?? []),
+    ];
     if (annotations.length === 0) return undefined;
     return {
       schemaVersion: 1,
-      annotations: annotations.map(({ createdAt: _createdAt, ...annotation }) => annotation),
+      annotations: annotations
+        .sort((a, b) => a.createdAt - b.createdAt)
+        .map(({ createdAt: _createdAt, ...annotation }) => annotation),
     };
   },
 }));

--- a/apps/web/src/stores/previewAnnotationStore.ts
+++ b/apps/web/src/stores/previewAnnotationStore.ts
@@ -41,7 +41,7 @@ export interface SavedPreviewAnnotation extends PreviewAnnotationPayload {
   readonly createdAt: number;
 }
 
-/** Saved local diff annotation with stable identity and creation ordering. */
+/** Saved local code comment with stable identity and creation ordering. */
 export interface SavedDiffAnnotation extends DiffAnnotationPayload {
   /** Stable sort key independent of display number. */
   readonly createdAt: number;
@@ -64,7 +64,7 @@ export interface DiffAnnotationInput {
 interface PreviewAnnotationStore {
   /** Saved annotation sets keyed by thread id. */
   readonly byThread: Record<string, SavedPreviewAnnotation[]>;
-  /** Saved Dev diff annotations keyed by thread id. */
+  /** Saved Dev code comments keyed by thread id. */
   readonly diffByThread: Record<string, SavedDiffAnnotation[]>;
   /** Active unsaved drafts keyed by thread id. */
   readonly drafts: Record<string, PreviewDraftAnnotation | undefined>;
@@ -205,7 +205,7 @@ export const usePreviewAnnotationStore = create<PreviewAnnotationStore>((set, ge
   saveDiffAnnotation(threadId, input, id) {
     const existing = get().diffByThread[threadId] ?? [];
     const note = input.note.trim();
-    if (!note) throw new Error("diff annotation note is required");
+    if (!note) throw new Error("code comment note is required");
     const annotation: SavedDiffAnnotation = {
       kind: "diff",
       id: id ?? crypto.randomUUID(),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -162,7 +162,11 @@ export {
   PREVIEW_ANNOTATION_STRING_MAX,
   PreviewAnnotationVisualProposalSchema,
   PreviewAnnotationPayloadSchema,
+  DiffAnnotationPayloadSchema,
+  ComposerAnnotationPayloadSchema,
   PreviewAnnotationBundleSchema,
+  isDiffAnnotationPayload,
+  isPreviewAnnotationPayload,
   isBrowserCaptureSpillAppDataPath,
   clampMcodeBrowserCaptureV2,
   clampAttachedBrowserCaptureForOutbound,
@@ -185,6 +189,8 @@ export type {
   BrowserCaptureSpillFile,
   PreviewAnnotationVisualProposal,
   PreviewAnnotationPayload,
+  DiffAnnotationPayload,
+  ComposerAnnotationPayload,
   PreviewAnnotationBundle,
 } from "./models/browser-preview.js";
 

--- a/packages/contracts/src/models/__tests__/preview-annotation.test.ts
+++ b/packages/contracts/src/models/__tests__/preview-annotation.test.ts
@@ -62,7 +62,7 @@ describe("PreviewAnnotationBundleSchema", () => {
     ).toBe(true);
   });
 
-  it("accepts local diff annotations without creating screenshot attachments", () => {
+  it("accepts local code comments without creating screenshot attachments", () => {
     const bundle = {
       schemaVersion: 1 as const,
       annotations: [annotation, diffAnnotation],

--- a/packages/contracts/src/models/__tests__/preview-annotation.test.ts
+++ b/packages/contracts/src/models/__tests__/preview-annotation.test.ts
@@ -4,6 +4,7 @@ import {
   PreviewAnnotationBundleSchema,
   SendMessageSchema,
   previewAnnotationSnapshotAttachmentMeta,
+  previewAnnotationSnapshotAttachments,
   previewAnnotationSnapshotStoredAttachment,
 } from "../../index.js";
 
@@ -40,6 +41,17 @@ const annotation = {
   },
 };
 
+const diffAnnotation = {
+  kind: "diff" as const,
+  id: "00000000-0000-4000-8000-000000000002",
+  displayNumber: 2,
+  filePath: "apps/web/src/App.tsx",
+  side: "right" as const,
+  line: 42,
+  lineContent: "return <App />;",
+  note: "Handle the loading branch here.",
+};
+
 describe("PreviewAnnotationBundleSchema", () => {
   it("accepts a bounded annotation payload", () => {
     expect(
@@ -48,6 +60,16 @@ describe("PreviewAnnotationBundleSchema", () => {
         annotations: [annotation],
       }).success,
     ).toBe(true);
+  });
+
+  it("accepts local diff annotations without creating screenshot attachments", () => {
+    const bundle = {
+      schemaVersion: 1 as const,
+      annotations: [annotation, diffAnnotation],
+    };
+
+    expect(PreviewAnnotationBundleSchema().safeParse(bundle).success).toBe(true);
+    expect(previewAnnotationSnapshotAttachments(bundle)).toHaveLength(1);
   });
 
   it("rejects annotations without note or proposed changes", () => {

--- a/packages/contracts/src/models/browser-preview.ts
+++ b/packages/contracts/src/models/browser-preview.ts
@@ -429,12 +429,55 @@ export type PreviewAnnotationPayload = z.infer<
 >;
 
 /**
+ * One saved line comment captured while reviewing a local agent diff.
+ */
+export const DiffAnnotationPayloadSchema = lazySchema(() =>
+  z.object({
+    kind: z.literal("diff"),
+    id: z.string().uuid(),
+    displayNumber: z.number().int().positive(),
+    filePath: z.string().min(1).max(1024),
+    side: z.enum(["left", "right"]),
+    line: z.number().int().positive(),
+    lineContent: z.string().max(4096),
+    note: z.string().trim().min(1).max(PREVIEW_ANNOTATION_STRING_MAX.note),
+  }),
+);
+
+export type DiffAnnotationPayload = z.infer<
+  ReturnType<typeof DiffAnnotationPayloadSchema>
+>;
+
+/** One visual or code target attached to a composer message. */
+export const ComposerAnnotationPayloadSchema = lazySchema(() =>
+  z.union([PreviewAnnotationPayloadSchema(), DiffAnnotationPayloadSchema()]),
+);
+
+export type ComposerAnnotationPayload = z.infer<
+  ReturnType<typeof ComposerAnnotationPayloadSchema>
+>;
+
+/** Returns whether a composer annotation targets a local diff line. */
+export function isDiffAnnotationPayload(
+  annotation: ComposerAnnotationPayload,
+): annotation is DiffAnnotationPayload {
+  return "kind" in annotation && annotation.kind === "diff";
+}
+
+/** Returns whether a composer annotation targets the browser Preview. */
+export function isPreviewAnnotationPayload(
+  annotation: ComposerAnnotationPayload,
+): annotation is PreviewAnnotationPayload {
+  return !isDiffAnnotationPayload(annotation);
+}
+
+/**
  * Structured Annotation bundle payload sent beside normal composer content.
  */
 export const PreviewAnnotationBundleSchema = lazySchema(() =>
   z.object({
     schemaVersion: z.literal(1),
-    annotations: z.array(PreviewAnnotationPayloadSchema()).min(1),
+    annotations: z.array(ComposerAnnotationPayloadSchema()).min(1),
   }),
 );
 
@@ -484,7 +527,11 @@ export function previewAnnotationSnapshotStoredAttachment(
 export function previewAnnotationSnapshotAttachments(
   bundle: PreviewAnnotationBundle | undefined,
 ): AttachmentMeta[] {
-  return bundle?.annotations.map(previewAnnotationSnapshotAttachmentMeta) ?? [];
+  return (
+    bundle?.annotations
+      .filter(isPreviewAnnotationPayload)
+      .map(previewAnnotationSnapshotAttachmentMeta) ?? []
+  );
 }
 
 /**
@@ -493,5 +540,9 @@ export function previewAnnotationSnapshotAttachments(
 export function previewAnnotationSnapshotStoredAttachments(
   bundle: PreviewAnnotationBundle | null | undefined,
 ): StoredAttachment[] {
-  return bundle?.annotations.map(previewAnnotationSnapshotStoredAttachment) ?? [];
+  return (
+    bundle?.annotations
+      .filter(isPreviewAnnotationPayload)
+      .map(previewAnnotationSnapshotStoredAttachment) ?? []
+  );
 }


### PR DESCRIPTION
## What

Adds inline code comments and a responsive worktree file browser to Dev Review.

## Why

Users need to send feedback tied to specific changed lines while reviewing agent work. They also need access to the full worktree without leaving the diff.

## Key Changes

- Add line comment controls to unified and split diffs, then attach those comments to the next composer message.
- Reuse the pull request file tree for the full worktree, with responsive default visibility and a toolbar toggle.
- Use one line-number gutter in Dev Review while preserving pull request diff behavior.
- Label code feedback as comments and keep the Dark Mode comment button opaque on hover.
- Add focused coverage for comment creation, composer delivery, file-pane behavior, line numbering, and hover styling.

## Verification

- `bun run verify`
- Live Playwright checks for comment creation, composer feedback, responsive file-pane behavior, and Dark Mode hover colors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786900886&installation_id=129163861&pr_number=876&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F876&signature=6b7303f05d4fd28843b53d6b1c7d67883187ef0a2fd0abf4c417176f5b958131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->