### PR TITLE
fix(chat): keep streaming transcript pinned to tail

### DIFF
--- a/apps/web/e2e/chat-auto-scroll.spec.ts
+++ b/apps/web/e2e/chat-auto-scroll.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test, type Page } from "@playwright/test";
+import { getDefaultSettings } from "@mcode/contracts";
+import { mockWebSocketServer } from "./helpers/e2e-helpers";
+
+const now = new Date("2026-01-01T00:00:00.000Z").toISOString();
+
+const workspace = {
+  id: "ws-chat-auto-scroll",
+  name: "Chat Auto Scroll",
+  path: "/tmp/chat-auto-scroll",
+  provider_config: {},
+  is_git_repo: true,
+  pinned: false,
+  last_opened_at: Date.now(),
+  sort_order: 0,
+  created_at: now,
+  updated_at: now,
+};
+
+const thread = {
+  id: "thread-chat-auto-scroll",
+  workspace_id: workspace.id,
+  title: "Chat auto scroll",
+  status: "active" as const,
+  mode: "direct" as const,
+  worktree_path: null,
+  branch: "main",
+  issue_number: null,
+  pr_number: null,
+  pr_status: null,
+  created_at: now,
+  updated_at: now,
+  model: "claude-sonnet-4-6",
+  deleted_at: null,
+  worktree_managed: false,
+  sdk_session_id: null,
+  provider: "claude",
+  last_context_tokens: null,
+  context_window: null,
+  reasoning_level: null,
+  interaction_mode: null,
+  permission_mode: null,
+  parent_thread_id: null,
+  forked_from_message_id: null,
+};
+
+function message(sequence: number, role: "user" | "assistant") {
+  return {
+    id: `${role}-${sequence}`,
+    thread_id: thread.id,
+    role,
+    content: `${role} message ${sequence}\n${"A full line of transcript content. ".repeat(12)}`,
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: now,
+    sequence,
+    attachments: null,
+    tool_call_count: 0,
+  };
+}
+
+const history = Array.from({ length: 24 }, (_, index) =>
+  message(index + 1, index % 2 === 0 ? "user" : "assistant"),
+);
+
+async function distanceFromBottom(page: Page): Promise<number> {
+  return page.locator("[data-testid='message-list'] .overflow-y-auto").evaluate(
+    (element) => element.scrollHeight - element.scrollTop - element.clientHeight,
+  );
+}
+
+test("follows a sent message and streaming response until the user scrolls away", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1100, height: 700 });
+  const ws = await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": [thread],
+    "conversation.page": {
+      messages: history,
+      hasMore: false,
+      answeredPlanMessageIds: [],
+      narrativeByMessage: {},
+    },
+    "narrative.list": { tools: [], thoughts: [], hooks: [] },
+    "settings.get": getDefaultSettings(),
+    "provider.listModels": () => [
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", group: "Claude" },
+    ],
+    "agent.send": { ok: true },
+  });
+  await page.goto("/");
+  await page.getByRole("group", { name: "Chat Auto Scroll project" }).click();
+  await page.locator("[data-testid='thread-item']").first().click();
+
+  const scroller = page.locator("[data-testid='message-list'] .overflow-y-auto");
+  await expect(scroller).toHaveCSS("opacity", "1");
+  await expect.poll(() => distanceFromBottom(page)).toBeLessThanOrEqual(2);
+
+  await scroller.evaluate((element) => {
+    element.dispatchEvent(new WheelEvent("wheel", { deltaY: -100, bubbles: true }));
+    element.scrollTop = element.scrollHeight;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  await expect.poll(() => distanceFromBottom(page)).toBeLessThanOrEqual(2);
+
+  const editor = page.locator('[contenteditable="true"]').first();
+  await editor.fill(`Follow this message\n${"New user content. ".repeat(80)}`);
+  await editor.press("Enter");
+  await expect(page.locator("[data-message-role='user']").filter({ hasText: "Follow this message" }))
+    .toBeVisible();
+  await expect.poll(() => distanceFromBottom(page)).toBeLessThanOrEqual(2);
+
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "textDelta",
+    delta: `Streaming response\n${"Growing agent output. ".repeat(120)}`,
+    isFinalResponse: true,
+  });
+  await expect(page.getByTestId("assistant-response-text").filter({ hasText: "Streaming response" }))
+    .toBeVisible();
+  await expect.poll(() => distanceFromBottom(page)).toBeLessThanOrEqual(2);
+
+  await scroller.evaluate((element) => {
+    element.dispatchEvent(new WheelEvent("wheel", { deltaY: -200, bubbles: true }));
+    element.scrollTop = Math.max(0, element.scrollTop - 500);
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  await expect(page.getByRole("button", { name: "Scroll to bottom" })).toBeVisible();
+  await page.waitForTimeout(100);
+
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "textDelta",
+    delta: `\n${"More agent output. ".repeat(80)}`,
+    isFinalResponse: true,
+  });
+  await expect.poll(() => distanceFromBottom(page)).toBeGreaterThan(64);
+
+  await scroller.evaluate((element) => {
+    element.scrollTop = 0;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  await page.getByRole("button", { name: "New messages below" }).click();
+  await scroller.dispatchEvent("wheel", { deltaY: -100 });
+  await page.waitForTimeout(250);
+  await expect(page.getByRole("button", { name: "Scroll to bottom" })).toBeVisible();
+  await expect.poll(() => distanceFromBottom(page)).toBeGreaterThan(64);
+
+  await page.getByRole("button", { name: "Scroll to bottom" }).click();
+  await expect.poll(() => distanceFromBottom(page)).toBeLessThanOrEqual(2);
+});

--- a/apps/web/e2e/streaming-text-rendering.spec.ts
+++ b/apps/web/e2e/streaming-text-rendering.spec.ts
@@ -58,6 +58,23 @@ const userMessage = {
   tool_call_count: 0,
 };
 
+function transcriptMessage(index: number) {
+  return {
+    id: `history-message-${index}`,
+    thread_id: thread.id,
+    role: index % 2 === 0 ? "assistant" as const : "user" as const,
+    content: `Historical transcript row ${index}. This row gives the scrollport enough height to stay scrollable during live follow.`,
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: now,
+    sequence: index,
+    attachments: null,
+    tool_call_count: 0,
+  };
+}
+
 test("streaming assistant text uses plain text, then settled text uses markdown", async ({ page }) => {
   const ws = await mockWebSocketServer(page, {
     "workspace.list": [workspace],
@@ -102,4 +119,77 @@ test("streaming assistant text uses plain text, then settled text uses markdown"
   await expect(assistantText).toHaveCount(1);
   await expect(assistantText).toContainText("Hello stream");
   await expect(assistantText).not.toContainText("Hello **stream**");
+});
+
+test("first streaming delta keeps the visible transcript pinned without flashing scroll affordances", async ({ page }) => {
+  const ws = await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": [thread],
+    "conversation.page": {
+      messages: Array.from({ length: 24 }, (_, index) => transcriptMessage(index + 1)),
+      hasMore: false,
+      answeredPlanMessageIds: [],
+      narrativeByMessage: {},
+    },
+    "narrative.list": { tools: [], thoughts: [], hooks: [] },
+  });
+
+  await page.goto("/");
+  await page.getByRole("group", { name: "Streaming Text Workspace project" }).click();
+  await page.locator("[data-testid='thread-item']").first().click();
+  await page.waitForSelector("[data-testid=message-list]");
+
+  await page.evaluate(async () => {
+    const scrollport = document.querySelector("[data-testid='message-list'] .overflow-y-auto") as HTMLElement | null;
+    if (!scrollport) throw new Error("message list scrollport not found");
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    scrollport.scrollTop = scrollport.scrollHeight;
+  });
+
+  await page.evaluate(() => {
+    const samples: Array<{ distanceFromBottom: number; hasScrollAffordance: boolean }> = [];
+    (window as unknown as { __streamingScrollSamples?: typeof samples }).__streamingScrollSamples = samples;
+    const startedAt = performance.now();
+    const sample = () => {
+      const scrollport = document.querySelector("[data-testid='message-list'] .overflow-y-auto") as HTMLElement | null;
+      const liveResponse = document.querySelector("[data-testid='assistant-response-text']");
+      if (scrollport && liveResponse) {
+        samples.push({
+          distanceFromBottom: scrollport.scrollHeight - scrollport.scrollTop - scrollport.clientHeight,
+          hasScrollAffordance: document.querySelector(
+            "button[aria-label='Scroll to bottom'],button[aria-label='New messages below']",
+          ) != null,
+        });
+      }
+      if (performance.now() - startedAt < 250) {
+        requestAnimationFrame(sample);
+      }
+    };
+    requestAnimationFrame(sample);
+  });
+
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "turnStarted",
+  });
+  await ws.sendPush("agent.event", {
+    threadId: thread.id,
+    type: "textDelta",
+    delta: "The first streamed assistant response should follow the tail immediately.",
+    isFinalResponse: true,
+  });
+
+  await expect(page.locator("[data-testid='assistant-response-text']").last()).toContainText(
+    "The first streamed assistant response",
+  );
+  await page.waitForTimeout(300);
+
+  const samples = await page.evaluate(() =>
+    (window as unknown as {
+      __streamingScrollSamples?: Array<{ distanceFromBottom: number; hasScrollAffordance: boolean }>;
+    }).__streamingScrollSamples ?? [],
+  );
+  expect(samples.length).toBeGreaterThan(0);
+  expect(Math.max(...samples.map((sample) => sample.distanceFromBottom))).toBeLessThanOrEqual(4);
+  expect(samples.some((sample) => sample.hasScrollAffordance)).toBe(false);
 });

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -397,8 +397,17 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   /** Clears tail pin when the user scrolls content upward (wheel / trackpad). */
   const handleWheel = useCallback((e: WheelEvent<HTMLDivElement>) => {
     if (e.deltaY < 0) {
+      const interruptedPendingTailScroll = scrollTimerRef.current !== null;
       scrollToTailIntentRef.current = false;
       pinListTailRef.current = false;
+      if (scrollTimerRef.current) {
+        clearTimeout(scrollTimerRef.current);
+        scrollTimerRef.current = null;
+      }
+      if (interruptedPendingTailScroll) {
+        isScrolledUpRef.current = true;
+        setShowScrollBtn(true);
+      }
       streamingFollowPauseUntilRef.current = Date.now() + WHEEL_UP_FOLLOW_PAUSE_MS;
     }
   }, []);
@@ -434,11 +443,18 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     const awayFromTail = distanceFromBottom > USER_AWAY_FROM_BOTTOM_PX;
-    if (scrollToTailIntentRef.current && !awayFromTail) {
+    const wasScrolledUp = isScrolledUpRef.current;
+    const completedTailScroll = scrollToTailIntentRef.current && !awayFromTail;
+    if (completedTailScroll) {
       scrollToTailIntentRef.current = false;
     }
     const scrolledUp = awayFromTail && !scrollToTailIntentRef.current;
-    if (awayFromTail) pinListTailRef.current = false;
+    if (awayFromTail) {
+      pinListTailRef.current = false;
+    } else if (pinListTailRef.current || wasScrolledUp || completedTailScroll) {
+      pinListTailRef.current = true;
+      pinTailBaselineMaxScrollRef.current = maxScroll;
+    }
     isScrolledUpRef.current = scrolledUp;
     setShowScrollBtn(scrolledUp);
     if (!awayFromTail) {
@@ -627,6 +643,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     useFlushSync: false,
   });
   virtualizerRef.current = virtualizer;
+  const virtualTotalSize = virtualizer.getTotalSize();
 
   // Pinned to tail: always compensate for size changes so the viewport tracks
   // the bottom as rows measure. Adjusting by +delta when at scrollOffset = oldMaxScroll
@@ -652,6 +669,29 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     return item.start < scrollOffset;
   };
 
+  /** Pins the visible transcript to the current measured tail before paint. */
+  const snapToBottom = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    pinListTailRef.current = true;
+    el.scrollTop = el.scrollHeight;
+    pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
+    requestAnimationFrame(() => {
+      const current = containerRef.current;
+      if (!current || !pinListTailRef.current) return;
+      current.scrollTop = current.scrollHeight;
+      pinTailBaselineMaxScrollRef.current = Math.max(
+        0,
+        current.scrollHeight - current.clientHeight,
+      );
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!pinListTailRef.current) return;
+    snapToBottom();
+  }, [items.length, snapToBottom, virtualTotalSize]);
+
   /**
    * Programmatic scroll to the list tail. Auto-follow uses the scroll element
    * directly (no virtualizer reconcile, no CSS smooth). The floating button
@@ -659,35 +699,23 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
    */
   const scrollToBottom = useCallback(
     (smooth: boolean) => {
+      if (!smooth) {
+        if (scrollTimerRef.current) return;
+        snapToBottom();
+        return;
+      }
       if (scrollTimerRef.current) return;
-      const delay = smooth ? 200 : 0;
       scrollTimerRef.current = setTimeout(() => {
         scrollTimerRef.current = null;
         const count = itemsLengthRef.current;
         if (count === 0) return;
-        const el = containerRef.current;
-        if (smooth) {
-          virtualizer.scrollToIndex(count - 1, {
-            align: "end",
-            behavior: "smooth",
-          });
-          return;
-        }
-        if (el) {
-          pinListTailRef.current = true;
-          el.scrollTop = el.scrollHeight;
-          pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
-          requestAnimationFrame(() => {
-            const el2 = containerRef.current;
-            if (el2) {
-              el2.scrollTop = el2.scrollHeight;
-              pinTailBaselineMaxScrollRef.current = Math.max(0, el2.scrollHeight - el2.clientHeight);
-            }
-          });
-        }
-      }, delay);
+        virtualizer.scrollToIndex(count - 1, {
+          align: "end",
+          behavior: "smooth",
+        });
+      }, 200);
     },
-    [virtualizer],
+    [snapToBottom, virtualizer],
   );
 
   /**
@@ -1040,7 +1068,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   }, [activeThreadId, items.length, loading, beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
 
   // Discrete events (new message, tool call) -> scroll if at bottom, else highlight button
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isInitialLoadRef.current) return;
     if (suppressPassiveAutoBottomScrollRef.current) return;
     if (isScrolledUpRef.current) {
@@ -1059,8 +1087,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     scrollToBottom(false);
   }, [activeThreadId, messages.length, toolCalls.length, isAgentRunning, scrollToBottom]);
 
-  // Streaming deltas -> scroll if at bottom, else highlight button
-  useEffect(() => {
+  // Streaming deltas -> scroll before paint when following the tail, else highlight button.
+  useLayoutEffect(() => {
     if (suppressPassiveAutoBottomScrollRef.current) return;
     if (!streamingText || isInitialLoadRef.current) return;
     if (isScrolledUpRef.current) {
@@ -1177,7 +1205,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       >
         <div
           className="relative w-full"
-          style={{ height: virtualizer.getTotalSize() }}
+          style={{ height: virtualTotalSize }}
         >
           {virtualizer.getVirtualItems().map((vi) => {
             const item = items[vi.index];

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -18,15 +18,16 @@
  * `positionAtBottom({ measureFirst: true })` calls `scrollToIndex` with
  * `behavior: "auto"` so the list anchors to the tail before rows finish measuring.
  */
-import { render, act } from "@testing-library/react";
+import { render, act, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const measureSpy = vi.fn();
 const scrollToIndexSpy = vi.fn();
+let totalSizeValue = 0;
 
 const mockVirtualizer = {
   getVirtualItems: () => [],
-  getTotalSize: () => 0,
+  getTotalSize: () => totalSizeValue,
   measure: measureSpy,
   scrollToIndex: scrollToIndexSpy,
   measureElement: () => {},
@@ -103,6 +104,7 @@ import { rememberScrollTop, recallScrollTop, clearScrollMemory } from "../scroll
 beforeEach(() => {
   measureSpy.mockClear();
   scrollToIndexSpy.mockClear();
+  totalSizeValue = 0;
   clearScrollMemory();
 });
 
@@ -111,6 +113,109 @@ afterEach(() => {
 });
 
 describe("MessageList thread switch", () => {
+  it("keeps the measured transcript tail pinned as virtualized content grows", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m1", sequence: 1 }];
+    totalSizeValue = 6000;
+    const { rerender, container } = render(<MessageList />);
+
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    let scrollHeight = 6000;
+    let scrollTop = 5600;
+    Object.defineProperty(scrollEl, "scrollHeight", {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(scrollEl, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(scrollEl, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+
+    scrollHeight = 8000;
+    totalSizeValue = 8000;
+    act(() => rerender(<MessageList />));
+
+    expect(scrollTop).toBe(8000);
+  });
+
+  it("preserves the reading position when virtualized content grows after wheel-up", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m1", sequence: 1 }];
+    totalSizeValue = 6000;
+    const { rerender, container } = render(<MessageList />);
+
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    let scrollHeight = 6000;
+    let scrollTop = 3000;
+    Object.defineProperty(scrollEl, "scrollHeight", {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(scrollEl, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(scrollEl, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+
+    fireEvent.wheel(scrollEl, { deltaY: -100 });
+    scrollHeight = 8000;
+    totalSizeValue = 8000;
+    act(() => rerender(<MessageList />));
+
+    expect(scrollTop).toBe(3000);
+  });
+
+  it("does not restore tail pin when wheel-up remains inside the bottom cushion", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m1", sequence: 1 }];
+    totalSizeValue = 6000;
+    const { rerender, container } = render(<MessageList />);
+
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    let scrollHeight = 6000;
+    let scrollTop = 5600;
+    Object.defineProperty(scrollEl, "scrollHeight", {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(scrollEl, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(scrollEl, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+
+    fireEvent.wheel(scrollEl, { deltaY: -100 });
+    scrollTop = 5580;
+    fireEvent.scroll(scrollEl);
+    scrollHeight = 8000;
+    totalSizeValue = 8000;
+    act(() => rerender(<MessageList />));
+
+    expect(scrollTop).toBe(5580);
+  });
+
   it("does not call virtualizer.measure() on a cache-hit switch", () => {
     loadingValue = false;            // cache hit ⇒ loading is false synchronously
     messagesValue = [{ id: "m1", sequence: 1 }];


### PR DESCRIPTION
## What

Keep the chat transcript pinned to its measured tail while a sent message or agent response grows, unless the user has deliberately scrolled away.

## Why

The first live row could be measured after the passive follow effect ran. That left the viewport above the new content even when the user had been at the bottom.

## Key Changes

- Snap to the measured tail before paint and repeat the snap after virtualized row height changes while follow mode is active.
- Preserve the reading position after upward scrolling, including interrupted tail navigation and sticky-message jumps inside the bottom cushion.
- Add component and browser coverage for sent messages, first streaming deltas, continued streaming, deliberate scroll-away, and down-button recovery.

## Verification

- `bun run e2e -- chat-auto-scroll.spec.ts streaming-text-rendering.spec.ts --workers=1`: 3 passed.
- Focused browser stress run with five repetitions: 15 passed.
- `bun run verify`: typecheck and lint passed. After the final main sync, 2,321 of 2,322 frontend tests passed locally; main's new diff-memory benchmark exceeded its 5-second timeout on Windows.
- GitHub CI: unit tests, build, typecheck, lint, and all four browser shards passed.
- Reviewer QA: no actionable findings; merge-ready.
