### PR TITLE
fix(web): align sidebar thread icons

### DIFF
--- a/apps/web/e2e/sidebar-thread-preview.spec.ts
+++ b/apps/web/e2e/sidebar-thread-preview.spec.ts
@@ -189,14 +189,49 @@ test.describe("Sidebar thread preview", () => {
     // PR icons pin to a fixed left column (aligned with the workspace chevron);
     // the provider icon sits in the row's indent, between the PR column and the title.
     const prIcon = await prRow.getByTitle(/PR #42/).boundingBox();
-    const directProvider = await directRow.getByLabel("Provider, Claude").boundingBox();
-    const prProvider = await prRow.getByLabel("Provider, Claude").boundingBox();
+    const prIconMark = await prRow
+      .getByTitle(/PR #42/)
+      .locator("svg")
+      .boundingBox();
+    const directProvider = await directRow
+      .getByLabel("Provider, Claude")
+      .boundingBox();
+    const directProviderMark = await directRow
+      .getByLabel("Provider, Claude")
+      .locator("svg")
+      .boundingBox();
+    const prProvider = await prRow
+      .getByLabel("Provider, Claude")
+      .boundingBox();
     expect(prIcon).not.toBeNull();
+    expect(prIconMark).not.toBeNull();
     expect(directProvider).not.toBeNull();
+    expect(directProviderMark).not.toBeNull();
     expect(prProvider).not.toBeNull();
-    expect(Math.abs((directProvider?.x ?? 0) - (prProvider?.x ?? 0))).toBeLessThanOrEqual(1);
-    expect((prIcon?.x ?? 0) + (prIcon?.width ?? 0)).toBeLessThanOrEqual((prProvider?.x ?? 0) + 1);
-    expect((prProvider?.x ?? 0) + (prProvider?.width ?? 0)).toBeLessThanOrEqual((prTitle?.x ?? 0) + 1);
+    expect(
+      Math.abs((directProvider?.x ?? 0) - (prProvider?.x ?? 0)),
+    ).toBeLessThanOrEqual(1);
+    expect((prIcon?.x ?? 0) + (prIcon?.width ?? 0)).toBeLessThanOrEqual(
+      (prProvider?.x ?? 0) + 1,
+    );
+    const providerToTitleGap =
+      (directTitle?.x ?? 0) -
+      ((directProvider?.x ?? 0) + (directProvider?.width ?? 0));
+    expect(providerToTitleGap).toBeGreaterThanOrEqual(3.5);
+    expect(providerToTitleGap).toBeLessThanOrEqual(4.5);
+    const titleCenterY =
+      (directTitle?.y ?? 0) + (directTitle?.height ?? 0) / 2;
+    const providerCenterY =
+      (directProviderMark?.y ?? 0) +
+      (directProviderMark?.height ?? 0) / 2;
+    expect(titleCenterY - providerCenterY).toBeGreaterThanOrEqual(0.5);
+    expect(titleCenterY - providerCenterY).toBeLessThanOrEqual(1.5);
+    const prIconCenterY =
+      (prIconMark?.y ?? 0) + (prIconMark?.height ?? 0) / 2;
+    const prTitleCenterY =
+      (prTitle?.y ?? 0) + (prTitle?.height ?? 0) / 2;
+    expect(prTitleCenterY - prIconCenterY).toBeGreaterThanOrEqual(0.5);
+    expect(prTitleCenterY - prIconCenterY).toBeLessThanOrEqual(1.5);
 
     await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-worktree"]').getByLabel("Running")).toBeVisible();
     await expect(page.locator('[data-testid="thread-item"][data-thread-id="thread-completed"]').getByLabel("Completed")).toBeVisible();

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -293,6 +293,20 @@ describe("ProjectTree thread interactions", () => {
     );
   });
 
+  it("optically aligns the provider mark and separates it from the thread title", () => {
+    setupStoreMocks();
+
+    render(<ProjectTree />);
+
+    const row = screen.getByRole("button", { name: /My Thread/i });
+    const provider = screen.getByLabelText("Provider, Claude");
+    const providerLeft = Number.parseFloat(provider.style.left);
+    const titleLeft = Number.parseFloat(row.style.paddingLeft);
+
+    expect(provider).toHaveClass("-mt-px");
+    expect(titleLeft - (providerLeft + 16)).toBe(4);
+  });
+
   it("offers Explorer and rename actions from the project menu", () => {
     setupStoreMocks();
 
@@ -681,11 +695,11 @@ describe("ProjectTree PR-ability gating by mode", () => {
     expect(screen.queryByTitle(/PR #42/)).toBeNull();
   });
 
-  it("renders the PR icon and number badge for a worktree thread with a pr_number", () => {
+  it("optically aligns the PR icon for a worktree thread with a pr_number", () => {
     renderWithThread(
       makeThread({ mode: "worktree", pr_number: 42, pr_status: "open" }),
     );
-    expect(screen.getByTitle(/PR #42/)).toBeInTheDocument();
+    expect(screen.getByTitle(/PR #42/)).toHaveClass("-mt-px");
     expect(screen.queryByText("#42")).toBeNull();
   });
 

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1244,7 +1244,7 @@ function VirtualizedThreadList({
                 ? "bg-accent text-foreground"
                 : "text-muted-foreground/85 hover:bg-accent/40 hover:text-foreground",
             )}
-            style={{ paddingLeft: `${38 + depth * 12}px` }}
+            style={{ paddingLeft: `${42 + depth * 12}px` }}
           >
             {prable && thread.pr_number != null
               ? (() => {
@@ -1254,7 +1254,7 @@ function VirtualizedThreadList({
                   return (
                     <span
                       title={`PR #${thread.pr_number} \u2013 ${thread.pr_status ?? "open"}`}
-                      className="absolute left-1.5 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center"
+                      className="absolute left-1.5 top-1/2 -mt-px flex h-4 w-4 -translate-y-1/2 items-center justify-center"
                     >
                       <PrIcon size={12} className={prColor} />
                     </span>
@@ -1264,7 +1264,7 @@ function VirtualizedThreadList({
             <span
               aria-label={`Provider, ${providerMeta.label}`}
               className={cn(
-                "absolute top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center",
+                "absolute top-1/2 -mt-px flex h-4 w-4 -translate-y-1/2 items-center justify-center",
                 providerMeta.color,
                 scaffoldDim,
               )}


### PR DESCRIPTION
## What

Align provider and pull request icons with thread titles in the project sidebar, and add space between the provider mark and title.

## Why

The provider and pull request marks sat optically low in compact thread rows. The provider slot also ended directly against the title.

## Key Changes

- Lift provider and pull request marks by 1px within the existing 32px rows.
- Add 4px between the provider slot and thread title.
- Cover the spacing and alignment with component tests and Chromium bounding-box checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786901974&installation_id=129163861&pr_number=878&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F878&signature=b4ac5a04f955ae4e4cc2d4e18e5c4b4e3bb147bf5a35a463a17bdd31b0c0a7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved sidebar thread row spacing and indentation for clearer hierarchy.
  - Refined alignment of pull request and provider icons for more consistent visual presentation.
  - Adjusted icon positioning and vertical centering to improve alignment with thread titles and metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->