### PR TITLE
feat(server): batch pull request watcher polling

### DIFF
--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -18,24 +18,38 @@ describe("CiWatcherService", () => {
   let watcher: CiWatcherService;
   let mockGithubService: {
     getCheckRuns: ReturnType<typeof vi.fn>;
+    getPullRequestWatchSnapshots: ReturnType<typeof vi.fn>;
     cancelCheckRuns: ReturnType<typeof vi.fn>;
     cancelAllInFlight: ReturnType<typeof vi.fn>;
   };
   let mockBroadcast: ReturnType<typeof vi.fn>;
+  let mockPullRequestStateChange: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     mockGithubService = {
       getCheckRuns: vi.fn(),
+      getPullRequestWatchSnapshots: vi.fn(),
       cancelCheckRuns: vi.fn().mockResolvedValue(undefined),
       cancelAllInFlight: vi.fn().mockResolvedValue(undefined),
     };
     // Default: return no_checks so watch() immediate fetch resolves without side effects.
     mockGithubService.getCheckRuns.mockResolvedValue(makeChecks("no_checks"));
+    mockGithubService.getPullRequestWatchSnapshots.mockImplementation(
+      async (targets: Array<{ threadId: string; prNumber: number }>) => Promise.all(
+        targets.map(async (target) => ({
+          ...target,
+          state: "OPEN",
+          checks: await mockGithubService.getCheckRuns(),
+        })),
+      ),
+    );
     mockBroadcast = vi.fn();
+    mockPullRequestStateChange = vi.fn();
     watcher = new CiWatcherService(
       mockGithubService as unknown as GithubService,
       mockBroadcast,
+      mockPullRequestStateChange,
     );
   });
 
@@ -103,6 +117,38 @@ describe("CiWatcherService", () => {
     expect(mockBroadcast).toHaveBeenCalledWith("thread.checksUpdated", {
       threadId: "t1",
       checks: pending,
+    });
+  });
+
+  it("polls two watched pull requests through one batch call", async () => {
+    watcher.watch("t1", 41, "feature-1", "/repo", { skipInitialFetch: true });
+    watcher.watch("t2", 42, "feature-2", "/repo", { skipInitialFetch: true });
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(mockGithubService.getPullRequestWatchSnapshots).toHaveBeenCalledTimes(1);
+    expect(mockGithubService.getPullRequestWatchSnapshots).toHaveBeenCalledWith([
+      { threadId: "t1", prNumber: 41, repoPath: "/repo" },
+      { threadId: "t2", prNumber: 42, repoPath: "/repo" },
+    ]);
+  });
+
+  it("stops polling and publishes a merged pull request state", async () => {
+    mockGithubService.getPullRequestWatchSnapshots.mockResolvedValue([{
+      threadId: "t1",
+      prNumber: 41,
+      state: "MERGED",
+      checks: makeChecks("passing"),
+    }]);
+    watcher.watch("t1", 41, "feature-1", "/repo", { skipInitialFetch: true });
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(watcher.isWatching("t1")).toBe(false);
+    expect(mockPullRequestStateChange).toHaveBeenCalledWith({
+      threadId: "t1",
+      prNumber: 41,
+      state: "MERGED",
     });
   });
 

--- a/apps/server/src/__tests__/ci-watcher.test.ts
+++ b/apps/server/src/__tests__/ci-watcher.test.ts
@@ -152,6 +152,38 @@ describe("CiWatcherService", () => {
     });
   });
 
+  it("ignores a stale snapshot after the thread is relinked", async () => {
+    mockGithubService.getPullRequestWatchSnapshots.mockResolvedValue([{
+      threadId: "t1",
+      prNumber: 41,
+      state: "MERGED",
+      checks: makeChecks("passing"),
+    }]);
+    watcher.watch("t1", 42, "feature-2", "/repo", { skipInitialFetch: true });
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(watcher.isWatching("t1")).toBe(true);
+    expect(mockPullRequestStateChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps polling a terminal pull request when persisting its state fails", async () => {
+    mockGithubService.getPullRequestWatchSnapshots.mockResolvedValue([{
+      threadId: "t1",
+      prNumber: 41,
+      state: "CLOSED",
+      checks: makeChecks("no_checks"),
+    }]);
+    mockPullRequestStateChange.mockImplementation(() => {
+      throw new Error("database unavailable");
+    });
+    watcher.watch("t1", 41, "feature-1", "/repo", { skipInitialFetch: true });
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(watcher.isWatching("t1")).toBe(true);
+  });
+
   it("does NOT broadcast when state is unchanged", async () => {
     const passing = makeChecks("passing");
     mockGithubService.getCheckRuns.mockResolvedValue(passing);

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -486,6 +486,106 @@ describe("GithubService.getCheckRuns", () => {
   });
 });
 
+describe("GithubService.getPullRequestWatchSnapshots", () => {
+  let ghService: GithubService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKillProcessTree.mockResolvedValue(undefined);
+    ghService = new GithubService({} as WorkspaceRepo);
+    vi.spyOn(ghService, "resolveRepoSlug").mockResolvedValue("owner/test-repo");
+  });
+
+  it("fetches two pull request snapshots in one GraphQL subprocess", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: CallbackFn) => {
+        expect(args.slice(0, 2)).toEqual(["api", "graphql"]);
+        expect(args.find((arg) => arg.startsWith("query="))).toContain("pr0: pullRequest");
+        expect(args.find((arg) => arg.startsWith("query="))).toContain("pr1: pullRequest");
+        cb(null, JSON.stringify({
+          data: {
+            repository: {
+              pr0: {
+                number: 41,
+                state: "OPEN",
+                commits: {
+                  nodes: [{
+                    commit: {
+                      statusCheckRollup: {
+                        contexts: {
+                          nodes: [{
+                            __typename: "CheckRun",
+                            name: "test",
+                            status: "IN_PROGRESS",
+                            conclusion: null,
+                            startedAt: "2026-07-18T10:00:00Z",
+                            completedAt: null,
+                            checkSuite: { app: { databaseId: 15368 } },
+                          }],
+                        },
+                      },
+                    },
+                  }],
+                },
+              },
+              pr1: {
+                number: 42,
+                state: "MERGED",
+                commits: { nodes: [] },
+              },
+            },
+          },
+        }), "");
+      },
+    );
+
+    const snapshots = await ghService.getPullRequestWatchSnapshots([
+      { threadId: "thread-1", prNumber: 41, repoPath: "/repo" },
+      { threadId: "thread-2", prNumber: 42, repoPath: "/repo" },
+    ]);
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots[0]).toMatchObject({
+      threadId: "thread-1",
+      prNumber: 41,
+      state: "OPEN",
+      checks: { aggregate: "pending" },
+    });
+    expect(snapshots[1]).toMatchObject({
+      threadId: "thread-2",
+      prNumber: 42,
+      state: "MERGED",
+      checks: { aggregate: "no_checks" },
+    });
+  });
+
+  it("queries a duplicated pull request once and fans the snapshot out to both threads", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: CallbackFn) => {
+        const query = args.find((arg) => arg.startsWith("query=")) ?? "";
+        expect(query).toContain("pr0: pullRequest");
+        expect(query).not.toContain("pr1: pullRequest");
+        cb(null, JSON.stringify({
+          data: {
+            repository: {
+              pr0: { number: 41, state: "OPEN", commits: { nodes: [] } },
+            },
+          },
+        }), "");
+      },
+    );
+
+    const snapshots = await ghService.getPullRequestWatchSnapshots([
+      { threadId: "thread-1", prNumber: 41, repoPath: "C:\\Repo" },
+      { threadId: "thread-2", prNumber: 41, repoPath: "c:/repo/" },
+    ]);
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    expect(snapshots.map((snapshot) => snapshot.threadId)).toEqual(["thread-1", "thread-2"]);
+  });
+});
+
 describe("GithubService.resolveRepoSlug", () => {
   let ghService: GithubService;
 

--- a/apps/server/src/__tests__/github-service-checks.test.ts
+++ b/apps/server/src/__tests__/github-service-checks.test.ts
@@ -584,6 +584,136 @@ describe("GithubService.getPullRequestWatchSnapshots", () => {
     expect(mockExecFile).toHaveBeenCalledTimes(1);
     expect(snapshots.map((snapshot) => snapshot.threadId)).toEqual(["thread-1", "thread-2"]);
   });
+
+  it("keeps case-distinct POSIX repository paths in separate batches", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: CallbackFn) => {
+        const number = Number(args.find((arg) => arg.startsWith("number0="))?.split("=")[1]);
+        cb(null, JSON.stringify({
+          data: {
+            repository: {
+              pr0: { number, state: "OPEN", commits: { nodes: [] } },
+            },
+          },
+        }), "");
+      },
+    );
+
+    await ghService.getPullRequestWatchSnapshots([
+      { threadId: "thread-upper", prNumber: 41, repoPath: "/repo/A" },
+      { threadId: "thread-lower", prNumber: 42, repoPath: "/repo/a" },
+    ]);
+
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds repository work before resolving slugs", async () => {
+    const releases: Array<() => void> = [];
+    let active = 0;
+    let maxActive = 0;
+    vi.mocked(ghService.resolveRepoSlug).mockImplementation(() => new Promise((resolve) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      const slugNumber = releases.length;
+      releases.push(() => {
+        active--;
+        resolve(`owner/repo-${slugNumber}`);
+      });
+    }));
+    mockExecFile.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: CallbackFn) => {
+        const number = Number(args.find((arg) => arg.startsWith("number0="))?.split("=")[1]);
+        cb(null, JSON.stringify({
+          data: {
+            repository: {
+              pr0: { number, state: "OPEN", commits: { nodes: [] } },
+            },
+          },
+        }), "");
+      },
+    );
+
+    const pending = ghService.getPullRequestWatchSnapshots(
+      Array.from({ length: 5 }, (_, index) => ({
+        threadId: `thread-${index}`,
+        prNumber: index + 1,
+        repoPath: `/repo/${index}`,
+      })),
+    );
+
+    await waitFor(() => releases.length === 3, "expected the fixed worker pool to fill");
+    expect(maxActive).toBe(3);
+    for (let index = 0; index < 5; index++) {
+      await waitFor(() => releases.length > index, `expected repository worker ${index}`);
+      releases[index]();
+    }
+    await pending;
+    expect(maxActive).toBe(3);
+  });
+
+  it("does not start queued repository work after global cancellation", async () => {
+    const started: string[] = [];
+    const rejecters: Array<(error: Error) => void> = [];
+    vi.mocked(ghService.resolveRepoSlug).mockImplementation((repoPath) => new Promise((_, reject) => {
+      started.push(repoPath);
+      rejecters.push(reject);
+    }));
+
+    const pending = ghService.getPullRequestWatchSnapshots(
+      Array.from({ length: 5 }, (_, index) => ({
+        threadId: `thread-${index}`,
+        prNumber: index + 1,
+        repoPath: `/repo/${index}`,
+      })),
+    );
+
+    await waitFor(() => started.length === 3, "expected the fixed worker pool to fill");
+    await ghService.cancelAllInFlight();
+    for (const reject of rejecters) reject(new Error("cancelled"));
+    await pending;
+
+    expect(started).toHaveLength(3);
+  });
+
+  it("skips queued work for a repository after teardown", async () => {
+    const started: string[] = [];
+    const releases: Array<() => void> = [];
+    vi.mocked(ghService.resolveRepoSlug).mockImplementation((repoPath) => new Promise((resolve) => {
+      started.push(repoPath);
+      releases.push(() => resolve("owner/repo"));
+    }));
+    mockExecFile.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: CallbackFn) => {
+        const number = Number(args.find((arg) => arg.startsWith("number0="))?.split("=")[1]);
+        cb(null, JSON.stringify({
+          data: {
+            repository: {
+              pr0: { number, state: "OPEN", commits: { nodes: [] } },
+            },
+          },
+        }), "");
+      },
+    );
+
+    const pending = ghService.getPullRequestWatchSnapshots(
+      Array.from({ length: 5 }, (_, index) => ({
+        threadId: `thread-${index}`,
+        prNumber: index + 1,
+        repoPath: `/repo/${index}`,
+      })),
+    );
+
+    await waitFor(() => started.length === 3, "expected the fixed worker pool to fill");
+    await ghService.cancelForRepoPath("/repo/3");
+    for (let index = 0; index < 4; index++) {
+      await waitFor(() => releases.length > index, `expected repository worker ${index}`);
+      releases[index]();
+    }
+    await pending;
+
+    expect(started).not.toContain("/repo/3");
+    expect(started).toContain("/repo/4");
+  });
 });
 
 describe("GithubService.resolveRepoSlug", () => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -315,6 +315,13 @@ ipcServer.onConnection((port) => {
 const ciWatcherService = new CiWatcherService(githubService, (channel, data) => {
   broadcast(channel as Parameters<typeof broadcast>[0], data as Parameters<typeof broadcast>[1]);
   portPush.send(channel as Parameters<typeof portPush.send>[0], data as Parameters<typeof portPush.send>[1]);
+}, ({ threadId, prNumber, state }) => {
+  const thread = threadRepo.findById(threadId);
+  if (thread?.pr_number !== prNumber) return;
+  threadService.linkPr(threadId, prNumber, state);
+  const payload = { threadId, prNumber, prStatus: state };
+  broadcast("thread.prLinked", payload);
+  portPush.send("thread.prLinked", payload);
 });
 gitWatcherService.setThreadCheckoutChangedListener((threadId) => {
   ciWatcherService.unwatch(threadId);

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -1,5 +1,5 @@
 import { logger } from "@mcode/shared";
-import type { GithubService } from "./github-service";
+import type { GithubService, PullRequestWatchSnapshot } from "./github-service";
 import type { ChecksStatus } from "@mcode/contracts";
 
 /** Internal tracking entry for a watched thread. */
@@ -14,12 +14,20 @@ export interface WatchEntry {
 /** Broadcast function signature matching the server push system. */
 type BroadcastFn = (channel: string, data: unknown) => void;
 
-// 15s for in-progress checks: responsive enough to catch completion within a PR review window.
-// Worst case: 5 active threads × 4 calls/min = 20 calls/min, well within GitHub's 5000/hr limit.
+/** A terminal lifecycle change detected while polling a linked pull request. */
+export interface PullRequestStateChange {
+  threadId: string;
+  prNumber: number;
+  state: "CLOSED" | "MERGED";
+}
+
+/** Persists and publishes a terminal pull request lifecycle change. */
+type PullRequestStateChangeFn = (change: PullRequestStateChange) => void;
+
+// In-progress checks refresh every 15s. Threads in one repository share a bounded batch,
+// so adding another watched PR does not add another request to that polling cycle.
 const ACTIVE_INTERVAL_MS = 15_000;
-// 20s for terminal checks: catches externally-triggered CI runs (push from terminal / another
-// machine) within the window where they'd be most noticeable to the user.
-// Worst case: 5 passive threads × 3 calls/min = 15 calls/min, well within GitHub's 5000/hr limit.
+// Terminal checks refresh every 20s to catch a new external run without polling each PR alone.
 const PASSIVE_INTERVAL_MS = 20_000;
 // When the user just pushed, GitHub Actions take a few seconds to register the new run.
 // Bump the cache on this curve so "pending" appears within ~3s of push completion.
@@ -42,6 +50,7 @@ export class CiWatcherService {
   constructor(
     private readonly githubService: GithubService,
     private readonly broadcast: BroadcastFn,
+    private readonly onPullRequestStateChange?: PullRequestStateChangeFn,
   ) {
     this.startPassiveTimer();
   }
@@ -217,34 +226,28 @@ export class CiWatcherService {
         && t.pr_status.toLowerCase() !== "closed",
     );
 
-    const fetches = candidates.map(async (t) => {
+    const targets = candidates.flatMap((t) => {
       const wsId = getWorkspaceId(t.id);
       const repoPath = wsId ? workspacePaths.get(wsId) : undefined;
-      if (!repoPath || t.pr_number == null) return;
+      if (!repoPath || t.pr_number == null) return [];
 
       // Insert placeholder synchronously so concurrent watch() calls see this threadId
       // and skip re-insertion during the async fetch window.
       if (!this.active.has(t.id) && !this.passive.has(t.id)) {
         this.passive.set(t.id, { threadId: t.id, prNumber: t.pr_number, branch: t.branch, repoPath, cache: null });
       }
-
-      try {
-        const checks = await this.githubService.getCheckRuns(t.branch, repoPath);
-        const entry = this.passive.get(t.id) ?? this.active.get(t.id);
-        if (!entry) return; // was unwatched during fetch
-        entry.cache = checks;
-
-        // Promote to active if checks are pending; it's already in passive
-        if (checks.aggregate === "pending") {
-          this.passive.delete(t.id);
-          this.active.set(t.id, entry);
-        }
-      } catch (err) {
-        logger.debug("CiWatcher seed failed for thread", { threadId: t.id, error: String(err) });
-      }
+      return [{ threadId: t.id, prNumber: t.pr_number, repoPath }];
     });
 
-    await Promise.allSettled(fetches);
+    try {
+      const snapshots = await this.githubService.getPullRequestWatchSnapshots(targets);
+      for (const snapshot of snapshots) {
+        const entry = this.passive.get(snapshot.threadId) ?? this.active.get(snapshot.threadId);
+        if (entry) this.applyWatchSnapshot(entry, snapshot);
+      }
+    } catch (err) {
+      logger.debug("CiWatcher seed batch failed", { error: String(err) });
+    }
 
     if (this.active.size > 0) this.startActiveTimer();
     logger.info(`CiWatcher seeded: ${this.active.size} active, ${this.passive.size} passive`);
@@ -316,43 +319,33 @@ export class CiWatcherService {
     if (set.size === 0) return;
 
     const entries = [...set.values()];
-    const results = await Promise.allSettled(
-      entries.map(async (entry) => {
-        const checks = await this.githubService.getCheckRuns(entry.branch, entry.repoPath);
-        return { entry, checks };
-      }),
-    );
-
-    for (const result of results) {
-      if (result.status === "rejected") continue;
-      const { entry, checks } = result.value;
-
-      // Guard: thread was unwatched while the fetch was in flight
-      if (!this.active.has(entry.threadId) && !this.passive.has(entry.threadId)) continue;
-
-      const changed = this.hasChanged(entry.cache, checks);
-      entry.cache = checks;
-
-      if (changed) {
-        this.broadcast("thread.checksUpdated", {
+    try {
+      const snapshots = await this.githubService.getPullRequestWatchSnapshots(
+        entries.map((entry) => ({
           threadId: entry.threadId,
-          checks,
-        });
+          prNumber: entry.prNumber,
+          repoPath: entry.repoPath,
+        })),
+      );
+      for (const snapshot of snapshots) {
+        const entry = this.active.get(snapshot.threadId) ?? this.passive.get(snapshot.threadId);
+        if (entry) this.applyWatchSnapshot(entry, snapshot);
       }
-
-      // Promote/demote between sets
-      if (set === this.passive && checks.aggregate === "pending") {
-        this.passive.delete(entry.threadId);
-        this.active.set(entry.threadId, entry);
-        this.startActiveTimer();
-        // Passive set shrank — stop timer if now empty.
-        if (this.passive.size === 0) this.stopPassiveTimer();
-      } else if (set === this.active && checks.aggregate !== "pending") {
-        this.active.delete(entry.threadId);
-        this.passive.set(entry.threadId, entry);
-        this.startPassiveTimer();
-        if (this.active.size === 0) this.stopActiveTimer();
-      }
+    } catch (err) {
+      logger.debug("CiWatcher batch tick failed", { error: String(err) });
     }
+  }
+
+  private applyWatchSnapshot(entry: WatchEntry, snapshot: PullRequestWatchSnapshot): void {
+    if (snapshot.state === "CLOSED" || snapshot.state === "MERGED") {
+      this.unwatch(entry.threadId);
+      this.onPullRequestStateChange?.({
+        threadId: entry.threadId,
+        prNumber: entry.prNumber,
+        state: snapshot.state,
+      });
+      return;
+    }
+    this.refresh(entry.threadId, snapshot.checks);
   }
 }

--- a/apps/server/src/services/ci-watcher.ts
+++ b/apps/server/src/services/ci-watcher.ts
@@ -337,13 +337,14 @@ export class CiWatcherService {
   }
 
   private applyWatchSnapshot(entry: WatchEntry, snapshot: PullRequestWatchSnapshot): void {
+    if (entry.prNumber !== snapshot.prNumber) return;
     if (snapshot.state === "CLOSED" || snapshot.state === "MERGED") {
-      this.unwatch(entry.threadId);
       this.onPullRequestStateChange?.({
         threadId: entry.threadId,
         prNumber: entry.prNumber,
         state: snapshot.state,
       });
+      this.unwatch(entry.threadId);
       return;
     }
     this.refresh(entry.threadId, snapshot.checks);

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -7,8 +7,27 @@
 import { injectable, inject } from "tsyringe";
 import { execFile, type ChildProcess } from "child_process";
 import type { PrInfo, PrDetail, ChecksStatus, CheckRun } from "@mcode/contracts";
+import { logger } from "@mcode/shared";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import { killProcessTree } from "./process-kill.js";
+
+const MAX_PULL_REQUESTS_PER_WATCH_BATCH = 25;
+const MAX_CHECK_CONTEXTS_PER_PULL_REQUEST = 100;
+
+/** One linked thread whose pull request lifecycle and checks need refreshing. */
+export interface PullRequestWatchTarget {
+  threadId: string;
+  prNumber: number;
+  repoPath: string;
+}
+
+/** One watched pull request snapshot returned from GitHub. */
+export interface PullRequestWatchSnapshot {
+  threadId: string;
+  prNumber: number;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  checks: ChecksStatus;
+}
 
 /**
  * Handles GitHub PR lookups and listing via the `gh` CLI.
@@ -517,6 +536,133 @@ export class GithubService {
   }
 
   /**
+   * Fetch lifecycle state and check runs for many linked threads in bounded GraphQL batches.
+   * Threads in the same repository share one GitHub request per batch, and duplicate PR
+   * identities are queried once before their result is fanned back out to each thread.
+   */
+  async getPullRequestWatchSnapshots(
+    targets: readonly PullRequestWatchTarget[],
+  ): Promise<PullRequestWatchSnapshot[]> {
+    if (targets.length === 0) return [];
+    for (const target of targets) {
+      if (
+        target.threadId.length === 0
+        || !Number.isInteger(target.prNumber)
+        || target.prNumber <= 0
+        || target.repoPath.length === 0
+      ) {
+        throw new Error("Pull request watch targets require a thread, PR number, and repository path");
+      }
+    }
+
+    const repositoryGroups = groupWatchTargetsByRepository(targets);
+    const groupResults = await Promise.allSettled(
+      repositoryGroups.map((group) => this.fetchRepositoryWatchSnapshots(group)),
+    );
+
+    return groupResults.flatMap((result, index) => {
+      if (result.status === "fulfilled") return result.value;
+      logger.debug("Pull request watch batch failed", {
+        repoPath: repositoryGroups[index]?.repoPath,
+        error: String(result.reason),
+      });
+      return [];
+    });
+  }
+
+  private async fetchRepositoryWatchSnapshots(
+    group: PullRequestWatchRepositoryGroup,
+  ): Promise<PullRequestWatchSnapshot[]> {
+    const slug = await this.resolveRepoSlug(group.repoPath);
+    const [owner, repository] = slug.split("/");
+    if (!owner || !repository) throw new Error(`Unexpected repository slug: ${slug}`);
+
+    const targetsByPullRequest = new Map<number, PullRequestWatchTarget[]>();
+    for (const target of group.targets) {
+      const matchingTargets = targetsByPullRequest.get(target.prNumber) ?? [];
+      matchingTargets.push(target);
+      targetsByPullRequest.set(target.prNumber, matchingTargets);
+    }
+
+    const uniquePullRequestNumbers = [...targetsByPullRequest.keys()];
+    const snapshots: PullRequestWatchSnapshot[] = [];
+    for (
+      let offset = 0;
+      offset < uniquePullRequestNumbers.length;
+      offset += MAX_PULL_REQUESTS_PER_WATCH_BATCH
+    ) {
+      const batchNumbers = uniquePullRequestNumbers.slice(
+        offset,
+        offset + MAX_PULL_REQUESTS_PER_WATCH_BATCH,
+      );
+      const snapshotsByNumber = await this.runPullRequestWatchBatch(
+        group.repoPath,
+        owner,
+        repository,
+        batchNumbers,
+      );
+      for (const [prNumber, snapshot] of snapshotsByNumber) {
+        for (const target of targetsByPullRequest.get(prNumber) ?? []) {
+          snapshots.push({ ...snapshot, threadId: target.threadId });
+        }
+      }
+    }
+    return snapshots;
+  }
+
+  private async runPullRequestWatchBatch(
+    repoPath: string,
+    owner: string,
+    repository: string,
+    prNumbers: readonly number[],
+  ): Promise<Map<number, Omit<PullRequestWatchSnapshot, "threadId">>> {
+    const query = buildPullRequestWatchQuery(prNumbers.length);
+    const args = [
+      "api",
+      "graphql",
+      "-f",
+      `query=${query}`,
+      "-f",
+      `owner=${owner}`,
+      "-f",
+      `repository=${repository}`,
+    ];
+    for (const [index, prNumber] of prNumbers.entries()) {
+      args.push("-F", `number${index}=${prNumber}`);
+    }
+
+    await this.acquire();
+    try {
+      const stdout = await new Promise<string>((resolve, reject) => {
+        let tracked: TrackedGithubProcess | null = null;
+        const child = execFile(
+          "gh",
+          args,
+          {
+            cwd: repoPath,
+            encoding: "utf-8",
+            timeout: 15_000,
+            maxBuffer: 2 * 1024 * 1024,
+            windowsHide: true,
+          },
+          (error, output) => {
+            tracked?.finish();
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve(output);
+          },
+        );
+        tracked = this.trackProcess(child, { repoPath });
+      });
+      return parsePullRequestWatchBatch(stdout, prNumbers);
+    } finally {
+      this.release();
+    }
+  }
+
+  /**
    * Resolve the GitHub owner/repo slug for a local repository path.
    * Results are cached for 30 minutes (SLUG_TTL_MS) to handle repo renames gracefully.
    * Validates the returned value matches `owner/repo` format before caching.
@@ -632,10 +778,199 @@ interface CheckRunsInflight {
   cancelled: boolean;
 }
 
+interface PullRequestWatchRepositoryGroup {
+  repoPath: string;
+  targets: PullRequestWatchTarget[];
+}
+
+interface RawWatchCheckRun {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  appId: number;
+}
+
 function noChecks(): ChecksStatus {
   return { aggregate: "no_checks", runs: [], fetchedAt: Date.now() };
 }
 
 function normalizeRepoPath(repoPath: string | null | undefined): string | null {
   return repoPath ? repoPath.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase() : null;
+}
+
+function groupWatchTargetsByRepository(
+  targets: readonly PullRequestWatchTarget[],
+): PullRequestWatchRepositoryGroup[] {
+  const groups = new Map<string, PullRequestWatchRepositoryGroup>();
+  for (const target of targets) {
+    const key = normalizeRepoPath(target.repoPath) ?? target.repoPath;
+    const group = groups.get(key) ?? { repoPath: target.repoPath, targets: [] };
+    group.targets.push(target);
+    groups.set(key, group);
+  }
+  return [...groups.values()];
+}
+
+function buildPullRequestWatchQuery(prCount: number): string {
+  const numberVariables = Array.from(
+    { length: prCount },
+    (_, index) => `$number${index}: Int!`,
+  ).join("\n");
+  const pullRequests = Array.from({ length: prCount }, (_, index) => `
+    pr${index}: pullRequest(number: $number${index}) {
+      number
+      state
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              contexts(first: ${MAX_CHECK_CONTEXTS_PER_PULL_REQUEST}) {
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    status
+                    conclusion
+                    startedAt
+                    completedAt
+                    checkSuite { app { databaseId } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }`).join("\n");
+
+  return `query PullRequestWatchBatch(
+    $owner: String!
+    $repository: String!
+    ${numberVariables}
+  ) {
+    repository(owner: $owner, name: $repository) {${pullRequests}
+    }
+  }`;
+}
+
+function parsePullRequestWatchBatch(
+  stdout: string,
+  expectedPrNumbers: readonly number[],
+): Map<number, Omit<PullRequestWatchSnapshot, "threadId">> {
+  const envelope = JSON.parse(stdout) as unknown;
+  if (!isRecord(envelope) || !isRecord(envelope.data) || !isRecord(envelope.data.repository)) {
+    throw new Error("GitHub returned an invalid pull request watch response");
+  }
+
+  const fetchedAt = Date.now();
+  const snapshots = new Map<number, Omit<PullRequestWatchSnapshot, "threadId">>();
+  for (const [index, expectedPrNumber] of expectedPrNumbers.entries()) {
+    const pullRequest = envelope.data.repository[`pr${index}`];
+    if (pullRequest === null) continue;
+    if (!isRecord(pullRequest)) {
+      throw new Error(`GitHub returned invalid data for pull request ${expectedPrNumber}`);
+    }
+    if (pullRequest.number !== expectedPrNumber || !isPullRequestState(pullRequest.state)) {
+      throw new Error(`GitHub returned mismatched data for pull request ${expectedPrNumber}`);
+    }
+
+    const rawChecks = readWatchCheckRuns(pullRequest);
+    snapshots.set(expectedPrNumber, {
+      prNumber: expectedPrNumber,
+      state: pullRequest.state,
+      checks: summarizeWatchCheckRuns(rawChecks, fetchedAt),
+    });
+  }
+  return snapshots;
+}
+
+function readWatchCheckRuns(pullRequest: Record<string, unknown>): RawWatchCheckRun[] {
+  const commits = isRecord(pullRequest.commits) && Array.isArray(pullRequest.commits.nodes)
+    ? pullRequest.commits.nodes
+    : [];
+  const latestCommit = commits.at(0);
+  if (!isRecord(latestCommit) || !isRecord(latestCommit.commit)) return [];
+  const rollup = latestCommit.commit.statusCheckRollup;
+  if (!isRecord(rollup) || !isRecord(rollup.contexts) || !Array.isArray(rollup.contexts.nodes)) {
+    return [];
+  }
+
+  return rollup.contexts.nodes.flatMap((node) => {
+    if (!isRecord(node) || node.__typename !== "CheckRun" || typeof node.name !== "string") {
+      return [];
+    }
+    const app = isRecord(node.checkSuite) && isRecord(node.checkSuite.app)
+      ? node.checkSuite.app
+      : null;
+    return [{
+      name: node.name,
+      status: typeof node.status === "string" ? node.status : "IN_PROGRESS",
+      conclusion: typeof node.conclusion === "string" ? node.conclusion : null,
+      startedAt: typeof node.startedAt === "string" ? node.startedAt : null,
+      completedAt: typeof node.completedAt === "string" ? node.completedAt : null,
+      appId: app && typeof app.databaseId === "number" ? app.databaseId : 0,
+    }];
+  });
+}
+
+function summarizeWatchCheckRuns(
+  rawChecks: readonly RawWatchCheckRun[],
+  fetchedAt: number,
+): ChecksStatus {
+  const latestChecks = new Map<string, RawWatchCheckRun>();
+  for (const check of rawChecks) {
+    const key = `${check.name}\0${check.appId}`;
+    const existing = latestChecks.get(key);
+    if (!existing || (check.startedAt ?? "") > (existing.startedAt ?? "")) {
+      latestChecks.set(key, check);
+    }
+  }
+
+  const runs = [...latestChecks.values()].map<CheckRun>((check) => {
+    const status: CheckRun["status"] = check.status === "COMPLETED"
+      ? "completed"
+      : check.status === "QUEUED"
+        ? "queued"
+        : "in_progress";
+    const conclusion = normalizeWatchConclusion(check.conclusion);
+    const durationMs = status === "completed" && check.startedAt && check.completedAt
+      ? new Date(check.completedAt).getTime() - new Date(check.startedAt).getTime()
+      : null;
+    return { name: check.name, status, conclusion, durationMs, startedAt: check.startedAt };
+  });
+
+  let aggregate: ChecksStatus["aggregate"];
+  if (runs.length === 0) {
+    aggregate = "no_checks";
+  } else if (runs.some((run) => run.conclusion === "failure" || run.conclusion === "timed_out")) {
+    aggregate = "failing";
+  } else if (runs.some((run) => run.status !== "completed")) {
+    aggregate = "pending";
+  } else if (runs.some((run) => run.conclusion === "success")) {
+    aggregate = "passing";
+  } else {
+    aggregate = "no_checks";
+  }
+  return { aggregate, runs, fetchedAt };
+}
+
+function normalizeWatchConclusion(conclusion: string | null): CheckRun["conclusion"] {
+  if (conclusion === null) return null;
+  const normalized = conclusion.toLowerCase();
+  if (normalized === "success") return "success";
+  if (normalized === "cancelled") return "cancelled";
+  if (normalized === "skipped") return "skipped";
+  if (normalized === "timed_out") return "timed_out";
+  if (normalized === "neutral") return "neutral";
+  return "failure";
+}
+
+function isPullRequestState(value: unknown): value is PullRequestWatchSnapshot["state"] {
+  return value === "OPEN" || value === "CLOSED" || value === "MERGED";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/server/src/services/github-service.ts
+++ b/apps/server/src/services/github-service.ts
@@ -49,6 +49,8 @@ export class GithubService {
   private readonly checkRunsInflight = new Map<string, CheckRunsInflight>();
   /** Live gh subprocesses keyed by the repository path that owns their cwd. */
   private readonly activeProcesses = new Set<TrackedGithubProcess>();
+  /** Active batched watch requests, including repository work waiting for a worker. */
+  private readonly pullRequestWatchRequests = new Set<PullRequestWatchRequest>();
 
   /** Maximum number of gh subprocesses that may run concurrently. */
   private readonly maxConcurrent = 3;
@@ -85,6 +87,11 @@ export class GithubService {
    */
   async cancelForRepoPath(repoPath: string): Promise<void> {
     const normalized = normalizeRepoPath(repoPath);
+    if (normalized) {
+      for (const request of this.pullRequestWatchRequests) {
+        request.cancelledRepoPaths.add(normalized);
+      }
+    }
     for (const [key, inflight] of this.checkRunsInflight) {
       if (inflight.repoPath !== normalized) continue;
       inflight.cancelled = true;
@@ -96,6 +103,9 @@ export class GithubService {
 
   /** Cancel every in-flight gh subprocess owned by this service. */
   async cancelAllInFlight(): Promise<void> {
+    for (const request of this.pullRequestWatchRequests) {
+      request.cancelled = true;
+    }
     for (const inflight of this.checkRunsInflight.values()) {
       inflight.cancelled = true;
       inflight.resolve(noChecks());
@@ -556,24 +566,54 @@ export class GithubService {
     }
 
     const repositoryGroups = groupWatchTargetsByRepository(targets);
-    const groupResults = await Promise.allSettled(
-      repositoryGroups.map((group) => this.fetchRepositoryWatchSnapshots(group)),
+    const request: PullRequestWatchRequest = {
+      cancelled: false,
+      cancelledRepoPaths: new Set(),
+    };
+    const groupResults = new Array<PullRequestWatchSnapshot[] | undefined>(
+      repositoryGroups.length,
     );
+    let nextGroupIndex = 0;
+    this.pullRequestWatchRequests.add(request);
 
-    return groupResults.flatMap((result, index) => {
-      if (result.status === "fulfilled") return result.value;
-      logger.debug("Pull request watch batch failed", {
-        repoPath: repositoryGroups[index]?.repoPath,
-        error: String(result.reason),
-      });
-      return [];
-    });
+    try {
+      const workerCount = Math.min(this.maxConcurrent, repositoryGroups.length);
+      await Promise.all(Array.from({ length: workerCount }, async () => {
+        while (!request.cancelled) {
+          const groupIndex = nextGroupIndex++;
+          const group = repositoryGroups[groupIndex];
+          if (!group) return;
+          if (this.isPullRequestWatchCancelled(request, group.repoPath)) continue;
+
+          await this.acquire();
+          try {
+            if (this.isPullRequestWatchCancelled(request, group.repoPath)) continue;
+            groupResults[groupIndex] = await this.fetchRepositoryWatchSnapshots(group, request);
+          } catch (error) {
+            if (!this.isPullRequestWatchCancelled(request, group.repoPath)) {
+              logger.debug("Pull request watch batch failed", {
+                repoPath: group.repoPath,
+                error: String(error),
+              });
+            }
+          } finally {
+            this.release();
+          }
+        }
+      }));
+      return groupResults.flatMap((result) => result ?? []);
+    } finally {
+      this.pullRequestWatchRequests.delete(request);
+    }
   }
 
   private async fetchRepositoryWatchSnapshots(
     group: PullRequestWatchRepositoryGroup,
+    request: PullRequestWatchRequest,
   ): Promise<PullRequestWatchSnapshot[]> {
+    if (this.isPullRequestWatchCancelled(request, group.repoPath)) return [];
     const slug = await this.resolveRepoSlug(group.repoPath);
+    if (this.isPullRequestWatchCancelled(request, group.repoPath)) return [];
     const [owner, repository] = slug.split("/");
     if (!owner || !repository) throw new Error(`Unexpected repository slug: ${slug}`);
 
@@ -591,6 +631,7 @@ export class GithubService {
       offset < uniquePullRequestNumbers.length;
       offset += MAX_PULL_REQUESTS_PER_WATCH_BATCH
     ) {
+      if (this.isPullRequestWatchCancelled(request, group.repoPath)) return [];
       const batchNumbers = uniquePullRequestNumbers.slice(
         offset,
         offset + MAX_PULL_REQUESTS_PER_WATCH_BATCH,
@@ -600,7 +641,9 @@ export class GithubService {
         owner,
         repository,
         batchNumbers,
+        request,
       );
+      if (this.isPullRequestWatchCancelled(request, group.repoPath)) return [];
       for (const [prNumber, snapshot] of snapshotsByNumber) {
         for (const target of targetsByPullRequest.get(prNumber) ?? []) {
           snapshots.push({ ...snapshot, threadId: target.threadId });
@@ -615,6 +658,7 @@ export class GithubService {
     owner: string,
     repository: string,
     prNumbers: readonly number[],
+    request: PullRequestWatchRequest,
   ): Promise<Map<number, Omit<PullRequestWatchSnapshot, "threadId">>> {
     const query = buildPullRequestWatchQuery(prNumbers.length);
     const args = [
@@ -631,35 +675,40 @@ export class GithubService {
       args.push("-F", `number${index}=${prNumber}`);
     }
 
-    await this.acquire();
-    try {
-      const stdout = await new Promise<string>((resolve, reject) => {
-        let tracked: TrackedGithubProcess | null = null;
-        const child = execFile(
-          "gh",
-          args,
-          {
-            cwd: repoPath,
-            encoding: "utf-8",
-            timeout: 15_000,
-            maxBuffer: 2 * 1024 * 1024,
-            windowsHide: true,
-          },
-          (error, output) => {
-            tracked?.finish();
-            if (error) {
-              reject(error);
-              return;
-            }
-            resolve(output);
-          },
-        );
-        tracked = this.trackProcess(child, { repoPath });
-      });
-      return parsePullRequestWatchBatch(stdout, prNumbers);
-    } finally {
-      this.release();
-    }
+    if (this.isPullRequestWatchCancelled(request, repoPath)) return new Map();
+    const stdout = await new Promise<string>((resolve, reject) => {
+      let tracked: TrackedGithubProcess | null = null;
+      const child = execFile(
+        "gh",
+        args,
+        {
+          cwd: repoPath,
+          encoding: "utf-8",
+          timeout: 15_000,
+          maxBuffer: 2 * 1024 * 1024,
+          windowsHide: true,
+        },
+        (error, output) => {
+          tracked?.finish();
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(output);
+        },
+      );
+      tracked = this.trackProcess(child, { repoPath });
+    });
+    return parsePullRequestWatchBatch(stdout, prNumbers);
+  }
+
+  private isPullRequestWatchCancelled(
+    request: PullRequestWatchRequest,
+    repoPath: string,
+  ): boolean {
+    const normalized = normalizeRepoPath(repoPath);
+    return request.cancelled
+      || (normalized !== null && request.cancelledRepoPaths.has(normalized));
   }
 
   /**
@@ -783,6 +832,11 @@ interface PullRequestWatchRepositoryGroup {
   targets: PullRequestWatchTarget[];
 }
 
+interface PullRequestWatchRequest {
+  cancelled: boolean;
+  cancelledRepoPaths: Set<string>;
+}
+
 interface RawWatchCheckRun {
   name: string;
   status: string;
@@ -797,7 +851,12 @@ function noChecks(): ChecksStatus {
 }
 
 function normalizeRepoPath(repoPath: string | null | undefined): string | null {
-  return repoPath ? repoPath.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase() : null;
+  if (!repoPath) return null;
+  const normalized = repoPath.replace(/\\/g, "/").replace(/\/+$/, "");
+  const isWindowsStyle = repoPath.includes("\\")
+    || /^[A-Za-z]:\//.test(normalized)
+    || normalized.startsWith("//");
+  return isWindowsStyle ? normalized.toLowerCase() : normalized;
 }
 
 function groupWatchTargetsByRepository(

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -573,8 +573,10 @@ async function dispatch(
             })),
           );
       for (const snapshot of linkedSnapshots) {
-        const thread = linkedThreadsById.get(snapshot.threadId);
-        if (!thread) continue;
+        const requestedThread = linkedThreadsById.get(snapshot.threadId);
+        if (!requestedThread) continue;
+        const thread = deps.threadService.findById(snapshot.threadId);
+        if (!thread || thread.pr_number !== snapshot.prNumber) continue;
         const statusChanged = thread.pr_status?.toLowerCase() !== snapshot.state.toLowerCase();
         if (statusChanged) {
           deps.threadService.linkPr(thread.id, snapshot.prNumber, snapshot.state);

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -558,8 +558,50 @@ async function dispatch(
       const workspace = deps.workspaceService.findById(params.workspaceId);
       if (!workspace) return [];
       const results: Array<{ threadId: string; prNumber: number; prStatus: string }> = [];
+
+      const linkedThreads = needsCheck.filter(
+        (thread): thread is typeof thread & { pr_number: number } => thread.pr_number != null,
+      );
+      const linkedThreadsById = new Map(linkedThreads.map((thread) => [thread.id, thread]));
+      const linkedSnapshots = linkedThreads.length === 0
+        ? []
+        : await deps.githubService.getPullRequestWatchSnapshots(
+            linkedThreads.map((thread) => ({
+              threadId: thread.id,
+              prNumber: thread.pr_number,
+              repoPath: workspace.path,
+            })),
+          );
+      for (const snapshot of linkedSnapshots) {
+        const thread = linkedThreadsById.get(snapshot.threadId);
+        if (!thread) continue;
+        const statusChanged = thread.pr_status?.toLowerCase() !== snapshot.state.toLowerCase();
+        if (statusChanged) {
+          deps.threadService.linkPr(thread.id, snapshot.prNumber, snapshot.state);
+          results.push({
+            threadId: thread.id,
+            prNumber: snapshot.prNumber,
+            prStatus: snapshot.state,
+          });
+        }
+
+        if (snapshot.state === "OPEN") {
+          deps.ciWatcherService.watch(
+            thread.id,
+            snapshot.prNumber,
+            thread.branch,
+            workspace.path,
+            { skipInitialFetch: true },
+          );
+          deps.ciWatcherService.refresh(thread.id, snapshot.checks);
+        } else {
+          deps.ciWatcherService.unwatch(thread.id);
+        }
+      }
+
+      const unlinkedThreads = needsCheck.filter((thread) => thread.pr_number == null);
       await Promise.allSettled(
-        needsCheck.map(async (t) => {
+        unlinkedThreads.map(async (t) => {
           const pr = await deps.githubService.getBranchPr(t.branch, workspace.path);
           if (pr) {
             const numberChanged = t.pr_number !== pr.number;

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -880,6 +880,24 @@ describe("routeMessage thread.syncPrs", () => {
             pr_status: "OPEN",
           },
         ]),
+        findById: vi.fn().mockImplementation((threadId: string) => ({
+          "thread-1": {
+            id: "thread-1",
+            branch: "feat/one",
+            mode: "worktree",
+            checkout_state: "named",
+            pr_number: 41,
+            pr_status: "OPEN",
+          },
+          "thread-2": {
+            id: "thread-2",
+            branch: "feat/two",
+            mode: "worktree",
+            checkout_state: "named",
+            pr_number: 42,
+            pr_status: "OPEN",
+          },
+        })[threadId] ?? null),
         linkPr: vi.fn(),
       },
       githubService: {
@@ -916,6 +934,67 @@ describe("routeMessage thread.syncPrs", () => {
     );
     expect(refresh).toHaveBeenCalledWith("thread-1", checks);
     expect(unwatch).toHaveBeenCalledWith("thread-2");
+  });
+
+  it("ignores a linked snapshot when the thread was relinked during the request", async () => {
+    const checks = { aggregate: "passing" as const, runs: [], fetchedAt: 1 };
+    const linkPr = vi.fn();
+    const watch = vi.fn();
+    const refresh = vi.fn();
+    const unwatch = vi.fn();
+    const deps = {
+      workspaceService: {
+        findById: vi.fn().mockReturnValue({
+          id: "ws-1",
+          path: "C:/repo",
+          is_git_repo: true,
+        }),
+      },
+      threadService: {
+        list: vi.fn().mockReturnValue([{
+          id: "thread-1",
+          branch: "feat/one",
+          mode: "worktree",
+          checkout_state: "named",
+          pr_number: 41,
+          pr_status: "OPEN",
+        }]),
+        findById: vi.fn().mockReturnValue({
+          id: "thread-1",
+          branch: "feat/relinked",
+          mode: "worktree",
+          checkout_state: "named",
+          pr_number: 99,
+          pr_status: "OPEN",
+        }),
+        linkPr,
+      },
+      githubService: {
+        getPullRequestWatchSnapshots: vi.fn().mockResolvedValue([{
+          threadId: "thread-1",
+          prNumber: 41,
+          state: "MERGED",
+          checks,
+        }]),
+        getBranchPr: vi.fn(),
+      },
+      ciWatcherService: { watch, refresh, unwatch },
+    } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-sync-stale",
+        method: "thread.syncPrs",
+        params: { workspaceId: "ws-1" },
+      }),
+      deps,
+    );
+
+    expect(response.result).toEqual([]);
+    expect(linkPr).not.toHaveBeenCalled();
+    expect(watch).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(unwatch).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -843,6 +843,80 @@ describe("routeMessage thread.syncPrs", () => {
     );
     expect(watch).toHaveBeenCalledWith("named-thread", 42, "feat/named", "C:/repo");
   });
+
+  it("refreshes linked pull requests through one batch and stops terminal watchers", async () => {
+    const checks = { aggregate: "passing" as const, runs: [], fetchedAt: 1 };
+    const getPullRequestWatchSnapshots = vi.fn().mockResolvedValue([
+      { threadId: "thread-1", prNumber: 41, state: "OPEN", checks },
+      { threadId: "thread-2", prNumber: 42, state: "MERGED", checks },
+    ]);
+    const watch = vi.fn();
+    const refresh = vi.fn();
+    const unwatch = vi.fn();
+    const deps = {
+      workspaceService: {
+        findById: vi.fn().mockReturnValue({
+          id: "ws-1",
+          path: "C:/repo",
+          is_git_repo: true,
+        }),
+      },
+      threadService: {
+        list: vi.fn().mockReturnValue([
+          {
+            id: "thread-1",
+            branch: "feat/one",
+            mode: "worktree",
+            checkout_state: "named",
+            pr_number: 41,
+            pr_status: "OPEN",
+          },
+          {
+            id: "thread-2",
+            branch: "feat/two",
+            mode: "worktree",
+            checkout_state: "named",
+            pr_number: 42,
+            pr_status: "OPEN",
+          },
+        ]),
+        linkPr: vi.fn(),
+      },
+      githubService: {
+        getPullRequestWatchSnapshots,
+        getBranchPr: vi.fn(),
+      },
+      ciWatcherService: { watch, refresh, unwatch },
+    } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-sync-linked",
+        method: "thread.syncPrs",
+        params: { workspaceId: "ws-1" },
+      }),
+      deps,
+    );
+
+    expect(getPullRequestWatchSnapshots).toHaveBeenCalledTimes(1);
+    expect(getPullRequestWatchSnapshots).toHaveBeenCalledWith([
+      { threadId: "thread-1", prNumber: 41, repoPath: "C:/repo" },
+      { threadId: "thread-2", prNumber: 42, repoPath: "C:/repo" },
+    ]);
+    expect(deps.githubService.getBranchPr).not.toHaveBeenCalled();
+    expect(response.result).toEqual([
+      { threadId: "thread-2", prNumber: 42, prStatus: "MERGED" },
+    ]);
+    expect(watch).toHaveBeenCalledWith(
+      "thread-1",
+      41,
+      "feat/one",
+      "C:/repo",
+      { skipInitialFetch: true },
+    );
+    expect(refresh).toHaveBeenCalledWith("thread-1", checks);
+    expect(unwatch).toHaveBeenCalledWith("thread-2");
+  });
 });
 
 describe("routeMessage github.checkStatus", () => {


### PR DESCRIPTION
## What

Batch pull request lifecycle and CI polling through bounded GraphQL requests.

## Why

One GitHub lookup ran per watched thread, increasing CLI processes and rate-limit usage.

## Key Changes

- Batch up to 25 pull requests per repository and deduplicate repeated identities.
- Include lifecycle state and up to 100 check contexts in each snapshot.
- Stop polling terminal pull requests, then persist and broadcast the final state.
- Keep branch-based discovery for threads without a linked pull request.
- Add service, watcher, and router coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786935846&installation_id=129163861&pr_number=882&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F882&signature=cff50ac25f151e45f7bb04cfc19a4f73db98d3f6820c8663a9a9d1d728d707ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Pull request and CI status synchronization is now more efficient, especially when updating multiple linked pull requests.
  - Linked pull requests are refreshed in batches, reducing redundant status checks.
  - Merged or closed pull requests are automatically removed from CI monitoring.
  - Pull request status changes are propagated to connected clients and reflected in thread updates.
  - Synchronization now avoids unnecessary branch lookups when pull request details are already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->