### PR TITLE
feat: track agent-authored file changes

### DIFF
--- a/apps/server/drizzle/0021_bright_vargas.sql
+++ b/apps/server/drizzle/0021_bright_vargas.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `turn_snapshots` ADD `file_effects` text DEFAULT '{"revision":0,"fileCount":0,"additions":0,"deletions":0,"effects":[]}' NOT NULL;

--- a/apps/server/drizzle/meta/0021_snapshot.json
+++ b/apps/server/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1770 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "11007ec1-331f-4923-98a3-e5d23ef44582",
+  "prevId": "cfb7e489-4168-421a-a44c-00c85976507b",
+  "tables": {
+    "cleanup_jobs": {
+      "name": "cleanup_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cleanup_jobs_thread_id_unique": {
+          "name": "cleanup_jobs_thread_id_unique",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cleanup_jobs_retry": {
+          "name": "idx_cleanup_jobs_retry",
+          "columns": [
+            "next_retry_at",
+            "attempts",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diff_summaries": {
+      "name": "diff_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_turn_id": {
+          "name": "last_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_diff_summaries_thread": {
+          "name": "idx_diff_summaries_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "diff_summaries_thread_id_threads_id_fk": {
+          "name": "diff_summaries_thread_id_threads_id_fk",
+          "tableFrom": "diff_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_executions": {
+      "name": "hook_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hook_name": {
+          "name": "hook_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "did_block": {
+          "name": "did_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_hook_executions_message": {
+          "name": "idx_hook_executions_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hook_executions_message_id_messages_id_fk": {
+          "name": "hook_executions_message_id_messages_id_fk",
+          "tableFrom": "hook_executions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_annotations": {
+          "name": "preview_annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quoted_text": {
+          "name": "quoted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_messages_thread": {
+          "name": "idx_messages_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_sequence": {
+          "name": "idx_messages_sequence",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_reply_to_message_id_messages_id_fk": {
+          "name": "messages_reply_to_message_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "reply_to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_question_answers": {
+      "name": "plan_question_answers",
+      "columns": {
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_question_answers_thread": {
+          "name": "idx_plan_question_answers_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_question_answers_assistant_message_id_messages_id_fk": {
+          "name": "plan_question_answers_assistant_message_id_messages_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_question_answers_thread_id_threads_id_fk": {
+          "name": "plan_question_answers_thread_id_threads_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plans_thread": {
+          "name": "idx_plans_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plans_thread_version": {
+          "name": "idx_plans_thread_version",
+          "columns": [
+            "thread_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plans_thread_id_threads_id_fk": {
+          "name": "plans_thread_id_threads_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_message_id_messages_id_fk": {
+          "name": "plans_message_id_messages_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_cache": {
+      "name": "provider_model_cache",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_request_review_links": {
+      "name": "pull_request_review_links",
+      "columns": {
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_node_id": {
+          "name": "repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_state": {
+          "name": "pr_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "head_repository_node_id": {
+          "name": "head_repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_owner": {
+          "name": "head_repository_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_name": {
+          "name": "head_repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_oid": {
+          "name": "head_oid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_branch": {
+          "name": "local_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_remote": {
+          "name": "push_remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_ref": {
+          "name": "push_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "managed_remote_name": {
+          "name": "managed_remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_thread_id": {
+          "name": "primary_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_pull_request_review_links_identity": {
+          "name": "idx_pull_request_review_links_identity",
+          "columns": [
+            "provider",
+            "repository_node_id",
+            "pull_request_number"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_primary_thread": {
+          "name": "idx_pull_request_review_links_primary_thread",
+          "columns": [
+            "primary_thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_workspace": {
+          "name": "idx_pull_request_review_links_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pull_request_review_links_worktree_path": {
+          "name": "idx_pull_request_review_links_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_request_review_links_workspace_id_workspaces_id_fk": {
+          "name": "pull_request_review_links_workspace_id_workspaces_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pull_request_review_links_primary_thread_id_threads_id_fk": {
+          "name": "pull_request_review_links_primary_thread_id_threads_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "primary_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thought_segments": {
+      "name": "thought_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_final_response": {
+          "name": "is_final_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_thought_segments_message": {
+          "name": "idx_thought_segments_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thought_segments_message_id_messages_id_fk": {
+          "name": "thought_segments_message_id_messages_id_fk",
+          "tableFrom": "thought_segments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tasks": {
+      "name": "thread_tasks",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_json": {
+          "name": "tasks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tasks_thread_id_threads_id_fk": {
+          "name": "thread_tasks_thread_id_threads_id_fk",
+          "tableFrom": "thread_tasks",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkout_state": {
+          "name": "checkout_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'named'"
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_tokens": {
+          "name": "last_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interaction_mode": {
+          "name": "interaction_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "orchestration_mode": {
+          "name": "orchestration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_message_id": {
+          "name": "forked_from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_compact_summary": {
+          "name": "last_compact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "copilot_agent": {
+          "name": "copilot_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window_mode": {
+          "name": "context_window_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codex_fast_mode": {
+          "name": "codex_fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_open_in_app": {
+          "name": "default_open_in_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file_changes": {
+          "name": "has_file_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_threads_workspace": {
+          "name": "idx_threads_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_deleted": {
+          "name": "idx_threads_workspace_deleted",
+          "columns": [
+            "workspace_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_recency": {
+          "name": "idx_threads_workspace_recency",
+          "columns": [
+            "workspace_id",
+            "\"updated_at\" desc"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_status": {
+          "name": "idx_threads_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_parent_thread_id": {
+          "name": "idx_threads_parent_thread_id",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_forked_from_message_id": {
+          "name": "idx_threads_forked_from_message_id",
+          "columns": [
+            "forked_from_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_workspace_id_workspaces_id_fk": {
+          "name": "threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_call_records": {
+      "name": "tool_call_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_truncated": {
+          "name": "output_truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_total_bytes": {
+          "name": "output_total_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_artifact_path": {
+          "name": "output_artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tool_call_records_message": {
+          "name": "idx_tool_call_records_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tool_call_records_parent": {
+          "name": "idx_tool_call_records_parent",
+          "columns": [
+            "parent_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_call_records_message_id_messages_id_fk": {
+          "name": "tool_call_records_message_id_messages_id_fk",
+          "tableFrom": "tool_call_records",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turn_snapshots": {
+      "name": "turn_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_before": {
+          "name": "ref_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_after": {
+          "name": "ref_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "file_effects": {
+          "name": "file_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"revision\":0,\"fileCount\":0,\"additions\":0,\"deletions\":0,\"effects\":[]}'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_turn_snapshots_message": {
+          "name": "idx_turn_snapshots_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_turn_snapshots_thread": {
+          "name": "idx_turn_snapshots_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "turn_snapshots_message_id_messages_id_fk": {
+          "name": "turn_snapshots_message_id_messages_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_snapshots_thread_id_threads_id_fk": {
+          "name": "turn_snapshots_thread_id_threads_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_path_unique": {
+          "name": "workspaces_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspaces_sort_order": {
+          "name": "idx_workspaces_sort_order",
+          "columns": [
+            "\"sort_order\" asc"
+          ],
+          "isUnique": false
+        },
+        "idx_workspaces_pinned_last_opened": {
+          "name": "idx_workspaces_pinned_last_opened",
+          "columns": [
+            "\"pinned\" desc",
+            "\"last_opened_at\" desc"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_threads_workspace_recency": {
+        "columns": {
+          "\"updated_at\" desc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_sort_order": {
+        "columns": {
+          "\"sort_order\" asc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_pinned_last_opened": {
+        "columns": {
+          "\"pinned\" desc": {
+            "isExpression": true
+          },
+          "\"last_opened_at\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1784255902625,
       "tag": "0020_normalize_reasoning_modes",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1784398924316,
+      "tag": "0021_bright_vargas",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/__tests__/agent-service-turn-started.test.ts
+++ b/apps/server/src/__tests__/agent-service-turn-started.test.ts
@@ -186,6 +186,7 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       (e) => e.type === AgentEventType.TurnStarted,
     ).length;
     expect(turnStartedCount, "turnStarted must be emitted exactly once").toBe(1);
+    expect(svc.getCurrentFileEffectTurnId(thread.id)).toMatch(/^\d+$/);
 
     expect(svc.activeThreadIds()).toContain(thread.id);
 

--- a/apps/server/src/__tests__/snapshot-service.integration.test.ts
+++ b/apps/server/src/__tests__/snapshot-service.integration.test.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
@@ -149,6 +149,47 @@ describe("SnapshotService integration", () => {
     expect(fileStat).toBeDefined();
     expect(fileStat!.additions).toBe(expectedLineCount);
     expect(fileStat!.deletions).toBe(0);
+  }, GIT_OPERATION_TIMEOUT_MS);
+
+  it("scopes historical diffs and stats to attributed paths", async () => {
+    const refBefore = await service.captureRef(tmpDir);
+    writeFileSync(join(tmpDir, "authored.txt"), "agent change\n");
+    writeFileSync(join(tmpDir, "unrelated.txt"), "git pull change\n");
+    const refAfter = await service.captureRef(tmpDir);
+
+    const diff = await service.getDiff(
+      tmpDir,
+      refBefore,
+      refAfter,
+      undefined,
+      undefined,
+      ["authored.txt"],
+    );
+    const stats = await service.getDiffStats(tmpDir, refBefore, refAfter, ["authored.txt"]);
+
+    expect(diff).toContain("authored.txt");
+    expect(diff).not.toContain("unrelated.txt");
+    expect(stats.map((entry) => entry.filePath)).toEqual(["authored.txt"]);
+  }, GIT_OPERATION_TIMEOUT_MS);
+
+  it("keeps both sides of a rename when opening the renamed file", async () => {
+    const refBefore = await service.captureRef(tmpDir);
+    renameSync(join(tmpDir, "existing.txt"), join(tmpDir, "renamed.txt"));
+    const refAfter = await service.captureRef(tmpDir);
+
+    const diff = await service.getDiff(
+      tmpDir,
+      refBefore,
+      refAfter,
+      "renamed.txt",
+      undefined,
+      ["renamed.txt", "existing.txt"],
+      [["renamed.txt", "existing.txt"]],
+    );
+
+    expect(diff).toContain("similarity index 100%");
+    expect(diff).toContain("rename from existing.txt");
+    expect(diff).toContain("rename to renamed.txt");
   }, GIT_OPERATION_TIMEOUT_MS);
 
   it("gitignored files are excluded from getFilesChanged", async () => {

--- a/apps/server/src/__tests__/snapshot-service.test.ts
+++ b/apps/server/src/__tests__/snapshot-service.test.ts
@@ -118,3 +118,85 @@ describe("SnapshotService.validateRef", () => {
     expect(fake.calls).toHaveLength(0);
   });
 });
+
+describe("SnapshotService ref and numstat validation", () => {
+  it("rejects flag-shaped refs before invoking Git", async () => {
+    const fake = new FakeGitExecutor();
+    const service = new SnapshotService(fake);
+
+    await expect(service.getFileAtRef("/repo", "--batch", "file.txt")).resolves.toEqual({
+      kind: "missing",
+    });
+    await expect(service.getFilesChanged("/repo", "--output=x", "after")).resolves.toEqual([]);
+    await expect(service.getDiff("/repo", "--output=x", "after")).resolves.toBe("");
+    await expect(service.getDiffStats("/repo", "before", "--output=x")).resolves.toEqual([]);
+    expect(fake.calls).toHaveLength(0);
+  });
+
+  it("returns destination paths for simple and brace-form numstat renames", async () => {
+    const executor: GitExecutor = {
+      async exec() {
+        return {
+          stdout: "0\t0\told.txt => new.txt\n1\t2\tarch/{i386 => x86}/Makefile\n",
+          stderr: "",
+        };
+      },
+    };
+    const service = new SnapshotService(executor);
+
+    await expect(service.getDiffStats("/repo", "before", "after")).resolves.toEqual([
+      { filePath: "new.txt", additions: 0, deletions: 0 },
+      { filePath: "arch/x86/Makefile", additions: 1, deletions: 2 },
+    ]);
+  });
+});
+
+describe("SnapshotService attributed path batching", () => {
+  it("includes paths beyond the first 512 without exceeding per-call bounds", async () => {
+    const calls: string[][] = [];
+    const executor: GitExecutor = {
+      async exec(args) {
+        calls.push([...args]);
+        const lastPathspec = args.at(-1) ?? "";
+        return { stdout: `diff for ${lastPathspec}\n`, stderr: "" };
+      },
+    };
+    const service = new SnapshotService(executor);
+    const paths = Array.from({ length: 600 }, (_, index) => `src/file-${index}.ts`);
+
+    const diff = await service.getDiff("/repo", "before", "after", undefined, undefined, paths);
+
+    expect(calls).toHaveLength(5);
+    expect(calls.every((args) => args.filter((arg) => arg.startsWith(":(literal)")).length <= 128)).toBe(true);
+    expect(calls.flat()).toContain(":(literal)src/file-599.ts");
+    expect(diff).toContain(":(literal)src/file-599.ts");
+  });
+
+  it("keeps rename pairs together when a batch boundary is reached", async () => {
+    const calls: string[][] = [];
+    const executor: GitExecutor = {
+      async exec(args) {
+        calls.push([...args]);
+        return { stdout: "", stderr: "" };
+      },
+    };
+    const service = new SnapshotService(executor);
+    const singles = Array.from({ length: 127 }, (_, index) => [`src/file-${index}.ts`]);
+    const renamePair = ["src/new-name.ts", "src/old-name.ts"];
+    const groups = [...singles, renamePair];
+
+    await service.getDiff(
+      "/repo",
+      "before",
+      "after",
+      undefined,
+      undefined,
+      groups.flat(),
+      groups,
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toContain(":(literal)src/new-name.ts");
+    expect(calls[1]).toContain(":(literal)src/old-name.ts");
+  });
+});

--- a/apps/server/src/__tests__/turn-snapshot-repo.test.ts
+++ b/apps/server/src/__tests__/turn-snapshot-repo.test.ts
@@ -167,4 +167,29 @@ describe("TurnSnapshotRepo", () => {
 
     expect(repo.getByMessage(messageId)).toBeNull();
   });
+
+  it("returns an empty file summary when persisted effects fail contract validation", () => {
+    const now = new Date().toISOString();
+    db.prepare(
+      "INSERT INTO turn_snapshots (id, message_id, thread_id, ref_before, ref_after, files_changed, file_effects, worktree_path, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "corrupt-effects",
+      messageId,
+      threadId,
+      "before",
+      "after",
+      "[]",
+      JSON.stringify({ revision: 1, fileCount: 1, additions: 0, deletions: 0, effects: [null] }),
+      null,
+      now,
+    );
+
+    expect(repo.getById("corrupt-effects")?.file_effects).toEqual({
+      revision: 0,
+      fileCount: 0,
+      additions: 0,
+      deletions: 0,
+      effects: [],
+    });
+  });
 });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,6 +15,7 @@ import { randomUUID } from "crypto";
 import { execFileSync } from "child_process";
 import { killOrphanedServer, reapOrphanedPtys } from "./services/orphan-cleanup";
 import { PtyPidRegistry } from "./services/pty-pid-registry";
+import { sanitizePublicToolInput } from "./services/public-tool-input";
 
 // Services
 import { WorkspaceService } from "./services/workspace-service";
@@ -470,6 +471,11 @@ for (const provider of providerRegistry.resolveAll()) {
 
     let enrichedEvent = event;
 
+    if (event.type === AgentEventType.TurnStarted) {
+      const fileEffectTurnId = agentService.getCurrentFileEffectTurnId(event.threadId);
+      if (fileEffectTurnId) enrichedEvent = { ...event, fileEffectTurnId };
+    }
+
     // Enrich non-Agent tool calls with their parent Agent ID.
     // Prefer the SDK-provided parent_tool_use_id on the event (set by the
     // provider when the SDK message carries it). This is the only correct
@@ -513,6 +519,21 @@ for (const provider of providerRegistry.resolveAll()) {
       enrichedEvent = {
         ...event,
         error: normalizeAgentProviderError(providerForThread, event.error ?? ""),
+      };
+    }
+
+    // Provider mutation evidence may contain full before/after text for server-side
+    // verification. Keep that content inside AgentService and send only bounded,
+    // content-free tool metadata to clients.
+    if (enrichedEvent.type === AgentEventType.ToolUse) {
+      enrichedEvent = {
+        ...enrichedEvent,
+        toolInput: sanitizePublicToolInput(enrichedEvent.toolInput, enrichedEvent.toolName),
+      };
+    } else if (enrichedEvent.type === AgentEventType.ToolResult && enrichedEvent.toolInput) {
+      enrichedEvent = {
+        ...enrichedEvent,
+        toolInput: sanitizePublicToolInput(enrichedEvent.toolInput),
       };
     }
 

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -592,13 +592,20 @@ export class CodexEventMapper {
 
     if (itemType === "fileChange") {
       const changes = Array.isArray(item.changes) ? item.changes : [];
-      const paths = changes.map((c) => c.path).filter(Boolean).join(", ");
       return {
         type: AgentEventType.ToolUse,
         threadId: this.threadId,
         toolCallId,
         toolName: "file_change",
-        toolInput: paths.length > 0 ? { files: paths } : {},
+        toolInput: changes.length > 0
+          ? {
+              files: changes.map((change) => change.path).filter(Boolean).join(", "),
+              changes: changes
+                .filter((change) => typeof change.path === "string" && change.path.length > 0)
+                .slice(0, 256)
+                .map((change) => ({ path: change.path, kind: change.kind })),
+            }
+          : {},
         ...(nestParent ? { parentToolCallId: nestParent } : {}),
       };
     }

--- a/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-event-mapper.ts
@@ -469,6 +469,14 @@ function mapAcpToolCallUpdated(
     toolCallId: update.toolCallId,
     output,
     isError,
+    ...(diffs.length > 0 && Array.isArray(toolInput._mcodeFileMutations)
+      ? {
+          toolInput: {
+            _mcodeToolName: toolName,
+            _mcodeFileMutations: toolInput._mcodeFileMutations,
+          },
+        }
+      : {}),
   });
   return events;
 }

--- a/apps/server/src/providers/cursor/cursor-acp-tool-input-enrichment.ts
+++ b/apps/server/src/providers/cursor/cursor-acp-tool-input-enrichment.ts
@@ -74,6 +74,13 @@ export function enrichAcpToolInput(
       file_path: diff.path,
       old_string: diff.oldText,
       new_string: diff.newText,
+      _mcodeFileMutations: diffs.slice(0, 256).map((item) => ({
+        path: item.path,
+        kind: item.oldText.length === 0 ? "add" : item.newText.length === 0 ? "remove" : "edit",
+        fullFileContent: true,
+        beforeText: item.oldText,
+        afterText: item.newText,
+      })),
     };
   } else if (toolName === "Read") {
     const filePath =

--- a/apps/server/src/repositories/turn-snapshot-repo.ts
+++ b/apps/server/src/repositories/turn-snapshot-repo.ts
@@ -6,7 +6,11 @@
 import { randomUUID } from "crypto";
 import { injectable, inject } from "tsyringe";
 import type Database from "better-sqlite3";
-import type { TurnSnapshot } from "@mcode/contracts";
+import {
+  TurnFileEffectSummarySchema,
+  type TurnFileEffectSummary,
+  type TurnSnapshot,
+} from "@mcode/contracts";
 
 /** Row shape returned by SQLite for the turn_snapshots table. */
 interface TurnSnapshotRow {
@@ -16,6 +20,7 @@ interface TurnSnapshotRow {
   ref_before: string;
   ref_after: string;
   files_changed: string;
+  file_effects: string;
   worktree_path: string | null;
   created_at: string;
 }
@@ -27,6 +32,7 @@ export interface CreateTurnSnapshotInput {
   refBefore: string;
   refAfter: string;
   filesChanged: string[];
+  fileEffects?: TurnFileEffectSummary;
   worktreePath: string | null;
 }
 
@@ -39,6 +45,16 @@ function safeParseArray(json: string): string[] {
   }
 }
 
+function safeParseFileEffects(json: string): TurnFileEffectSummary {
+  try {
+    const parsed = TurnFileEffectSummarySchema().safeParse(JSON.parse(json));
+    if (parsed.success) return parsed.data;
+  } catch {
+    // Corrupt legacy metadata is treated as an empty authored summary.
+  }
+  return { revision: 0, fileCount: 0, additions: 0, deletions: 0, effects: [] };
+}
+
 function rowToTurnSnapshot(row: TurnSnapshotRow): TurnSnapshot {
   return {
     id: row.id,
@@ -47,13 +63,14 @@ function rowToTurnSnapshot(row: TurnSnapshotRow): TurnSnapshot {
     ref_before: row.ref_before,
     ref_after: row.ref_after,
     files_changed: safeParseArray(row.files_changed),
+    file_effects: safeParseFileEffects(row.file_effects),
     worktree_path: row.worktree_path,
     created_at: row.created_at,
   };
 }
 
 const TURN_SNAPSHOT_COLUMNS =
-  "id, message_id, thread_id, ref_before, ref_after, files_changed, worktree_path, created_at";
+  "id, message_id, thread_id, ref_before, ref_after, files_changed, file_effects, worktree_path, created_at";
 
 /** Repository for turn snapshot creation and retrieval against SQLite. */
 @injectable()
@@ -66,7 +83,7 @@ export class TurnSnapshotRepo {
 
   constructor(@inject("Database") db: Database.Database) {
     this.stmtInsert = db.prepare(
-      "INSERT INTO turn_snapshots (id, message_id, thread_id, ref_before, ref_after, files_changed, worktree_path, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO turn_snapshots (id, message_id, thread_id, ref_before, ref_after, files_changed, file_effects, worktree_path, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     );
     this.stmtGetById = db.prepare(
       `SELECT ${TURN_SNAPSHOT_COLUMNS} FROM turn_snapshots WHERE id = ?`,
@@ -87,6 +104,13 @@ export class TurnSnapshotRepo {
     const id = randomUUID();
     const now = new Date().toISOString();
     const filesChangedJson = JSON.stringify(input.filesChanged);
+    const fileEffects = TurnFileEffectSummarySchema().parse(input.fileEffects ?? {
+      revision: 0,
+      fileCount: 0,
+      additions: 0,
+      deletions: 0,
+      effects: [],
+    });
 
     this.stmtInsert.run(
       id,
@@ -95,6 +119,7 @@ export class TurnSnapshotRepo {
       input.refBefore,
       input.refAfter,
       filesChangedJson,
+      JSON.stringify(fileEffects),
       input.worktreePath,
       now,
     );
@@ -106,6 +131,7 @@ export class TurnSnapshotRepo {
       ref_before: input.refBefore,
       ref_after: input.refAfter,
       files_changed: input.filesChanged,
+      file_effects: fileEffects,
       worktree_path: input.worktreePath,
       created_at: now,
     };

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -1,6 +1,9 @@
 import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "events";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { AgentEventType } from "@mcode/contracts";
 import type {
   AgentEvent,
@@ -123,12 +126,15 @@ function makePreviewAnnotationBundle(): PreviewAnnotationBundle {
  * The returned `providerEmitter` lets the test fire events as if the SDK
  * produced them, exercising the handler registered in `init()`.
  */
-function buildService(): {
+function buildService(cwd = process.cwd()): {
   service: AgentService;
   providerEmitter: EventEmitter;
   attachmentService: AttachmentService;
   messageRepo: MessageRepo;
   memoryPressureService: { markActive: ReturnType<typeof vi.fn>; markIdle: ReturnType<typeof vi.fn> };
+  snapshotService: { captureRef: ReturnType<typeof vi.fn> };
+  turnSnapshotRepo: { create: ReturnType<typeof vi.fn> };
+  toolCallRecordRepo: { bulkCreate: ReturnType<typeof vi.fn> };
 } {
   const thread = makeThread();
   const providerEmitter = new EventEmitter();
@@ -152,18 +158,24 @@ function buildService(): {
   } as unknown as ThreadRepo;
 
   const workspaceRepo = {
-    findById: vi.fn(() => ({ id: "ws-1", path: "/workspace" })),
+    findById: vi.fn(() => ({ id: "ws-1", path: cwd })),
   } as unknown as WorkspaceRepo;
 
+  let assistantMessageCount = 0;
   const messageRepo = {
     listByThread: vi.fn(() => ({ messages: [] })),
     create: vi.fn(() => ({ id: "msg-1", sequence: 1 })),
     findByIdInThread: vi.fn(),
     listByThreadUpToSequence: vi.fn(() => []),
+    createAssistantIdempotent: vi.fn(() => ({
+      id: `assistant-${++assistantMessageCount}`,
+      sequence: assistantMessageCount + 1,
+      content: "",
+    })),
   } as unknown as MessageRepo;
 
   const gitService = {
-    resolveWorkingDir: vi.fn(() => "/workspace"),
+    resolveWorkingDir: vi.fn(() => cwd),
     listWorktrees: vi.fn(() => []),
   } as unknown as GitService;
 
@@ -279,6 +291,9 @@ function buildService(): {
     attachmentService,
     messageRepo,
     memoryPressureService: memoryPressureService as MemoryPressureService & { markActive: ReturnType<typeof vi.fn>; markIdle: ReturnType<typeof vi.fn> },
+    snapshotService: snapshotService as SnapshotService & { captureRef: ReturnType<typeof vi.fn> },
+    turnSnapshotRepo: turnSnapshotRepo as TurnSnapshotRepo & { create: ReturnType<typeof vi.fn> },
+    toolCallRecordRepo: toolCallRecordRepo as ToolCallRecordRepo & { bulkCreate: ReturnType<typeof vi.fn> },
   };
 }
 
@@ -441,9 +456,206 @@ describe("AgentService turn cleanup", () => {
       threadId: THREAD_ID,
     } satisfies AgentEvent);
 
-    // Thread should be active again
-    expect(service.activeThreadIds()).toContain(THREAD_ID);
-    expect(memoryPressureService.markActive).toHaveBeenCalled();
+    // The resumed turn becomes active after prior-turn persistence releases its barrier.
+    await vi.waitFor(() => {
+      expect(service.activeThreadIds()).toContain(THREAD_ID);
+      expect(memoryPressureService.markActive).toHaveBeenCalled();
+    });
+  });
+
+  it("initializes file tracking for provider-originated auto-resumed turns", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mcode-auto-resume-tracker-"));
+    try {
+      await writeFile(join(root, "tracked.txt"), "before\n");
+      const {
+        service,
+        providerEmitter,
+        snapshotService,
+        turnSnapshotRepo,
+      } = buildService(root);
+      service.init();
+      snapshotService.captureRef.mockClear();
+      const internals = service as unknown as {
+        turnFileTracker: { observeToolUse: (...args: unknown[]) => Promise<void> };
+      };
+      const observeToolUse = vi.spyOn(internals.turnFileTracker, "observeToolUse");
+
+      providerEmitter.emit("event", {
+        type: AgentEventType.TurnStarted,
+        threadId: THREAD_ID,
+      } satisfies AgentEvent);
+      providerEmitter.emit("event", {
+        type: AgentEventType.ToolUse,
+        threadId: THREAD_ID,
+        toolCallId: "auto-edit",
+        toolName: "Edit",
+        toolInput: { file_path: "tracked.txt" },
+      } satisfies AgentEvent);
+      await vi.waitFor(() => expect(observeToolUse).toHaveBeenCalledOnce());
+      await observeToolUse.mock.results[0]!.value;
+
+      await writeFile(join(root, "tracked.txt"), "after\n");
+      providerEmitter.emit("event", {
+        type: AgentEventType.ToolResult,
+        threadId: THREAD_ID,
+        toolCallId: "auto-edit",
+        output: "updated",
+        isError: false,
+      } satisfies AgentEvent);
+      providerEmitter.emit("event", {
+        type: AgentEventType.TurnComplete,
+        threadId: THREAD_ID,
+        reason: "end_turn",
+        costUsd: null,
+        tokensIn: 1,
+        tokensOut: 1,
+        contextWindow: 200000,
+        totalProcessedTokens: 2,
+        providerId: "claude",
+      } satisfies AgentEvent);
+
+      await vi.waitFor(() => expect(turnSnapshotRepo.create).toHaveBeenCalledOnce());
+      expect(snapshotService.captureRef).toHaveBeenCalledWith(root);
+      expect(turnSnapshotRepo.create.mock.calls[0]![0]).toMatchObject({
+        fileEffects: {
+          fileCount: 1,
+          effects: [expect.objectContaining({
+            path: "tracked.txt",
+            kind: "edited",
+            scope: "workspace",
+          })],
+        },
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps overlapping auto-resumed generations isolated until prior persistence finishes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mcode-auto-resume-overlap-"));
+    try {
+      await writeFile(join(root, "first.txt"), "before first\n");
+      await writeFile(join(root, "second.txt"), "before second\n");
+      const {
+        service,
+        providerEmitter,
+        turnSnapshotRepo,
+        toolCallRecordRepo,
+      } = buildService(root);
+      service.init();
+      const tracker = (service as unknown as {
+        turnFileTracker: {
+          observeToolUse: (...args: unknown[]) => Promise<void>;
+          observeToolResult: (...args: unknown[]) => Promise<void>;
+        };
+      }).turnFileTracker;
+      const observeToolUse = vi.spyOn(tracker, "observeToolUse");
+      const originalObserveToolResult = tracker.observeToolResult.bind(tracker);
+      let releaseFirstResult!: () => void;
+      const firstResultGate = new Promise<void>((resolve) => {
+        releaseFirstResult = resolve;
+      });
+      let resultCount = 0;
+      vi.spyOn(tracker, "observeToolResult").mockImplementation(async (...args) => {
+        resultCount += 1;
+        if (resultCount === 1) await firstResultGate;
+        await originalObserveToolResult(...args);
+      });
+
+      providerEmitter.emit("event", {
+        type: AgentEventType.TurnStarted,
+        threadId: THREAD_ID,
+      } satisfies AgentEvent);
+      providerEmitter.emit("event", {
+        type: AgentEventType.ToolUse,
+        threadId: THREAD_ID,
+        toolCallId: "first-edit",
+        toolName: "Edit",
+        toolInput: { file_path: "first.txt" },
+      } satisfies AgentEvent);
+      await vi.waitFor(() => expect(observeToolUse).toHaveBeenCalledTimes(1));
+      await observeToolUse.mock.results[0]!.value;
+      await writeFile(join(root, "first.txt"), "after first\n");
+      providerEmitter.emit("event", {
+        type: AgentEventType.ToolResult,
+        threadId: THREAD_ID,
+        toolCallId: "first-edit",
+        output: "updated",
+        isError: false,
+      } satisfies AgentEvent);
+      providerEmitter.emit("event", {
+        type: AgentEventType.TurnComplete,
+        threadId: THREAD_ID,
+        reason: "end_turn",
+        costUsd: null,
+        tokensIn: 1,
+        tokensOut: 1,
+        contextWindow: 200000,
+        totalProcessedTokens: 2,
+        providerId: "claude",
+      } satisfies AgentEvent);
+
+      providerEmitter.emit("event", {
+        type: AgentEventType.TurnStarted,
+        threadId: THREAD_ID,
+      } satisfies AgentEvent);
+      providerEmitter.emit("event", {
+        type: AgentEventType.ToolUse,
+        threadId: THREAD_ID,
+        toolCallId: "second-edit",
+        toolName: "Edit",
+        toolInput: { file_path: "second.txt" },
+      } satisfies AgentEvent);
+      await writeFile(join(root, "second.txt"), "after second\n");
+      providerEmitter.emit("event", {
+        type: AgentEventType.Message,
+        threadId: THREAD_ID,
+        content: "second turn complete",
+        tokens: null,
+      } satisfies AgentEvent);
+      providerEmitter.emit("event", {
+        type: AgentEventType.ToolResult,
+        threadId: THREAD_ID,
+        toolCallId: "second-edit",
+        output: "updated",
+        isError: false,
+      } satisfies AgentEvent);
+      providerEmitter.emit("event", {
+        type: AgentEventType.TurnComplete,
+        threadId: THREAD_ID,
+        reason: "end_turn",
+        costUsd: null,
+        tokensIn: 1,
+        tokensOut: 1,
+        contextWindow: 200000,
+        totalProcessedTokens: 2,
+        providerId: "claude",
+      } satisfies AgentEvent);
+      await vi.waitFor(() => expect(observeToolUse).toHaveBeenCalledTimes(2));
+      expect(turnSnapshotRepo.create).not.toHaveBeenCalled();
+
+      releaseFirstResult();
+      await vi.waitFor(() => expect(turnSnapshotRepo.create).toHaveBeenCalledTimes(2));
+      const firstSnapshot = turnSnapshotRepo.create.mock.calls[0]![0];
+      const secondSnapshot = turnSnapshotRepo.create.mock.calls[1]![0];
+      expect(firstSnapshot.fileEffects.effects.map((effect: { path: string }) => effect.path)).toEqual(["first.txt"]);
+      expect(secondSnapshot.fileEffects.effects.map((effect: { path: string }) => effect.path)).toEqual(["second.txt"]);
+      expect(toolCallRecordRepo.bulkCreate).toHaveBeenCalledTimes(2);
+      expect(toolCallRecordRepo.bulkCreate.mock.calls[0]![0]).toEqual([
+        expect.objectContaining({
+          toolCallId: "first-edit",
+          messageId: firstSnapshot.messageId,
+        }),
+      ]);
+      expect(toolCallRecordRepo.bulkCreate.mock.calls[1]![0]).toEqual([
+        expect.objectContaining({
+          toolCallId: "second-edit",
+          messageId: secondSnapshot.messageId,
+        }),
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("does not re-add thread after an Error event following TurnComplete", async () => {

--- a/apps/server/src/services/__tests__/diff-summary-source.test.ts
+++ b/apps/server/src/services/__tests__/diff-summary-source.test.ts
@@ -1,0 +1,70 @@
+import "reflect-metadata";
+import { describe, expect, it, vi } from "vitest";
+import { ThreadDiffSource, type TurnSnapshotRow } from "../diff-summary-source.js";
+import type { SnapshotService } from "../snapshot-service.js";
+import type { GitExecutor } from "../git-executor/index.js";
+
+describe("ThreadDiffSource", () => {
+  it("scopes aggregate calculations to attributed workspace files", async () => {
+    const getDiffStats = vi.fn(async () => [{
+      filePath: "authored.ts",
+      additions: 1,
+      deletions: 0,
+    }]);
+    const getDiff = vi.fn(async () => "diff --git a/authored.ts b/authored.ts");
+    const snapshotService = { getDiffStats, getDiff } as unknown as SnapshotService;
+    const gitExecutor = {
+      exec: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+    } as unknown as GitExecutor;
+    const snapshots: TurnSnapshotRow[] = [{
+      id: "snapshot",
+      message_id: "message",
+      thread_id: "thread",
+      ref_before: "abc111",
+      ref_after: "def222",
+      files_changed: JSON.stringify(["authored.ts"]),
+      file_effects: {
+        revision: 1,
+        fileCount: 1,
+        additions: 1,
+        deletions: 0,
+        effects: [{
+          path: "authored.ts",
+          kind: "added",
+          scope: "workspace",
+          additions: 1,
+          deletions: 0,
+          binary: false,
+          toolCallIds: ["write"],
+        }],
+      },
+      worktree_path: null,
+      created_at: new Date(0).toISOString(),
+    }];
+
+    const payload = await new ThreadDiffSource(
+      snapshots,
+      "C:/workspace",
+      snapshotService,
+      gitExecutor,
+    ).getDiff();
+
+    expect(getDiffStats).toHaveBeenCalledWith(
+      "C:/workspace",
+      "abc111",
+      "def222",
+      ["authored.ts"],
+      [["authored.ts"]],
+    );
+    expect(getDiff).toHaveBeenCalledWith(
+      "C:/workspace",
+      "abc111",
+      "def222",
+      undefined,
+      undefined,
+      ["authored.ts"],
+      [["authored.ts"]],
+    );
+    expect(payload.turnCount).toBe(1);
+  });
+});

--- a/apps/server/src/services/__tests__/narrative-store.test.ts
+++ b/apps/server/src/services/__tests__/narrative-store.test.ts
@@ -33,6 +33,44 @@ function insertMessage(
   ).run(id, "thread-1", role, content, now, sequence);
 }
 
+describe("NarrativeStore Move/Rename persistence sanitization", () => {
+  it.each(["Move", "rEnAmE"])(
+    "passes only bounded source and destination paths to persistence for %s",
+    (toolName) => {
+      let persistedInputSummary: string | undefined;
+      const store = new NarrativeStore(
+        {} as MessageRepo,
+        {
+          bulkCreate: (records: Array<{ inputSummary?: string }>) => {
+            persistedInputSummary = records[0]?.inputSummary;
+          },
+        } as unknown as ToolCallRecordRepo,
+        { bulkCreate: () => undefined } as unknown as ThoughtSegmentRepo,
+        { bulkCreate: () => undefined } as unknown as HookExecutionRepo,
+      );
+      store.beginTurn("thread-1");
+      store.resetTurnCounters("thread-1");
+      store.bufferToolCall("thread-1", {
+        toolCallId: `file-${toolName}`,
+        toolName,
+        toolInput: {
+          oldPath: "src/old.ts",
+          path: "src/new.ts",
+          beforeText: "SECRET_BEFORE",
+          afterText: "SECRET_AFTER",
+        },
+      });
+
+      store.persistNarrative("thread-1", "m1", "done", "completed");
+
+      expect(persistedInputSummary).toBe("src/old.ts -> src/new.ts");
+      expect(persistedInputSummary?.length).toBeLessThanOrEqual(200);
+      expect(persistedInputSummary).not.toContain("SECRET_BEFORE");
+      expect(persistedInputSummary).not.toContain("SECRET_AFTER");
+    },
+  );
+});
+
 describe("NarrativeStore.load (read seam)", () => {
   let db: Database.Database;
   let store: NarrativeStore;
@@ -314,6 +352,7 @@ describe("NarrativeStore write seam (server-side traps)", () => {
       expect(command.length).toBeGreaterThan(200);
       expect(record.input_summary).toBe(command);
     });
+
   });
 
   describe("Classification precedence + is_final_response safety net", () => {

--- a/apps/server/src/services/__tests__/public-tool-input.test.ts
+++ b/apps/server/src/services/__tests__/public-tool-input.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { sanitizePublicToolInput } from "../public-tool-input.js";
+
+describe("sanitizePublicToolInput", () => {
+  it("removes raw file content while preserving attribution metadata", () => {
+    expect(sanitizePublicToolInput({
+      file_path: "src/a.ts",
+      operation: "edit",
+      old_string: "secret before",
+      new_string: "secret after",
+      content: "secret body",
+      _mcodeFileMutations: [{ path: "src/a.ts", beforeText: "secret" }],
+    }, "Edit")).toEqual({ file_path: "src/a.ts", operation: "edit" });
+  });
+
+  it("preserves content fields for non-file tools", () => {
+    const input = { content: "Create the task", status: "pending" };
+    expect(sanitizePublicToolInput(input, "TaskCreate")).toBe(input);
+  });
+
+  it.each(["Move", "mOvE", "Rename", "rEnAmE"])(
+    "allowlists public metadata for %s without exposing mutation bodies",
+    (toolName) => {
+      const sanitized = sanitizePublicToolInput({
+        from: "src/old.ts",
+        to: "src/new.ts",
+        operation: "rename",
+        beforeText: "SECRET_BEFORE",
+        afterText: "SECRET_AFTER",
+        mutation: { beforeText: "SECRET_BEFORE", afterText: "SECRET_AFTER" },
+      }, toolName);
+
+      expect(sanitized).toEqual({
+        from: "src/old.ts",
+        to: "src/new.ts",
+        operation: "rename",
+      });
+      expect(JSON.stringify(sanitized)).not.toContain("SECRET_BEFORE");
+      expect(JSON.stringify(sanitized)).not.toContain("SECRET_AFTER");
+    },
+  );
+
+  it("recognizes source/destination-shaped file input without a tool name", () => {
+    const sanitized = sanitizePublicToolInput({
+      from: "src/old.ts",
+      to: "src/new.ts",
+      mutation: { beforeText: "SECRET_BEFORE", afterText: "SECRET_AFTER" },
+    });
+
+    expect(sanitized).toEqual({ from: "src/old.ts", to: "src/new.ts" });
+    expect(JSON.stringify(sanitized)).not.toContain("SECRET_BEFORE");
+    expect(JSON.stringify(sanitized)).not.toContain("SECRET_AFTER");
+  });
+});

--- a/apps/server/src/services/__tests__/snapshot-attribution.test.ts
+++ b/apps/server/src/services/__tests__/snapshot-attribution.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  attributedWorkspacePaths,
+  collectAttributedWorkspacePaths,
+} from "../snapshot-attribution.js";
+
+describe("snapshot attribution", () => {
+  it("includes both workspace rename paths and excludes external effects", () => {
+    expect(attributedWorkspacePaths({
+      files_changed: ["new.ts"],
+      file_effects: {
+        revision: 1,
+        fileCount: 2,
+        additions: 0,
+        deletions: 0,
+        effects: [
+          {
+            path: "new.ts",
+            oldPath: "old.ts",
+            kind: "renamed",
+            scope: "workspace",
+            additions: 0,
+            deletions: 0,
+            binary: false,
+            toolCallIds: ["rename"],
+          },
+          {
+            path: "C:/outside.txt",
+            kind: "edited",
+            scope: "external",
+            additions: null,
+            deletions: null,
+            binary: false,
+            toolCallIds: ["external"],
+          },
+        ],
+      },
+    })).toEqual(["new.ts", "old.ts"]);
+  });
+
+  it("unions legacy and attributed paths across turns", () => {
+    expect(collectAttributedWorkspacePaths([
+      { files_changed: JSON.stringify(["legacy.ts"]) },
+      {
+        files_changed: ["current.ts"],
+        file_effects: {
+          revision: 1,
+          fileCount: 1,
+          additions: 1,
+          deletions: 0,
+          effects: [{
+            path: "current.ts",
+            kind: "added",
+            scope: "workspace",
+            additions: 1,
+            deletions: 0,
+            binary: false,
+            toolCallIds: ["write"],
+          }],
+        },
+      },
+    ])).toEqual(["legacy.ts", "current.ts"]);
+  });
+
+  it("retains paths from later turns after the first 512 files", () => {
+    const snapshots = Array.from({ length: 600 }, (_, index) => ({
+      files_changed: [`file-${index}.ts`],
+    }));
+
+    const paths = collectAttributedWorkspacePaths(snapshots);
+
+    expect(paths).toHaveLength(600);
+    expect(paths.at(-1)).toBe("file-599.ts");
+  });
+
+  it("falls back to legacy paths when persisted file effects are corrupt", () => {
+    expect(attributedWorkspacePaths({
+      files_changed: ["legacy.ts"],
+      file_effects: JSON.stringify({
+        revision: 1,
+        fileCount: 1,
+        additions: 0,
+        deletions: 0,
+        effects: [null],
+      }),
+    })).toEqual(["legacy.ts"]);
+  });
+});

--- a/apps/server/src/services/__tests__/turn-file-tracker.test.ts
+++ b/apps/server/src/services/__tests__/turn-file-tracker.test.ts
@@ -1,0 +1,602 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { TurnFileEffectSummary } from "@mcode/contracts";
+import { TurnFileTracker } from "../turn-file-tracker.js";
+import {
+  createCursorAcpTurnState,
+  mapCursorAcpSessionNotification,
+} from "../../providers/cursor/cursor-acp-event-mapper.js";
+import { AgentEventType } from "@mcode/contracts";
+
+const dirs: string[] = [];
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function trackerWithBaseline(
+  baseline: Record<string, string | null>,
+  updates: TurnFileEffectSummary[],
+): TurnFileTracker {
+  return new TurnFileTracker(
+    async (_cwd, _ref, path) => {
+      const value = baseline[path.replaceAll("\\", "/")];
+      return value == null ? { kind: "missing" } : { kind: "text", text: value };
+    },
+    (_threadId, _turnId, summary) => updates.push(summary),
+  );
+}
+
+describe("TurnFileTracker", () => {
+  it("classifies added, edited, and removed files with net line totals", async () => {
+    const root = await tempDir("mcode-file-effects-");
+    await writeFile(join(root, "edited.txt"), "one\ntwo");
+    await writeFile(join(root, "removed.txt"), "old");
+    const updates: TurnFileEffectSummary[] = [];
+    const tracker = trackerWithBaseline({
+      "edited.txt": "one\ntwo",
+      "removed.txt": "old",
+      "added.txt": null,
+    }, updates);
+    await tracker.beginTurn("t", root, "before");
+
+    await tracker.observeToolUse("t", "edit", "Edit", { file_path: "edited.txt" });
+    await writeFile(join(root, "edited.txt"), "one\nthree");
+    await tracker.observeToolResult("t", "edit");
+    await tracker.observeToolUse("t", "add", "Write", { file_path: "added.txt", content: "a\nb" });
+    await writeFile(join(root, "added.txt"), "a\nb");
+    await tracker.observeToolResult("t", "add");
+    await tracker.observeToolUse("t", "remove", "Delete", { file_path: "removed.txt" });
+    await rm(join(root, "removed.txt"));
+    await tracker.observeToolResult("t", "remove", undefined);
+
+    const summary = await tracker.finalizeTurn("t");
+    expect(summary.effects.map((effect) => [effect.path, effect.kind])).toEqual([
+      ["added.txt", "added"],
+      ["edited.txt", "edited"],
+      ["removed.txt", "removed"],
+    ]);
+    expect(summary).toMatchObject({ fileCount: 3, additions: 3, deletions: 2 });
+    expect(updates.map((update) => update.revision)).toEqual([1, 2, 3]);
+  });
+
+  it("reports an observation failure while keeping finalization recoverable", async () => {
+    const root = await tempDir("mcode-file-effects-observation-error-");
+    await writeFile(join(root, "edited.txt"), "before\n");
+    const tracker = new TurnFileTracker(
+      async () => ({ kind: "text", text: "before\n" }),
+      () => {
+        throw new Error("update failed");
+      },
+    );
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "edit", "Edit", { file_path: "edited.txt" });
+    await writeFile(join(root, "edited.txt"), "after\n");
+
+    await expect(tracker.observeToolResult("t", "edit")).rejects.toThrow("update failed");
+    await expect(tracker.finalizeTurn("t")).resolves.toMatchObject({ fileCount: 1 });
+  });
+
+  it("counts repeated edits once and removes a reverted effect", async () => {
+    const root = await tempDir("mcode-file-effects-");
+    await writeFile(join(root, "same.txt"), "base");
+    const updates: TurnFileEffectSummary[] = [];
+    const tracker = trackerWithBaseline({ "same.txt": "base" }, updates);
+    await tracker.beginTurn("t", root, "before");
+
+    await tracker.observeToolUse("t", "a", "Edit", { file_path: "same.txt" });
+    await writeFile(join(root, "same.txt"), "first");
+    await tracker.observeToolResult("t", "a");
+    await tracker.observeToolUse("t", "b", "Edit", { file_path: "same.txt" });
+    await writeFile(join(root, "same.txt"), "second");
+    await tracker.observeToolResult("t", "b");
+    expect((await tracker.finalizeTurn("t")).fileCount).toBe(1);
+
+    await tracker.observeToolUse("t", "c", "Edit", { file_path: "same.txt" });
+    await writeFile(join(root, "same.txt"), "base");
+    await tracker.observeToolResult("t", "c");
+    expect(await tracker.finalizeTurn("t")).toMatchObject({ fileCount: 0, additions: 0, deletions: 0 });
+  });
+
+  it("detects a partial write even when the tool result is an error", async () => {
+    const root = await tempDir("mcode-file-effects-");
+    await writeFile(join(root, "partial.txt"), "before");
+    const tracker = trackerWithBaseline({ "partial.txt": "before" }, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "failed", "Write", { file_path: "partial.txt" });
+    await writeFile(join(root, "partial.txt"), "part");
+    await tracker.observeToolResult("t", "failed");
+    expect((await tracker.finalizeTurn("t")).effects[0]).toMatchObject({ kind: "edited" });
+  });
+
+  it("marks external and symlink-escaped paths without persisting content", async () => {
+    const root = await tempDir("mcode-file-effects-root-");
+    const external = await tempDir("mcode-file-effects-external-");
+    await writeFile(join(external, "outside.txt"), "old");
+    await symlink(join(external, "outside.txt"), join(root, "link.txt"));
+    const tracker = trackerWithBaseline({}, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "external", "Edit", {
+      file_path: join(root, "link.txt"),
+      old_string: "old",
+      new_string: "new",
+    });
+    await writeFile(join(external, "outside.txt"), "new");
+    await tracker.observeToolResult("t", "external");
+    const effect = (await tracker.finalizeTurn("t")).effects[0]!;
+    expect(effect).toMatchObject({ scope: "external", kind: "edited" });
+    expect(JSON.stringify(effect)).not.toContain("old");
+    expect(JSON.stringify(effect)).not.toContain("new");
+  });
+
+  it("fails closed for malformed paths, ignores shell tools, and bounds candidates", async () => {
+    const root = await tempDir("mcode-file-effects-");
+    const tracker = trackerWithBaseline({}, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "shell", "Bash", { command: "git pull origin main" });
+    await tracker.observeToolUse("t", "bad", "Write", { file_path: "bad\0path" });
+    await tracker.observeToolResult("t", "shell");
+    await tracker.observeToolResult("t", "bad");
+    expect((await tracker.finalizeTurn("t")).fileCount).toBe(0);
+  });
+
+  it("uses the tool-start state instead of unrelated earlier workspace changes", async () => {
+    const root = await tempDir("mcode-file-effects-tool-baseline-");
+    await writeFile(join(root, "same.txt"), "pulled-a\npulled-b\npulled-c\n");
+    const tracker = trackerWithBaseline({ "same.txt": "old-a\nold-b\n" }, []);
+    await tracker.beginTurn("t", root, "before-pull");
+
+    await tracker.observeToolUse("t", "edit", "Edit", { file_path: "same.txt" });
+    await writeFile(join(root, "same.txt"), "pulled-a\nagent-b\npulled-c\n");
+    await tracker.observeToolResult("t", "edit");
+
+    expect((await tracker.finalizeTurn("t")).effects[0]).toMatchObject({
+      kind: "edited",
+      additions: 1,
+      deletions: 1,
+    });
+  });
+
+  it("tracks explicit edits when no Git baseline is available", async () => {
+    const root = await tempDir("mcode-file-effects-no-git-");
+    await writeFile(join(root, "plain.txt"), "before\n");
+    const tracker = trackerWithBaseline({}, []);
+    await tracker.beginTurn("t", root, null);
+    await tracker.observeToolUse("t", "edit", "Edit", { file_path: "plain.txt" });
+    await writeFile(join(root, "plain.txt"), "after\n");
+    await tracker.observeToolResult("t", "edit");
+
+    expect((await tracker.finalizeTurn("t")).effects[0]).toMatchObject({
+      path: "plain.txt",
+      kind: "edited",
+      scope: "workspace",
+    });
+  });
+
+  it("does not treat Edit replacement snippets as full-file evidence", async () => {
+    const root = await tempDir("mcode-file-effects-snippet-");
+    await writeFile(join(root, "plain.txt"), "prefix\nneedle\nsuffix\n");
+    const tracker = trackerWithBaseline({}, []);
+    await tracker.beginTurn("t", root, null);
+
+    await tracker.observeToolUse("t", "edit", "Edit", {
+      file_path: "plain.txt",
+      old_string: "needle",
+      new_string: "replacement",
+    });
+    await tracker.observeToolResult("t", "edit");
+
+    expect((await tracker.finalizeTurn("t")).fileCount).toBe(0);
+  });
+
+  it("records completion-only external changes without inventing line totals", async () => {
+    const root = await tempDir("mcode-file-effects-completed-root-");
+    const external = await tempDir("mcode-file-effects-completed-external-");
+    const externalPath = join(external, "late.txt");
+    await writeFile(externalPath, "after\n");
+    const tracker = trackerWithBaseline({}, []);
+    await tracker.beginTurn("t", root, null);
+
+    await tracker.observeToolUse("t", "codex-file-change", "file_change", {
+      changes: [{ path: externalPath, kind: "edit" }],
+    });
+    await tracker.observeToolResult("t", "codex-file-change");
+
+    expect((await tracker.finalizeTurn("t")).effects[0]).toMatchObject({
+      path: externalPath,
+      kind: "edited",
+      scope: "external",
+      additions: null,
+      deletions: null,
+    });
+  });
+
+  it("keeps a provider-confirmed completion when a late Git ref already contains it", async () => {
+    const root = await tempDir("mcode-file-effects-late-ref-");
+    await writeFile(join(root, "late.txt"), "after\n");
+    const tracker = trackerWithBaseline({ "late.txt": "after\n" }, []);
+    const generation = tracker.beginTurn("t", root, null);
+
+    await tracker.observeToolUse("t", "codex-file-change", "file_change", {
+      changes: [{ path: "late.txt", kind: "edit" }],
+    });
+    await tracker.observeToolResult("t", "codex-file-change");
+    await tracker.setBaselineRef("t", generation, "captured-after-edit");
+
+    expect((await tracker.finalizeTurn("t")).effects[0]).toMatchObject({
+      path: "late.txt",
+      kind: "edited",
+      scope: "workspace",
+      additions: null,
+      deletions: null,
+    });
+  });
+
+  it("deduplicates bulk full-file evidence without synchronous file reads", async () => {
+    const root = await tempDir("mcode-file-effects-bulk-evidence-");
+    await writeFile(join(root, "bulk.txt"), "after\n");
+    const tracker = trackerWithBaseline({}, []);
+    tracker.beginTurn("t", root, null);
+    const fullBeforeText = "x".repeat(1_048_576);
+    const mutations = Array.from({ length: 256 }, () => ({
+      path: "bulk.txt",
+      kind: "edit",
+      fullFileContent: true,
+      beforeText: fullBeforeText,
+      afterText: "after\n",
+    }));
+
+    const startedAt = performance.now();
+    const observation = tracker.observeToolUse("t", "cursor-bulk", "edit", {
+      _mcodeFileMutations: mutations,
+    });
+    const synchronousDurationMs = performance.now() - startedAt;
+    await observation;
+    await tracker.observeToolResult("t", "cursor-bulk");
+
+    expect(synchronousDurationMs).toBeLessThan(250);
+    expect((await tracker.finalizeTurn("t")).effects).toHaveLength(1);
+  });
+
+  it("bounds synchronous path observation across bulk rename pairs", async () => {
+    const root = await tempDir("mcode-file-effects-bulk-renames-");
+    const tracker = trackerWithBaseline({}, []);
+    tracker.beginTurn("t", root, null);
+    const mutations = Array.from({ length: 256 }, (_, index) => ({
+      path: `renamed-${index}.txt`,
+      oldPath: `original-${index}.txt`,
+      kind: "rename",
+    }));
+
+    const startedAt = performance.now();
+    const observation = tracker.observeToolUse("t", "bulk-renames", "rename", {
+      _mcodeFileMutations: mutations,
+    });
+    const synchronousDurationMs = performance.now() - startedAt;
+    await observation;
+
+    expect(synchronousDurationMs).toBeLessThan(250);
+  });
+
+  it("falls back to complete async observation when a rename exceeds the remaining path budget", async () => {
+    const root = await tempDir("mcode-file-effects-mixed-budget-");
+    for (let index = 0; index < 3; index += 1) {
+      await writeFile(join(root, `edit-${index}.txt`), "before\n");
+    }
+    await writeFile(join(root, "source.txt"), "rename me\n");
+    const tracker = trackerWithBaseline({}, []);
+    tracker.beginTurn("t", root, null);
+    const mutations = [
+      ...Array.from({ length: 3 }, (_, index) => ({
+        path: `edit-${index}.txt`,
+        kind: "edit",
+      })),
+      { path: "destination.txt", oldPath: "source.txt", kind: "rename" },
+    ];
+
+    await tracker.observeToolUse("t", "mixed", "edit", { _mcodeFileMutations: mutations });
+    for (let index = 0; index < 3; index += 1) {
+      await writeFile(join(root, `edit-${index}.txt`), "after\n");
+    }
+    await rename(join(root, "source.txt"), join(root, "destination.txt"));
+    await tracker.observeToolResult("t", "mixed");
+
+    expect((await tracker.finalizeTurn("t")).effects).toContainEqual(expect.objectContaining({
+      path: "destination.txt",
+      oldPath: "source.txt",
+      kind: "renamed",
+    }));
+  });
+
+  it("records provider-confirmed external additions that exceed the read limit", async () => {
+    const root = await tempDir("mcode-file-effects-large-root-");
+    const external = await tempDir("mcode-file-effects-large-external-");
+    const externalPath = join(external, "large.txt");
+    await writeFile(externalPath, "x".repeat(1_048_577));
+    const tracker = trackerWithBaseline({}, []);
+    await tracker.beginTurn("t", root, null);
+
+    await tracker.observeToolUse("t", "codex-large-file", "file_change", {
+      changes: [{ path: externalPath, kind: "add" }],
+    });
+    await tracker.observeToolResult("t", "codex-large-file");
+
+    expect((await tracker.finalizeTurn("t")).effects[0]).toMatchObject({
+      path: externalPath,
+      kind: "added",
+      scope: "external",
+      additions: null,
+      deletions: null,
+      binary: true,
+    });
+  });
+
+  it("does not turn an unchanged oversized file into an edit", async () => {
+    const root = await tempDir("mcode-file-effects-oversized-");
+    await writeFile(join(root, "large.txt"), "x".repeat(1_048_577));
+    const tracker = trackerWithBaseline({ "large.txt": "ignored" }, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "large", "Edit", { file_path: "large.txt" });
+    await tracker.observeToolResult("t", "large");
+
+    expect((await tracker.finalizeTurn("t")).fileCount).toBe(0);
+  });
+
+  it("tracks an added file whose nested parent directories did not exist at ToolUse", async () => {
+    const root = await tempDir("mcode-file-effects-");
+    const tracker = trackerWithBaseline({ "new/nested/file.txt": null }, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "add-nested", "Write", {
+      file_path: "new/nested/file.txt",
+      content: "created",
+    });
+    await mkdir(join(root, "new", "nested"), { recursive: true });
+    await writeFile(join(root, "new", "nested", "file.txt"), "created");
+    await tracker.observeToolResult("t", "add-nested");
+    expect((await tracker.finalizeTurn("t")).effects[0]).toMatchObject({
+      path: join("new", "nested", "file.txt"),
+      kind: "added",
+      scope: "workspace",
+    });
+  });
+
+  it("stress handles 120 concurrent completions, repeated paths, and reversions", async () => {
+    const root = await tempDir("mcode-file-effects-stress-");
+    const updates: TurnFileEffectSummary[] = [];
+    const baseline: Record<string, string> = {};
+    for (let i = 0; i < 20; i += 1) {
+      baseline[`file-${i}.txt`] = "base";
+      await writeFile(join(root, `file-${i}.txt`), "base");
+    }
+    const tracker = trackerWithBaseline(baseline, updates);
+    await tracker.beginTurn("stress", root, "before");
+    const startedAt = performance.now();
+    const startedCpu = process.cpuUsage();
+    await Promise.all(Array.from({ length: 120 }, async (_, i) => {
+      const index = i % 20;
+      const id = `call-${i}`;
+      const path = `file-${index}.txt`;
+      await tracker.observeToolUse("stress", id, "Edit", { file_path: path });
+      await writeFile(join(root, path), i >= 100 ? `final-${index}` : `value-${i}`);
+      await tracker.observeToolResult("stress", id);
+    }));
+    await Promise.all(Array.from({ length: 5 }, async (_, index) => {
+      const id = `revert-${index}`;
+      const path = `file-${index}.txt`;
+      await tracker.observeToolUse("stress", id, "Edit", { file_path: path });
+      await writeFile(join(root, path), "base");
+      await tracker.observeToolResult("stress", id);
+    }));
+    const summary = await tracker.finalizeTurn("stress");
+    const durationMs = performance.now() - startedAt;
+    const cpu = process.cpuUsage(startedCpu);
+    const cpuMs = (cpu.user + cpu.system) / 1_000;
+    expect(summary.fileCount).toBe(15);
+    expect(summary.effects).toHaveLength(15);
+    expect(summary.revision).toBeGreaterThan(0);
+    expect(updates.every((update, index) => index === 0 || update.revision > updates[index - 1]!.revision)).toBe(true);
+    expect(cpuMs).toBeLessThan(2_500);
+    console.info(`turn-file-tracker stress: 125 completions in ${durationMs.toFixed(1)}ms wall / ${cpuMs.toFixed(1)}ms CPU, revision ${summary.revision}`);
+  }, 15_000);
+
+  it("keeps an older finalizing generation isolated from a newly-started turn", async () => {
+    const root = await tempDir("mcode-file-effects-generation-");
+    await writeFile(join(root, "one.txt"), "base");
+    const tracker = trackerWithBaseline({ "one.txt": "base" }, []);
+    const first = await tracker.beginTurn("t", root, "first");
+    await tracker.observeToolUse("t", "first-edit", "Edit", { file_path: "one.txt" });
+    await writeFile(join(root, "one.txt"), "first");
+    await tracker.observeToolResult("t", "first-edit");
+
+    const second = await tracker.beginTurn("t", root, "second");
+    await tracker.observeToolUse("t", "second-edit", "Edit", { file_path: "one.txt" });
+    await writeFile(join(root, "one.txt"), "second");
+    await tracker.observeToolResult("t", "second-edit");
+
+    expect((await tracker.finalizeTurn("t", first)).effects[0]?.toolCallIds).toEqual(["first-edit"]);
+    tracker.clearTurn("t", first);
+    expect((await tracker.finalizeTurn("t", second)).effects[0]?.toolCallIds).toEqual(["second-edit"]);
+  });
+
+  it("routes a late result to the generation that received ToolUse after retry rollover", async () => {
+    const root = await tempDir("mcode-file-effects-late-result-");
+    await writeFile(join(root, "late.txt"), "base");
+    const tracker = trackerWithBaseline({ "late.txt": "base" }, []);
+    const first = await tracker.beginTurn("t", root, "first");
+    await tracker.observeToolUse("t", "late-call", "Edit", { file_path: "late.txt" });
+    const second = await tracker.beginTurn("t", root, "second");
+    await writeFile(join(root, "late.txt"), "changed");
+    await tracker.observeToolResult("t", "late-call");
+
+    expect((await tracker.finalizeTurn("t", first)).effects[0]).toMatchObject({
+      path: "late.txt",
+      kind: "edited",
+      toolCallIds: ["late-call"],
+    });
+    expect((await tracker.finalizeTurn("t", second)).fileCount).toBe(0);
+  });
+
+  it("tracks every completion-time Cursor ACP diff on an existing tool call", async () => {
+    const root = await tempDir("mcode-file-effects-cursor-");
+    await writeFile(join(root, "one.txt"), "one\n");
+    await writeFile(join(root, "two.txt"), "two\n");
+    const tracker = trackerWithBaseline({ "one.txt": "one\n", "two.txt": "two\n" }, []);
+    await tracker.beginTurn("cursor-thread", root, "before");
+    const state = createCursorAcpTurnState();
+    const start = mapCursorAcpSessionNotification({
+      sessionId: "s",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "cursor-edit",
+        title: "Edit File",
+        kind: "edit",
+        status: "in_progress",
+        rawInput: { file_path: "one.txt" },
+      },
+    } as never, "cursor-thread", state);
+    for (const event of start) {
+      if (event.type === AgentEventType.ToolUse) {
+        await tracker.observeToolUse(event.threadId, event.toolCallId, event.toolName, event.toolInput);
+      }
+    }
+
+    await writeFile(join(root, "one.txt"), "one changed\n");
+    await writeFile(join(root, "two.txt"), "two changed\n");
+    const completed = mapCursorAcpSessionNotification({
+      sessionId: "s",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "cursor-edit",
+        title: "Edit File",
+        kind: "edit",
+        status: "completed",
+        content: [
+          { type: "diff", path: "one.txt", oldText: "one\n", newText: "one changed\n" },
+          { type: "diff", path: "two.txt", oldText: "two\n", newText: "two changed\n" },
+        ],
+      },
+    } as never, "cursor-thread", state);
+    for (const event of completed) {
+      if (event.type === AgentEventType.ToolResult) {
+        await tracker.observeToolResult(event.threadId, event.toolCallId, event.toolInput);
+      }
+    }
+
+    expect((await tracker.finalizeTurn("cursor-thread")).effects.map((effect) => effect.path)).toEqual([
+      "one.txt",
+      "two.txt",
+    ]);
+  });
+
+  it("emits one validated explicit rename with a normalized old path", async () => {
+    const root = await tempDir("mcode-file-effects-rename-");
+    await writeFile(join(root, "old.txt"), "one\n");
+    const tracker = trackerWithBaseline({ "old.txt": "one\n", "new.txt": null }, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "rename", "Move", {
+      from: join(".", "old.txt"),
+      to: "new.txt",
+    });
+    await rename(join(root, "old.txt"), join(root, "new.txt"));
+    await tracker.observeToolResult("t", "rename");
+
+    expect(await tracker.finalizeTurn("t")).toMatchObject({
+      fileCount: 1,
+      additions: 0,
+      deletions: 0,
+      effects: [{ path: "new.txt", oldPath: "old.txt", kind: "renamed" }],
+    });
+  });
+
+  it("does not label a copy as a rename when the normalized source still exists", async () => {
+    const root = await tempDir("mcode-file-effects-invalid-rename-");
+    await writeFile(join(root, "old.txt"), "one\n");
+    const tracker = trackerWithBaseline({ "old.txt": "one\n", "new.txt": null }, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "copy", "Move", {
+      from: "old.txt",
+      to: join(".", "new.txt"),
+    });
+    await writeFile(join(root, "new.txt"), "one\n");
+    await tracker.observeToolResult("t", "copy");
+
+    expect((await tracker.finalizeTurn("t")).effects).toEqual([
+      expect.objectContaining({ path: "new.txt", kind: "added" }),
+    ]);
+  });
+
+  it("coalesces bounded hash-matched remove/add pairs one-to-one", async () => {
+    const root = await tempDir("mcode-file-effects-hash-renames-");
+    const changes: Array<{ path: string; kind: string }> = [];
+    const baseline: Record<string, string | null> = {};
+    for (let index = 0; index < 8; index += 1) {
+      const oldPath = `old-${index}.txt`;
+      const newPath = `new-${index}.txt`;
+      const content = `unique-${index}\n`;
+      baseline[oldPath] = content;
+      baseline[newPath] = null;
+      changes.push({ path: oldPath, kind: "remove" }, { path: newPath, kind: "add" });
+      await writeFile(join(root, oldPath), content);
+    }
+    const tracker = trackerWithBaseline(baseline, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "move-batch", "file_change", { changes });
+    await Promise.all(Array.from({ length: 8 }, (_, index) => (
+      rename(join(root, `old-${index}.txt`), join(root, `new-${index}.txt`))
+    )));
+    await tracker.observeToolResult("t", "move-batch");
+
+    const summary = await tracker.finalizeTurn("t");
+    expect(summary.fileCount).toBe(8);
+    expect(summary.additions).toBe(0);
+    expect(summary.deletions).toBe(0);
+    expect(summary.effects).toEqual(Array.from({ length: 8 }, (_, index) => expect.objectContaining({
+      path: `new-${index}.txt`,
+      oldPath: `old-${index}.txt`,
+      kind: "renamed",
+    })));
+  });
+
+  it.each([
+    { label: "added", before: "", after: "one\n", additions: 1, deletions: 0 },
+    { label: "removed", before: "one\n", after: "", additions: 0, deletions: 1 },
+    { label: "edited", before: "one\n", after: "two\n", additions: 1, deletions: 1 },
+  ])("uses Git-style trailing-newline totals for $label files", async ({ before, after, additions, deletions }) => {
+    const root = await tempDir("mcode-file-effects-lines-");
+    if (before !== "") await writeFile(join(root, "lines.txt"), before);
+    const tracker = trackerWithBaseline({ "lines.txt": before === "" ? null : before }, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "lines", before === "" ? "Write" : after === "" ? "Delete" : "Edit", {
+      file_path: "lines.txt",
+    });
+    if (after === "") await rm(join(root, "lines.txt"), { force: true });
+    else await writeFile(join(root, "lines.txt"), after);
+    await tracker.observeToolResult("t", "lines");
+    expect((await tracker.finalizeTurn("t")).effects[0]).toMatchObject({ additions, deletions });
+  });
+
+  it.each([
+    { label: "added", before: "one", after: "one\n" },
+    { label: "removed", before: "one\n", after: "one" },
+  ])("counts an EOF newline $label as one added and one removed line", async ({ before, after }) => {
+    const root = await tempDir("mcode-file-effects-eof-newline-");
+    await writeFile(join(root, "lines.txt"), before);
+    const tracker = trackerWithBaseline({ "lines.txt": before }, []);
+    await tracker.beginTurn("t", root, "before");
+    await tracker.observeToolUse("t", "lines", "Edit", { file_path: "lines.txt" });
+    await writeFile(join(root, "lines.txt"), after);
+    await tracker.observeToolResult("t", "lines");
+    expect((await tracker.finalizeTurn("t")).effects[0]).toMatchObject({
+      additions: 1,
+      deletions: 1,
+    });
+  });
+});

--- a/apps/server/src/services/__tests__/turn-finalizer.test.ts
+++ b/apps/server/src/services/__tests__/turn-finalizer.test.ts
@@ -12,6 +12,7 @@ import type { ThreadRepo } from "../../repositories/thread-repo";
 import type { SnapshotService } from "../snapshot-service";
 import type { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo";
 import type { TurnOutcome } from "../turn-outcome";
+import type { TurnFileTracker } from "../turn-file-tracker";
 import { broadcast } from "../../transport/push";
 
 vi.mock("../../transport/push.js", () => ({ broadcast: vi.fn() }));
@@ -118,6 +119,7 @@ describe("TurnFinalizer.finalize — turn outcome → tool-call status", () => {
 
     expect(broadcast).toHaveBeenCalledWith("turn.persisted", {
       threadId: THREAD,
+      turnId: null,
       messageId: "m1",
       toolCallCount: 1,
       filesChanged: [],
@@ -405,7 +407,10 @@ describe("TurnFinalizer.hasRecordableActivity — TurnSubstance predicate", () =
  * has_file_changes flag update.
  */
 describe("TurnFinalizer.finalize — git snapshot write", () => {
-  function build(filesChanged: string[]) {
+  function build(
+    filesChanged: string[],
+    options?: { refAfter?: string; fileTracker?: TurnFileTracker },
+  ) {
     const runSpy = vi.fn();
     const messageRepo = {
       listByThread: vi.fn(() => ({
@@ -421,7 +426,7 @@ describe("TurnFinalizer.finalize — git snapshot write", () => {
       clearTurn: vi.fn(),
     } as unknown as NarrativeStore;
     const snapshotService = {
-      captureRef: vi.fn(() => Promise.resolve("def222")),
+      captureRef: vi.fn(() => Promise.resolve(options?.refAfter ?? "def222")),
       getFilesChanged: vi.fn(() => Promise.resolve(filesChanged)),
     } as unknown as SnapshotService;
     const turnSnapshotRepo = { create: vi.fn() } as unknown as TurnSnapshotRepo;
@@ -436,8 +441,9 @@ describe("TurnFinalizer.finalize — git snapshot write", () => {
       snapshotService,
       turnSnapshotRepo,
       db,
+      options?.fileTracker,
     );
-    return { finalizer, db, turnSnapshotRepo, runSpy };
+    return { finalizer, db, snapshotService, turnSnapshotRepo, runSpy };
   }
 
   beforeEach(() => {
@@ -576,5 +582,111 @@ describe("TurnFinalizer.finalize — git snapshot write", () => {
     await finalizer.finalize(THREAD, "completed");
 
     expect(db.prepare).not.toHaveBeenCalled();
+  });
+
+  it("persists an empty authored summary when the repository ref is unchanged", async () => {
+    const emptySummary = { revision: 0, fileCount: 0, additions: 0, deletions: 0, effects: [] };
+    const fileTracker = {
+      finalizeTurn: vi.fn(async () => emptySummary),
+      clearTurn: vi.fn(),
+    } as unknown as TurnFileTracker;
+    const { finalizer, turnSnapshotRepo } = build([], { refAfter: "abc111", fileTracker });
+    finalizer.recordTurnRef(THREAD, "abc111", "/workspace", 1);
+
+    await finalizer.finalize(THREAD, "completed");
+
+    expect(turnSnapshotRepo.create).toHaveBeenCalledWith(expect.objectContaining({
+      messageId: "msg-1",
+      refBefore: "abc111",
+      refAfter: "abc111",
+      filesChanged: [],
+      fileEffects: emptySummary,
+    }));
+  });
+
+  it("persists external effects when Git refs are unavailable", async () => {
+    const fileEffects = {
+      revision: 1,
+      fileCount: 1,
+      additions: 0,
+      deletions: 0,
+      effects: [{
+        path: "C:/outside.txt",
+        kind: "edited" as const,
+        scope: "external" as const,
+        additions: null,
+        deletions: null,
+        binary: false,
+        toolCallIds: ["edit"],
+      }],
+    };
+    const fileTracker = {
+      finalizeTurn: vi.fn(async () => fileEffects),
+      clearTurn: vi.fn(),
+    } as unknown as TurnFileTracker;
+    const { finalizer, snapshotService, turnSnapshotRepo, runSpy } = build([], { fileTracker });
+    finalizer.recordTurnRef(THREAD, null, "/workspace", 1);
+
+    await finalizer.finalize(THREAD, "completed");
+
+    expect(snapshotService.captureRef).not.toHaveBeenCalled();
+    expect(turnSnapshotRepo.create).toHaveBeenCalledWith(expect.objectContaining({
+      messageId: "msg-1",
+      refBefore: "",
+      refAfter: "",
+      filesChanged: [],
+      fileEffects,
+    }));
+    expect(runSpy).toHaveBeenCalledWith(THREAD);
+  });
+
+  it("uses a late ref update pinned before finalization waits", async () => {
+    let releasePrerequisite: (() => void) | undefined;
+    const prerequisite = new Promise<void>((resolve) => {
+      releasePrerequisite = resolve;
+    });
+    const { finalizer, turnSnapshotRepo } = build(["late.ts"]);
+    finalizer.recordTurnRef(THREAD, null, "/workspace", 1);
+
+    const finalized = finalizer.finalize(THREAD, "completed", prerequisite);
+    finalizer.recordTurnRef(THREAD, "captured-before", "/workspace", 1);
+    releasePrerequisite?.();
+    await finalized;
+
+    expect(turnSnapshotRepo.create).toHaveBeenCalledWith(expect.objectContaining({
+      refBefore: "captured-before",
+      refAfter: "def222",
+      filesChanged: ["late.ts"],
+    }));
+  });
+
+  it("keeps out-of-order ref captures attached to their own generations", async () => {
+    let releaseFirst: (() => void) | undefined;
+    let releaseSecond: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const { finalizer, turnSnapshotRepo } = build(["tracked.ts"]);
+    finalizer.recordTurnRef(THREAD, null, "/workspace", 1);
+    const first = finalizer.finalize(THREAD, "completed", firstGate);
+    finalizer.recordTurnRef(THREAD, null, "/workspace", 2);
+    const second = finalizer.finalize(THREAD, "completed", secondGate);
+
+    finalizer.recordTurnRef(THREAD, "second-before", "/workspace", 2);
+    finalizer.recordTurnRef(THREAD, "first-before", "/workspace", 1);
+    releaseFirst?.();
+    await first;
+    releaseSecond?.();
+    await second;
+
+    expect(turnSnapshotRepo.create).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      refBefore: "first-before",
+    }));
+    expect(turnSnapshotRepo.create).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      refBefore: "second-before",
+    }));
   });
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -43,6 +43,7 @@ import { MessageRepo } from "../repositories/message-repo";
 import { HookExecutionRepo, type CreateHookExecutionInput } from "../repositories/hook-execution-repo";
 import { NarrativeStore } from "./narrative-store.js";
 import { TurnFinalizer } from "./turn-finalizer.js";
+import { TurnFileTracker } from "./turn-file-tracker.js";
 import { PlanQuestionService } from "./plan-question-service.js";
 import { TurnSnapshotRepo } from "../repositories/turn-snapshot-repo";
 import type Database from "better-sqlite3";
@@ -220,6 +221,20 @@ export class AgentService {
    * {@link TurnFinalizer.finalize} from each turn-end path.
    */
   private readonly turnFinalizer: TurnFinalizer;
+  /** Explicit provider mutation tracker used for authored file effects. */
+  private readonly turnFileTracker: TurnFileTracker;
+  /** Tracker initialization for the active generation of each thread. */
+  private readonly fileTrackingSetupByThread = new Map<string, Promise<void>>();
+  /** Serializes provider file events behind tracker initialization. */
+  private readonly fileTrackingActivityByThread = new Map<string, Promise<void>>();
+  /** Pre-turn Git capture that may continue after an auto-resumed tracker becomes ready. */
+  private readonly fileTrackingRefCaptureByThread = new Map<string, Promise<void>>();
+  /** Prevents a resumed turn from replacing the prior generation before persistence. */
+  private readonly fileTrackingFinalizationByThread = new Map<string, Promise<void>>();
+  /** Holds a resumed provider event stream until the preceding turn is persisted. */
+  private readonly providerEventBarrierByThread = new Map<string, Promise<void>>();
+  /** Provider events whose file-tracking portion ran before deferred narrative handling. */
+  private readonly earlyFileTrackingEvents = new WeakSet<object>();
   /**
    * Classifies a failed send as transient or fatal and caps the automatic
    * retry, so a brief flake doesn't cost the user a manual re-send while a
@@ -340,6 +355,12 @@ export class AgentService {
     private readonly planQuestionService: PlanQuestionService,
     @inject(FileService) private readonly fileService?: FileService,
   ) {
+    this.turnFileTracker = new TurnFileTracker(
+      (cwd, ref, path) => this.snapshotService.getFileAtRef(cwd, ref, path),
+      (threadId, turnId, summary) => {
+        broadcast("turn.fileEffectsUpdated", { threadId, turnId, summary });
+      },
+    );
     this.turnFinalizer = new TurnFinalizer(
       this.messageRepo,
       this.threadRepo,
@@ -347,12 +368,82 @@ export class AgentService {
       this.snapshotService,
       this.turnSnapshotRepo,
       this.db,
+      this.turnFileTracker,
     );
     this.goalCommand = new GoalCommand(
       { messageRepo: this.messageRepo, db: this.db },
       broadcast,
     );
     this.commandRouter = new CommandRouter([this.goalCommand]);
+  }
+
+  /** Initialize file tracking once for the active turn, including provider-originated resumes. */
+  private ensureTurnFileTracking(threadId: string, cwdOverride?: string): Promise<void> {
+    const existing = this.fileTrackingSetupByThread.get(threadId);
+    if (existing) return existing;
+    const thread = this.threadRepo.findById(threadId);
+    if (!thread) return Promise.resolve();
+    const workspace = this.workspaceRepo.findById(thread.workspace_id);
+    if (!workspace) return Promise.resolve();
+    const cwd = cwdOverride ?? this.gitService.resolveWorkingDir(
+      workspace.path,
+      thread.mode,
+      thread.worktree_path,
+    );
+    let generation: number;
+    try {
+      generation = this.turnFileTracker.beginTurn(threadId, cwd, null);
+      this.turnFinalizer.recordTurnRef(threadId, null, cwd, generation);
+    } catch (err) {
+      logger.warn("Failed to initialize file tracker", {
+        threadId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return Promise.resolve();
+    }
+    const setup = Promise.resolve();
+    this.fileTrackingSetupByThread.set(threadId, setup);
+    this.fileTrackingActivityByThread.set(threadId, setup);
+    const refCapture = (async () => {
+      try {
+        const refBefore = await this.snapshotService.captureRef(cwd);
+        this.turnFinalizer.recordTurnRef(threadId, refBefore, cwd, generation);
+        await this.turnFileTracker.setBaselineRef(threadId, generation, refBefore);
+      } catch (err) {
+        logger.warn("Failed to capture ref_before", {
+          threadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+    this.fileTrackingRefCaptureByThread.set(threadId, refCapture);
+    return setup;
+  }
+
+  /** Return the server tracker generation that owns live file effects for a thread. */
+  getCurrentFileEffectTurnId(threadId: string): string | undefined {
+    return this.turnFileTracker.getCurrentTurnId(threadId);
+  }
+
+  /** Start one provider file observation immediately and retain its completion for finalization. */
+  private queueTurnFileTracking(threadId: string, action: () => Promise<void>): void {
+    const setup = this.fileTrackingSetupByThread.get(threadId);
+    if (!setup) return;
+    const previous = this.fileTrackingActivityByThread.get(threadId) ?? setup;
+    let observation: Promise<void>;
+    try {
+      observation = action();
+    } catch (err) {
+      observation = Promise.reject(err);
+    }
+    const guardedObservation = observation.catch((err) => {
+      logger.warn("Failed to observe provider file event", {
+        threadId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    const next = Promise.all([previous, guardedObservation]).then(() => undefined);
+    this.fileTrackingActivityByThread.set(threadId, next);
   }
 
   /**
@@ -626,16 +717,16 @@ export class AgentService {
 
     this.threadRepo.updateStatus(threadId, "active");
 
-    // Capture git snapshot ref_before for this turn
-    try {
-      const refBefore = await this.snapshotService.captureRef(cwd);
-      this.turnFinalizer.recordTurnRef(threadId, refBefore, cwd);
-    } catch (err) {
-      logger.warn("Failed to capture ref_before", {
-        threadId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+    const resolvedProvider = this.providerRegistry.resolve(effectiveProvider);
+    // Emit before baseline I/O so the UI enters running state immediately. AgentService's
+    // provider listener initializes the tracker synchronously before the broadcaster reads its id.
+    (resolvedProvider as unknown as import("events").EventEmitter).emit("event", {
+      type: AgentEventType.TurnStarted,
+      threadId,
+    } satisfies AgentEvent);
+
+    await this.ensureTurnFileTracking(threadId, cwd);
+    await this.fileTrackingRefCaptureByThread.get(threadId);
     this.narrativeStore.beginTurn(threadId);
     this.narrativeStore.resetTurnCounters(threadId);
 
@@ -710,18 +801,6 @@ export class AgentService {
     // Replaces the former setSdkSessionId(...) + resume:true two-step dance.
     const resumeFrom: string | undefined =
       isResume && thread.sdk_session_id ? thread.sdk_session_id : undefined;
-
-    const resolvedProvider = this.providerRegistry.resolve(effectiveProvider);
-
-    // Emit the live-session "turn started" signal before any other events so
-    // clients can populate runningThreadIds (drives sidebar + composer indicators).
-    // Cast to EventEmitter since IAgentProvider only exposes on(); all providers
-    // extend EventEmitter, matching the same pattern used for synthetic error/ended
-    // emission in the catch block below.
-    (resolvedProvider as unknown as import("events").EventEmitter).emit("event", {
-      type: AgentEventType.TurnStarted,
-      threadId,
-    } satisfies AgentEvent);
 
     let providerMessage = providerWireOverride ?? wirePayload;
     if (effectiveProvider !== "codex") {
@@ -1891,14 +1970,38 @@ export class AgentService {
   ): Promise<void> | null {
     if (this.terminalFinalizedThreads.has(threadId)) return null;
     this.terminalFinalizedThreads.add(threadId);
-    return this.turnFinalizer.finalize(threadId, outcome).catch((err) => {
+    const setup = this.fileTrackingSetupByThread.get(threadId);
+    const activity = this.fileTrackingActivityByThread.get(threadId) ?? setup;
+    const refCapture = this.fileTrackingRefCaptureByThread.get(threadId);
+    const prerequisite = Promise.all([
+      activity ?? Promise.resolve(),
+      refCapture ?? Promise.resolve(),
+    ]);
+    const finalize = this.turnFinalizer.finalize(threadId, outcome, prerequisite)
+      .catch((err) => {
       logger.error("finalize failed on terminal event", {
         threadId,
         outcome,
         source,
         error: err instanceof Error ? err.message : String(err),
       });
+      });
+    this.fileTrackingFinalizationByThread.set(threadId, finalize);
+    void finalize.finally(() => {
+      if (this.fileTrackingSetupByThread.get(threadId) === setup) {
+        this.fileTrackingSetupByThread.delete(threadId);
+      }
+      if (this.fileTrackingActivityByThread.get(threadId) === activity) {
+        this.fileTrackingActivityByThread.delete(threadId);
+      }
+      if (this.fileTrackingRefCaptureByThread.get(threadId) === refCapture) {
+        this.fileTrackingRefCaptureByThread.delete(threadId);
+      }
+      if (this.fileTrackingFinalizationByThread.get(threadId) === finalize) {
+        this.fileTrackingFinalizationByThread.delete(threadId);
+      }
     });
+    return finalize;
   }
 
   /**
@@ -2060,7 +2163,50 @@ export class AgentService {
     });
 
     for (const provider of this.providerRegistry.resolveAll()) {
-      provider.on("event", (event: AgentEvent) => {
+      const handleEvent = (event: AgentEvent): void => {
+        const priorFinalization = this.fileTrackingFinalizationByThread.get(event.threadId);
+        const existingBarrier = this.providerEventBarrierByThread.get(event.threadId);
+        if (!existingBarrier && priorFinalization && event.type === AgentEventType.TurnStarted) {
+          this.fileTrackingSetupByThread.delete(event.threadId);
+          this.fileTrackingActivityByThread.delete(event.threadId);
+          this.fileTrackingRefCaptureByThread.delete(event.threadId);
+          void this.ensureTurnFileTracking(event.threadId);
+          this.earlyFileTrackingEvents.add(event);
+        }
+        if (existingBarrier && event.type === AgentEventType.ToolUse) {
+          this.queueTurnFileTracking(event.threadId, () => (
+            this.turnFileTracker.observeToolUse(
+              event.threadId,
+              event.toolCallId,
+              event.toolName,
+              event.toolInput,
+            )
+          ));
+          this.earlyFileTrackingEvents.add(event);
+        }
+        if (existingBarrier && event.type === AgentEventType.ToolResult) {
+          this.queueTurnFileTracking(event.threadId, () => (
+            this.turnFileTracker.observeToolResult(
+              event.threadId,
+              event.toolCallId,
+              event.toolInput,
+            )
+          ));
+          this.earlyFileTrackingEvents.add(event);
+        }
+        const barrier = existingBarrier
+          ?? (event.type === AgentEventType.TurnStarted ? priorFinalization : undefined);
+        if (barrier) {
+          if (!existingBarrier) this.providerEventBarrierByThread.set(event.threadId, barrier);
+          void barrier.then(() => {
+            if (event.type === AgentEventType.TurnStarted
+              && this.providerEventBarrierByThread.get(event.threadId) === barrier) {
+              this.providerEventBarrierByThread.delete(event.threadId);
+            }
+            handleEvent(event);
+          });
+          return;
+        }
         // Plan mode: feed streaming text to the question parser.
         // Buffer questions until the session closes (`ended`) so the client
         // cannot submit answers against a still-active session, which would
@@ -2273,6 +2419,16 @@ export class AgentService {
         if (event.type === AgentEventType.ToolUse) {
           this.narrativeStore.closeOpenThought(event.threadId);
           this.bufferToolCall(event.threadId, event);
+          if (!this.earlyFileTrackingEvents.delete(event)) {
+            this.queueTurnFileTracking(event.threadId, () => (
+              this.turnFileTracker.observeToolUse(
+                event.threadId,
+                event.toolCallId,
+                event.toolName,
+                event.toolInput,
+              )
+            ));
+          }
         }
 
         if (event.type === AgentEventType.HookStarted) {
@@ -2345,6 +2501,15 @@ export class AgentService {
         }
 
         if (event.type === AgentEventType.ToolResult) {
+          if (!this.earlyFileTrackingEvents.delete(event)) {
+            this.queueTurnFileTracking(event.threadId, () => (
+              this.turnFileTracker.observeToolResult(
+                event.threadId,
+                event.toolCallId,
+                event.toolInput,
+              )
+            ));
+          }
           this.narrativeStore.updateBufferedToolCallOutput(
             event.threadId,
             event.toolCallId,
@@ -2367,6 +2532,12 @@ export class AgentService {
         }
 
         if (event.type === AgentEventType.TurnStarted) {
+          if (!this.earlyFileTrackingEvents.delete(event)) {
+            this.fileTrackingSetupByThread.delete(event.threadId);
+            this.fileTrackingActivityByThread.delete(event.threadId);
+            this.fileTrackingRefCaptureByThread.delete(event.threadId);
+            void this.ensureTurnFileTracking(event.threadId);
+          }
           // Re-add to activeSessionIds for auto-resumed turns (ScheduleWakeup/loop).
           // For sendMessage()-originated turns this is a no-op since sendMessage()
           // already added the thread before emitting TurnStarted.
@@ -2572,7 +2743,8 @@ export class AgentService {
           this.pendingExitPlanMarkdown.delete(event.threadId);
           this.planCapturedThisTurn.delete(event.threadId);
         }
-      });
+      };
+      provider.on("event", handleEvent);
     }
   }
 

--- a/apps/server/src/services/diff-summary-source.ts
+++ b/apps/server/src/services/diff-summary-source.ts
@@ -7,6 +7,12 @@
 import type { GitExecutor } from "./git-executor/index.js";
 import { RealGitExecutor } from "./git-executor/real-git-executor.js";
 import type { SnapshotService } from "./snapshot-service.js";
+import type { TurnFileEffectSummary } from "@mcode/contracts";
+import {
+  attributedWorkspacePaths,
+  collectAttributedWorkspacePathGroups,
+  collectAttributedWorkspacePaths,
+} from "./snapshot-attribution.js";
 
 /** Per-file diff statistics. */
 export interface FileDiffStat {
@@ -48,6 +54,7 @@ export interface TurnSnapshotRow {
   ref_before: string;
   ref_after: string;
   files_changed: string;
+  file_effects?: TurnFileEffectSummary | string;
   worktree_path: string | null;
   created_at: string;
 }
@@ -68,10 +75,11 @@ export class ThreadDiffSource implements DiffSummarySource {
 
   /** Build the aggregate diff payload from the thread's turn snapshots. */
   async getDiff(): Promise<DiffPayload> {
-    const withChanges = this.snapshots.filter((s) => {
-      const files = JSON.parse(s.files_changed) as string[];
-      return files.length > 0;
-    });
+    const withChanges = this.snapshots.filter((snapshot) => (
+      snapshot.ref_before.length > 0
+      && snapshot.ref_after.length > 0
+      && attributedWorkspacePaths(snapshot).length > 0
+    ));
 
     if (withChanges.length === 0) {
       return { stats: [], diff: "", commits: "", turnCount: 0, lastTurnId: null };
@@ -79,11 +87,15 @@ export class ThreadDiffSource implements DiffSummarySource {
 
     const first = withChanges[0]!;
     const last = withChanges[withChanges.length - 1]!;
+    const attributedPaths = collectAttributedWorkspacePaths(withChanges);
+    const attributedPathGroups = collectAttributedWorkspacePathGroups(withChanges);
 
     const stats = await this.snapshotService.getDiffStats(
       this.cwd,
       first.ref_before,
       last.ref_after,
+      attributedPaths,
+      attributedPathGroups,
     );
 
     const commits = await this.getCommitLog(first.ref_before, last.ref_after);
@@ -92,6 +104,10 @@ export class ThreadDiffSource implements DiffSummarySource {
       this.cwd,
       first.ref_before,
       last.ref_after,
+      undefined,
+      undefined,
+      attributedPaths,
+      attributedPathGroups,
     );
 
     let diff: string;

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -683,20 +683,32 @@ export class NarrativeStore {
 
   /** Generate a human-readable summary of tool input. */
   private summarizeInput(toolName: string, input: Record<string, unknown>): string {
-    switch (toolName) {
-      case "Read":
-      case "Edit":
-      case "Write":
+    switch (toolName.toLowerCase()) {
+      case "read":
+      case "edit":
+      case "write":
         return String(input.file_path ?? input.filePath ?? "");
-      case "Bash":
-      case "Shell":
-      case "Terminal":
+      case "move":
+      case "rename": {
+        const source = input.oldPath ?? input.old_path ?? input.oldFilePath
+          ?? input.sourcePath ?? input.source_path ?? input.source ?? input.from;
+        const destination = input.newPath ?? input.new_path ?? input.destinationPath
+          ?? input.destination_path ?? input.destination ?? input.to ?? input.path
+          ?? input.file_path ?? input.filePath ?? input.target_file ?? input.targetFile;
+        return [source, destination]
+          .filter((value): value is string => typeof value === "string")
+          .join(" -> ")
+          .slice(0, 200);
+      }
+      case "bash":
+      case "shell":
+      case "terminal":
       case "command_execution":
         return String(input.command ?? "").slice(0, MAX_PERSISTED_COMMAND_CHARS);
-      case "Grep":
-      case "Glob":
+      case "grep":
+      case "glob":
         return String(input.pattern ?? "");
-      case "Agent":
+      case "agent":
         return String(input.description ?? "").slice(0, 100);
       default:
         return JSON.stringify(input).slice(0, 200);

--- a/apps/server/src/services/public-tool-input.ts
+++ b/apps/server/src/services/public-tool-input.ts
@@ -1,0 +1,124 @@
+const RAW_FILE_CONTENT_KEYS = new Set([
+  "_mcodeFileMutations",
+  "beforeText",
+  "afterText",
+  "before_text",
+  "after_text",
+  "old_string",
+  "new_string",
+  "oldText",
+  "newText",
+  "old_text",
+  "new_text",
+  "content",
+  "patch",
+  "replacement",
+]);
+
+const FILE_OPERATION_TOOLS = new Set([
+  "edit",
+  "write",
+  "delete",
+  "remove",
+  "create",
+  "move",
+  "rename",
+  "apply_patch",
+  "strreplace",
+  "searchreplace",
+  "file_change",
+]);
+
+const SAFE_FILE_METADATA_KEYS = new Set([
+  "file_path",
+  "filePath",
+  "target_file",
+  "targetFile",
+  "path",
+  "oldPath",
+  "old_path",
+  "old_file_path",
+  "oldFilePath",
+  "sourcePath",
+  "source_path",
+  "source",
+  "from",
+  "newPath",
+  "new_path",
+  "destinationPath",
+  "destination_path",
+  "destination",
+  "to",
+  "operation",
+  "operationType",
+  "operation_type",
+  "kind",
+]);
+
+const FILE_PATH_KEYS = new Set([
+  "file_path",
+  "filePath",
+  "target_file",
+  "targetFile",
+  "path",
+  "oldPath",
+  "old_path",
+  "old_file_path",
+  "oldFilePath",
+  "sourcePath",
+  "source_path",
+  "source",
+  "from",
+  "newPath",
+  "new_path",
+  "destinationPath",
+  "destination_path",
+  "destination",
+  "to",
+]);
+
+const FILE_SOURCE_PATH_KEYS = [
+  "oldPath",
+  "old_path",
+  "old_file_path",
+  "oldFilePath",
+  "sourcePath",
+  "source_path",
+  "source",
+  "from",
+] as const;
+
+const FILE_DESTINATION_PATH_KEYS = [
+  "file_path",
+  "filePath",
+  "target_file",
+  "targetFile",
+  "path",
+  "newPath",
+  "new_path",
+  "destinationPath",
+  "destination_path",
+  "destination",
+  "to",
+] as const;
+
+/** Remove raw file bodies while preserving path and operation metadata for the timeline. */
+export function sanitizePublicToolInput(
+  input: Record<string, unknown>,
+  toolName?: string,
+): Record<string, unknown> {
+  const normalized = toolName?.toLowerCase();
+  const explicitFileTool = normalized != null && FILE_OPERATION_TOOLS.has(normalized);
+  const sourceDestinationShapedInput = FILE_SOURCE_PATH_KEYS.some((key) => key in input)
+    && FILE_DESTINATION_PATH_KEYS.some((key) => key in input);
+  const fileShapedInput = "_mcodeFileMutations" in input
+    || sourceDestinationShapedInput
+    || ([...FILE_PATH_KEYS].some((key) => key in input)
+      && [...RAW_FILE_CONTENT_KEYS].some((key) => key in input));
+  if (!explicitFileTool && !fileShapedInput) return input;
+  return Object.fromEntries(
+    Object.entries(input).filter(([key, value]) =>
+      SAFE_FILE_METADATA_KEYS.has(key)
+      && (typeof value === "string" || typeof value === "number" || typeof value === "boolean")),
+  );
+}

--- a/apps/server/src/services/snapshot-attribution.ts
+++ b/apps/server/src/services/snapshot-attribution.ts
@@ -1,0 +1,75 @@
+import { TurnFileEffectSummarySchema, type TurnFileEffectSummary } from "@mcode/contracts";
+
+/** Minimal persisted snapshot fields needed to scope historical Git calculations. */
+export interface SnapshotAttributionInput {
+  files_changed: readonly string[] | string;
+  file_effects?: TurnFileEffectSummary | string;
+}
+
+function parseFileEffects(value: SnapshotAttributionInput["file_effects"]): TurnFileEffectSummary | null {
+  if (!value) return null;
+  try {
+    const parsed = TurnFileEffectSummarySchema().safeParse(
+      typeof value === "string" ? JSON.parse(value) : value,
+    );
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseLegacyPaths(value: SnapshotAttributionInput["files_changed"]): string[] {
+  if (Array.isArray(value)) return [...value];
+  try {
+    const parsed = JSON.parse(value as string) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((path): path is string => typeof path === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Return bounded workspace path groups authored in one turn, preserving rename pairs. */
+export function attributedWorkspacePathGroups(snapshot: SnapshotAttributionInput): string[][] {
+  const fileEffects = parseFileEffects(snapshot.file_effects);
+  const groups = fileEffects && fileEffects.fileCount > 0
+    ? fileEffects.effects.flatMap((effect) => (
+        effect.scope === "workspace"
+          ? [[effect.path, ...(effect.oldPath ? [effect.oldPath] : [])]]
+          : []
+      ))
+    : parseLegacyPaths(snapshot.files_changed).map((path) => [path]);
+  const bounded: string[][] = [];
+  let pathCount = 0;
+  for (const group of groups) {
+    const uniqueGroup = [...new Set(group)];
+    if (pathCount + uniqueGroup.length > 512) break;
+    bounded.push(uniqueGroup);
+    pathCount += uniqueGroup.length;
+  }
+  return bounded;
+}
+
+/** Return bounded workspace paths authored in one turn, including both sides of renames. */
+export function attributedWorkspacePaths(snapshot: SnapshotAttributionInput): string[] {
+  return [...new Set(attributedWorkspacePathGroups(snapshot).flat())];
+}
+
+/** Return distinct workspace path groups across turns while retaining rename relationships. */
+export function collectAttributedWorkspacePathGroups(
+  snapshots: readonly SnapshotAttributionInput[],
+): string[][] {
+  const seen = new Set<string>();
+  return snapshots.flatMap(attributedWorkspacePathGroups).filter((group) => {
+    const key = group.join("\0");
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/** Return every distinct workspace path authored across the supplied turns. */
+export function collectAttributedWorkspacePaths(
+  snapshots: readonly SnapshotAttributionInput[],
+): string[] {
+  return [...new Set(collectAttributedWorkspacePathGroups(snapshots).flat())];
+}

--- a/apps/server/src/services/snapshot-service.ts
+++ b/apps/server/src/services/snapshot-service.ts
@@ -11,6 +11,101 @@ import { randomUUID } from "node:crypto";
 import type { GitExecutor } from "./git-executor/index.js";
 import { RealGitExecutor } from "./git-executor/real-git-executor.js";
 
+const MAX_ATTRIBUTED_PATHS = 16_384;
+const MAX_PATHS_PER_GIT_CALL = 128;
+const MAX_PATHSPEC_CHARS_PER_GIT_CALL = 20_000;
+
+function literalPathspecs(paths: readonly string[]): string[] {
+  return [...new Set(paths)]
+    .filter((path) => (
+      path.length > 0
+      && path.length <= 4096
+      && !path.includes("\0")
+      && !/^(?:[A-Za-z]:[\\/]|[\\/])/.test(path)
+      && path !== ".."
+      && !path.startsWith("../")
+      && !path.startsWith("..\\")
+    ))
+    .map((path) => `:(literal)${path.replaceAll("\\", "/")}`);
+}
+
+function batchPathspecGroups(pathGroups: readonly (readonly string[])[]): string[][] {
+  const literalGroups = pathGroups
+    .map(literalPathspecs)
+    .filter((group) => group.length > 0);
+  const totalPaths = literalGroups.reduce((total, group) => total + group.length, 0);
+  if (totalPaths > MAX_ATTRIBUTED_PATHS) {
+    throw new Error(`Snapshot diff is limited to ${MAX_ATTRIBUTED_PATHS} attributed paths`);
+  }
+  const batches: string[][] = [];
+  let current: string[] = [];
+  let currentChars = 0;
+  for (const group of literalGroups) {
+    const groupChars = group.reduce((total, pathspec) => total + pathspec.length, 0);
+    if (group.length > MAX_PATHS_PER_GIT_CALL || groupChars > MAX_PATHSPEC_CHARS_PER_GIT_CALL) {
+      throw new Error("A related snapshot path group exceeds the Git command limit");
+    }
+    if (current.length > 0 && (
+      current.length + group.length > MAX_PATHS_PER_GIT_CALL
+      || currentChars + groupChars > MAX_PATHSPEC_CHARS_PER_GIT_CALL
+    )) {
+      batches.push(current);
+      current = [];
+      currentChars = 0;
+    }
+    current.push(...group);
+    currentChars += groupChars;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+function selectedPathGroups(
+  filePath: string,
+  pathGroups: readonly (readonly string[])[],
+): readonly (readonly string[])[] {
+  const normalize = (path: string): string => path.replaceAll("\\", "/");
+  const connected = new Set([normalize(filePath)]);
+  let addedPath = true;
+  while (addedPath) {
+    addedPath = false;
+    for (const group of pathGroups) {
+      if (!group.some((path) => connected.has(normalize(path)))) continue;
+      for (const path of group) {
+        const normalized = normalize(path);
+        if (connected.has(normalized)) continue;
+        connected.add(normalized);
+        addedPath = true;
+      }
+    }
+  }
+  return pathGroups.filter((group) => group.some((path) => connected.has(normalize(path))));
+}
+
+function parseNumstat(stdout: string): { filePath: string; additions: number; deletions: number }[] {
+  return stdout
+    .trim()
+    .split("\n")
+    .filter((line) => line.includes("\t"))
+    .map((line) => {
+      const [addStr, delStr, ...pathParts] = line.split("\t");
+      return {
+        filePath: numstatDestinationPath(pathParts.join("\t")),
+        additions: addStr === "-" ? 0 : parseInt(addStr ?? "0", 10),
+        deletions: delStr === "-" ? 0 : parseInt(delStr ?? "0", 10),
+      };
+    });
+}
+
+function numstatDestinationPath(path: string): string {
+  const braceRename = path.match(/^(.*)\{([^{}]*) => ([^{}]*)\}(.*)$/);
+  if (braceRename) {
+    return `${braceRename[1]}${braceRename[3]}${braceRename[4]}`;
+  }
+  const separatorIndex = path.lastIndexOf(" => ");
+  return separatorIndex >= 0 ? path.slice(separatorIndex + 4) : path;
+}
+
 /** Service for capturing and comparing git working tree snapshots. */
 @injectable()
 export class SnapshotService {
@@ -58,7 +153,11 @@ export class SnapshotService {
 
   /** Get list of files changed between two refs (tree or commit SHAs). */
   async getFilesChanged(cwd: string, refBefore: string, refAfter: string): Promise<string[]> {
-    if (refBefore === refAfter) {
+    if (!refBefore
+      || !refAfter
+      || refBefore.startsWith("-")
+      || refAfter.startsWith("-")
+      || refBefore === refAfter) {
       return [];
     }
 
@@ -79,6 +178,39 @@ export class SnapshotService {
     }
   }
 
+  /** Read one UTF-8 file from an immutable tree ref, returning null when absent. */
+  async getFileAtRef(
+    cwd: string,
+    ref: string,
+    relativePath: string,
+  ): Promise<{ kind: "text"; text: string } | { kind: "missing" } | { kind: "unavailable" }> {
+    if (!ref
+      || ref.startsWith("-")
+      || !relativePath
+      || relativePath.startsWith("..")
+      || relativePath.includes("\0")) {
+      return { kind: "missing" };
+    }
+    try {
+      const object = `${ref}:${relativePath.replaceAll("\\", "/")}`;
+      const { stdout: sizeOut } = await this.gitExecutor.exec(
+        ["-C", cwd, "cat-file", "-s", object],
+        { timeout: RealGitExecutor.DEFAULT_TIMEOUT },
+      );
+      const size = Number.parseInt(sizeOut.trim(), 10);
+      if (!Number.isFinite(size) || size > 1_048_576) return { kind: "unavailable" };
+      const { stdout } = await this.gitExecutor.exec(
+        ["-C", cwd, "show", object],
+        { timeout: RealGitExecutor.DEFAULT_TIMEOUT },
+      );
+      return Buffer.byteLength(stdout, "utf8") <= 1_048_576
+        ? { kind: "text", text: stdout }
+        : { kind: "unavailable" };
+    } catch {
+      return { kind: "missing" };
+    }
+  }
+
   /**
    * Get a unified diff between two refs (tree or commit SHAs).
    * Optionally scoped to a single file path.
@@ -90,18 +222,32 @@ export class SnapshotService {
     refAfter: string,
     filePath?: string,
     maxLines?: number,
+    allowedPaths?: readonly string[],
+    allowedPathGroups?: readonly (readonly string[])[],
   ): Promise<string> {
-    const args = ["-C", cwd, "diff", "--find-renames", refBefore, refAfter];
-
-    if (filePath) {
-      args.push("--", filePath);
-    }
+    if (!refBefore || !refAfter || refBefore.startsWith("-") || refAfter.startsWith("-")) return "";
+    const allGroups = allowedPathGroups ?? allowedPaths?.map((path) => [path]);
+    const requestedGroups = filePath
+      ? allGroups
+        ? selectedPathGroups(filePath, allGroups)
+        : [[filePath]]
+      : allGroups;
+    const pathspecBatches = requestedGroups
+      ? batchPathspecGroups(requestedGroups)
+      : [undefined];
+    if (pathspecBatches.length === 0) return "";
 
     try {
-      const { stdout } = await this.gitExecutor.exec(args, {
-        timeout: RealGitExecutor.DEFAULT_TIMEOUT,
-      });
-      const result = stdout.trim();
+      const outputs: string[] = [];
+      for (const pathspecs of pathspecBatches) {
+        const args = ["-C", cwd, "diff", "--find-renames", refBefore, refAfter];
+        if (pathspecs) args.push("--", ...pathspecs);
+        const { stdout } = await this.gitExecutor.exec(args, {
+          timeout: RealGitExecutor.DEFAULT_TIMEOUT,
+        });
+        if (stdout.trim()) outputs.push(stdout.trim());
+      }
+      const result = outputs.join("\n");
 
       if (maxLines) {
         return result.split("\n").slice(0, maxLines).join("\n");
@@ -133,27 +279,32 @@ export class SnapshotService {
     cwd: string,
     refBefore: string,
     refAfter: string,
+    allowedPaths?: readonly string[],
+    allowedPathGroups?: readonly (readonly string[])[],
   ): Promise<{ filePath: string; additions: number; deletions: number }[]> {
-    if (refBefore === refAfter) return [];
+    if (!refBefore
+      || !refAfter
+      || refBefore.startsWith("-")
+      || refAfter.startsWith("-")
+      || refBefore === refAfter) return [];
+    const pathGroups = allowedPathGroups ?? allowedPaths?.map((path) => [path]);
+    const pathspecBatches = pathGroups
+      ? batchPathspecGroups(pathGroups)
+      : [undefined];
+    if (pathspecBatches.length === 0) return [];
 
     try {
-      const { stdout } = await this.gitExecutor.exec(
-        ["-C", cwd, "diff", "--numstat", "--find-renames", refBefore, refAfter],
-        { timeout: RealGitExecutor.DEFAULT_TIMEOUT },
-      );
-
-      return stdout
-        .trim()
-        .split("\n")
-        .filter((line) => line.includes("\t"))
-        .map((line) => {
-          const [addStr, delStr, ...pathParts] = line.split("\t");
-          return {
-            filePath: pathParts.join("\t"),
-            additions: addStr === "-" ? 0 : parseInt(addStr ?? "0", 10),
-            deletions: delStr === "-" ? 0 : parseInt(delStr ?? "0", 10),
-          };
-        });
+      const stats = new Map<string, { filePath: string; additions: number; deletions: number }>();
+      for (const pathspecs of pathspecBatches) {
+        const args = ["-C", cwd, "diff", "--numstat", "--find-renames", refBefore, refAfter];
+        if (pathspecs) args.push("--", ...pathspecs);
+        const { stdout } = await this.gitExecutor.exec(
+          args,
+          { timeout: RealGitExecutor.DEFAULT_TIMEOUT },
+        );
+        for (const entry of parseNumstat(stdout)) stats.set(entry.filePath, entry);
+      }
+      return [...stats.values()];
     } catch {
       return [];
     }

--- a/apps/server/src/services/turn-file-tracker.ts
+++ b/apps/server/src/services/turn-file-tracker.ts
@@ -1,0 +1,847 @@
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import type { FileEffect, TurnFileEffectSummary } from "@mcode/contracts";
+import { MAX_TURN_FILE_EFFECTS } from "@mcode/contracts";
+
+const MAX_FILE_BYTES = 1_048_576;
+const MAX_EVIDENCE_TEXT_BYTES = 1_048_576;
+const MAX_LINE_DIFF_WORK = 2_000_000;
+const MAX_SYNC_OBSERVATION_PATHS = 4;
+const MAX_SYNC_OBSERVATION_BYTES = 1_048_576;
+const EMPTY_SUMMARY: TurnFileEffectSummary = {
+  revision: 0,
+  fileCount: 0,
+  additions: 0,
+  deletions: 0,
+  effects: [],
+};
+
+type OperationHint = "add" | "edit" | "remove" | "rename";
+
+interface MutationCandidate {
+  path: string;
+  operationHint: OperationHint;
+  providerConfirmed?: boolean;
+  oldPath?: string;
+  beforeText?: string;
+  afterText?: string;
+}
+
+interface CandidateObservation {
+  resolvedPath: Pick<TrackedPath, "path" | "displayPath" | "scope"> | null;
+  resolvedOldPath: Pick<TrackedPath, "path" | "displayPath" | "scope"> | null;
+  baseline: FileState | null;
+  oldBaseline: FileState | null;
+}
+
+interface SyncObservationBudget {
+  remainingPaths: number;
+  remainingBytes: number;
+}
+
+interface FileState {
+  known: boolean;
+  exists: boolean;
+  hash: string | null;
+  text: string | null;
+  binary: boolean;
+}
+
+interface TrackedPath {
+  path: string;
+  displayPath: string;
+  scope: "workspace" | "external";
+  operationHint: OperationHint;
+  oldPath?: string;
+  oldResolvedPath?: string;
+  oldBaseline?: FileState;
+  oldCurrent?: FileState;
+  baseline: FileState;
+  current: FileState;
+  effectCandidate?: EffectCandidate | null;
+  providerConfirmed: boolean;
+  toolCallIds: Set<string>;
+}
+
+interface TurnState {
+  generation: number;
+  cwd: string;
+  canonicalRoot: string;
+  baselineRef: string | null;
+  revision: number;
+  tracked: Map<string, TrackedPath>;
+  summary: TurnFileEffectSummary;
+  chain: Promise<void>;
+}
+
+/** Callback invoked after a verified net file-effect summary changes. */
+export type FileEffectUpdateListener = (
+  threadId: string,
+  turnId: string,
+  summary: TurnFileEffectSummary,
+) => void;
+
+/** Reads one UTF-8 file from the immutable pre-turn tree, or null when absent. */
+export type TurnBaselineReader = (
+  cwd: string,
+  ref: string,
+  relativePath: string,
+) => Promise<{ kind: "text"; text: string } | { kind: "missing" } | { kind: "unavailable" }>;
+
+/**
+ * Tracks bounded, explicit agent file mutations and reduces them to net turn effects.
+ * Git supplies the immutable in-project baseline; external paths use the state observed
+ * when an explicit file tool starts or provider-supplied full before text.
+ */
+export class TurnFileTracker {
+  private readonly turns = new Map<string, Map<number, TurnState>>();
+  private readonly currentGeneration = new Map<string, number>();
+  /** Origin generation for an explicit file tool, keyed by thread and provider call id. */
+  private readonly generationByToolCall = new Map<string, number>();
+  private nextGeneration = 1;
+
+  constructor(
+    private readonly readBaseline: TurnBaselineReader,
+    private readonly onUpdate: FileEffectUpdateListener,
+  ) {}
+
+  /** Start a fresh tracker scope for an agent turn. */
+  beginTurn(threadId: string, cwd: string, baselineRef: string | null): number {
+    const canonicalRoot = realpathSync.native(cwd);
+    const generation = this.nextGeneration++;
+    const generations = this.turns.get(threadId) ?? new Map<number, TurnState>();
+    generations.set(generation, {
+      generation,
+      cwd,
+      canonicalRoot,
+      baselineRef,
+      revision: 0,
+      tracked: new Map(),
+      summary: EMPTY_SUMMARY,
+      chain: Promise.resolve(),
+    });
+    while (generations.size > 4) {
+      const oldest = generations.keys().next().value as number | undefined;
+      if (oldest === undefined) break;
+      generations.delete(oldest);
+    }
+    this.turns.set(threadId, generations);
+    this.currentGeneration.set(threadId, generation);
+    return generation;
+  }
+
+  /** Return the authoritative tracker generation for the active turn. */
+  getCurrentTurnId(threadId: string): string | undefined {
+    const generation = this.currentGeneration.get(threadId);
+    return generation === undefined ? undefined : String(generation);
+  }
+
+  /** Attach a Git baseline that completed after the turn tracker was initialized. */
+  setBaselineRef(threadId: string, generation: number, baselineRef: string): Promise<void> {
+    return this.enqueue(threadId, async (turn) => {
+      if (turn.baselineRef !== null) return;
+      turn.baselineRef = baselineRef;
+      for (const tracked of turn.tracked.values()) {
+        if (!tracked.providerConfirmed || tracked.scope !== "workspace") continue;
+        const baseline = await this.readGitBaseline(turn, tracked.displayPath);
+        if (baseline) tracked.baseline = baseline;
+        if (tracked.oldPath && tracked.oldResolvedPath) {
+          const oldBaseline = await this.readGitBaseline(turn, tracked.oldPath);
+          if (oldBaseline) tracked.oldBaseline = oldBaseline;
+          tracked.oldCurrent = await readBoundedState(tracked.oldResolvedPath);
+        }
+        tracked.current = await readBoundedState(tracked.path);
+        tracked.effectCandidate = buildEffect(tracked);
+      }
+      this.publishSummary(turn, threadId);
+    }, generation);
+  }
+
+  /** Capture baselines for explicit file mutations named by a provider ToolUse event. */
+  observeToolUse(
+    threadId: string,
+    toolCallId: string,
+    toolName: string,
+    toolInput: Record<string, unknown>,
+  ): Promise<void> {
+    const candidates = extractMutationCandidates(toolName, toolInput);
+    if (candidates.length === 0) return Promise.resolve();
+    const generation = this.currentGeneration.get(threadId);
+    if (generation === undefined) return Promise.resolve();
+    const turn = this.getTurn(threadId, generation);
+    if (!turn) return Promise.resolve();
+    const boundedCandidates = dedupeMutationCandidates(candidates).slice(0, MAX_TURN_FILE_EFFECTS);
+    const syncBudget: SyncObservationBudget = {
+      remainingPaths: MAX_SYNC_OBSERVATION_PATHS,
+      remainingBytes: MAX_SYNC_OBSERVATION_BYTES,
+    };
+    const observations = boundedCandidates.map((candidate) => {
+      const requiredPaths = candidate.operationHint === "rename" && candidate.oldPath ? 2 : 1;
+      return candidate.providerConfirmed === true
+        || candidate.beforeText !== undefined
+        || syncBudget.remainingPaths < requiredPaths
+        ? undefined
+        : observeCandidateSynchronously(turn.canonicalRoot, candidate, syncBudget);
+    });
+    this.generationByToolCall.set(toolGenerationKey(threadId, toolCallId), generation);
+    return this.enqueue(threadId, async (queuedTurn) => {
+      for (const [index, candidate] of boundedCandidates.entries()) {
+        await this.captureCandidate(queuedTurn, toolCallId, candidate, observations[index]);
+      }
+    }, generation);
+  }
+
+  /** Verify all paths attributed to a completed file tool and publish the net summary. */
+  observeToolResult(
+    threadId: string,
+    toolCallId: string,
+    lateToolInput?: Record<string, unknown>,
+  ): Promise<void> {
+    const key = toolGenerationKey(threadId, toolCallId);
+    const lateToolName = lateToolInput && typeof lateToolInput._mcodeToolName === "string"
+      ? lateToolInput._mcodeToolName
+      : "Edit";
+    const lateCandidates = lateToolInput
+      ? extractMutationCandidates(lateToolName, lateToolInput)
+      : [];
+    const generation = this.generationByToolCall.get(key)
+      ?? (lateCandidates.length > 0 ? this.currentGeneration.get(threadId) : undefined);
+    if (generation === undefined) return Promise.resolve();
+    if (lateCandidates.length > 0) this.generationByToolCall.set(key, generation);
+    const result = this.enqueue(threadId, async (turn) => {
+      if (lateToolInput) {
+        for (const candidate of lateCandidates.slice(0, MAX_TURN_FILE_EFFECTS)) {
+          await this.captureCandidate(turn, toolCallId, candidate);
+        }
+      }
+      await this.recompute(turn, threadId, toolCallId);
+    }, generation);
+    return result.finally(() => this.generationByToolCall.delete(key));
+  }
+
+  /** Return the latest net summary after all queued observations settle. */
+  async finalizeTurn(threadId: string, generation?: number): Promise<TurnFileEffectSummary> {
+    const turn = this.getTurn(threadId, generation);
+    if (!turn) return EMPTY_SUMMARY;
+    await turn.chain;
+    return turn.summary;
+  }
+
+  /** Clear a completed turn after its summary has been persisted. */
+  clearTurn(threadId: string, generation?: number): void {
+    const target = generation ?? this.currentGeneration.get(threadId);
+    if (target === undefined) return;
+    const generations = this.turns.get(threadId);
+    generations?.delete(target);
+    if (generations?.size === 0) this.turns.delete(threadId);
+    if (this.currentGeneration.get(threadId) === target) {
+      const latest = generations && generations.size > 0
+        ? [...generations.keys()].at(-1)
+        : undefined;
+      if (latest === undefined) this.currentGeneration.delete(threadId);
+      else this.currentGeneration.set(threadId, latest);
+    }
+    for (const [key, origin] of this.generationByToolCall) {
+      if (origin === target && key.startsWith(`${threadId}\0`)) {
+        this.generationByToolCall.delete(key);
+      }
+    }
+  }
+
+  private enqueue(
+    threadId: string,
+    work: (turn: TurnState) => Promise<void>,
+    generation?: number,
+  ): Promise<void> {
+    const turn = this.getTurn(threadId, generation);
+    if (!turn) return Promise.resolve();
+    const operation = turn.chain.then(() => work(turn));
+    turn.chain = operation.catch(() => undefined);
+    return operation;
+  }
+
+  private getTurn(threadId: string, generation?: number): TurnState | undefined {
+    const target = generation ?? this.currentGeneration.get(threadId);
+    return target === undefined ? undefined : this.turns.get(threadId)?.get(target);
+  }
+
+  private async captureCandidate(
+    turn: TurnState,
+    toolCallId: string,
+    candidate: MutationCandidate,
+    observation?: CandidateObservation,
+  ): Promise<void> {
+    if (turn.tracked.size >= MAX_TURN_FILE_EFFECTS) return;
+    const resolvedPath = observation
+      ? observation.resolvedPath
+      : await resolveCandidatePath(turn.canonicalRoot, candidate.path);
+    if (!resolvedPath) return;
+    const resolvedOldPath = candidate.operationHint === "rename" && candidate.oldPath
+      ? observation
+        ? observation.resolvedOldPath
+        : await resolveCandidatePath(turn.canonicalRoot, candidate.oldPath)
+      : null;
+    const validOldPath = resolvedOldPath?.path !== resolvedPath.path ? resolvedOldPath : null;
+    const existing = turn.tracked.get(resolvedPath.path);
+    if (existing) {
+      existing.toolCallIds.add(toolCallId);
+      existing.providerConfirmed ||= candidate.providerConfirmed === true;
+      existing.effectCandidate = undefined;
+      if (existing.operationHint !== "rename" || candidate.operationHint === "rename") {
+        existing.operationHint = candidate.operationHint;
+      }
+      if (validOldPath) {
+        const oldBaseline = candidate.beforeText !== undefined
+          ? stateFromEvidenceText(candidate.beforeText)
+          : observation?.oldBaseline
+            ? observation.oldBaseline
+            : candidate.providerConfirmed === true
+              ? await this.readProviderConfirmedBaseline(turn, validOldPath, "remove")
+              : await readBoundedState(validOldPath.path);
+        existing.oldPath = validOldPath.displayPath;
+        existing.oldResolvedPath = validOldPath.path;
+        existing.oldBaseline = oldBaseline;
+        existing.oldCurrent = oldBaseline;
+      }
+      return;
+    }
+
+    let baseline = candidate.beforeText !== undefined && !validOldPath
+      ? stateFromEvidenceText(candidate.beforeText)
+      : observation?.baseline ?? null;
+    baseline ??= candidate.providerConfirmed === true
+      ? await this.readProviderConfirmedBaseline(turn, resolvedPath, candidate.operationHint)
+      : await readBoundedState(resolvedPath.path);
+    const oldBaseline = validOldPath
+      ? candidate.beforeText !== undefined
+        ? stateFromEvidenceText(candidate.beforeText)
+        : observation?.oldBaseline
+          ? observation.oldBaseline
+        : candidate.providerConfirmed === true
+          ? await this.readProviderConfirmedBaseline(turn, validOldPath, "remove")
+          : await readBoundedState(validOldPath.path)
+      : undefined;
+    turn.tracked.set(resolvedPath.path, {
+      ...resolvedPath,
+      operationHint: candidate.operationHint,
+      ...(validOldPath ? {
+        oldPath: validOldPath.displayPath,
+        oldResolvedPath: validOldPath.path,
+        oldBaseline,
+        oldCurrent: oldBaseline,
+      } : {}),
+      baseline,
+      current: baseline,
+      providerConfirmed: candidate.providerConfirmed === true,
+      toolCallIds: new Set([toolCallId]),
+    });
+  }
+
+  private async readProviderConfirmedBaseline(
+    turn: TurnState,
+    resolvedPath: Pick<TrackedPath, "path" | "displayPath" | "scope">,
+    operationHint: OperationHint,
+  ): Promise<FileState> {
+    if (resolvedPath.scope === "workspace" && turn.baselineRef) {
+      const baseline = await this.readGitBaseline(turn, resolvedPath.displayPath);
+      if (baseline) return baseline;
+    }
+    return inferredProviderBaseline(operationHint);
+  }
+
+  private async readGitBaseline(turn: TurnState, relativePath: string): Promise<FileState | null> {
+    if (!turn.baselineRef || !relativePath || relativePath.startsWith("..")) return null;
+    try {
+      const baseline = await this.readBaseline(turn.cwd, turn.baselineRef, relativePath);
+      if (baseline.kind === "missing") {
+        return missingState();
+      }
+      if (baseline.kind === "unavailable") {
+        return unknownExistingState();
+      }
+      return stateFromEvidenceText(baseline.text);
+    } catch {
+      return unknownExistingState();
+    }
+  }
+
+  private async recompute(turn: TurnState, threadId: string, toolCallId: string): Promise<void> {
+    for (const tracked of turn.tracked.values()) {
+      if (!tracked.toolCallIds.has(toolCallId)) continue;
+      tracked.current = await readBoundedState(tracked.path);
+      if (tracked.oldResolvedPath) {
+        tracked.oldCurrent = await readBoundedState(tracked.oldResolvedPath);
+      }
+      tracked.effectCandidate = buildEffect(tracked);
+    }
+    this.publishSummary(turn, threadId);
+  }
+
+  private publishSummary(turn: TurnState, threadId: string): void {
+    const candidates = [...turn.tracked.values()].flatMap((tracked) => (
+      tracked.effectCandidate ? [tracked.effectCandidate] : []
+    ));
+    const effects = collapseHashMatchedRenames(candidates);
+    effects.sort((a, b) => a.path.localeCompare(b.path));
+    const additions = effects.reduce((total, effect) => total + (effect.additions ?? 0), 0);
+    const deletions = effects.reduce((total, effect) => total + (effect.deletions ?? 0), 0);
+    const comparable = { fileCount: effects.length, additions, deletions, effects };
+    if (JSON.stringify(comparable) === JSON.stringify({
+      fileCount: turn.summary.fileCount,
+      additions: turn.summary.additions,
+      deletions: turn.summary.deletions,
+      effects: turn.summary.effects,
+    })) return;
+    turn.revision += 1;
+    turn.summary = { revision: turn.revision, ...comparable };
+    this.onUpdate(threadId, String(turn.generation), turn.summary);
+  }
+}
+
+function toolGenerationKey(threadId: string, toolCallId: string): string {
+  return `${threadId}\0${toolCallId}`;
+}
+
+function extractMutationCandidates(
+  toolName: string,
+  input: Record<string, unknown>,
+): MutationCandidate[] {
+  const normalized = toolName.toLowerCase();
+  if (Array.isArray(input._mcodeFileMutations)) {
+    const candidates: MutationCandidate[] = [];
+    const seenPaths = new Set<string>();
+    for (const value of input._mcodeFileMutations) {
+      if (candidates.length >= MAX_TURN_FILE_EFFECTS) break;
+      if (!value || typeof value !== "object") continue;
+      const mutation = value as Record<string, unknown>;
+      if (typeof mutation.path !== "string") continue;
+      const oldPath = pickString(mutation, ["oldPath", "old_path", "sourcePath", "source_path", "from"]);
+      const identity = `${mutation.path}\0${oldPath ?? ""}`;
+      if (seenPaths.has(identity)) continue;
+      seenPaths.add(identity);
+      const beforeText = boundedEvidenceText(
+        mutation.fullFileContent === true && typeof mutation.beforeText === "string"
+          ? mutation.beforeText
+          : undefined,
+      );
+      const afterText = boundedEvidenceText(
+        mutation.fullFileContent === true && typeof mutation.afterText === "string"
+          ? mutation.afterText
+          : undefined,
+      );
+      candidates.push({
+        path: mutation.path,
+        operationHint: normalizeOperation(mutation.kind ?? mutation.operation),
+        ...(oldPath ? { oldPath } : {}),
+        ...(beforeText !== undefined ? { beforeText } : {}),
+        ...(afterText !== undefined ? { afterText } : {}),
+      });
+    }
+    return candidates;
+  }
+  if (normalized === "file_change" && Array.isArray(input.changes)) {
+    const candidates: MutationCandidate[] = [];
+    const seenPaths = new Set<string>();
+    for (const value of input.changes) {
+      if (candidates.length >= MAX_TURN_FILE_EFFECTS) break;
+      if (!value || typeof value !== "object") continue;
+      const change = value as Record<string, unknown>;
+      if (typeof change.path !== "string") continue;
+      const oldPath = pickString(change, ["oldPath", "old_path", "sourcePath", "source_path", "from"]);
+      const identity = `${change.path}\0${oldPath ?? ""}`;
+      if (seenPaths.has(identity)) continue;
+      seenPaths.add(identity);
+      candidates.push({
+        path: change.path,
+        operationHint: normalizeOperation(change.kind ?? change.operation),
+        providerConfirmed: true,
+        ...(oldPath ? { oldPath } : {}),
+      });
+    }
+    return candidates;
+  }
+  if (!isExplicitFileTool(normalized)) return [];
+  const path = pickString(input, normalized === "rename" || normalized === "move"
+    ? [
+        "newPath", "new_path", "destinationPath", "destination_path", "destination", "to",
+        "file_path", "filePath", "path", "target_file", "targetFile",
+      ]
+    : ["file_path", "filePath", "path", "target_file", "targetFile"]);
+  if (!path) return [];
+  const oldPath = pickString(input, [
+    "oldPath", "old_path", "old_file_path", "oldFilePath", "sourcePath", "source_path", "from",
+  ]);
+  return [{
+    path,
+    operationHint: normalizeOperation(input.operation ?? input.kind ?? toolName),
+    ...(oldPath ? { oldPath } : {}),
+  }];
+}
+
+function isExplicitFileTool(name: string): boolean {
+  return [
+    "edit", "write", "delete", "remove", "create", "rename", "move",
+    "apply_patch", "strreplace", "searchreplace",
+  ].includes(name);
+}
+
+function normalizeOperation(value: unknown): OperationHint {
+  const text = String(value ?? "").toLowerCase();
+  if (text.includes("delete") || text.includes("remove")) return "remove";
+  if (text.includes("rename") || text.includes("move")) return "rename";
+  if (text.includes("add") || text.includes("create") || text.includes("write")) return "add";
+  return "edit";
+}
+
+function pickString(input: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function boundedEvidenceText(value: string | undefined): string | undefined {
+  if (value === undefined || Buffer.byteLength(value, "utf8") > MAX_EVIDENCE_TEXT_BYTES) return undefined;
+  return value;
+}
+
+function dedupeMutationCandidates(candidates: MutationCandidate[]): MutationCandidate[] {
+  const unique = new Map<string, MutationCandidate>();
+  for (const candidate of candidates) {
+    const identity = `${candidate.path}\0${candidate.oldPath ?? ""}`;
+    if (!unique.has(identity)) unique.set(identity, candidate);
+  }
+  return [...unique.values()];
+}
+
+function observeCandidateSynchronously(
+  canonicalRoot: string,
+  candidate: MutationCandidate,
+  budget: SyncObservationBudget,
+): CandidateObservation {
+  const resolvedPath = observePathSynchronously(canonicalRoot, candidate.path, budget);
+  const resolvedOldPath = candidate.operationHint === "rename" && candidate.oldPath
+    ? observePathSynchronously(canonicalRoot, candidate.oldPath, budget)
+    : null;
+  return {
+    resolvedPath: resolvedPath?.path ?? null,
+    resolvedOldPath: resolvedOldPath?.path ?? null,
+    baseline: resolvedPath?.baseline ?? null,
+    oldBaseline: resolvedOldPath?.baseline ?? null,
+  };
+}
+
+function observePathSynchronously(
+  canonicalRoot: string,
+  candidatePath: string,
+  budget: SyncObservationBudget,
+): {
+  path: Pick<TrackedPath, "path" | "displayPath" | "scope">;
+  baseline: FileState;
+} | null {
+  if (budget.remainingPaths === 0) return null;
+  budget.remainingPaths -= 1;
+  const path = resolveCandidatePathSynchronously(canonicalRoot, candidatePath);
+  return path ? { path, baseline: readBoundedStateSynchronously(path.path, budget) } : null;
+}
+
+function resolveCandidatePathSynchronously(
+  canonicalRoot: string,
+  candidatePath: string,
+): Pick<TrackedPath, "path" | "displayPath" | "scope"> | null {
+  if (candidatePath.length === 0 || candidatePath.length > 4096 || candidatePath.includes("\0")) return null;
+  const absolute = resolve(canonicalRoot, candidatePath);
+  const canonical = canonicalizePotentialPathSynchronously(absolute);
+  if (!canonical) return null;
+  const relativePath = relative(canonicalRoot, canonical);
+  const scope = relativePath === "" || (!relativePath.startsWith(`..${sep}`) && relativePath !== ".." && !isAbsolute(relativePath))
+    ? "workspace"
+    : "external";
+  return {
+    path: canonical,
+    displayPath: scope === "workspace" ? relativePath : canonical,
+    scope,
+  };
+}
+
+function canonicalizePotentialPathSynchronously(absolutePath: string): string | null {
+  let cursor = absolutePath;
+  const missing: string[] = [];
+  for (let depth = 0; depth < 64; depth += 1) {
+    try {
+      const existing = realpathSync.native(cursor);
+      return resolve(existing, ...missing);
+    } catch {
+      const parent = dirname(cursor);
+      if (parent === cursor) return null;
+      missing.unshift(basename(cursor));
+      cursor = parent;
+    }
+  }
+  return null;
+}
+
+async function resolveCandidatePath(
+  canonicalRoot: string,
+  candidatePath: string,
+): Promise<Pick<TrackedPath, "path" | "displayPath" | "scope"> | null> {
+  if (candidatePath.length === 0 || candidatePath.length > 4096 || candidatePath.includes("\0")) return null;
+  const absolute = resolve(canonicalRoot, candidatePath);
+  const canonical = await canonicalizePotentialPath(absolute);
+  if (!canonical) return null;
+  const relativePath = relative(canonicalRoot, canonical);
+  const scope = relativePath === "" || (!relativePath.startsWith(`..${sep}`) && relativePath !== ".." && !isAbsolute(relativePath))
+    ? "workspace"
+    : "external";
+  return {
+    path: canonical,
+    displayPath: scope === "workspace" ? relativePath : canonical,
+    scope,
+  };
+}
+
+async function canonicalizePotentialPath(absolutePath: string): Promise<string | null> {
+  let cursor = absolutePath;
+  const missing: string[] = [];
+  for (let depth = 0; depth < 64; depth += 1) {
+    try {
+      const existing = await realpath(cursor);
+      return resolve(existing, ...missing);
+    } catch {
+      const parent = dirname(cursor);
+      if (parent === cursor) return null;
+      missing.unshift(basename(cursor));
+      cursor = parent;
+    }
+  }
+  return null;
+}
+
+async function readBoundedState(path: string): Promise<FileState> {
+  try {
+    const stat = await lstat(path);
+    if (!stat.isFile() || stat.size > MAX_FILE_BYTES) {
+      return unknownExistingState();
+    }
+    const bytes = await readFile(path);
+    const binary = bytes.includes(0);
+    return {
+      known: true,
+      exists: true,
+      hash: createHash("sha256").update(bytes).digest("hex"),
+      text: binary ? null : bytes.toString("utf8"),
+      binary,
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "ENOENT" || code === "ENOTDIR"
+      ? missingState()
+      : unknownExistingState();
+  }
+}
+
+function readBoundedStateSynchronously(path: string, budget: SyncObservationBudget): FileState {
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.size > MAX_FILE_BYTES || stat.size > budget.remainingBytes) {
+      return unknownExistingState();
+    }
+    budget.remainingBytes -= stat.size;
+    const bytes = readFileSync(path);
+    const binary = bytes.includes(0);
+    return {
+      known: true,
+      exists: true,
+      hash: createHash("sha256").update(bytes).digest("hex"),
+      text: binary ? null : bytes.toString("utf8"),
+      binary,
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "ENOENT" || code === "ENOTDIR"
+      ? missingState()
+      : unknownExistingState();
+  }
+}
+
+function stateFromEvidenceText(text: string): FileState {
+  const bytes = Buffer.from(text, "utf8");
+  return {
+    known: true,
+    exists: true,
+    hash: createHash("sha256").update(bytes).digest("hex"),
+    text,
+    binary: false,
+  };
+}
+
+function missingState(): FileState {
+  return { known: true, exists: false, hash: null, text: null, binary: false };
+}
+
+function unknownExistingState(): FileState {
+  return { known: false, exists: true, hash: null, text: null, binary: true };
+}
+
+function inferredProviderBaseline(operationHint: OperationHint): FileState {
+  return operationHint === "add" ? missingState() : unknownExistingState();
+}
+
+interface EffectCandidate {
+  effect: FileEffect;
+  beforeHash: string | null;
+  afterHash: string | null;
+}
+
+function buildEffect(tracked: TrackedPath): EffectCandidate | null {
+  const after = tracked.current;
+  const isValidatedRename = tracked.operationHint === "rename"
+    && tracked.oldPath !== undefined
+    && tracked.oldBaseline?.known === true
+    && tracked.oldCurrent?.known === true
+    && tracked.baseline.known
+    && after.known
+    && tracked.oldBaseline?.exists === true
+    && tracked.oldCurrent?.exists === false
+    && tracked.baseline.exists === false
+    && after.exists;
+  if (!tracked.baseline.known || !after.known) {
+    if (!tracked.providerConfirmed) return null;
+    const kind = tracked.operationHint === "remove" && after.known && !after.exists
+      ? "removed"
+      : tracked.operationHint === "add" && after.exists
+        ? "added"
+        : tracked.operationHint === "edit" && after.exists
+          ? "edited"
+          : null;
+    if (!kind) return null;
+    return {
+      effect: {
+        path: tracked.displayPath,
+        kind,
+        scope: tracked.scope,
+        additions: null,
+        deletions: null,
+        binary: tracked.baseline.binary || after.binary,
+        toolCallIds: [...tracked.toolCallIds].slice(0, 32),
+      },
+      beforeHash: null,
+      afterHash: after.hash,
+    };
+  }
+  if (!isValidatedRename
+    && tracked.baseline.exists === after.exists
+    && tracked.baseline.hash === after.hash) {
+    if (!tracked.providerConfirmed) return null;
+    const kind = tracked.operationHint === "remove"
+      ? "removed"
+      : tracked.operationHint === "add"
+        ? "added"
+        : tracked.operationHint === "edit"
+          ? "edited"
+          : null;
+    if (!kind) return null;
+    return {
+      effect: {
+        path: tracked.displayPath,
+        kind,
+        scope: tracked.scope,
+        additions: null,
+        deletions: null,
+        binary: tracked.baseline.binary || after.binary,
+        toolCallIds: [...tracked.toolCallIds].slice(0, 32),
+      },
+      beforeHash: tracked.baseline.hash,
+      afterHash: after.hash,
+    };
+  }
+  const kind = isValidatedRename
+    ? "renamed"
+    : !tracked.baseline.exists && after.exists
+    ? "added"
+    : tracked.baseline.exists && !after.exists
+      ? "removed"
+      : "edited";
+  const before = isValidatedRename ? tracked.oldBaseline! : tracked.baseline;
+  const stats = lineStats(
+    before.exists ? before.text : "",
+    after.exists ? after.text : "",
+  );
+  return {
+    effect: {
+      path: tracked.displayPath,
+      kind,
+      scope: tracked.scope,
+      ...(kind === "renamed" && tracked.oldPath ? { oldPath: tracked.oldPath } : {}),
+      additions: stats?.additions ?? null,
+      deletions: stats?.deletions ?? null,
+      binary: before.binary || after.binary,
+      toolCallIds: [...tracked.toolCallIds].slice(0, 32),
+    },
+    beforeHash: before.hash,
+    afterHash: after.hash,
+  };
+}
+
+function collapseHashMatchedRenames(candidates: EffectCandidate[]): FileEffect[] {
+  const removedByHash = new Map<string, EffectCandidate[]>();
+  for (const candidate of candidates) {
+    if (candidate.effect.kind !== "removed" || !candidate.beforeHash) continue;
+    const matches = removedByHash.get(candidate.beforeHash) ?? [];
+    matches.push(candidate);
+    removedByHash.set(candidate.beforeHash, matches);
+  }
+
+  const consumed = new Set<EffectCandidate>();
+  const effects: FileEffect[] = [];
+  for (const candidate of candidates) {
+    if (candidate.effect.kind !== "added" || !candidate.afterHash) continue;
+    const source = removedByHash.get(candidate.afterHash)?.shift();
+    if (!source) continue;
+    consumed.add(source);
+    consumed.add(candidate);
+    effects.push({
+      ...candidate.effect,
+      kind: "renamed",
+      oldPath: source.effect.path,
+      additions: 0,
+      deletions: 0,
+      binary: source.effect.binary || candidate.effect.binary,
+      toolCallIds: [...new Set([
+        ...source.effect.toolCallIds,
+        ...candidate.effect.toolCallIds,
+      ])].slice(0, 32),
+    });
+  }
+  for (const candidate of candidates) {
+    if (!consumed.has(candidate)) effects.push(candidate.effect);
+  }
+  return effects;
+}
+
+function lineStats(before: string | null, after: string | null): { additions: number; deletions: number } | null {
+  if (before === null || after === null) return null;
+  const left = tokenizeLines(before);
+  const right = tokenizeLines(after);
+  if (left.length * right.length > MAX_LINE_DIFF_WORK) return null;
+  let previous = new Uint32Array(right.length + 1);
+  for (let i = 1; i <= left.length; i += 1) {
+    const current = new Uint32Array(right.length + 1);
+    for (let j = 1; j <= right.length; j += 1) {
+      current[j] = left[i - 1] === right[j - 1]
+        ? previous[j - 1]! + 1
+        : Math.max(previous[j]!, current[j - 1]!);
+    }
+    previous = current;
+  }
+  const common = previous[right.length] ?? 0;
+  return { additions: right.length - common, deletions: left.length - common };
+}
+
+function tokenizeLines(text: string): string[] {
+  if (text.length === 0) return [];
+  return text.match(/[^\n]*\n|[^\n]+$/g) ?? [];
+}

--- a/apps/server/src/services/turn-finalizer.ts
+++ b/apps/server/src/services/turn-finalizer.ts
@@ -29,11 +29,14 @@ import type { TurnSnapshotRepo } from "../repositories/turn-snapshot-repo";
 import type { SnapshotService } from "./snapshot-service";
 import type { NarrativeStore } from "./narrative-store";
 import type { TurnOutcome } from "./turn-outcome";
+import type { TurnFileTracker } from "./turn-file-tracker.js";
+import type { TurnFileEffectSummary } from "@mcode/contracts";
 
 /** Pre-turn git ref captured at send time, used to diff the turn's file changes. */
 interface TurnRef {
-  ref: string;
+  ref: string | null;
   cwd: string;
+  fileTrackerGeneration?: number;
 }
 
 /** Provider assistant body buffered during a turn, materialized at finalize. */
@@ -63,6 +66,8 @@ export function deriveTurnAssistantMessageId(threadId: string, anchorId: string)
 export class TurnFinalizer {
   /** Pre-turn git ref per thread, captured at send time, consumed by the snapshot. */
   private readonly turnRefBefore = new Map<string, TurnRef>();
+  /** Generation-addressable refs let late captures update the exact turn already queued for finalization. */
+  private readonly turnRefsByGeneration = new Map<string, Map<number, TurnRef>>();
   /** Guards against re-entrant or duplicate finalize for the same thread. */
   private readonly persistingThreads = new Set<string>();
   /** Last persisted assistant message id per thread, for late-hook attachment. */
@@ -85,6 +90,7 @@ export class TurnFinalizer {
     private readonly snapshotService: SnapshotService,
     private readonly turnSnapshotRepo: TurnSnapshotRepo,
     private readonly db: Database.Database,
+    private readonly turnFileTracker?: TurnFileTracker,
   ) {}
 
   /** Append a streaming assistant-text delta for the current turn. */
@@ -134,8 +140,28 @@ export class TurnFinalizer {
   }
 
   /** Record the pre-turn git ref so the turn's file changes can be diffed at finalize. */
-  recordTurnRef(threadId: string, ref: string, cwd: string): void {
-    this.turnRefBefore.set(threadId, { ref, cwd });
+  recordTurnRef(threadId: string, ref: string | null, cwd: string, fileTrackerGeneration?: number): void {
+    if (fileTrackerGeneration !== undefined) {
+      const generationRefs = this.turnRefsByGeneration.get(threadId) ?? new Map<number, TurnRef>();
+      const existingGeneration = generationRefs.get(fileTrackerGeneration);
+      const turnRef = existingGeneration ?? { ref, cwd, fileTrackerGeneration };
+      turnRef.ref = ref;
+      turnRef.cwd = cwd;
+      generationRefs.set(fileTrackerGeneration, turnRef);
+      while (generationRefs.size > 4) {
+        const oldest = generationRefs.keys().next().value as number | undefined;
+        if (oldest === undefined) break;
+        generationRefs.delete(oldest);
+      }
+      this.turnRefsByGeneration.set(threadId, generationRefs);
+      const current = this.turnRefBefore.get(threadId);
+      if (current?.fileTrackerGeneration === undefined
+        || current.fileTrackerGeneration <= fileTrackerGeneration) {
+        this.turnRefBefore.set(threadId, turnRef);
+      }
+      return;
+    }
+    this.turnRefBefore.set(threadId, { ref, cwd, fileTrackerGeneration });
   }
 
   /** The last persisted assistant message id, for attaching late hooks (Stop/SessionEnd). */
@@ -191,9 +217,17 @@ export class TurnFinalizer {
    * written behind {@link materializeAssistantRow} and the narrative persists
    * against it.
    */
-  async finalize(threadId: string, outcome: TurnOutcome): Promise<void> {
+  async finalize(
+    threadId: string,
+    outcome: TurnOutcome,
+    prerequisite: Promise<unknown> = Promise.resolve(),
+  ): Promise<void> {
+    const turnRef = this.turnRefBefore.get(threadId);
     const tail = this.finalizeChainByThread.get(threadId) ?? Promise.resolve();
-    const next = tail.then(() => this.runFinalizeOnce(threadId, outcome));
+    const next = tail.then(async () => {
+      await prerequisite;
+      await this.runFinalizeOnce(threadId, outcome, turnRef);
+    });
     this.finalizeChainByThread.set(threadId, next);
     try {
       await next;
@@ -205,10 +239,13 @@ export class TurnFinalizer {
   }
 
   /** Runs one finalize pass; concurrent calls for the same thread are queued by {@link finalize}. */
-  private async runFinalizeOnce(threadId: string, outcome: TurnOutcome): Promise<void> {
+  private async runFinalizeOnce(
+    threadId: string,
+    outcome: TurnOutcome,
+    turnRef: TurnRef | undefined,
+  ): Promise<void> {
     if (this.persistingThreads.has(threadId)) return;
     this.persistingThreads.add(threadId);
-    const turnRef = this.turnRefBefore.get(threadId);
     try {
       // TurnSubstance guard: nothing worth keeping → leave no assistant row.
       if (!this.hasRecordableActivity(threadId)) {
@@ -241,13 +278,20 @@ export class TurnFinalizer {
         outcome,
       );
 
-      const filesChanged = await this.captureSnapshot(threadId, messageId, turnRef);
+      const fileEffects = this.turnFileTracker
+        ? await this.turnFileTracker.finalizeTurn(threadId, turnRef?.fileTrackerGeneration)
+        : undefined;
+      const filesChanged = await this.captureSnapshot(threadId, messageId, turnRef, fileEffects);
 
       broadcast("turn.persisted", {
         threadId,
+        turnId: turnRef?.fileTrackerGeneration !== undefined
+          ? String(turnRef.fileTrackerGeneration)
+          : null,
         messageId,
         toolCallCount,
         filesChanged,
+        ...(fileEffects ? { fileEffects } : {}),
       });
 
       this.clearTurn(threadId, turnRef);
@@ -266,26 +310,45 @@ export class TurnFinalizer {
     threadId: string,
     messageId: string,
     refData: TurnRef | undefined,
+    fileEffects: TurnFileEffectSummary | undefined,
   ): Promise<string[]> {
-    if (!refData) return [];
+    let filesChanged = fileEffects
+      ? fileEffects.effects
+          .filter((effect) => effect.scope === "workspace")
+          .map((effect) => effect.path)
+      : [];
+    if (!refData) return filesChanged;
+
+    let refAfter: string | null = null;
+    if (refData.ref) {
+      try {
+        refAfter = await this.snapshotService.captureRef(refData.cwd);
+      } catch (err) {
+        logger.warn("Failed to capture ref_after", {
+          threadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    if (!fileEffects && refData.ref && refAfter) {
+      filesChanged = await this.snapshotService.getFilesChanged(refData.cwd, refData.ref, refAfter);
+    }
+
+    const hasFileEffects = (fileEffects?.fileCount ?? 0) > 0;
+    if (!hasFileEffects && (!refData.ref || !refAfter)) return filesChanged;
+
     try {
-      const refAfter = await this.snapshotService.captureRef(refData.cwd);
-      if (refAfter === refData.ref) return [];
-      const filesChanged = await this.snapshotService.getFilesChanged(
-        refData.cwd,
-        refData.ref,
-        refAfter,
-      );
       const writeTurn = this.db.transaction((files: string[]) => {
         this.turnSnapshotRepo.create({
           messageId,
           threadId,
-          refBefore: refData.ref,
-          refAfter,
+          refBefore: refData.ref ?? "",
+          refAfter: refAfter ?? "",
           filesChanged: files,
+          ...(fileEffects ? { fileEffects } : {}),
           worktreePath: null,
         });
-        if (files.length > 0) {
+        if (hasFileEffects || files.length > 0) {
           this.db
             .prepare("UPDATE threads SET has_file_changes = 1 WHERE id = ? AND has_file_changes = 0")
             .run(threadId);
@@ -298,7 +361,7 @@ export class TurnFinalizer {
         threadId,
         error: err instanceof Error ? err.message : String(err),
       });
-      return [];
+      return filesChanged;
     }
   }
 
@@ -386,6 +449,13 @@ export class TurnFinalizer {
    * arriving after the turn can still increment the completed turn's counter.
    */
   private clearTurn(threadId: string, turnRef: TurnRef | undefined): void {
+    if (turnRef?.fileTrackerGeneration !== undefined) {
+      const generationRefs = this.turnRefsByGeneration.get(threadId);
+      if (generationRefs?.get(turnRef.fileTrackerGeneration) === turnRef) {
+        generationRefs.delete(turnRef.fileTrackerGeneration);
+        if (generationRefs.size === 0) this.turnRefsByGeneration.delete(threadId);
+      }
+    }
     if (turnRef !== undefined && this.turnRefBefore.get(threadId) === turnRef) {
       this.turnRefBefore.delete(threadId);
     }
@@ -394,6 +464,7 @@ export class TurnFinalizer {
     this.bufferedAttachmentsByThread.delete(threadId);
     this.materializedThreads.delete(threadId);
     this.narrativeStore.clearTurn(threadId);
+    this.turnFileTracker?.clearTurn(threadId, turnRef?.fileTrackerGeneration);
     this.persistingThreads.delete(threadId);
   }
 

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -256,6 +256,7 @@ export const turnSnapshots = sqliteTable(
     refBefore: text("ref_before").notNull(),
     refAfter: text("ref_after").notNull(),
     filesChanged: text("files_changed").notNull().default("[]"),
+    fileEffects: text("file_effects").notNull().default('{"revision":0,"fileCount":0,"additions":0,"deletions":0,"effects":[]}'),
     worktreePath: text("worktree_path"),
     createdAt: text("created_at").notNull().default(timestampDefault),
   },

--- a/apps/server/src/transport/push.test.ts
+++ b/apps/server/src/transport/push.test.ts
@@ -98,6 +98,26 @@ describe("broadcast", () => {
     expect(JSON.parse(a[0].buf.toString("utf-8")).data.threadId).toBe("thread-a");
   });
 
+  it("routes live file effects only to clients subscribed to that thread", () => {
+    const a: Array<{ buf: Buffer; binary: boolean }> = [];
+    const b: Array<{ buf: Buffer; binary: boolean }> = [];
+    const wsA = fakeOpenSocket(a);
+    const wsB = fakeOpenSocket(b);
+    addClient(wsA);
+    addClient(wsB);
+    subscribeClientToThread(wsA, "thread-a");
+    subscribeClientToThread(wsB, "thread-b");
+
+    broadcast("turn.fileEffectsUpdated", {
+      threadId: "thread-a",
+      turnId: "turn-1",
+      summary: { revision: 1, fileCount: 0, additions: 0, deletions: 0, effects: [] },
+    });
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(0);
+  });
+
   it("stops routing after a client unsubscribes from a thread", () => {
     const received: Array<{ buf: Buffer; binary: boolean }> = [];
     const ws = fakeOpenSocket(received);

--- a/apps/server/src/transport/push.ts
+++ b/apps/server/src/transport/push.ts
@@ -10,7 +10,10 @@ import { getTransportPayloadValidator } from "./payload-validation.js";
 
 const clients = new Set<WebSocket>();
 const threadSubscriptions = new Map<WebSocket, Set<string>>();
-const SUBSCRIPTION_SCOPED_CHANNELS = new Set<WsChannelName>(["agent.event"]);
+const SUBSCRIPTION_SCOPED_CHANNELS = new Set<WsChannelName>([
+  "agent.event",
+  "turn.fileEffectsUpdated",
+]);
 
 let _sessionCount = 0;
 const sessionChangeListeners: ((count: number) => void)[] = [];

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -59,6 +59,12 @@ import {
   isProviderAvailabilityError,
 } from "../services/provider-availability-errors.js";
 import type { ProviderAvailabilityService } from "../services/provider-availability-service.js";
+import {
+  attributedWorkspacePathGroups,
+  attributedWorkspacePaths,
+  collectAttributedWorkspacePathGroups,
+  collectAttributedWorkspacePaths,
+} from "../services/snapshot-attribution.js";
 
 const PREVIEW_ANNOTATION_FENCE_START = "<!-- mcode-preview-annotations:v1";
 const PREVIEW_ANNOTATION_FENCE_END = "mcode-preview-annotations:end -->";
@@ -1066,7 +1072,20 @@ async function dispatch(
         if (!ws) throw new Error(`Workspace not found: ${snapshotThread.workspace_id}`);
         snapshotCwd = deps.gitService.resolveWorkingDir(ws.path, snapshotThread.mode, snapshotThread.worktree_path);
       }
-      return await deps.snapshotService.getDiff(snapshotCwd, snapshot.ref_before, snapshot.ref_after, params.filePath, params.maxLines);
+      const attributedPaths = attributedWorkspacePaths(snapshot);
+      const attributedPathGroups = attributedWorkspacePathGroups(snapshot);
+      if (params.filePath && !attributedPaths.some(
+        (path) => path.replaceAll("\\", "/") === params.filePath!.replaceAll("\\", "/"),
+      )) return "";
+      return await deps.snapshotService.getDiff(
+        snapshotCwd,
+        snapshot.ref_before,
+        snapshot.ref_after,
+        params.filePath,
+        params.maxLines,
+        attributedPaths,
+        attributedPathGroups,
+      );
     }
     case "snapshot.getDiffStats": {
       const snapshot = deps.turnSnapshotRepo.getById(params.snapshotId);
@@ -1081,7 +1100,13 @@ async function dispatch(
         if (!ws) throw new Error(`Workspace not found: ${snapshotThread.workspace_id}`);
         snapshotCwd = deps.gitService.resolveWorkingDir(ws.path, snapshotThread.mode, snapshotThread.worktree_path);
       }
-      return await deps.snapshotService.getDiffStats(snapshotCwd, snapshot.ref_before, snapshot.ref_after);
+      return await deps.snapshotService.getDiffStats(
+        snapshotCwd,
+        snapshot.ref_before,
+        snapshot.ref_after,
+        attributedWorkspacePaths(snapshot),
+        attributedWorkspacePathGroups(snapshot),
+      );
     }
     case "snapshot.cleanup":
       return { removed: deps.turnSnapshotRepo.deleteExpired(
@@ -1092,8 +1117,15 @@ async function dispatch(
     case "snapshot.getCumulativeDiff": {
       const snapshots = deps.turnSnapshotRepo.listByThread(params.threadId);
       if (snapshots.length === 0) return "";
-      const first = snapshots[0];
-      const last = snapshots[snapshots.length - 1];
+      const withGitRefs = snapshots.filter((snapshot) => snapshot.ref_before && snapshot.ref_after);
+      if (withGitRefs.length === 0) return "";
+      const first = withGitRefs[0];
+      const last = withGitRefs[withGitRefs.length - 1];
+      const attributedPaths = collectAttributedWorkspacePaths(withGitRefs);
+      const attributedPathGroups = collectAttributedWorkspacePathGroups(withGitRefs);
+      if (params.filePath && !attributedPaths.some(
+        (path) => path.replaceAll("\\", "/") === params.filePath!.replaceAll("\\", "/"),
+      )) return "";
       let cwd: string;
       if (first.worktree_path) {
         cwd = first.worktree_path;
@@ -1110,6 +1142,8 @@ async function dispatch(
         last.ref_after,
         params.filePath,
         params.maxLines,
+        attributedPaths,
+        attributedPathGroups,
       );
     }
 

--- a/apps/web/src/__tests__/running-session-signal.test.ts
+++ b/apps/web/src/__tests__/running-session-signal.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@/stores/thread-store-test-utils";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useThreadStore } from "@/stores/threadStore";
+import { useTaskStore } from "@/stores/taskStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { createMockThread } from "./mocks/transport";
 import type { GoalState } from "@mcode/contracts";
@@ -14,6 +15,11 @@ describe("running-session signal", () => {
     resetThreadStoreForTests({
       runningThreadIds: new Set(),
       currentThreadId: null,
+    });
+    useTaskStore.setState({
+      tasksByThread: {},
+      taskBubbleByThread: {},
+      pendingTaskBubbleReplacementByThread: {},
     });
   });
 
@@ -31,12 +37,30 @@ describe("running-session signal", () => {
     let now = 1000;
     vi.spyOn(Date, "now").mockImplementation(() => now++);
     const store = useThreadStore.getState();
-    store.handleAgentEvent("t-1", { method: "session.turnStarted", type: "turnStarted", threadId: "t-1" });
+    store.handleAgentEvent("t-1", {
+      method: "session.turnStarted",
+      type: "turnStarted",
+      threadId: "t-1",
+      fileEffectTurnId: "turn-1",
+    });
     const firstStart = getTestThreadAgentStartTime("t-1");
     expect(firstStart).toBeDefined();
-    store.handleAgentEvent("t-1", { method: "session.turnStarted", type: "turnStarted", threadId: "t-1" });
+    useTaskStore.getState().setTasks("t-1", [{
+      id: "task-1",
+      content: "Keep this task",
+      status: "pending",
+      group: "Tasks",
+    }]);
+    store.handleAgentEvent("t-1", {
+      method: "session.turnStarted",
+      type: "turnStarted",
+      threadId: "t-1",
+      fileEffectTurnId: "turn-1",
+    });
     expect(useThreadStore.getState().runningThreadIds.size).toBe(1);
     expect(getTestThreadAgentStartTime("t-1")).toBe(firstStart);
+    expect(useTaskStore.getState().taskBubbleByThread["t-1"]).toHaveLength(1);
+    expect(useTaskStore.getState().pendingTaskBubbleReplacementByThread["t-1"]).toBeUndefined();
     vi.restoreAllMocks();
   });
 

--- a/apps/web/src/__tests__/threadStore-turn-persist.test.ts
+++ b/apps/web/src/__tests__/threadStore-turn-persist.test.ts
@@ -14,6 +14,13 @@ vi.mock("@/transport", async () => ({
 
 const THREAD_ID = "thread-turn-persist";
 
+function startTrackedTurn(turnId: string): void {
+  useThreadStore.getState().handleAgentEvent(THREAD_ID, {
+    method: "session.turnStarted",
+    fileEffectTurnId: turnId,
+  });
+}
+
 describe("handleTurnPersisted", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,5 +106,162 @@ describe("handleTurnPersisted", () => {
     expect(readThreadField(THREAD_ID, (r) => r.persistedFilesChanged["server-tools-only"])).toEqual(
       ["README.md"],
     );
+  });
+
+  it("keeps live file revisions monotonic and isolated by thread", () => {
+    const other = "thread-other";
+    startTrackedTurn("turn-1");
+    useThreadStore.getState().handleFileEffectsUpdated(THREAD_ID, "turn-1", {
+      revision: 2,
+      fileCount: 2,
+      additions: 3,
+      deletions: 1,
+      effects: [],
+    });
+    useThreadStore.getState().handleFileEffectsUpdated(THREAD_ID, "turn-1", {
+      revision: 1,
+      fileCount: 1,
+      additions: 1,
+      deletions: 0,
+      effects: [],
+    });
+    expect(readThreadField(THREAD_ID, (r) => r.fileEffectSummary.revision)).toBe(2);
+    expect(readThreadField(other, (r) => r.fileEffectSummary.fileCount)).toBe(0);
+  });
+
+  it("resets file revisions before dispatching the next turn", async () => {
+    startTrackedTurn("turn-1");
+    useThreadStore.getState().handleFileEffectsUpdated(THREAD_ID, "turn-1", {
+      revision: 7,
+      fileCount: 2,
+      additions: 5,
+      deletions: 1,
+      effects: [],
+    });
+    useThreadStore.setState({ runningThreadIds: new Set() });
+
+    await useThreadStore.getState().sendMessage(THREAD_ID, "next turn");
+    useThreadStore.getState().handleFileEffectsUpdated(THREAD_ID, "turn-1", {
+      revision: 8,
+      fileCount: 8,
+      additions: 8,
+      deletions: 8,
+      effects: [],
+    });
+    expect(readThreadField(THREAD_ID, (r) => r.fileEffectSummary.revision)).toBe(0);
+
+    startTrackedTurn("turn-2");
+    useThreadStore.getState().handleFileEffectsUpdated(THREAD_ID, "turn-2", {
+      revision: 1,
+      fileCount: 1,
+      additions: 1,
+      deletions: 0,
+      effects: [],
+    });
+
+    expect(readThreadField(THREAD_ID, (r) => r.fileEffectSummary)).toMatchObject({
+      revision: 1,
+      fileCount: 1,
+      additions: 1,
+      deletions: 0,
+    });
+  });
+
+  it("hands finalized effects to the persisted turn without rolling live state backward", () => {
+    startTrackedTurn("turn-1");
+    useThreadStore.getState().handleFileEffectsUpdated(THREAD_ID, "turn-1", {
+      revision: 3,
+      fileCount: 2,
+      additions: 5,
+      deletions: 1,
+      effects: [],
+    });
+    useThreadStore.getState().handleTurnPersisted({
+      threadId: THREAD_ID,
+      messageId: "server-turn",
+      turnId: "turn-1",
+      toolCallCount: 1,
+      filesChanged: ["a.ts", "b.ts"],
+      fileEffects: { revision: 2, fileCount: 1, additions: 1, deletions: 0, effects: [] },
+    });
+    expect(readThreadField(THREAD_ID, (r) => r.fileEffectSummary)).toMatchObject({
+      revision: 3,
+      fileCount: 2,
+    });
+  });
+
+  it("rejects delayed live and persisted effects from a previous turn", () => {
+    useThreadStore.setState({
+      records: seedThreadRecord(THREAD_ID, {
+        currentTurnMessageId: "assistant-turn-2",
+        pendingTurnPersistLocalMessageId: "assistant-turn-1",
+        fileEffectTurnId: "turn-2",
+        fileEffectSummary: {
+          revision: 1,
+          fileCount: 1,
+          additions: 1,
+          deletions: 0,
+          effects: [],
+        },
+      }),
+    });
+
+    useThreadStore.getState().handleFileEffectsUpdated(THREAD_ID, "turn-1", {
+      revision: 9,
+      fileCount: 9,
+      additions: 9,
+      deletions: 9,
+      effects: [],
+    });
+    useThreadStore.getState().handleTurnPersisted({
+      threadId: THREAD_ID,
+      turnId: "turn-1",
+      messageId: "server-turn-1",
+      toolCallCount: 1,
+      filesChanged: ["old.ts"],
+      fileEffects: {
+        revision: 10,
+        fileCount: 10,
+        additions: 10,
+        deletions: 10,
+        effects: [],
+      },
+    });
+
+    expect(readThreadField(THREAD_ID, (r) => r.fileEffectSummary)).toMatchObject({
+      revision: 1,
+      fileCount: 1,
+    });
+  });
+
+  it("replaces file-effect ownership when an already-running thread auto-resumes", () => {
+    useThreadStore.setState({
+      runningThreadIds: new Set([THREAD_ID]),
+      records: seedThreadRecord(THREAD_ID, {
+        fileEffectTurnId: "turn-1",
+        fileEffectSummary: {
+          revision: 4,
+          fileCount: 4,
+          additions: 4,
+          deletions: 0,
+          effects: [],
+        },
+      }),
+    });
+
+    startTrackedTurn("turn-2");
+    useThreadStore.getState().handleFileEffectsUpdated(THREAD_ID, "turn-2", {
+      revision: 1,
+      fileCount: 1,
+      additions: 2,
+      deletions: 0,
+      effects: [],
+    });
+
+    expect(readThreadField(THREAD_ID, (r) => r.fileEffectTurnId)).toBe("turn-2");
+    expect(readThreadField(THREAD_ID, (r) => r.fileEffectSummary)).toMatchObject({
+      revision: 1,
+      fileCount: 1,
+    });
   });
 });

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -849,6 +849,9 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
   const taskBubbleTasks = useTaskStore((s) =>
     threadId ? s.taskBubbleByThread[threadId] ?? EMPTY_TASK_BUBBLE_TASKS : EMPTY_TASK_BUBBLE_TASKS,
   );
+  const fileEffectSummary = useThreadStore((s) =>
+    threadId ? getThreadRecord(s.records, threadId).fileEffectSummary : undefined,
+  );
 
   const [input, setInput] = useState("");
   const [mentions, setMentions] = useState<MessageMention[]>([]);
@@ -2828,7 +2831,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
       {threadId && taskBubbleTasks.length > 0 && !branchFromMessageId && !isNewThread && (
         <div className="mb-2 flex justify-center">
-          <TaskBubble tasks={taskBubbleTasks} />
+          <TaskBubble tasks={taskBubbleTasks} fileEffects={fileEffectSummary} />
         </div>
       )}
 

--- a/apps/web/src/components/chat/FileEffectFacts.tsx
+++ b/apps/web/src/components/chat/FileEffectFacts.tsx
@@ -1,0 +1,19 @@
+import type { TurnFileEffectSummary } from "@mcode/contracts";
+
+/** Compact Codex-style file, addition, and deletion facts for a turn. */
+export function FileEffectFacts({ summary }: { summary: TurnFileEffectSummary }) {
+  if (summary.fileCount === 0) return null;
+  const fileLabel = `${summary.fileCount} ${summary.fileCount === 1 ? "file" : "files"} changed`;
+  return (
+    <>
+      <span className="text-muted-foreground/45" aria-hidden>·</span>
+      <span>{fileLabel}</span>
+      {summary.additions > 0 && (
+        <span className="text-[var(--diff-add-strong)]">+{summary.additions}</span>
+      )}
+      {summary.deletions > 0 && (
+        <span className="text-[var(--diff-delete-strong)]">−{summary.deletions}</span>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/chat/TaskBubble.test.tsx
+++ b/apps/web/src/components/chat/TaskBubble.test.tsx
@@ -94,4 +94,35 @@ describe("getTaskAggregateStatus", () => {
 
     expect(viewport).toHaveClass("overflow-x-hidden", "overflow-y-auto", "scroll-py-2");
   });
+
+  it("renders live file, addition, and deletion facts beside step progress", () => {
+    render(
+      <TaskBubble
+        tasks={[item("one", "completed", "Finish one")]}
+        fileEffects={{
+          revision: 3,
+          fileCount: 20,
+          additions: 1211,
+          deletions: 195,
+          effects: [],
+        }}
+      />,
+    );
+    const bubble = screen.getByTestId("task-bubble");
+    expect(bubble).toHaveTextContent("1/1 steps");
+    expect(bubble).toHaveTextContent("20 files changed");
+    expect(bubble).toHaveTextContent("+1211");
+    expect(bubble).toHaveTextContent("−195");
+  });
+
+  it("uses singular file copy and omits zero line facts", () => {
+    render(
+      <TaskBubble
+        tasks={[item("one", "in_progress", "Finish one")]}
+        fileEffects={{ revision: 1, fileCount: 1, additions: 0, deletions: 0, effects: [] }}
+      />,
+    );
+    expect(screen.getByTestId("task-bubble")).toHaveTextContent("1 file changed");
+    expect(screen.getByTestId("task-bubble")).not.toHaveTextContent("+0");
+  });
 });

--- a/apps/web/src/components/chat/TaskBubble.tsx
+++ b/apps/web/src/components/chat/TaskBubble.tsx
@@ -4,6 +4,8 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { TaskItem as TaskRow } from "@/components/tasks/TaskItem";
 import { TaskPanelHeader } from "@/components/tasks/TaskPanelHeader";
+import type { TurnFileEffectSummary } from "@mcode/contracts";
+import { FileEffectFacts } from "./FileEffectFacts";
 
 /** Aggregate status displayed by the composer Task bubble. */
 export type TaskAggregateStatus = "active" | "completed" | "pending" | "mixed";
@@ -76,7 +78,13 @@ function ProgressCircle({
 }
 
 /** Composer-adjacent parent-agent task bubble. */
-export function TaskBubble({ tasks }: { tasks: readonly TaskItem[] }) {
+export function TaskBubble({
+  tasks,
+  fileEffects,
+}: {
+  tasks: readonly TaskItem[];
+  fileEffects?: TurnFileEffectSummary;
+}) {
   const [expanded, setExpanded] = useState(false);
   const aggregate = getTaskAggregateStatus(tasks);
   if (!aggregate) return null;
@@ -110,13 +118,14 @@ export function TaskBubble({ tasks }: { tasks: readonly TaskItem[] }) {
         size="sm"
         data-testid="task-bubble"
         aria-expanded={expanded}
-        aria-label={`${settled} of ${total} tasks settled`}
+        aria-label={`${settled} of ${total} tasks settled${fileEffects?.fileCount ? `, ${fileEffects.fileCount} ${fileEffects.fileCount === 1 ? "file" : "files"} changed, ${fileEffects.additions} lines added, ${fileEffects.deletions} lines removed` : ""}`}
         onClick={() => setExpanded((value) => !value)}
         className="h-8 gap-2 rounded-full bg-card/75 px-3"
       >
         <ProgressCircle settled={settled} total={total} status={aggregate} />
-        <span className="font-mono text-xs tabular-nums text-muted-foreground">
+        <span className="flex min-w-0 items-center gap-1.5 whitespace-nowrap font-mono text-xs tabular-nums text-muted-foreground">
           {settled}/{total} steps
+          {fileEffects && <FileEffectFacts summary={fileEffects} />}
         </span>
       </Button>
     </div>

--- a/apps/web/src/components/chat/narrative/__tests__/NarrativeIndicator.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/NarrativeIndicator.test.tsx
@@ -99,4 +99,22 @@ describe("NarrativeIndicator exit lifecycle", () => {
     });
     expect(container.querySelector('[data-state="running"]')).not.toBeNull();
   });
+
+  it("keeps file facts out of the narrative status line", () => {
+    const misplacedFileEffects = {
+      fileEffects: { revision: 1, fileCount: 1, additions: 4, deletions: 2, effects: [] },
+    };
+    render(
+      <NarrativeIndicator
+        stepCount={2}
+        subagentCount={0}
+        activeToolCalls={[]}
+        isAgentRunning
+        {...misplacedFileEffects}
+      />,
+    );
+    expect(screen.queryByText("1 file changed")).not.toBeInTheDocument();
+    expect(screen.queryByText("+4")).not.toBeInTheDocument();
+    expect(screen.queryByText("−2")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/lib/thread-hydrator/__tests__/snapshot-builder.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/snapshot-builder.test.ts
@@ -44,4 +44,22 @@ describe("SnapshotBuilder", () => {
     });
     expect(result.latestTurnWithChanges).toBe("new");
   });
+
+  it("hydrates the newest empty authored summary after an earlier changed turn", () => {
+    const changed = {
+      revision: 2,
+      fileCount: 1,
+      additions: 3,
+      deletions: 0,
+      effects: [],
+    };
+    const empty = { revision: 0, fileCount: 0, additions: 0, deletions: 0, effects: [] };
+    const result = SnapshotBuilder.deriveFileChanges([
+      { message_id: "changed", files_changed: ["a.ts"], file_effects: changed } as unknown as TurnSnapshot,
+      { message_id: "unchanged", files_changed: [], file_effects: empty } as unknown as TurnSnapshot,
+    ]);
+
+    expect(result.persistedFilesChanged).toEqual({ changed: ["a.ts"] });
+    expect(result.fileEffectSummary).toEqual(empty);
+  });
 });

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -195,7 +195,10 @@ export class AuxiliaryHydrator {
         if (!latestCached) return;
 
         const fileChanges = SnapshotBuilder.deriveFileChanges(snapshots);
-        if (Object.keys(fileChanges.persistedFilesChanged).length === 0) return;
+        if (
+          Object.keys(fileChanges.persistedFilesChanged).length === 0
+          && fileChanges.fileEffectSummary.fileCount === 0
+        ) return;
 
         cacheRecord(threadId, {
           ...latestCached,
@@ -204,6 +207,7 @@ export class AuxiliaryHydrator {
             ...fileChanges.persistedFilesChanged,
           },
           latestTurnWithChanges: fileChanges.latestTurnWithChanges,
+          fileEffectSummary: fileChanges.fileEffectSummary,
         });
 
         if (!commitToStore) return;
@@ -221,6 +225,7 @@ export class AuxiliaryHydrator {
                 ...fileChanges.persistedFilesChanged,
               },
               latestTurnWithChanges: fileChanges.latestTurnWithChanges,
+              fileEffectSummary: fileChanges.fileEffectSummary,
             }),
           };
         });

--- a/apps/web/src/lib/thread-hydrator/snapshot-builder.ts
+++ b/apps/web/src/lib/thread-hydrator/snapshot-builder.ts
@@ -14,6 +14,7 @@ export interface SnapshotBuilderInput {
 export interface FileChangeFields {
   persistedFilesChanged: Record<string, string[]>;
   latestTurnWithChanges: string | null;
+  fileEffectSummary: ThreadRecord["fileEffectSummary"];
 }
 
 /**
@@ -28,6 +29,7 @@ export type ThreadRecordPatch = Pick<
   | "persistedToolCallCounts"
   | "persistedFilesChanged"
   | "latestTurnWithChanges"
+  | "fileEffectSummary"
   | "answeredPlanMessageIds"
 >;
 
@@ -59,6 +61,7 @@ export class SnapshotBuilder {
       persistedToolCallCounts,
       persistedFilesChanged: fileChanges.persistedFilesChanged,
       latestTurnWithChanges: fileChanges.latestTurnWithChanges,
+      fileEffectSummary: fileChanges.fileEffectSummary,
       answeredPlanMessageIds: new Set(answeredPlanMessageIds ?? []),
     };
   }
@@ -70,14 +73,22 @@ export class SnapshotBuilder {
   static deriveFileChanges(snapshots: TurnSnapshot[]): FileChangeFields {
     const persistedFilesChanged: Record<string, string[]> = {};
     let latestTurnWithChanges: string | null = null;
+    let fileEffectSummary: ThreadRecord["fileEffectSummary"] = {
+      revision: 0,
+      fileCount: 0,
+      additions: 0,
+      deletions: 0,
+      effects: [],
+    };
 
     for (const snap of snapshots) {
+      if (snap.file_effects) fileEffectSummary = snap.file_effects;
       if (snap.files_changed.length === 0) continue;
       persistedFilesChanged[snap.message_id] = snap.files_changed;
       latestTurnWithChanges = snap.message_id;
     }
 
-    return { persistedFilesChanged, latestTurnWithChanges };
+    return { persistedFilesChanged, latestTurnWithChanges, fileEffectSummary };
   }
 }
 

--- a/apps/web/src/stores/thread-record.ts
+++ b/apps/web/src/stores/thread-record.ts
@@ -8,6 +8,7 @@ import type {
   PlanAnswer,
   ProviderUsageInfo,
   GoalState,
+  TurnFileEffectSummary,
 } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
@@ -87,6 +88,10 @@ export interface ThreadRecord {
   persistedToolCallCounts: Record<string, number>;
   persistedFilesChanged: Record<string, string[]>;
   latestTurnWithChanges: string | null;
+  /** Live or just-finalized agent-attributed file-effect aggregate for the current turn. */
+  fileEffectSummary: TurnFileEffectSummary;
+  /** Server tracker generation that owns the live file-effect aggregate. */
+  fileEffectTurnId: string;
   serverMessageIds: Record<string, string>;
   narrativeByMessage: ThreadNarrativeByMessage;
   answeredPlanMessageIds: Set<string>;
@@ -149,6 +154,8 @@ export function createEmptyThreadRecord(): ThreadRecord {
     persistedToolCallCounts: {},
     persistedFilesChanged: {},
     latestTurnWithChanges: null,
+    fileEffectSummary: { revision: 0, fileCount: 0, additions: 0, deletions: 0, effects: [] },
+    fileEffectTurnId: "",
     serverMessageIds: {},
     narrativeByMessage: {},
     answeredPlanMessageIds: new Set(),

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { Message, ToolCall, HookExecution, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, ToolCallRecord, ThoughtSegmentRecord } from "@/transport";
-import type { ContextWindowMode, MessageMention, ReasoningLevel, OrchestrationMode, PlanQuestion, PlanAnswer, QuotaCategory, ProviderBillingMode, ProviderUsageInfo, GoalLookupResult, GoalState, PreviewAnnotationBundle } from "@mcode/contracts";
+import type { ContextWindowMode, MessageMention, ReasoningLevel, OrchestrationMode, PlanQuestion, PlanAnswer, QuotaCategory, ProviderBillingMode, ProviderUsageInfo, GoalLookupResult, GoalState, PreviewAnnotationBundle, TurnFileEffectSummary } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import type { ThoughtSegment } from "@/components/chat/narrative/types";
 import {
@@ -142,7 +142,20 @@ interface ThreadState {
   evictNarrativeForMessage: (messageId: string) => void;
 
   /** Handle server-side tool call persistence confirmation. */
-  handleTurnPersisted: (payload: { threadId: string; messageId: string; toolCallCount: number; filesChanged: string[] }) => void;
+  handleTurnPersisted: (payload: {
+    threadId: string;
+    messageId: string;
+    turnId?: string | null;
+    toolCallCount: number;
+    filesChanged: string[];
+    fileEffects?: TurnFileEffectSummary;
+  }) => void;
+  /** Apply a monotonic live file-effect update for one thread. */
+  handleFileEffectsUpdated: (
+    threadId: string,
+    turnId: string,
+    summary: TurnFileEffectSummary,
+  ) => void;
   /** Clear the interrupt file-notice banner for one thread (user dismissed). */
   clearInterruptStopFileNotice: (threadId: string) => void;
   /** Clears composer recall state for one thread after the Composer applies it. */
@@ -373,6 +386,7 @@ function resetTurnEphemeral(_rec: ThreadRecord): Partial<ThreadRecord> {
     hooks: [],
     currentTurnMessageId: "",
     currentTurnResponseKey: "",
+    fileEffectTurnId: "",
   };
 }
 
@@ -1123,6 +1137,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           ...settingsPatch,
           ...messagePatch,
           agentStartTime: Date.now(),
+          fileEffectSummary: { revision: 0, fileCount: 0, additions: 0, deletions: 0, effects: [] },
           currentTurnResponseKey: createTurnResponseKey(threadId),
           lastFallback: undefined,
           rateLimit: undefined,
@@ -1852,16 +1867,28 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (method === "session.turnStarted") {
+      const fileEffectTurnId = typeof params.fileEffectTurnId === "string"
+        ? params.fileEffectTurnId
+        : "";
+      const currentState = get();
+      const currentRecord = getThreadRecord(currentState.records, threadId);
+      if (currentState.runningThreadIds.has(threadId)
+        && currentRecord.fileEffectTurnId === fileEffectTurnId) {
+        return;
+      }
       useTaskStore.getState().prepareTaskBubbleForNewTurn(threadId);
       set((state) => {
-        if (state.runningThreadIds.has(threadId)) return {};
-        const next = new Set(state.runningThreadIds);
-        next.add(threadId);
+        const rec = getThreadRecord(state.records, threadId);
+        const next = state.runningThreadIds.has(threadId)
+          ? state.runningThreadIds
+          : new Set([...state.runningThreadIds, threadId]);
         return {
           runningThreadIds: next,
           records: patchThreadRecord(state.records, threadId, {
             agentStartTime: Date.now(),
-            ...resetTurnEphemeral(getThreadRecord(state.records, threadId)),
+            fileEffectSummary: { revision: 0, fileCount: 0, additions: 0, deletions: 0, effects: [] },
+            ...resetTurnEphemeral(rec),
+            fileEffectTurnId,
             currentTurnResponseKey: createTurnResponseKey(threadId),
           }),
         };
@@ -3027,6 +3054,22 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
   },
 
+  handleFileEffectsUpdated: (threadId, turnId, summary) => {
+    set((state) => {
+      const rec = getThreadRecord(state.records, threadId);
+      if (rec.fileEffectTurnId !== turnId) return state;
+      if (summary.revision <= rec.fileEffectSummary.revision) {
+        return state;
+      }
+      return {
+        records: patchThreadRecord(state.records, threadId, {
+          fileEffectTurnId: turnId,
+          fileEffectSummary: summary,
+        }),
+      };
+    });
+  },
+
   /**
    * Fetch provider usage from the server and merge it into usageByProvider.
    * Silently ignores errors so the popover shows stale or empty state rather than crashing.
@@ -3122,6 +3165,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       }
 
       const localMsgId = resolveTurnPersistLocalMessageId(rec, payload.messageId);
+      const ownsLiveFileEffects = payload.turnId != null
+        && payload.turnId === rec.fileEffectTurnId
+        && (localMsgId === rec.currentTurnMessageId
+          || localMsgId === rec.pendingTurnPersistLocalMessageId);
       const ensuredMessages =
         payload.filesChanged.length > 0 || payload.toolCallCount > 0
           ? ensureAssistantMessageForTurnPersist(rec, payload.threadId, localMsgId)
@@ -3152,6 +3199,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               : rec.pendingTurnPersistLocalMessageId,
           interruptStopFileNotice,
           awaitingUserStopPersist,
+          ...(payload.fileEffects
+            && ownsLiveFileEffects
+            && payload.fileEffects.revision >= rec.fileEffectSummary.revision
+            ? { fileEffectSummary: payload.fileEffects }
+            : {}),
         }),
       };
     });

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -1,4 +1,4 @@
-import type { Settings, ProviderAvailability } from "@mcode/contracts";
+import type { Settings, ProviderAvailability, TurnFileEffectSummary } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { pushEmitter } from "./ws-transport";
 import { getTransport } from "@/transport";
@@ -341,12 +341,26 @@ export function startPushListeners(): void {
 
   // turn.persisted: server has persisted tool calls for a completed turn
   unsubs.push(
+    pushEmitter.on("turn.fileEffectsUpdated", (data) => {
+      const payload = data as { threadId: string; turnId: string; summary: TurnFileEffectSummary };
+      useThreadStore.getState().handleFileEffectsUpdated(
+        payload.threadId,
+        payload.turnId,
+        payload.summary,
+      );
+    }),
+  );
+
+  // turn.persisted: server has persisted tool calls for a completed turn
+  unsubs.push(
     pushEmitter.on("turn.persisted", (data) => {
       const payload = data as {
         threadId: string;
+        turnId?: string | null;
         messageId: string;
         toolCallCount: number;
         filesChanged: string[];
+        fileEffects?: TurnFileEffectSummary;
       };
       useThreadStore.getState().handleTurnPersisted(payload);
 

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -55,6 +55,8 @@ export const AgentEventSchema = lazySchema(() =>
        *  Used by the client to populate `runningThreadIds` for live-session UI indicators. */
       type: z.literal(AgentEventType.TurnStarted),
       threadId: z.string(),
+      /** Server tracker generation that owns live file effects for this turn. */
+      fileEffectTurnId: z.string().optional(),
     }),
     z.object({
       type: z.literal(AgentEventType.Message),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -108,6 +108,14 @@ export { TurnSnapshotSchema } from "./models/turn-snapshot.js";
 export type { TurnSnapshot } from "./models/turn-snapshot.js";
 
 export {
+  FileEffectKindSchema,
+  FileEffectSchema,
+  TurnFileEffectSummarySchema,
+  MAX_TURN_FILE_EFFECTS,
+} from "./models/file-effect.js";
+export type { FileEffect, TurnFileEffectSummary } from "./models/file-effect.js";
+
+export {
   SettingsSchema,
   PartialSettingsSchema,
   getDefaultSettings,

--- a/packages/contracts/src/models/file-effect.ts
+++ b/packages/contracts/src/models/file-effect.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { lazySchema } from "../utils/lazySchema.js";
+
+/** Maximum file effects retained and transported for one agent turn. */
+export const MAX_TURN_FILE_EFFECTS = 256;
+
+/** Net filesystem operation attributed to an explicit agent file mutation. */
+export const FileEffectKindSchema = lazySchema(() =>
+  z.enum(["added", "edited", "removed", "renamed"]),
+);
+
+/** A bounded, content-free description of one file changed by an agent turn. */
+export const FileEffectSchema = lazySchema(() =>
+  z.object({
+    path: z.string().min(1).max(4096),
+    kind: FileEffectKindSchema(),
+    scope: z.enum(["workspace", "external"]),
+    oldPath: z.string().min(1).max(4096).optional(),
+    additions: z.number().int().nonnegative().nullable(),
+    deletions: z.number().int().nonnegative().nullable(),
+    binary: z.boolean(),
+    toolCallIds: z.array(z.string().min(1).max(256)).max(32),
+  }),
+);
+
+/** Monotonic live and persisted aggregate for agent-attributed file effects. */
+export const TurnFileEffectSummarySchema = lazySchema(() =>
+  z.object({
+    revision: z.number().int().nonnegative(),
+    fileCount: z.number().int().nonnegative().max(MAX_TURN_FILE_EFFECTS),
+    additions: z.number().int().nonnegative(),
+    deletions: z.number().int().nonnegative(),
+    effects: z.array(FileEffectSchema()).max(MAX_TURN_FILE_EFFECTS),
+  }),
+);
+
+/** Net filesystem operation attributed to an explicit agent file mutation. */
+export type FileEffect = z.infer<ReturnType<typeof FileEffectSchema>>;
+
+/** Monotonic live and persisted aggregate for agent-attributed file effects. */
+export type TurnFileEffectSummary = z.infer<ReturnType<typeof TurnFileEffectSummarySchema>>;

--- a/packages/contracts/src/models/turn-snapshot.ts
+++ b/packages/contracts/src/models/turn-snapshot.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { TurnFileEffectSummarySchema } from "./file-effect.js";
 
 /** Git snapshot refs for reconstructing diffs on demand. */
 export const TurnSnapshotSchema = z.object({
@@ -8,6 +9,7 @@ export const TurnSnapshotSchema = z.object({
   ref_before: z.string(),
   ref_after: z.string(),
   files_changed: z.array(z.string()),
+  file_effects: TurnFileEffectSummarySchema().optional(),
   worktree_path: z.string().nullable(),
   created_at: z.string(),
 });

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -8,6 +8,7 @@ import { ChecksStatusSchema } from "../github.js";
 import { PermissionRequestSchema, PermissionDecisionSchema } from "../models/permission.js";
 import { ProviderAvailabilitySchema } from "../providers/availability.js";
 import { lazySchema } from "../utils/lazySchema.js";
+import { TurnFileEffectSummarySchema } from "../models/file-effect.js";
 
 /** All push channel definitions keyed by channel name. */
 export const WS_CHANNELS = {
@@ -76,9 +77,17 @@ export const WS_CHANNELS = {
   "workspace.orderChanged": z.object({}),
   "turn.persisted": z.object({
     threadId: z.string(),
+    turnId: z.string().nullable().optional(),
     messageId: z.string(),
     toolCallCount: z.number(),
     filesChanged: z.array(z.string()),
+    fileEffects: TurnFileEffectSummarySchema().optional(),
+  }),
+  /** Live net file effects attributed to explicit agent mutation tools. */
+  "turn.fileEffectsUpdated": z.object({
+    threadId: z.string(),
+    turnId: z.string(),
+    summary: TurnFileEffectSummarySchema(),
   }),
   /** Emitted when the model proposes a batch of clarifying questions in plan mode. */
   "plan.questions": z.object({


### PR DESCRIPTION
## What

Track explicit agent file changes and show live file and line totals in the plan-steps bubble.

## Why

Git snapshots can include unrelated changes from pulls, worktree setup, or dirty state. The UI should report only agent-authored files and retain attribution after restart.

## Key Changes

- Normalize file mutations from Codex, Claude, and Cursor tool events.
- Track added, edited, removed, renamed, external, large, and binary files with bounded work.
- Persist validated file effects with each turn snapshot and hydrate them after restart.
- Scope historical and cumulative diffs to attributed paths while preserving rename pairs.
- Show file counts and line totals beside plan progress.

## Verification

- Reviewer QA approved the release.
- Server suite: 1,819 tests passed.
- Focused web store, hydration, and plan-bubble tests passed.
- Live Playwright check passed on the rebuilt worktree runtime.
- Typecheck, lint, and diff checks passed.
