### PR TITLE
fix(web): clear submitted composer feedback

### DIFF
--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -2489,6 +2489,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       if (threadId) clearDraftFromStore(threadId);
       // Hide the reply bar with the composer reset; sendMessage still receives reply IDs from this render.
       if (threadId) clearReply(threadId);
+      if (annotationScopeId && outboundPreviewAnnotations) {
+        usePreviewAnnotationStore.getState().clearThread(annotationScopeId);
+        setPreviewDesignModeActive(annotationScopeId, false);
+      }
 
       if (isNewThread && workspaceId) {
         setNewThreadMode(submittedNewThreadMode);
@@ -2588,11 +2592,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
 
       if (submittedGoalObjective) setGoalPending(false);
 
-      if (annotationScopeId && outboundPreviewAnnotations) {
-        usePreviewAnnotationStore.getState().clearThread(annotationScopeId);
-        setPreviewDesignModeActive(annotationScopeId, false);
-      }
-
       // Auto-save last-used mode and access as defaults (model defaults are managed in Settings)
       const { settings, loaded, update: updateSettings } = useSettingsStore.getState();
       if (loaded && (mode !== settings.agent.defaults.mode || access !== settings.agent.defaults.permission)) {
@@ -2665,6 +2664,20 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     const queued = queuedSendRef.current;
     if (!queued) return;
     setQueuedSend(null);
+    setInput("");
+    setMentions([]);
+    clearDraftFromStore(threadId);
+    if (annotationScopeId && queued.previewAnnotations) {
+      usePreviewAnnotationStore.getState().clearThread(annotationScopeId);
+      setPreviewDesignModeActive(annotationScopeId, false);
+    }
+    if (editorRef.current) {
+      editorRef.current.update(() => {
+        const root = $getRoot();
+        root.clear();
+        root.append($createParagraphNode());
+      });
+    }
     useThreadStore.getState().sendMessage(
       threadId,
       queued.content,

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -2667,6 +2667,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     setInput("");
     setMentions([]);
     clearDraftFromStore(threadId);
+    const currentAttachments = collectAndClearAttachments();
     if (annotationScopeId && queued.previewAnnotations) {
       usePreviewAnnotationStore.getState().clearThread(annotationScopeId);
       setPreviewDesignModeActive(annotationScopeId, false);
@@ -2683,7 +2684,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       queued.content,
       modelId,
       access,
-      undefined,
+      currentAttachments.length > 0 ? currentAttachments : undefined,
       queued.displayContent,
       reasoning,
       provider,

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -850,7 +850,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     threadId ? s.taskBubbleByThread[threadId] ?? EMPTY_TASK_BUBBLE_TASKS : EMPTY_TASK_BUBBLE_TASKS,
   );
   const fileEffectSummary = useThreadStore((s) =>
-    threadId ? getThreadRecord(s.records, threadId).fileEffectSummary : undefined,
+    threadId ? s.records.get(threadId)?.fileEffectSummary : undefined,
   );
 
   const [input, setInput] = useState("");

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -133,7 +133,11 @@ vi.mock("../CopilotAgentSelector", () => ({
 }));
 
 vi.mock("../AttachmentPreview", () => ({
-  AttachmentPreview: () => <div />,
+  AttachmentPreview: ({ attachments }: { attachments: Array<{ name: string }> }) => (
+    <div data-testid="attachment-preview">
+      {attachments.map((attachment) => attachment.name).join(",")}
+    </div>
+  ),
 }));
 
 vi.mock("../FileTagPopup", () => ({
@@ -633,6 +637,15 @@ describe("Composer checkout confirmation", () => {
     });
 
     const user = userEvent.setup();
+    window.desktopBridge = {
+      getPathForFile: () => "C:\\tmp\\handoff.txt",
+    } as unknown as typeof window.desktopBridge;
+    await user.upload(
+      screen.getByTestId("composer-attachment-input"),
+      new File(["handoff context"], "handoff.txt", { type: "text/plain" }),
+    );
+    delete (window as unknown as Record<string, unknown>).desktopBridge;
+    expect(screen.getByTestId("attachment-preview")).toHaveTextContent("handoff.txt");
     await user.type(screen.getByLabelText("Message Mcode"), "Queued follow-up");
     await user.click(screen.getByLabelText("Send message"));
     expect(mockTransport.sendMessage).not.toHaveBeenCalled();
@@ -647,9 +660,17 @@ describe("Composer checkout confirmation", () => {
 
     await waitFor(() => expect(mockTransport.sendMessage).toHaveBeenCalled());
     expect(screen.queryByTestId("composer-annotation-bundle")).not.toBeInTheDocument();
+    expect(screen.getByTestId("attachment-preview")).toBeEmptyDOMElement();
     expect(usePreviewAnnotationStore.getState().byThread[thread.id] ?? []).toEqual([]);
     expect(usePreviewDesignModeStore.getState().modes[thread.id]).toBe(false);
     const sendCall = (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+    expect(sendCall?.[4]).toEqual([
+      expect.objectContaining({
+        name: "handoff.txt",
+        mimeType: "text/plain",
+        sourcePath: "C:\\tmp\\handoff.txt",
+      }),
+    ]);
     expect(sendCall?.[17]).toMatchObject({
       schemaVersion: 1,
       annotations: [

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -297,7 +297,10 @@ describe("Composer checkout confirmation", () => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
     lastComposerText = "";
-    resetThreadStoreForTests({ runningThreadIds: new Set() });
+    resetThreadStoreForTests({
+      records: seedThreadRecord("thread-1"),
+      runningThreadIds: new Set(),
+    });
     useQueueStore.setState({ queues: {}, toast: null, editingThreadId: null });
     usePreviewAnnotationStore.setState({ byThread: {}, diffByThread: {}, drafts: {} });
     usePreviewDesignModeStore.setState({ modes: {} });
@@ -511,6 +514,44 @@ describe("Composer checkout confirmation", () => {
     expect(usePreviewDesignModeStore.getState().modes[thread.id]).toBe(false);
   });
 
+  it("clears annotations and comments as soon as feedback dispatch starts", async () => {
+    const workspace = createMockWorkspace({ id: "ws-1", is_git_repo: true });
+    const thread = createMockThread({ id: "thread-1", workspace_id: "ws-1" });
+    useWorkspaceStore.setState({
+      workspaces: [workspace],
+      activeWorkspaceId: workspace.id,
+      threads: [thread],
+      activeThreadId: thread.id,
+      branches: [branch("main", true)],
+      newThreadMode: "direct",
+      newThreadBranch: "main",
+      selectedWorktree: null,
+    });
+    usePreviewDesignModeStore.getState().setActive(thread.id, true);
+    usePreviewAnnotationStore.setState({
+      drafts: {},
+      byThread: {
+        [thread.id]: [makeSavedAnnotation()],
+      },
+      diffByThread: {
+        [thread.id]: [makeSavedDiffAnnotation()],
+      },
+    });
+    (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<void>(() => {}),
+    );
+
+    render(<Composer threadId={thread.id} workspaceId="ws-1" />);
+
+    await userEvent.click(screen.getByLabelText("Send message"));
+    await waitFor(() => expect(mockTransport.sendMessage).toHaveBeenCalled());
+
+    expect(screen.queryByTestId("composer-annotation-bundle")).not.toBeInTheDocument();
+    expect(usePreviewAnnotationStore.getState().byThread[thread.id] ?? []).toEqual([]);
+    expect(usePreviewAnnotationStore.getState().diffByThread[thread.id] ?? []).toEqual([]);
+    expect(usePreviewDesignModeStore.getState().modes[thread.id]).toBe(false);
+  });
+
   it("sends workspace-scoped annotations from a new thread composer", async () => {
     seedComposerState("direct");
     useWorkspaceStore.setState({
@@ -573,6 +614,7 @@ describe("Composer checkout confirmation", () => {
         [thread.id]: [makeSavedAnnotation()],
       },
     });
+    usePreviewDesignModeStore.getState().setActive(thread.id, true);
     (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
     render(<Composer threadId={thread.id} workspaceId="ws-1" />);
@@ -604,6 +646,9 @@ describe("Composer checkout confirmation", () => {
     });
 
     await waitFor(() => expect(mockTransport.sendMessage).toHaveBeenCalled());
+    expect(screen.queryByTestId("composer-annotation-bundle")).not.toBeInTheDocument();
+    expect(usePreviewAnnotationStore.getState().byThread[thread.id] ?? []).toEqual([]);
+    expect(usePreviewDesignModeStore.getState().modes[thread.id]).toBe(false);
     const sendCall = (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1);
     expect(sendCall?.[17]).toMatchObject({
       schemaVersion: 1,

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -301,10 +301,7 @@ describe("Composer checkout confirmation", () => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
     lastComposerText = "";
-    resetThreadStoreForTests({
-      records: seedThreadRecord("thread-1"),
-      runningThreadIds: new Set(),
-    });
+    resetThreadStoreForTests({ runningThreadIds: new Set() });
     useQueueStore.setState({ queues: {}, toast: null, editingThreadId: null });
     usePreviewAnnotationStore.setState({ byThread: {}, diffByThread: {}, drafts: {} });
     usePreviewDesignModeStore.setState({ modes: {} });


### PR DESCRIPTION
## What

Clear browser preview annotations and file diff comments from the composer as soon as their message starts dispatching.

## Why

Composer feedback cleanup waited for the send promise to resolve. Providers can keep that promise pending after the message has entered the thread, leaving submitted feedback in the composer.

## Key Changes

- Reset preview annotations, diff comments, and preview design mode at dispatch time.
- Apply the same reset when a handoff-queued message begins sending, including its attachments.
- Cover deferred provider sends and handoff dispatches with Composer regression tests.
- Keep the Composer thread selector stable while its record hydrates.

## Verification

- Live Playwright check: submitted one preview annotation and one diff comment while the agent request remained pending. The sent bubble kept both references and the composer cleared.
- Playwright regression check: all three Composer cases that failed on the base commit now pass.
- `bun run test -- src/components/chat/__tests__/Composer.checkout-dialog.test.tsx`
- `bun run verify`
