### PR TITLE
fix(web): speed up long thread switching

### DIFF
--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -273,6 +273,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const scrollToTailIntentRef = useRef(false);
   /** Previous `scrollTop` from the last `onScroll` pass; detects upward interrupts during smooth tail scroll. */
   const prevScrollTopRef = useRef(0);
+  /** Prevents layout-driven scroll events from consuming warm history before the user asks for it. */
+  const historyPaginationIntentRef = useRef(false);
   /** Ref mirror of sticky-user-message visibility to avoid redundant setState on scroll. */
   const showStickyUserMessageRef = useRef(false);
   /** Previous effective top padding; used to compensate scrollTop when padding changes. */
@@ -397,6 +399,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   /** Clears tail pin when the user scrolls content upward (wheel / trackpad). */
   const handleWheel = useCallback((e: WheelEvent<HTMLDivElement>) => {
     if (e.deltaY < 0) {
+      historyPaginationIntentRef.current = true;
       const interruptedPendingTailScroll = scrollTimerRef.current !== null;
       scrollToTailIntentRef.current = false;
       pinListTailRef.current = false;
@@ -409,8 +412,19 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
         setShowScrollBtn(true);
       }
       streamingFollowPauseUntilRef.current = Date.now() + WHEEL_UP_FOLLOW_PAUSE_MS;
+      const el = containerRef.current;
+      if (
+        el &&
+        el.scrollTop < PAGINATION_THRESHOLD &&
+        activeThreadId &&
+        hasMore &&
+        !isLoadingMore
+      ) {
+        historyPaginationIntentRef.current = false;
+        void loadOlderMessages(activeThreadId);
+      }
     }
-  }, []);
+  }, [activeThreadId, hasMore, isLoadingMore, loadOlderMessages]);
 
   /** Track scroll-to-bottom button visibility and trigger upward pagination near the top. */
   const handleScroll = useCallback(() => {
@@ -468,10 +482,12 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     // Trigger loading older messages when near the top
     if (
       el.scrollTop < PAGINATION_THRESHOLD &&
+      historyPaginationIntentRef.current &&
       activeThreadId &&
       hasMore &&
       !isLoadingMore
     ) {
+      historyPaginationIntentRef.current = false;
       loadOlderMessages(activeThreadId);
     }
 
@@ -917,6 +933,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       }
       turnExpandRef.current.clear();
       scrollToTailIntentRef.current = false;
+      historyPaginationIntentRef.current = false;
       prevMessageCountRef.current = 0;
       firstMessageIdRef.current = null;
       prevScrollHeightRef.current = 0;

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -274,7 +274,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   /** Previous `scrollTop` from the last `onScroll` pass; detects upward interrupts during smooth tail scroll. */
   const prevScrollTopRef = useRef(0);
   /** Prevents layout-driven scroll events from consuming warm history before the user asks for it. */
-  const historyPaginationIntentRef = useRef(false);
+  const olderHistoryRequestedRef = useRef(false);
   /** Ref mirror of sticky-user-message visibility to avoid redundant setState on scroll. */
   const showStickyUserMessageRef = useRef(false);
   /** Previous effective top padding; used to compensate scrollTop when padding changes. */
@@ -396,10 +396,28 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     });
   }, []);
 
+  /** Load older messages only after an upward gesture reaches the top threshold. */
+  const loadOlderHistoryWhenRequested = useCallback(() => {
+    const el = containerRef.current;
+    if (
+      !olderHistoryRequestedRef.current ||
+      !el ||
+      el.scrollTop >= PAGINATION_THRESHOLD ||
+      !activeThreadId ||
+      !hasMore ||
+      isLoadingMore
+    ) {
+      return;
+    }
+
+    olderHistoryRequestedRef.current = false;
+    void loadOlderMessages(activeThreadId);
+  }, [activeThreadId, hasMore, isLoadingMore, loadOlderMessages]);
+
   /** Clears tail pin when the user scrolls content upward (wheel / trackpad). */
   const handleWheel = useCallback((e: WheelEvent<HTMLDivElement>) => {
     if (e.deltaY < 0) {
-      historyPaginationIntentRef.current = true;
+      olderHistoryRequestedRef.current = true;
       const interruptedPendingTailScroll = scrollTimerRef.current !== null;
       scrollToTailIntentRef.current = false;
       pinListTailRef.current = false;
@@ -412,19 +430,9 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
         setShowScrollBtn(true);
       }
       streamingFollowPauseUntilRef.current = Date.now() + WHEEL_UP_FOLLOW_PAUSE_MS;
-      const el = containerRef.current;
-      if (
-        el &&
-        el.scrollTop < PAGINATION_THRESHOLD &&
-        activeThreadId &&
-        hasMore &&
-        !isLoadingMore
-      ) {
-        historyPaginationIntentRef.current = false;
-        void loadOlderMessages(activeThreadId);
-      }
+      loadOlderHistoryWhenRequested();
     }
-  }, [activeThreadId, hasMore, isLoadingMore, loadOlderMessages]);
+  }, [loadOlderHistoryWhenRequested]);
 
   /** Track scroll-to-bottom button visibility and trigger upward pagination near the top. */
   const handleScroll = useCallback(() => {
@@ -479,20 +487,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
     syncStickyUserMessageVisibility();
 
-    // Trigger loading older messages when near the top
-    if (
-      el.scrollTop < PAGINATION_THRESHOLD &&
-      historyPaginationIntentRef.current &&
-      activeThreadId &&
-      hasMore &&
-      !isLoadingMore
-    ) {
-      historyPaginationIntentRef.current = false;
-      loadOlderMessages(activeThreadId);
-    }
+    loadOlderHistoryWhenRequested();
 
     prevScrollTopRef.current = el.scrollTop;
-  }, [activeThreadId, hasMore, isLoadingMore, loadOlderMessages, syncStickyUserMessageVisibility]);
+  }, [loadOlderHistoryWhenRequested, syncStickyUserMessageVisibility]);
 
   useEffect(() => {
     for (const message of messages) {
@@ -933,7 +931,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       }
       turnExpandRef.current.clear();
       scrollToTailIntentRef.current = false;
-      historyPaginationIntentRef.current = false;
+      olderHistoryRequestedRef.current = false;
       prevMessageCountRef.current = 0;
       firstMessageIdRef.current = null;
       prevScrollHeightRef.current = 0;

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -23,6 +23,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const measureSpy = vi.fn();
 const scrollToIndexSpy = vi.fn();
+const loadOlderMessagesSpy = vi.fn();
 let totalSizeValue = 0;
 
 const mockVirtualizer = {
@@ -42,6 +43,7 @@ vi.mock("@tanstack/react-virtual", () => ({
 let loadingValue = false;
 let activeThreadIdValue = "thread-A";
 let messagesValue: { id: string; sequence: number }[] = [{ id: "m1", sequence: 1 }];
+let hasMoreMessagesValue = false;
 
 function buildMockRecord() {
   return {
@@ -53,7 +55,7 @@ function buildMockRecord() {
     persistedToolCallCounts: {},
     persistedFilesChanged: {},
     latestTurnWithChanges: null,
-    hasMoreMessages: false,
+    hasMoreMessages: hasMoreMessagesValue,
     isLoadingMore: false,
     permissions: [],
     hooks: [],
@@ -71,7 +73,7 @@ vi.mock("@/stores/threadStore", () => ({
       records,
       currentThreadId: activeThreadIdValue,
       runningThreadIds: new Set(),
-      loadOlderMessages: vi.fn(),
+      loadOlderMessages: loadOlderMessagesSpy,
     });
   }),
 }));
@@ -104,7 +106,9 @@ import { rememberScrollTop, recallScrollTop, clearScrollMemory } from "../scroll
 beforeEach(() => {
   measureSpy.mockClear();
   scrollToIndexSpy.mockClear();
+  loadOlderMessagesSpy.mockClear();
   totalSizeValue = 0;
+  hasMoreMessagesValue = false;
   clearScrollMemory();
 });
 
@@ -214,6 +218,46 @@ describe("MessageList thread switch", () => {
     act(() => rerender(<MessageList />));
 
     expect(scrollTop).toBe(5580);
+  });
+
+  it("waits for upward user intent before consuming prefetched history", async () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m1", sequence: 1 }];
+    hasMoreMessagesValue = true;
+    const { container } = render(<MessageList />);
+
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    Object.defineProperty(scrollEl, "scrollHeight", {
+      configurable: true,
+      value: 2000,
+    });
+    Object.defineProperty(scrollEl, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(scrollEl, "scrollTop", {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+    await vi.waitFor(() => {
+      expect(scrollEl.style.opacity).toBe("1");
+    });
+    scrollEl.scrollTop = 0;
+
+    act(() => {
+      fireEvent.scroll(scrollEl);
+    });
+    expect(loadOlderMessagesSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.wheel(scrollEl, { deltaY: -100 });
+      fireEvent.scroll(scrollEl);
+    });
+
+    expect(loadOlderMessagesSpy).toHaveBeenCalledOnce();
+    expect(loadOlderMessagesSpy).toHaveBeenCalledWith("thread-A");
   });
 
   it("does not call virtualizer.measure() on a cache-hit switch", () => {

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -20,12 +20,14 @@ import {
   clearRecordCache,
   cacheRecord,
   getCachedRecord,
+  hasPrefetchedHistoryPage,
 } from "@/lib/thread-hydrator/record-cache";
 import { createEmptyThreadRecord, patchThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 import {
   createThreadHydrator,
   BACKGROUND_PREFETCH_LIMIT,
   HYDRATION_TTL_MS,
+  HISTORY_PREFETCH_SIZE,
   MESSAGE_FETCH_SIZE,
   type ThreadHydrator,
 } from "@/lib/thread-hydrator";
@@ -175,7 +177,7 @@ describe("ThreadHydrator", () => {
     expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
   });
 
-  it("commits the latest tail before prefetching earlier history", async () => {
+  it("keeps prefetched earlier history out of live state until pagination", async () => {
     const history = Array.from({ length: 100 }, (_, index) => createMockMessage({
       id: `a-${index + 1}`,
       thread_id: THREAD_A,
@@ -198,16 +200,28 @@ describe("ThreadHydrator", () => {
 
     await hydrator.hydrate(THREAD_A, "active");
 
-    expect(mockTransport.loadConversationPage).toHaveBeenNthCalledWith(1, THREAD_A, 12);
-    expect(getTestActiveMessages()).toEqual(history.slice(88));
+    const visibleTail = history.slice(-MESSAGE_FETCH_SIZE);
+    const historyCursor = visibleTail[0].sequence;
+    expect(mockTransport.loadConversationPage).toHaveBeenNthCalledWith(1, THREAD_A, MESSAGE_FETCH_SIZE);
+    expect(getTestActiveMessages()).toEqual(visibleTail);
 
     await vi.waitFor(() => {
-      expect(mockTransport.loadConversationPage).toHaveBeenNthCalledWith(2, THREAD_A, 88, 89);
-      expect(getTestActiveMessages()).toEqual(history);
+      expect(mockTransport.loadConversationPage).toHaveBeenNthCalledWith(
+        2,
+        THREAD_A,
+        HISTORY_PREFETCH_SIZE,
+        historyCursor,
+      );
     });
+    expect(getTestActiveMessages()).toEqual(visibleTail);
+
+    await useThreadStore.getState().loadOlderMessages(THREAD_A);
+
+    expect(getTestActiveMessages()).toEqual(history);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(2);
   });
 
-  it("resumes earlier-history hydration when a cached tail is reopened", async () => {
+  it("compacts cached history for restore and keeps its older rows warm", async () => {
     const history = Array.from({ length: 100 }, (_, index) => createMockMessage({
       id: `cached-a-${index + 1}`,
       thread_id: THREAD_A,
@@ -217,19 +231,15 @@ describe("ThreadHydrator", () => {
       ...makeCachedRecord(history.slice(88)),
       hasMoreMessages: true,
     });
-    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValue({
-      messages: history.slice(0, 88),
-      hasMore: false,
-      narrativeByMessage: {},
-    });
-
     await hydrator.hydrate(THREAD_A, "active");
 
+    expect(getTestActiveMessages()).toEqual(history.slice(-MESSAGE_FETCH_SIZE));
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
+
+    await useThreadStore.getState().loadOlderMessages(THREAD_A);
+
     expect(getTestActiveMessages()).toEqual(history.slice(88));
-    await vi.waitFor(() => {
-      expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, 88, 89);
-      expect(getTestActiveMessages()).toEqual(history);
-    });
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
   });
 
   it("preserves an existing open goal when lookup returns non-authoritative null", async () => {
@@ -598,7 +608,7 @@ describe("ThreadHydrator", () => {
     expect(useThreadStore.getState().records.get(THREAD_A)?.persistedFilesChanged).toEqual({});
   });
 
-  it("coalesces repeated cached older-history requests by thread and cursor", async () => {
+  it("keeps repeated cache-hit switches bounded without refetching loaded history", async () => {
     const tailA = Array.from({ length: 12 }, (_, index) => createMockMessage({
       id: `tail-a-${index + 89}`,
       thread_id: THREAD_A,
@@ -611,42 +621,18 @@ describe("ThreadHydrator", () => {
     }));
     cacheRecord(THREAD_A, { ...makeCachedRecord(tailA), hasMoreMessages: true });
     cacheRecord(THREAD_B, { ...makeCachedRecord(tailB), hasMoreMessages: true });
-    const resolvers = new Map<string, (value: {
-      messages: typeof msgA[];
-      hasMore: boolean;
-      narrativeByMessage: Record<string, never>;
-    }) => void>();
-    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
-      (threadId: string) => new Promise((resolve) => {
-        resolvers.set(threadId, resolve);
-      }),
-    );
-
     for (let index = 0; index < 20; index++) {
       await hydrator.hydrate(index % 2 === 0 ? THREAD_A : THREAD_B, "active");
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
-    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(2);
-    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, 88, 89);
-    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_B, 88, 89);
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
+    expect(getTestActiveMessages()).toEqual(tailB.slice(-MESSAGE_FETCH_SIZE));
+    expect(hasPrefetchedHistoryPage(THREAD_B, 99)).toBe(true);
 
-    const earlierA = createMockMessage({
-      id: "earlier-a-88",
-      thread_id: THREAD_A,
-      sequence: 88,
-    });
-    const earlierB = createMockMessage({
-      id: "earlier-b-88",
-      thread_id: THREAD_B,
-      sequence: 88,
-    });
-    resolvers.get(THREAD_A)?.({ messages: [earlierA], hasMore: false, narrativeByMessage: {} });
-    resolvers.get(THREAD_B)?.({ messages: [earlierB], hasMore: false, narrativeByMessage: {} });
+    await useThreadStore.getState().loadOlderMessages(THREAD_B);
 
-    await vi.waitFor(() => {
-      expect(getTestActiveMessages()).toEqual([earlierB, ...tailB]);
-    });
+    expect(getTestActiveMessages()).toEqual(tailB);
     expect(getCachedRecord(THREAD_A)?.messages).toEqual(tailA);
   });
 

--- a/apps/web/src/lib/thread-hydrator/index.ts
+++ b/apps/web/src/lib/thread-hydrator/index.ts
@@ -13,9 +13,12 @@ export { SnapshotBuilder, snapshotBuilder } from "./snapshot-builder";
 export type { SnapshotBuilderInput, FileChangeFields, ThreadRecordPatch } from "./snapshot-builder";
 export {
   cacheRecord,
+  cachePrefetchedHistoryPage,
   evictCachedRecord,
   getCachedRecord,
   hasCachedRecord,
+  hasPrefetchedHistoryPage,
+  takePrefetchedHistoryPage,
   clearRecordCache,
   resizeRecordCache,
   RECORD_CACHE_SIZE,

--- a/apps/web/src/lib/thread-hydrator/record-cache.ts
+++ b/apps/web/src/lib/thread-hydrator/record-cache.ts
@@ -1,6 +1,7 @@
 import { LruCache } from "@/lib/lru-cache";
 import { forgetScrollTop } from "@/components/chat/scrollPositionMemory";
 import type { ThreadRecord } from "@/stores/thread-record";
+import type { ConversationPage } from "@mcode/contracts";
 
 /**
  * Initial default thread cache capacity.
@@ -14,6 +15,13 @@ export const RECORD_CACHE_SIZE = 15;
  * here so the next visit restores synchronously without an RPC round-trip.
  */
 const cache = new LruCache<string, ThreadRecord>(RECORD_CACHE_SIZE);
+
+interface PrefetchedHistoryPage {
+  before: number;
+  page: ConversationPage;
+}
+
+const historyCache = new LruCache<string, PrefetchedHistoryPage>(RECORD_CACHE_SIZE);
 
 /** Read the cached record for a thread, refreshing LRU recency on hit. */
 export function getCachedRecord(threadId: string): ThreadRecord | undefined {
@@ -30,17 +38,46 @@ export function cacheRecord(threadId: string, record: ThreadRecord): void {
   const evicted = cache.set(threadId, record);
   if (evicted) {
     forgetScrollTop(evicted);
+    historyCache.delete(evicted);
   }
+}
+
+/** Cache one older-history page without attaching its messages to live React state. */
+export function cachePrefetchedHistoryPage(
+  threadId: string,
+  before: number,
+  page: ConversationPage,
+): void {
+  historyCache.set(threadId, { before, page });
+}
+
+/** Check whether the requested older-history cursor is already warm. */
+export function hasPrefetchedHistoryPage(threadId: string, before: number): boolean {
+  const entry = historyCache.get(threadId);
+  return entry?.before === before;
+}
+
+/** Consume the warm older-history page for the requested cursor. */
+export function takePrefetchedHistoryPage(
+  threadId: string,
+  before: number,
+): ConversationPage | undefined {
+  const entry = historyCache.get(threadId);
+  if (entry?.before !== before) return undefined;
+  historyCache.delete(threadId);
+  return entry.page;
 }
 
 /** Remove a single thread's cached record. No-op when absent. */
 export function evictCachedRecord(threadId: string): void {
   cache.delete(threadId);
+  historyCache.delete(threadId);
 }
 
 /** Drop all cached records. Used in tests and on workspace deletion. */
 export function clearRecordCache(): void {
   cache.clear();
+  historyCache.clear();
 }
 
 /**
@@ -51,7 +88,9 @@ export function clearRecordCache(): void {
  */
 export function resizeRecordCache(capacity: number): void {
   const evicted = cache.resize(capacity);
+  historyCache.resize(capacity);
   for (const threadId of evicted) {
     forgetScrollTop(threadId);
+    historyCache.delete(threadId);
   }
 }

--- a/apps/web/src/lib/thread-hydrator/record-cache.ts
+++ b/apps/web/src/lib/thread-hydrator/record-cache.ts
@@ -21,7 +21,7 @@ interface PrefetchedHistoryPage {
   page: ConversationPage;
 }
 
-const historyCache = new LruCache<string, PrefetchedHistoryPage>(RECORD_CACHE_SIZE);
+const prefetchedHistoryCache = new LruCache<string, PrefetchedHistoryPage>(RECORD_CACHE_SIZE);
 
 /** Read the cached record for a thread, refreshing LRU recency on hit. */
 export function getCachedRecord(threadId: string): ThreadRecord | undefined {
@@ -38,7 +38,7 @@ export function cacheRecord(threadId: string, record: ThreadRecord): void {
   const evicted = cache.set(threadId, record);
   if (evicted) {
     forgetScrollTop(evicted);
-    historyCache.delete(evicted);
+    prefetchedHistoryCache.delete(evicted);
   }
 }
 
@@ -48,12 +48,12 @@ export function cachePrefetchedHistoryPage(
   before: number,
   page: ConversationPage,
 ): void {
-  historyCache.set(threadId, { before, page });
+  prefetchedHistoryCache.set(threadId, { before, page });
 }
 
 /** Check whether the requested older-history cursor is already warm. */
 export function hasPrefetchedHistoryPage(threadId: string, before: number): boolean {
-  const entry = historyCache.get(threadId);
+  const entry = prefetchedHistoryCache.get(threadId);
   return entry?.before === before;
 }
 
@@ -62,22 +62,22 @@ export function takePrefetchedHistoryPage(
   threadId: string,
   before: number,
 ): ConversationPage | undefined {
-  const entry = historyCache.get(threadId);
+  const entry = prefetchedHistoryCache.get(threadId);
   if (entry?.before !== before) return undefined;
-  historyCache.delete(threadId);
+  prefetchedHistoryCache.delete(threadId);
   return entry.page;
 }
 
 /** Remove a single thread's cached record. No-op when absent. */
 export function evictCachedRecord(threadId: string): void {
   cache.delete(threadId);
-  historyCache.delete(threadId);
+  prefetchedHistoryCache.delete(threadId);
 }
 
 /** Drop all cached records. Used in tests and on workspace deletion. */
 export function clearRecordCache(): void {
   cache.clear();
-  historyCache.clear();
+  prefetchedHistoryCache.clear();
 }
 
 /**
@@ -88,9 +88,9 @@ export function clearRecordCache(): void {
  */
 export function resizeRecordCache(capacity: number): void {
   const evicted = cache.resize(capacity);
-  historyCache.resize(capacity);
+  prefetchedHistoryCache.resize(capacity);
   for (const threadId of evicted) {
     forgetScrollTop(threadId);
-    historyCache.delete(threadId);
+    prefetchedHistoryCache.delete(threadId);
   }
 }

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -1,8 +1,10 @@
 import {
+  cachePrefetchedHistoryPage,
   cacheRecord,
   evictCachedRecord,
   getCachedRecord,
   hasCachedRecord,
+  hasPrefetchedHistoryPage,
 } from "./record-cache";
 import {
   createEmptyThreadRecord,
@@ -21,17 +23,34 @@ import type {
 } from "./types";
 import { SnapshotBuilder, snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
+import type { ConversationPage } from "@mcode/contracts";
 
 interface HistoryHydrate {
   expectedEpoch: number;
   promise: Promise<void>;
 }
 
-/** Latest messages fetched before the selected thread first paints. */
-export const MESSAGE_FETCH_SIZE = 12;
+function selectConversationPage(
+  page: ConversationPage,
+  messages: ConversationPage["messages"],
+  hasMore: boolean,
+): ConversationPage {
+  const messageIds = new Set(messages.map((message) => message.id));
+  return {
+    messages,
+    hasMore,
+    answeredPlanMessageIds: page.answeredPlanMessageIds?.filter((id) => messageIds.has(id)),
+    narrativeByMessage: Object.fromEntries(
+      Object.entries(page.narrativeByMessage).filter(([messageId]) => messageIds.has(messageId)),
+    ),
+  };
+}
 
-/** Earlier messages filled in after the latest tail has painted. */
-export const HISTORY_PREFETCH_SIZE = 88;
+/** Latest messages fetched before the selected thread first paints. */
+export const MESSAGE_FETCH_SIZE = 2;
+
+/** Older messages fetched after the latest tail paints and held outside live state. */
+export const HISTORY_PREFETCH_SIZE = 98;
 
 /** Auxiliary side-effect refresh TTL (permissions, tasks, plans). */
 export const HYDRATION_TTL_MS = 2000;
@@ -123,20 +142,34 @@ export class ThreadHydrator {
 
       if (hasCachedRecord(threadId)) return;
 
+      const tailStart = Math.max(0, pageResult.messages.length - MESSAGE_FETCH_SIZE);
+      const earlierMessages = pageResult.messages.slice(0, tailStart);
+      const tailPage = selectConversationPage(
+        pageResult,
+        pageResult.messages.slice(tailStart),
+        pageResult.hasMore || earlierMessages.length > 0,
+      );
       const patch = snapshotBuilder.build({
-        messages: pageResult.messages,
-        hasMore: pageResult.hasMore,
-        answeredPlanMessageIds: pageResult.answeredPlanMessageIds,
+        messages: tailPage.messages,
+        hasMore: tailPage.hasMore,
+        answeredPlanMessageIds: tailPage.answeredPlanMessageIds,
         snapshots,
       });
 
       const record: ThreadRecord = {
         ...createEmptyThreadRecord(),
         ...patch,
-        narrativeByMessage: pageResult.narrativeByMessage,
+        narrativeByMessage: tailPage.narrativeByMessage,
         settings: this.deps.getWorkspaceThreadSettings(threadId),
       };
       cacheRecord(threadId, record);
+      if (earlierMessages.length > 0 && tailPage.messages.length > 0) {
+        cachePrefetchedHistoryPage(
+          threadId,
+          tailPage.messages[0].sequence,
+          selectConversationPage(pageResult, earlierMessages, pageResult.hasMore),
+        );
+      }
     } catch {
       // Background prefetch is speculative; swallow errors silently.
     }
@@ -259,7 +292,8 @@ export class ThreadHydrator {
     opts?: ThreadHydratorOptions,
     restoreOpts?: { bumpLoadEpoch?: boolean },
   ): void {
-    this.restoreFromCache(threadId, cached, restoreOpts);
+    const visibleCached = this.compactCachedRecordForRestore(threadId, cached);
+    this.restoreFromCache(threadId, visibleCached, restoreOpts);
     const expectedEpoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
     void this.refreshThreadGoal(threadId, expectedEpoch);
     this.auxiliaryHydrator.hydrate(threadId, {
@@ -268,9 +302,46 @@ export class ThreadHydrator {
       commitFileChangesToStore: true,
       expectedLoadEpoch: expectedEpoch,
     });
-    if (cached.hasMoreMessages && cached.messages.length < BACKGROUND_PREFETCH_LIMIT) {
-      this.scheduleEarlierHistoryHydration(threadId, cached);
+    if (
+      visibleCached.hasMoreMessages &&
+      visibleCached.messages.length < BACKGROUND_PREFETCH_LIMIT
+    ) {
+      this.scheduleEarlierHistoryHydration(threadId, visibleCached);
     }
+  }
+
+  /** Keep cache-hit reconciliation bounded while retaining loaded history for upward pagination. */
+  private compactCachedRecordForRestore(threadId: string, cached: ThreadRecord): ThreadRecord {
+    if (cached.messages.length <= MESSAGE_FETCH_SIZE) return cached;
+
+    const tailStart = cached.messages.length - MESSAGE_FETCH_SIZE;
+    const earlierMessages = cached.messages.slice(0, tailStart);
+    const tailMessages = cached.messages.slice(tailStart);
+    const narrativeByMessage: ConversationPage["narrativeByMessage"] = {};
+    for (const [messageId, narrative] of Object.entries(cached.narrativeByMessage)) {
+      if (narrative) narrativeByMessage[messageId] = narrative;
+    }
+    const page: ConversationPage = {
+      messages: cached.messages,
+      hasMore: cached.hasMoreMessages,
+      answeredPlanMessageIds: [...cached.answeredPlanMessageIds],
+      narrativeByMessage,
+    };
+    const tailPage = selectConversationPage(page, tailMessages, true);
+    cachePrefetchedHistoryPage(
+      threadId,
+      tailMessages[0].sequence,
+      selectConversationPage(page, earlierMessages, cached.hasMoreMessages),
+    );
+
+    return {
+      ...cached,
+      messages: tailMessages,
+      oldestLoadedSequence: tailMessages[0].sequence,
+      hasMoreMessages: true,
+      narrativeByMessage: tailPage.narrativeByMessage,
+      answeredPlanMessageIds: new Set(tailPage.answeredPlanMessageIds ?? []),
+    };
   }
 
   /**
@@ -538,6 +609,7 @@ export class ThreadHydrator {
   ): void {
     if (!(page.hasMore ?? page.hasMoreMessages) || page.messages.length === 0) return;
     const before = page.messages[0].sequence;
+    if (hasPrefetchedHistoryPage(threadId, before)) return;
     const epoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
     const hydrateKey = `${threadId}:${before}`;
     setTimeout(() => {
@@ -583,43 +655,7 @@ export class ThreadHydrator {
       const expectedEpoch = getExpectedEpoch();
       if (state.currentThreadId !== threadId || current.loadEpoch !== expectedEpoch) return;
 
-      const currentIds = new Set(current.messages.map((message) => message.id));
-      const earlierMessages = page.messages.filter((message) => !currentIds.has(message.id));
-      const persistedToolCallCounts = { ...current.persistedToolCallCounts };
-      for (const message of earlierMessages) {
-        if (message.tool_call_count && message.tool_call_count > 0) {
-          persistedToolCallCounts[message.id] = message.tool_call_count;
-        }
-      }
-      const messages = [...earlierMessages, ...current.messages];
-
-      this.deps.setState((latest: ThreadHydratorWriteState) => {
-        const record = getThreadRecord(latest.records, threadId);
-        if (latest.currentThreadId !== threadId || record.loadEpoch !== expectedEpoch) {
-          return {};
-        }
-        return {
-          records: patchThreadRecord(latest.records, threadId, {
-            messages,
-            oldestLoadedSequence: messages[0]?.sequence ?? record.oldestLoadedSequence,
-            hasMoreMessages: page.hasMore,
-            persistedToolCallCounts,
-            narrativeByMessage: {
-              ...page.narrativeByMessage,
-              ...record.narrativeByMessage,
-            },
-            answeredPlanMessageIds: new Set([
-              ...record.answeredPlanMessageIds,
-              ...(page.answeredPlanMessageIds ?? []),
-            ]),
-          }),
-        };
-      });
-      const latest = this.deps.getState();
-      const latestRecord = getThreadRecord(latest.records, threadId);
-      if (latest.currentThreadId === threadId && latestRecord.loadEpoch === getExpectedEpoch()) {
-        cacheRecord(threadId, latestRecord);
-      }
+      cachePrefetchedHistoryPage(threadId, before, page);
     } catch {
       // The visible tail is complete; older history remains available on scroll.
     }

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -25,12 +25,13 @@ import { SnapshotBuilder, snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
 import type { ConversationPage } from "@mcode/contracts";
 
-interface HistoryHydrate {
+interface PendingHistoryPrefetch {
   expectedEpoch: number;
   promise: Promise<void>;
 }
 
-function selectConversationPage(
+/** Build a conversation page containing only the supplied messages and their metadata. */
+function buildConversationPageSubset(
   page: ConversationPage,
   messages: ConversationPage["messages"],
   hasMore: boolean,
@@ -49,14 +50,14 @@ function selectConversationPage(
 /** Latest messages fetched before the selected thread first paints. */
 export const MESSAGE_FETCH_SIZE = 2;
 
-/** Older messages fetched after the latest tail paints and held outside live state. */
-export const HISTORY_PREFETCH_SIZE = 98;
+/** Maximum messages fetched by a sidebar hover prefetch. */
+export const BACKGROUND_PREFETCH_LIMIT = 100;
+
+/** Older messages warmed after first paint and held outside live React state. */
+export const HISTORY_PREFETCH_SIZE = BACKGROUND_PREFETCH_LIMIT - MESSAGE_FETCH_SIZE;
 
 /** Auxiliary side-effect refresh TTL (permissions, tasks, plans). */
 export const HYDRATION_TTL_MS = 2000;
-
-/** Background hover prefetch limit (matches legacy prefetch.ts). */
-export const BACKGROUND_PREFETCH_LIMIT = 100;
 
 /**
  * Owns the full "load this thread" flow: cache lookup, RPC fetch, record
@@ -66,7 +67,7 @@ export class ThreadHydrator {
   private readonly auxiliaryHydrator: AuxiliaryHydrator;
   private readonly activeHydrates = new Map<string, Promise<void>>();
   private readonly backgroundHydrates = new Map<string, Promise<void>>();
-  private readonly historyHydrates = new Map<string, HistoryHydrate>();
+  private readonly pendingHistoryPrefetches = new Map<string, PendingHistoryPrefetch>();
 
   constructor(private readonly deps: ThreadHydratorDeps) {
     this.auxiliaryHydrator = new AuxiliaryHydrator({
@@ -144,7 +145,7 @@ export class ThreadHydrator {
 
       const tailStart = Math.max(0, pageResult.messages.length - MESSAGE_FETCH_SIZE);
       const earlierMessages = pageResult.messages.slice(0, tailStart);
-      const tailPage = selectConversationPage(
+      const tailPage = buildConversationPageSubset(
         pageResult,
         pageResult.messages.slice(tailStart),
         pageResult.hasMore || earlierMessages.length > 0,
@@ -167,7 +168,7 @@ export class ThreadHydrator {
         cachePrefetchedHistoryPage(
           threadId,
           tailPage.messages[0].sequence,
-          selectConversationPage(pageResult, earlierMessages, pageResult.hasMore),
+          buildConversationPageSubset(pageResult, earlierMessages, pageResult.hasMore),
         );
       }
     } catch {
@@ -292,8 +293,8 @@ export class ThreadHydrator {
     opts?: ThreadHydratorOptions,
     restoreOpts?: { bumpLoadEpoch?: boolean },
   ): void {
-    const visibleCached = this.compactCachedRecordForRestore(threadId, cached);
-    this.restoreFromCache(threadId, visibleCached, restoreOpts);
+    const renderableCachedRecord = this.compactCachedRecordForRestore(threadId, cached);
+    this.restoreFromCache(threadId, renderableCachedRecord, restoreOpts);
     const expectedEpoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
     void this.refreshThreadGoal(threadId, expectedEpoch);
     this.auxiliaryHydrator.hydrate(threadId, {
@@ -303,10 +304,10 @@ export class ThreadHydrator {
       expectedLoadEpoch: expectedEpoch,
     });
     if (
-      visibleCached.hasMoreMessages &&
-      visibleCached.messages.length < BACKGROUND_PREFETCH_LIMIT
+      renderableCachedRecord.hasMoreMessages &&
+      renderableCachedRecord.messages.length < BACKGROUND_PREFETCH_LIMIT
     ) {
-      this.scheduleEarlierHistoryHydration(threadId, visibleCached);
+      this.scheduleEarlierHistoryPrefetch(threadId, renderableCachedRecord);
     }
   }
 
@@ -327,11 +328,11 @@ export class ThreadHydrator {
       answeredPlanMessageIds: [...cached.answeredPlanMessageIds],
       narrativeByMessage,
     };
-    const tailPage = selectConversationPage(page, tailMessages, true);
+    const tailPage = buildConversationPageSubset(page, tailMessages, true);
     cachePrefetchedHistoryPage(
       threadId,
       tailMessages[0].sequence,
-      selectConversationPage(page, earlierMessages, cached.hasMoreMessages),
+      buildConversationPageSubset(page, earlierMessages, cached.hasMoreMessages),
     );
 
     return {
@@ -587,7 +588,7 @@ export class ThreadHydrator {
         if (goalLookup) this.applyGoalLookup(threadId, goalLookup, expectedEpoch);
       });
       if (commitOpts?.prefetchEarlierHistory !== false) {
-        this.scheduleEarlierHistoryHydration(threadId, pageResult);
+        this.scheduleEarlierHistoryPrefetch(threadId, pageResult);
       }
     } catch (e) {
       if (getState().currentThreadId === threadId) {
@@ -603,7 +604,7 @@ export class ThreadHydrator {
   }
 
   /** Defers older history until the browser has had a chance to paint the tail. */
-  private scheduleEarlierHistoryHydration(
+  private scheduleEarlierHistoryPrefetch(
     threadId: string,
     page: Pick<ThreadRecord, "messages"> & { hasMore?: boolean; hasMoreMessages?: boolean },
   ): void {
@@ -611,35 +612,35 @@ export class ThreadHydrator {
     const before = page.messages[0].sequence;
     if (hasPrefetchedHistoryPage(threadId, before)) return;
     const epoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
-    const hydrateKey = `${threadId}:${before}`;
+    const prefetchKey = `${threadId}:${before}`;
     setTimeout(() => {
       const state = this.deps.getState();
       if (state.currentThreadId !== threadId) return;
       if (getThreadRecord(state.records, threadId).loadEpoch !== epoch) return;
-      const existing = this.historyHydrates.get(hydrateKey);
+      const existing = this.pendingHistoryPrefetches.get(prefetchKey);
       if (existing) {
         existing.expectedEpoch = epoch;
         return;
       }
-      const hydrate: HistoryHydrate = {
+      const prefetch: PendingHistoryPrefetch = {
         expectedEpoch: epoch,
         promise: Promise.resolve(),
       };
-      hydrate.promise = this.hydrateEarlierHistory(
+      prefetch.promise = this.prefetchEarlierHistory(
         threadId,
         before,
-        () => hydrate.expectedEpoch,
+        () => prefetch.expectedEpoch,
       ).finally(() => {
-        if (this.historyHydrates.get(hydrateKey) === hydrate) {
-          this.historyHydrates.delete(hydrateKey);
+        if (this.pendingHistoryPrefetches.get(prefetchKey) === prefetch) {
+          this.pendingHistoryPrefetches.delete(prefetchKey);
         }
       });
-      this.historyHydrates.set(hydrateKey, hydrate);
+      this.pendingHistoryPrefetches.set(prefetchKey, prefetch);
     }, 0);
   }
 
-  /** Prepends the rest of the warm history window without blocking the tail. */
-  private async hydrateEarlierHistory(
+  /** Cache the older history window without attaching it to live React state. */
+  private async prefetchEarlierHistory(
     threadId: string,
     before: number,
     getExpectedEpoch: () => number,

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -25,6 +25,7 @@ import {
   cacheRecord,
   evictCachedRecord,
   getCachedRecord,
+  takePrefetchedHistoryPage,
 } from "@/lib/thread-hydrator/record-cache";
 import { shallowEqualBy } from "@/lib/shallowEqualBy";
 import { forgetScrollTop } from "@/components/chat/scrollPositionMemory";
@@ -966,11 +967,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     try {
       const cursor = getRec(threadId).oldestLoadedSequence;
       const epoch = getRec(threadId).loadEpoch;
+      const prefetchedPage = takePrefetchedHistoryPage(threadId, cursor);
       const {
         messages: olderMessages,
         hasMore,
+        answeredPlanMessageIds,
         narrativeByMessage,
-      } = await getTransport().loadConversationPage(threadId, OLDER_PAGE_SIZE, cursor);
+      } = prefetchedPage
+        ?? await getTransport().loadConversationPage(threadId, OLDER_PAGE_SIZE, cursor);
 
       const isStale = get().currentThreadId !== threadId
         || getRec(threadId).loadEpoch !== epoch;
@@ -992,6 +996,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         messages: [...olderMessages, ...r.messages],
         persistedToolCallCounts: { ...r.persistedToolCallCounts, ...newCounts },
         narrativeByMessage: { ...narrativeByMessage, ...r.narrativeByMessage },
+        answeredPlanMessageIds: new Set([
+          ...r.answeredPlanMessageIds,
+          ...(answeredPlanMessageIds ?? []),
+        ]),
         oldestLoadedSequence: newOldest,
         hasMoreMessages: hasMore,
         isLoadingMore: false,


### PR DESCRIPTION
## What
Keep long-thread navigation bounded by rendering the latest turn while retaining older messages in a warm history cache.

## Why
Progressive hydration appended prefetched history directly to live thread state. Virtualization limited DOM nodes, but React still rebuilt virtual items and height estimates for off-screen messages on each cache restore.

## Key Changes
- Hold prefetched history outside live thread state until the user scrolls upward.
- Compact restored records to the latest user and assistant turn, including after older history was opened.
- Preserve pagination metadata and answered-plan state when consuming a warm page.
- Add regressions for cache restore and user-initiated pagination.

## Verification
- In-app Browser: exercised a 240-message thread, loaded older history, and revisited it.
- Main-thread work on the fixture fell from 762-1,022 ms to 247-309 ms before history was opened.
- `bun run typecheck`
- `bun run lint`
- Focused Vitest coverage: 36 tests passed.
- `bun run verify` reached the local five-minute timeout without reporting a failing phase; hosted checks will run the full gate.
