### PR TITLE
refactor(agent): replace positional send arguments

### DIFF
--- a/apps/server/src/__tests__/agent-service-turn-started.test.ts
+++ b/apps/server/src/__tests__/agent-service-turn-started.test.ts
@@ -44,10 +44,9 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
   let turnSnapshotRepo: TurnSnapshotRepo;
   let taskRepo: TaskRepo;
   let svc: AgentService;
-  let providerStub: EventEmitter &
-    Partial<IAgentProvider> & {
-      sendTurn: ReturnType<typeof vi.fn>;
-    };
+  let providerStub: EventEmitter & Partial<IAgentProvider> & {
+    sendTurn: ReturnType<typeof vi.fn>;
+  };
   let capturedEvents: AgentEvent[];
   // Snapshot of capturedEvents.length taken synchronously when the provider's
   // sendMessage body is entered. If emit truly precedes the call, this must be >= 1.
@@ -134,12 +133,7 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       attachmentServiceStub,
       registryStub,
       threadServiceStub,
-      {
-        bulkCreate: () => {},
-        create: () => ({}),
-        listByMessage: () => [],
-        countByMessage: () => 0,
-      } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
+      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
       turnSnapshotRepo,
       snapshotServiceStub,
       db,
@@ -147,42 +141,15 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       taskRepo,
       settingsServiceStub,
       availabilityStub,
-      {
-        markAnswered: vi.fn(),
-        isAnswered: vi.fn(() => false),
-        listAnsweredForThread: vi.fn(() => []),
-      } as unknown as import("../repositories/plan-question-answers-repo.js").PlanQuestionAnswersRepo,
-      {
-        create: vi.fn(),
-        updateStatus: vi.fn(),
-        listByThread: vi.fn(() => []),
-        getLatestForThread: vi.fn(() => null),
-        getById: vi.fn(() => null),
-      } as unknown as import("../repositories/plan-repo.js").PlanRepo,
-      {
-        deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
-      } as any,
-      {
-        issue: vi.fn(),
-        tryConsume: vi.fn(() => false),
-        clear: vi.fn(),
-        hasActiveGrant: vi.fn(() => false),
-      } as any,
+      { markAnswered: vi.fn(), isAnswered: vi.fn(() => false), listAnsweredForThread: vi.fn(() => []) } as unknown as import("../repositories/plan-question-answers-repo.js").PlanQuestionAnswersRepo,
+      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../repositories/plan-repo.js").PlanRepo,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
       new NarrativeStore(
         messageRepo,
         toolCallRecordRepo,
-        {
-          bulkCreate: () => {},
-          create: () => ({}),
-          listByMessage: () => [],
-          countByMessage: () => 0,
-        } as unknown as import("../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
-        {
-          bulkCreate: () => {},
-          create: () => ({}),
-          listByMessage: () => [],
-          countByMessage: () => 0,
-        } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
       ),
       new PlanQuestionService(messageRepo, new PlanQuestionAnswersRepo(db)),
     );
@@ -190,14 +157,7 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
 
   it("emits turnStarted through the provider before provider.sendMessage resolves", async () => {
     const workspace = workspaceRepo.create("test-ws", process.cwd());
-    const thread = threadRepo.create(
-      workspace.id,
-      "Test Thread",
-      "direct",
-      "main",
-      true,
-      "claude",
-    );
+    const thread = threadRepo.create(workspace.id, "Test Thread", "direct", "main", true, "claude");
 
     // Kick off sendMessage without awaiting (provider.sendMessage never resolves).
     void svc.sendMessage({
@@ -210,10 +170,7 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     // TurnStarted must be the FIRST event on the bus (nothing precedes it).
-    expect(
-      capturedEvents.length,
-      "expected at least one event on the bus",
-    ).toBeGreaterThan(0);
+    expect(capturedEvents.length, "expected at least one event on the bus").toBeGreaterThan(0);
     expect(capturedEvents[0]).toMatchObject({
       type: AgentEventType.TurnStarted,
       threadId: thread.id,

--- a/apps/server/src/__tests__/agent-service-turn-started.test.ts
+++ b/apps/server/src/__tests__/agent-service-turn-started.test.ts
@@ -44,9 +44,10 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
   let turnSnapshotRepo: TurnSnapshotRepo;
   let taskRepo: TaskRepo;
   let svc: AgentService;
-  let providerStub: EventEmitter & Partial<IAgentProvider> & {
-    sendTurn: ReturnType<typeof vi.fn>;
-  };
+  let providerStub: EventEmitter &
+    Partial<IAgentProvider> & {
+      sendTurn: ReturnType<typeof vi.fn>;
+    };
   let capturedEvents: AgentEvent[];
   // Snapshot of capturedEvents.length taken synchronously when the provider's
   // sendMessage body is entered. If emit truly precedes the call, this must be >= 1.
@@ -133,7 +134,12 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       attachmentServiceStub,
       registryStub,
       threadServiceStub,
-      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
+      {
+        bulkCreate: () => {},
+        create: () => ({}),
+        listByMessage: () => [],
+        countByMessage: () => 0,
+      } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
       turnSnapshotRepo,
       snapshotServiceStub,
       db,
@@ -141,15 +147,42 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
       taskRepo,
       settingsServiceStub,
       availabilityStub,
-      { markAnswered: vi.fn(), isAnswered: vi.fn(() => false), listAnsweredForThread: vi.fn(() => []) } as unknown as import("../repositories/plan-question-answers-repo.js").PlanQuestionAnswersRepo,
-      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../repositories/plan-repo.js").PlanRepo,
-      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
-      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      {
+        markAnswered: vi.fn(),
+        isAnswered: vi.fn(() => false),
+        listAnsweredForThread: vi.fn(() => []),
+      } as unknown as import("../repositories/plan-question-answers-repo.js").PlanQuestionAnswersRepo,
+      {
+        create: vi.fn(),
+        updateStatus: vi.fn(),
+        listByThread: vi.fn(() => []),
+        getLatestForThread: vi.fn(() => null),
+        getById: vi.fn(() => null),
+      } as unknown as import("../repositories/plan-repo.js").PlanRepo,
+      {
+        deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
+      } as any,
+      {
+        issue: vi.fn(),
+        tryConsume: vi.fn(() => false),
+        clear: vi.fn(),
+        hasActiveGrant: vi.fn(() => false),
+      } as any,
       new NarrativeStore(
         messageRepo,
         toolCallRecordRepo,
-        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
-        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
+        {
+          bulkCreate: () => {},
+          create: () => ({}),
+          listByMessage: () => [],
+          countByMessage: () => 0,
+        } as unknown as import("../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+        {
+          bulkCreate: () => {},
+          create: () => ({}),
+          listByMessage: () => [],
+          countByMessage: () => 0,
+        } as unknown as import("../repositories/hook-execution-repo.js").HookExecutionRepo,
       ),
       new PlanQuestionService(messageRepo, new PlanQuestionAnswersRepo(db)),
     );
@@ -157,16 +190,30 @@ describe("AgentService.sendMessage emits TurnStarted", () => {
 
   it("emits turnStarted through the provider before provider.sendMessage resolves", async () => {
     const workspace = workspaceRepo.create("test-ws", process.cwd());
-    const thread = threadRepo.create(workspace.id, "Test Thread", "direct", "main", true, "claude");
+    const thread = threadRepo.create(
+      workspace.id,
+      "Test Thread",
+      "direct",
+      "main",
+      true,
+      "claude",
+    );
 
     // Kick off sendMessage without awaiting (provider.sendMessage never resolves).
-    void svc.sendMessage(thread.id, "hello", "default");
+    void svc.sendMessage({
+      threadId: thread.id,
+      content: "hello",
+      permissionMode: "default",
+    });
 
     // Let the async prelude (attachment persist + ref capture + settings.get) settle.
     await new Promise((r) => setTimeout(r, 10));
 
     // TurnStarted must be the FIRST event on the bus (nothing precedes it).
-    expect(capturedEvents.length, "expected at least one event on the bus").toBeGreaterThan(0);
+    expect(
+      capturedEvents.length,
+      "expected at least one event on the bus",
+    ).toBeGreaterThan(0);
     expect(capturedEvents[0]).toMatchObject({
       type: AgentEventType.TurnStarted,
       threadId: thread.id,

--- a/apps/server/src/services/__tests__/agent-service-existing-worktree.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-existing-worktree.test.ts
@@ -49,6 +49,28 @@ function createAgentServiceHarness() {
   return { db, threadRepo, workspaceRepo, gitService, threadService, service };
 }
 
+describe("AgentService.createAndSend defaults", () => {
+  it("uses the default model when the command omits it", async () => {
+    const { threadRepo, workspaceRepo, service } = createAgentServiceHarness();
+    const workspace = workspaceRepo.create("Repo", "/repo");
+
+    const thread = await service.createAndSend({
+      workspaceId: workspace.id,
+      content: "Use the default model",
+    });
+
+    expect(thread.model).toBe("claude-sonnet-4-6");
+    expect(threadRepo.findById(thread.id)?.model).toBe("claude-sonnet-4-6");
+    expect(service.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: thread.id,
+        content: "Use the default model",
+        model: "claude-sonnet-4-6",
+      }),
+    );
+  });
+});
+
 describe("AgentService.createAndSend existing worktree attach", () => {
   it("creates a new worktree as branchless from the selected base branch", async () => {
     const { threadRepo, workspaceRepo, threadService, service } = createAgentServiceHarness();

--- a/apps/server/src/services/__tests__/agent-service-existing-worktree.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-existing-worktree.test.ts
@@ -51,8 +51,7 @@ function createAgentServiceHarness() {
 
 describe("AgentService.createAndSend existing worktree attach", () => {
   it("creates a new worktree as branchless from the selected base branch", async () => {
-    const { threadRepo, workspaceRepo, threadService, service } =
-      createAgentServiceHarness();
+    const { threadRepo, workspaceRepo, threadService, service } = createAgentServiceHarness();
     const workspace = workspaceRepo.create("Repo", "/repo");
     const createdThread = {
       ...threadRepo.create(
@@ -95,8 +94,7 @@ describe("AgentService.createAndSend existing worktree attach", () => {
   });
 
   it("creates a new worktree on a PR branch as a named checkout", async () => {
-    const { threadRepo, workspaceRepo, threadService, service } =
-      createAgentServiceHarness();
+    const { threadRepo, workspaceRepo, threadService, service } = createAgentServiceHarness();
     const workspace = workspaceRepo.create("Repo", "/repo");
     const createdThread = {
       ...threadRepo.create(

--- a/apps/server/src/services/__tests__/agent-service-existing-worktree.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-existing-worktree.test.ts
@@ -51,7 +51,8 @@ function createAgentServiceHarness() {
 
 describe("AgentService.createAndSend existing worktree attach", () => {
   it("creates a new worktree as branchless from the selected base branch", async () => {
-    const { threadRepo, workspaceRepo, threadService, service } = createAgentServiceHarness();
+    const { threadRepo, workspaceRepo, threadService, service } =
+      createAgentServiceHarness();
     const workspace = workspaceRepo.create("Repo", "/repo");
     const createdThread = {
       ...threadRepo.create(
@@ -69,14 +70,14 @@ describe("AgentService.createAndSend existing worktree attach", () => {
     };
     vi.mocked(threadService.create).mockResolvedValue(createdThread);
 
-    const thread = await service.createAndSend(
-      workspace.id,
-      "Work from feature base",
-      "claude-sonnet-4-6",
-      "default",
-      "worktree",
-      "feature/base",
-    );
+    const thread = await service.createAndSend({
+      workspaceId: workspace.id,
+      content: "Work from feature base",
+      model: "claude-sonnet-4-6",
+      permissionMode: "default",
+      mode: "worktree",
+      branch: "feature/base",
+    });
 
     expect(threadService.create).toHaveBeenCalledWith(
       workspace.id,
@@ -94,7 +95,8 @@ describe("AgentService.createAndSend existing worktree attach", () => {
   });
 
   it("creates a new worktree on a PR branch as a named checkout", async () => {
-    const { threadRepo, workspaceRepo, threadService, service } = createAgentServiceHarness();
+    const { threadRepo, workspaceRepo, threadService, service } =
+      createAgentServiceHarness();
     const workspace = workspaceRepo.create("Repo", "/repo");
     const createdThread = {
       ...threadRepo.create(
@@ -112,15 +114,15 @@ describe("AgentService.createAndSend existing worktree attach", () => {
     };
     vi.mocked(threadService.create).mockResolvedValue(createdThread);
 
-    const thread = await service.createAndSend(
-      workspace.id,
-      "Review PR",
-      "claude-sonnet-4-6",
-      "default",
-      "worktree",
-      "contributor/pr-branch",
-      "named",
-    );
+    const thread = await service.createAndSend({
+      workspaceId: workspace.id,
+      content: "Review PR",
+      model: "claude-sonnet-4-6",
+      permissionMode: "default",
+      mode: "worktree",
+      branch: "contributor/pr-branch",
+      worktreeBranchMode: "named",
+    });
 
     expect(threadService.create).toHaveBeenCalledWith(
       workspace.id,
@@ -149,24 +151,18 @@ describe("AgentService.createAndSend existing worktree attach", () => {
       },
     ]);
 
-    const thread = await service.createAndSend(
-      workspace.id,
-      "Work in detached worktree",
-      "claude-sonnet-4-6",
-      "default",
-      "worktree",
-      "main",
-      undefined,
-      "/repo/.worktrees/branchless-existing/",
-      "main",
-      [],
-      undefined,
-      "claude",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    );
+    const thread = await service.createAndSend({
+      workspaceId: workspace.id,
+      content: "Work in detached worktree",
+      model: "claude-sonnet-4-6",
+      permissionMode: "default",
+      mode: "worktree",
+      branch: "main",
+      existingWorktreePath: "/repo/.worktrees/branchless-existing/",
+      existingWorktreeBaseBranch: "main",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(thread).toMatchObject({
       mode: "worktree",
@@ -190,20 +186,17 @@ describe("AgentService.createAndSend existing worktree attach", () => {
       },
     ]);
 
-    const thread = await service.createAndSend(
-      workspace.id,
-      "Work in named worktree",
-      "claude-sonnet-4-6",
-      "default",
-      "worktree",
-      "main",
-      undefined,
-      "/repo/.worktrees/feature-existing",
-      undefined,
-      [],
-      undefined,
-      "claude",
-    );
+    const thread = await service.createAndSend({
+      workspaceId: workspace.id,
+      content: "Work in named worktree",
+      model: "claude-sonnet-4-6",
+      permissionMode: "default",
+      mode: "worktree",
+      branch: "main",
+      existingWorktreePath: "/repo/.worktrees/feature-existing",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(thread).toMatchObject({
       mode: "worktree",
@@ -228,20 +221,18 @@ describe("AgentService.createAndSend existing worktree attach", () => {
     ]);
 
     await expect(
-      service.createAndSend(
-        workspace.id,
-        "Work in detached worktree",
-        "claude-sonnet-4-6",
-        "default",
-        "worktree",
-        "main",
-        undefined,
-        "/repo/.worktrees/branchless-existing",
-        "HEAD",
-        [],
-        undefined,
-        "claude",
-      ),
+      service.createAndSend({
+        workspaceId: workspace.id,
+        content: "Work in detached worktree",
+        model: "claude-sonnet-4-6",
+        permissionMode: "default",
+        mode: "worktree",
+        branch: "main",
+        existingWorktreePath: "/repo/.worktrees/branchless-existing",
+        existingWorktreeBaseBranch: "HEAD",
+        attachments: [],
+        provider: "claude",
+      }),
     ).rejects.toThrow("Base branch cannot be HEAD");
   });
 });

--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -174,12 +174,7 @@ function buildService({
     attachmentService,
     providerRegistry,
     threadService,
-    {
-      bulkCreate: () => {},
-      create: () => ({}),
-      listByMessage: () => [],
-      countByMessage: () => 0,
-    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -188,39 +183,16 @@ function buildService({
     settingsService,
     availability,
     planQuestionAnswersRepo,
-    {
-      create: vi.fn(),
-      updateStatus: vi.fn(),
-      listByThread: vi.fn(() => []),
-      getLatestForThread: vi.fn(() => null),
-      getById: vi.fn(() => null),
-    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-    {
-      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
-    } as any,
-    {
-      issue: vi.fn(),
-      tryConsume: vi.fn(() => false),
-      clear: vi.fn(),
-      hasActiveGrant: vi.fn(() => false),
-    } as any,
-    new NarrativeStore(
-      messageRepo,
-      toolCallRecordRepo,
-      {
-        bulkCreate: () => {},
-        create: () => ({}),
-        listByMessage: () => [],
-        countByMessage: () => 0,
-      } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
-      {
-        bulkCreate: () => {},
-        create: () => ({}),
-        listByMessage: () => [],
-        countByMessage: () => 0,
-      } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
-    ),
-    new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
+      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      new NarrativeStore(
+        messageRepo,
+        toolCallRecordRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+      ),
+      new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
   );
 }
 

--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -174,7 +174,12 @@ function buildService({
     attachmentService,
     providerRegistry,
     threadService,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    {
+      bulkCreate: () => {},
+      create: () => ({}),
+      listByMessage: () => [],
+      countByMessage: () => 0,
+    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -183,16 +188,39 @@ function buildService({
     settingsService,
     availability,
     planQuestionAnswersRepo,
-      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
-      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
-      new NarrativeStore(
-        messageRepo,
-        toolCallRecordRepo,
-        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
-        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
-      ),
-      new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
+    {
+      create: vi.fn(),
+      updateStatus: vi.fn(),
+      listByThread: vi.fn(() => []),
+      getLatestForThread: vi.fn(() => null),
+      getById: vi.fn(() => null),
+    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+    {
+      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
+    } as any,
+    {
+      issue: vi.fn(),
+      tryConsume: vi.fn(() => false),
+      clear: vi.fn(),
+      hasActiveGrant: vi.fn(() => false),
+    } as any,
+    new NarrativeStore(
+      messageRepo,
+      toolCallRecordRepo,
+      {
+        bulkCreate: () => {},
+        create: () => ({}),
+        listByMessage: () => [],
+        countByMessage: () => 0,
+      } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+      {
+        bulkCreate: () => {},
+        create: () => ({}),
+        listByMessage: () => [],
+        countByMessage: () => 0,
+      } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    ),
+    new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
   );
 }
 
@@ -210,15 +238,14 @@ describe("AgentService.sendMessage — provider availability gate", () => {
     const svc = buildService({ assertUsable, resolveProvider });
 
     await expect(
-      svc.sendMessage(
-        THREAD_ID,
-        "Hello",
-        "default",
-        "claude-sonnet-4-6",
-        [],
-        undefined,
-        "codex",
-      ),
+      svc.sendMessage({
+        threadId: THREAD_ID,
+        content: "Hello",
+        permissionMode: "default",
+        model: "claude-sonnet-4-6",
+        attachments: [],
+        provider: "codex",
+      }),
     ).rejects.toThrow(ProviderDisabledError);
 
     // Provider must NOT be resolved — no agent session started

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -2,13 +2,7 @@ import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { container } from "tsyringe";
 import type Database from "better-sqlite3";
-import type {
-  Thread,
-  IProviderRegistry,
-  GoalState,
-  AgentEvent,
-  GoalLookupResult,
-} from "@mcode/contracts";
+import type { Thread, IProviderRegistry, GoalState, AgentEvent, GoalLookupResult } from "@mcode/contracts";
 import { AgentEventType } from "@mcode/contracts";
 import { openMemoryDatabase } from "../../store/database.js";
 import { ThreadRepo } from "../../repositories/thread-repo.js";
@@ -76,12 +70,10 @@ function buildService(db: Database.Database) {
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendTurn: vi.fn<
-      (params: { message: string; [k: string]: unknown }) => Promise<void>
-    >(() => Promise.resolve()),
-    setGoal: vi.fn<(sid: string, condition: string) => GoalState>(
-      (_, condition) => makeGoal(condition),
+    sendTurn: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
+      () => Promise.resolve(),
     ),
+    setGoal: vi.fn<(sid: string, condition: string) => GoalState>((_, condition) => makeGoal(condition)),
     clearGoal: vi.fn<(sid: string) => boolean>(() => true),
     getGoal: vi.fn<(sid: string) => GoalState | undefined>(() => undefined),
     getGoalLookup: vi.fn<(_sid: string) => GoalLookupResult>(() => ({
@@ -91,19 +83,11 @@ function buildService(db: Database.Database) {
       reason: "missing" as const,
     })),
     hasNativeGoalCommand: vi.fn<(sid: string) => boolean>(() => false),
-    setNativeGoalMirror: vi.fn<(sid: string, condition: string) => GoalState>(
-      (_, condition) => makeGoal(condition),
-    ),
+    setNativeGoalMirror: vi.fn<(sid: string, condition: string) => GoalState>((_, condition) => makeGoal(condition)),
     clearNativeGoalMirror: vi.fn<(sid: string) => boolean>(() => true),
-    runNativeGoalCommand: vi.fn<
-      () => Promise<
-        | { kind: "active"; objective: string }
-        | { kind: "cleared"; objective: string }
-        | { kind: "empty" }
-        | { kind: "unavailable" }
-        | null
-      >
-    >(() => Promise.resolve(null)),
+    runNativeGoalCommand: vi.fn<() => Promise<{ kind: "active"; objective: string } | { kind: "cleared"; objective: string } | { kind: "empty" } | { kind: "unavailable" } | null>>(
+      () => Promise.resolve(null),
+    ),
   });
   // A provider lacking the goal capability (no setGoal/clearGoal/getGoal).
   // `/goal` must pass through to this provider as plain text.
@@ -112,14 +96,12 @@ function buildService(db: Database.Database) {
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendTurn: vi.fn<
-      (params: { message: string; [k: string]: unknown }) => Promise<void>
-    >(() => Promise.resolve()),
+    sendTurn: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
+      () => Promise.resolve(),
+    ),
   });
   const providerRegistry = {
-    resolve: vi.fn((id: string) =>
-      id === "claude" ? providerStub : nonGoalStub,
-    ),
+    resolve: vi.fn((id: string) => (id === "claude" ? providerStub : nonGoalStub)),
     resolveAll: vi.fn(() => [providerStub]),
     shutdown: vi.fn(),
   } as unknown as IProviderRegistry;
@@ -141,13 +123,7 @@ function buildService(db: Database.Database) {
   const settingsService = {
     get: vi.fn(() =>
       Promise.resolve({
-        model: {
-          defaults: {
-            fallbackId: undefined,
-            contextWindow: "auto",
-            thinking: false,
-          },
-        },
+        model: { defaults: { fallbackId: undefined, contextWindow: "auto", thinking: false } },
         agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
         provider: { enabled: {}, cli: {} },
       }),
@@ -167,12 +143,7 @@ function buildService(db: Database.Database) {
     attachmentService,
     providerRegistry,
     threadService,
-    {
-      bulkCreate: () => {},
-      create: () => ({}),
-      listByMessage: () => [],
-      countByMessage: () => 0,
-    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -181,34 +152,14 @@ function buildService(db: Database.Database) {
     settingsService,
     availability,
     planQuestionAnswersRepo,
-    {
-      create: vi.fn(),
-      updateStatus: vi.fn(),
-      listByThread: vi.fn(() => []),
-      getLatestForThread: vi.fn(() => null),
-      getById: vi.fn(() => null),
-    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-    {
-      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
-    } as any,
-    {
-      issue: vi.fn(),
-      tryConsume: vi.fn(() => false),
-      clear: vi.fn(),
-      hasActiveGrant: vi.fn(() => false),
-    } as any,
-    container.resolve(NarrativeStore),
-    container.resolve(PlanQuestionService),
+      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      container.resolve(NarrativeStore),
+      container.resolve(PlanQuestionService),
   );
 
-  return {
-    svc,
-    threadRepo,
-    workspaceRepo,
-    messageRepo,
-    providerStub,
-    nonGoalStub,
-  };
+  return { svc, threadRepo, workspaceRepo, messageRepo, providerStub, nonGoalStub };
 }
 
 describe("AgentService.sendMessage — /goal command", () => {
@@ -298,9 +249,7 @@ describe("AgentService.sendMessage — /goal command", () => {
       `mcode-${thread.id}`,
       "analyse this branch",
     );
-    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe(
-      "/goal analyse this branch",
-    );
+    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe("/goal analyse this branch");
   });
 
   it("completes a direct say-goal when the assistant says the requested text", async () => {
@@ -332,42 +281,34 @@ describe("AgentService.sendMessage — /goal command", () => {
       tokens: null,
     } satisfies AgentEvent);
 
-    for (
-      let i = 0;
-      i < 20 && providerStub.clearGoal.mock.calls.length === 0;
-      i++
-    ) {
+    for (let i = 0; i < 20 && providerStub.clearGoal.mock.calls.length === 0; i++) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
-    expect(events).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: AgentEventType.GoalUpdated,
-          threadId: thread.id,
-          goal: expect.objectContaining({
-            objective: "say hi",
-            status: "complete",
-            providerId: "claude",
-            controls: expect.objectContaining({ canClear: false }),
-          }),
-        }),
-        expect.objectContaining({
-          type: AgentEventType.GoalCleared,
-          threadId: thread.id,
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: AgentEventType.GoalUpdated,
+        threadId: thread.id,
+        goal: expect.objectContaining({
+          objective: "say hi",
+          status: "complete",
           providerId: "claude",
-          reason: "completed",
+          controls: expect.objectContaining({ canClear: false }),
         }),
-      ]),
-    );
-    expect(
-      events.some(
-        (event) =>
-          event.type === AgentEventType.Message &&
-          /^Goal achieved in \d+s\.$/.test(event.content),
-      ),
-    ).toBe(false);
+      }),
+      expect.objectContaining({
+        type: AgentEventType.GoalCleared,
+        threadId: thread.id,
+        providerId: "claude",
+        reason: "completed",
+      }),
+    ]));
+    expect(events.some(
+      (event) =>
+        event.type === AgentEventType.Message &&
+        /^Goal achieved in \d+s\.$/.test(event.content),
+    )).toBe(false);
   });
 
   it("does not complete broad goals from an arbitrary assistant answer", async () => {
@@ -428,22 +369,14 @@ describe("AgentService.sendMessage — /goal command", () => {
       tokens: null,
     } satisfies AgentEvent);
 
-    for (
-      let i = 0;
-      i < 20 && providerStub.clearGoal.mock.calls.length === 0;
-      i++
-    ) {
+    for (let i = 0; i < 20 && providerStub.clearGoal.mock.calls.length === 0; i++) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
-    expect(
-      events.some((event) => event.type === AgentEventType.GoalUpdated),
-    ).toBe(false);
-    expect(
-      events.some((event) => event.type === AgentEventType.GoalCleared),
-    ).toBe(false);
+    expect(events.some((event) => event.type === AgentEventType.GoalUpdated)).toBe(false);
+    expect(events.some((event) => event.type === AgentEventType.GoalCleared)).toBe(false);
   });
 
   it("rolls the installed goal back when the send fails so no Stop-hook gate lingers", async () => {
@@ -515,13 +448,11 @@ describe("AgentService.sendMessage — /goal command", () => {
     const calls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls;
     const messageEvents = calls.filter(
       ([channel, payload]) =>
-        channel === "agent.event" &&
-        (payload as { type?: string }).type === AgentEventType.Message,
+        channel === "agent.event" && (payload as { type?: string }).type === AgentEventType.Message,
     );
     const endedEvents = calls.filter(
       ([channel, payload]) =>
-        channel === "agent.event" &&
-        (payload as { type?: string }).type === AgentEventType.Ended,
+        channel === "agent.event" && (payload as { type?: string }).type === AgentEventType.Ended,
     );
     expect(messageEvents.length).toBeGreaterThanOrEqual(1);
     expect(endedEvents.length).toBe(0);
@@ -576,9 +507,7 @@ describe("AgentService.sendMessage — /goal command", () => {
     // received the raw text (no rewrite).
     expect(providerStub.setGoal).not.toHaveBeenCalled();
     expect(nonGoalStub.sendTurn).toHaveBeenCalledTimes(1);
-    expect(nonGoalStub.sendTurn.mock.calls[0][0].message).toBe(
-      "/goal something",
-    );
+    expect(nonGoalStub.sendTurn.mock.calls[0][0].message).toBe("/goal something");
   });
 
   it("persists a Codex goal completion receipt that arrives after TurnComplete", async () => {
@@ -636,9 +565,7 @@ describe("AgentService.sendMessage — /goal command", () => {
     ).rejects.toThrow("already has an active agent session");
 
     expect(providerStub.sendTurn).not.toHaveBeenCalled();
-    expect(messageRepo.listByThread(thread.id, 100).messages).toEqual(
-      beforeMessages,
-    );
+    expect(messageRepo.listByThread(thread.id, 100).messages).toEqual(beforeMessages);
   });
 
   it("rejects concurrent normal sends before either can persist a duplicate row", async () => {
@@ -665,9 +592,7 @@ describe("AgentService.sendMessage — /goal command", () => {
     await first;
 
     expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
-    const contents = messageRepo
-      .listByThread(thread.id, 100)
-      .messages.map((m) => m.content);
+    const contents = messageRepo.listByThread(thread.id, 100).messages.map((m) => m.content);
     expect(contents).toEqual(["first turn"]);
   });
 
@@ -695,13 +620,9 @@ describe("AgentService.sendMessage — /goal command", () => {
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
     expect(providerStub.sendTurn).not.toHaveBeenCalled();
-    const contents = messageRepo
-      .listByThread(thread.id, 100)
-      .messages.map((m) => m.content);
+    const contents = messageRepo.listByThread(thread.id, 100).messages.map((m) => m.content);
     expect(contents).toContain("/goal clear");
-    expect(contents.some((content) => content.includes("Goal cleared"))).toBe(
-      true,
-    );
+    expect(contents.some((content) => content.includes("Goal cleared"))).toBe(true);
   });
 
   it("thread.goal.clear during an active native Claude turn returns busy cache and keeps mirror", async () => {
@@ -760,17 +681,12 @@ describe("AgentService.sendMessage — /goal command", () => {
       source: "claude",
       controls: { canInspect: true, canClear: true },
     };
-    let resolveNativeRead!: (value: {
-      kind: "active";
-      objective: string;
-    }) => void;
+    let resolveNativeRead!: (value: { kind: "active"; objective: string }) => void;
     providerStub.hasNativeGoalCommand.mockReturnValue(true);
     providerStub.getGoal.mockReturnValue(activeGoal);
-    providerStub.runNativeGoalCommand.mockReturnValue(
-      new Promise((resolve) => {
-        resolveNativeRead = resolve;
-      }),
-    );
+    providerStub.runNativeGoalCommand.mockReturnValue(new Promise((resolve) => {
+      resolveNativeRead = resolve;
+    }));
     svc.init();
 
     providerStub.emit("event", {
@@ -782,11 +698,7 @@ describe("AgentService.sendMessage — /goal command", () => {
       tokensOut: 0,
     } satisfies AgentEvent);
 
-    for (
-      let i = 0;
-      i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0;
-      i++
-    ) {
+    for (let i = 0; i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0; i++) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
     providerStub.emit("event", {
@@ -806,20 +718,14 @@ describe("AgentService.sendMessage — /goal command", () => {
   it("idle native thread.goal.clear dispatches /goal off and returns authoritative native clear", async () => {
     const { svc, providerStub } = buildService(db);
     providerStub.hasNativeGoalCommand.mockReturnValue(true);
-    providerStub.runNativeGoalCommand.mockResolvedValue({
-      kind: "cleared",
-      objective: "wait",
-    });
+    providerStub.runNativeGoalCommand.mockResolvedValue({ kind: "cleared", objective: "wait" });
 
     await expect(svc.clearThreadGoal(thread.id)).resolves.toEqual({
       goal: null,
       authoritative: true,
       source: "claude-native-command",
     });
-    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(
-      `mcode-${thread.id}`,
-      "/goal off",
-    );
+    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(`mcode-${thread.id}`, "/goal off");
     expect(providerStub.clearGoal).not.toHaveBeenCalled();
   });
 
@@ -859,30 +765,18 @@ describe("AgentService.sendMessage — /goal command", () => {
       providerId: "claude",
     } satisfies AgentEvent);
 
-    for (
-      let i = 0;
-      i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0;
-      i++
-    ) {
+    for (let i = 0; i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0; i++) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
 
-    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(
-      `mcode-${thread.id}`,
-      "/goal",
-    );
+    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(`mcode-${thread.id}`, "/goal");
     const goalEvents = events.filter(
-      (event) =>
-        event.type === AgentEventType.GoalUpdated ||
-        event.type === AgentEventType.GoalCleared,
+      (event) => event.type === AgentEventType.GoalUpdated || event.type === AgentEventType.GoalCleared,
     );
     expect(goalEvents).toEqual([
       expect.objectContaining({
         type: AgentEventType.GoalUpdated,
-        goal: expect.objectContaining({
-          status: "complete",
-          objective: "say hi",
-        }),
+        goal: expect.objectContaining({ status: "complete", objective: "say hi" }),
       }),
       expect.objectContaining({
         type: AgentEventType.GoalCleared,
@@ -908,12 +802,9 @@ describe("AgentService.sendMessage — /goal command", () => {
     };
     let resolveGoal!: (goal: GoalState) => void;
     providerStub.hasNativeGoalCommand.mockReturnValue(true);
-    providerStub.getGoal.mockImplementation(
-      () =>
-        new Promise<GoalState>((resolve) => {
-          resolveGoal = resolve;
-        }) as unknown as GoalState,
-    );
+    providerStub.getGoal.mockImplementation(() => new Promise<GoalState>((resolve) => {
+      resolveGoal = resolve;
+    }) as unknown as GoalState);
     svc.init();
 
     providerStub.emit("event", {

--- a/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-goal-command.test.ts
@@ -2,7 +2,13 @@ import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { container } from "tsyringe";
 import type Database from "better-sqlite3";
-import type { Thread, IProviderRegistry, GoalState, AgentEvent, GoalLookupResult } from "@mcode/contracts";
+import type {
+  Thread,
+  IProviderRegistry,
+  GoalState,
+  AgentEvent,
+  GoalLookupResult,
+} from "@mcode/contracts";
 import { AgentEventType } from "@mcode/contracts";
 import { openMemoryDatabase } from "../../store/database.js";
 import { ThreadRepo } from "../../repositories/thread-repo.js";
@@ -70,10 +76,12 @@ function buildService(db: Database.Database) {
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendTurn: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
-      () => Promise.resolve(),
+    sendTurn: vi.fn<
+      (params: { message: string; [k: string]: unknown }) => Promise<void>
+    >(() => Promise.resolve()),
+    setGoal: vi.fn<(sid: string, condition: string) => GoalState>(
+      (_, condition) => makeGoal(condition),
     ),
-    setGoal: vi.fn<(sid: string, condition: string) => GoalState>((_, condition) => makeGoal(condition)),
     clearGoal: vi.fn<(sid: string) => boolean>(() => true),
     getGoal: vi.fn<(sid: string) => GoalState | undefined>(() => undefined),
     getGoalLookup: vi.fn<(_sid: string) => GoalLookupResult>(() => ({
@@ -83,11 +91,19 @@ function buildService(db: Database.Database) {
       reason: "missing" as const,
     })),
     hasNativeGoalCommand: vi.fn<(sid: string) => boolean>(() => false),
-    setNativeGoalMirror: vi.fn<(sid: string, condition: string) => GoalState>((_, condition) => makeGoal(condition)),
-    clearNativeGoalMirror: vi.fn<(sid: string) => boolean>(() => true),
-    runNativeGoalCommand: vi.fn<() => Promise<{ kind: "active"; objective: string } | { kind: "cleared"; objective: string } | { kind: "empty" } | { kind: "unavailable" } | null>>(
-      () => Promise.resolve(null),
+    setNativeGoalMirror: vi.fn<(sid: string, condition: string) => GoalState>(
+      (_, condition) => makeGoal(condition),
     ),
+    clearNativeGoalMirror: vi.fn<(sid: string) => boolean>(() => true),
+    runNativeGoalCommand: vi.fn<
+      () => Promise<
+        | { kind: "active"; objective: string }
+        | { kind: "cleared"; objective: string }
+        | { kind: "empty" }
+        | { kind: "unavailable" }
+        | null
+      >
+    >(() => Promise.resolve(null)),
   });
   // A provider lacking the goal capability (no setGoal/clearGoal/getGoal).
   // `/goal` must pass through to this provider as plain text.
@@ -96,12 +112,14 @@ function buildService(db: Database.Database) {
     supportsCompletion: true,
     sessionForkOnResume: "unsupported" as const,
     maxInputCharactersPerTurn: 16_000,
-    sendTurn: vi.fn<(params: { message: string; [k: string]: unknown }) => Promise<void>>(
-      () => Promise.resolve(),
-    ),
+    sendTurn: vi.fn<
+      (params: { message: string; [k: string]: unknown }) => Promise<void>
+    >(() => Promise.resolve()),
   });
   const providerRegistry = {
-    resolve: vi.fn((id: string) => (id === "claude" ? providerStub : nonGoalStub)),
+    resolve: vi.fn((id: string) =>
+      id === "claude" ? providerStub : nonGoalStub,
+    ),
     resolveAll: vi.fn(() => [providerStub]),
     shutdown: vi.fn(),
   } as unknown as IProviderRegistry;
@@ -123,7 +141,13 @@ function buildService(db: Database.Database) {
   const settingsService = {
     get: vi.fn(() =>
       Promise.resolve({
-        model: { defaults: { fallbackId: undefined, contextWindow: "auto", thinking: false } },
+        model: {
+          defaults: {
+            fallbackId: undefined,
+            contextWindow: "auto",
+            thinking: false,
+          },
+        },
         agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
         provider: { enabled: {}, cli: {} },
       }),
@@ -143,7 +167,12 @@ function buildService(db: Database.Database) {
     attachmentService,
     providerRegistry,
     threadService,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    {
+      bulkCreate: () => {},
+      create: () => ({}),
+      listByMessage: () => [],
+      countByMessage: () => 0,
+    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -152,14 +181,34 @@ function buildService(db: Database.Database) {
     settingsService,
     availability,
     planQuestionAnswersRepo,
-      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
-      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
-      container.resolve(NarrativeStore),
-      container.resolve(PlanQuestionService),
+    {
+      create: vi.fn(),
+      updateStatus: vi.fn(),
+      listByThread: vi.fn(() => []),
+      getLatestForThread: vi.fn(() => null),
+      getById: vi.fn(() => null),
+    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+    {
+      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
+    } as any,
+    {
+      issue: vi.fn(),
+      tryConsume: vi.fn(() => false),
+      clear: vi.fn(),
+      hasActiveGrant: vi.fn(() => false),
+    } as any,
+    container.resolve(NarrativeStore),
+    container.resolve(PlanQuestionService),
   );
 
-  return { svc, threadRepo, workspaceRepo, messageRepo, providerStub, nonGoalStub };
+  return {
+    svc,
+    threadRepo,
+    workspaceRepo,
+    messageRepo,
+    providerStub,
+    nonGoalStub,
+  };
 }
 
 describe("AgentService.sendMessage — /goal command", () => {
@@ -177,15 +226,14 @@ describe("AgentService.sendMessage — /goal command", () => {
   it("/goal <condition> installs the goal AND invokes the provider with a directive payload", async () => {
     const { svc, providerStub, messageRepo } = buildService(db);
 
-    await svc.sendMessage(
-      thread.id,
-      "/goal analyse this branch",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "/goal analyse this branch",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     // Goal installed on the matching session id used by ClaudeProvider.
     expect(providerStub.setGoal).toHaveBeenCalledWith(
@@ -210,31 +258,16 @@ describe("AgentService.sendMessage — /goal command", () => {
   it("installs a typed composer goal without persisting slash-command text", async () => {
     const { svc, providerStub, messageRepo } = buildService(db);
 
-    await svc.sendMessage(
-      thread.id,
-      "Analyse this branch",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      [],
-      undefined,
-      "Analyse this branch",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "Analyse this branch",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+      mentions: [],
+      goalObjective: "Analyse this branch",
+    });
 
     expect(providerStub.setGoal).toHaveBeenCalledWith(
       `mcode-${thread.id}`,
@@ -251,22 +284,23 @@ describe("AgentService.sendMessage — /goal command", () => {
     const { svc, providerStub } = buildService(db);
     providerStub.hasNativeGoalCommand.mockReturnValue(true);
 
-    await svc.sendMessage(
-      thread.id,
-      "/goal analyse this branch",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "/goal analyse this branch",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(providerStub.setGoal).not.toHaveBeenCalled();
     expect(providerStub.setNativeGoalMirror).toHaveBeenCalledWith(
       `mcode-${thread.id}`,
       "analyse this branch",
     );
-    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe("/goal analyse this branch");
+    expect(providerStub.sendTurn.mock.calls[0][0].message).toBe(
+      "/goal analyse this branch",
+    );
   });
 
   it("completes a direct say-goal when the assistant says the requested text", async () => {
@@ -298,34 +332,42 @@ describe("AgentService.sendMessage — /goal command", () => {
       tokens: null,
     } satisfies AgentEvent);
 
-    for (let i = 0; i < 20 && providerStub.clearGoal.mock.calls.length === 0; i++) {
+    for (
+      let i = 0;
+      i < 20 && providerStub.clearGoal.mock.calls.length === 0;
+      i++
+    ) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
-    expect(events).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        type: AgentEventType.GoalUpdated,
-        threadId: thread.id,
-        goal: expect.objectContaining({
-          objective: "say hi",
-          status: "complete",
-          providerId: "claude",
-          controls: expect.objectContaining({ canClear: false }),
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AgentEventType.GoalUpdated,
+          threadId: thread.id,
+          goal: expect.objectContaining({
+            objective: "say hi",
+            status: "complete",
+            providerId: "claude",
+            controls: expect.objectContaining({ canClear: false }),
+          }),
         }),
-      }),
-      expect.objectContaining({
-        type: AgentEventType.GoalCleared,
-        threadId: thread.id,
-        providerId: "claude",
-        reason: "completed",
-      }),
-    ]));
-    expect(events.some(
-      (event) =>
-        event.type === AgentEventType.Message &&
-        /^Goal achieved in \d+s\.$/.test(event.content),
-    )).toBe(false);
+        expect.objectContaining({
+          type: AgentEventType.GoalCleared,
+          threadId: thread.id,
+          providerId: "claude",
+          reason: "completed",
+        }),
+      ]),
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.type === AgentEventType.Message &&
+          /^Goal achieved in \d+s\.$/.test(event.content),
+      ),
+    ).toBe(false);
   });
 
   it("does not complete broad goals from an arbitrary assistant answer", async () => {
@@ -386,14 +428,22 @@ describe("AgentService.sendMessage — /goal command", () => {
       tokens: null,
     } satisfies AgentEvent);
 
-    for (let i = 0; i < 20 && providerStub.clearGoal.mock.calls.length === 0; i++) {
+    for (
+      let i = 0;
+      i < 20 && providerStub.clearGoal.mock.calls.length === 0;
+      i++
+    ) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
-    expect(events.some((event) => event.type === AgentEventType.GoalUpdated)).toBe(false);
-    expect(events.some((event) => event.type === AgentEventType.GoalCleared)).toBe(false);
+    expect(
+      events.some((event) => event.type === AgentEventType.GoalUpdated),
+    ).toBe(false);
+    expect(
+      events.some((event) => event.type === AgentEventType.GoalCleared),
+    ).toBe(false);
   });
 
   it("rolls the installed goal back when the send fails so no Stop-hook gate lingers", async () => {
@@ -402,15 +452,14 @@ describe("AgentService.sendMessage — /goal command", () => {
 
     // sendMessage swallows the send failure (emits an error event, marks the
     // thread errored) rather than rejecting, so this resolves normally.
-    await svc.sendMessage(
-      thread.id,
-      "/goal analyse this branch",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "/goal analyse this branch",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     // onDispatch installed the goal just before the failing send...
     expect(providerStub.setGoal).toHaveBeenCalledWith(
@@ -426,15 +475,14 @@ describe("AgentService.sendMessage — /goal command", () => {
     providerStub.hasNativeGoalCommand.mockReturnValue(true);
     providerStub.sendTurn.mockRejectedValueOnce(new Error("provider boom"));
 
-    await svc.sendMessage(
-      thread.id,
-      "/goal clear",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "/goal clear",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(providerStub.sendTurn.mock.calls[0][0].message).toBe("/goal off");
     expect(providerStub.clearNativeGoalMirror).not.toHaveBeenCalled();
@@ -443,15 +491,14 @@ describe("AgentService.sendMessage — /goal command", () => {
   it("/goal clear short-circuits — clears the goal, does NOT invoke the provider, broadcasts a Message pill without Ended", async () => {
     const { svc, providerStub, messageRepo } = buildService(db);
 
-    await svc.sendMessage(
-      thread.id,
-      "/goal clear",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "/goal clear",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
     expect(providerStub.sendTurn).not.toHaveBeenCalled();
@@ -468,11 +515,13 @@ describe("AgentService.sendMessage — /goal command", () => {
     const calls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls;
     const messageEvents = calls.filter(
       ([channel, payload]) =>
-        channel === "agent.event" && (payload as { type?: string }).type === AgentEventType.Message,
+        channel === "agent.event" &&
+        (payload as { type?: string }).type === AgentEventType.Message,
     );
     const endedEvents = calls.filter(
       ([channel, payload]) =>
-        channel === "agent.event" && (payload as { type?: string }).type === AgentEventType.Ended,
+        channel === "agent.event" &&
+        (payload as { type?: string }).type === AgentEventType.Ended,
     );
     expect(messageEvents.length).toBeGreaterThanOrEqual(1);
     expect(endedEvents.length).toBe(0);
@@ -494,15 +543,14 @@ describe("AgentService.sendMessage — /goal command", () => {
       controls: { canInspect: true, canClear: true },
     } satisfies GoalState);
 
-    await svc.sendMessage(
-      thread.id,
-      "/goal",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "/goal",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(providerStub.sendTurn).not.toHaveBeenCalled();
     expect(providerStub.setGoal).not.toHaveBeenCalled();
@@ -515,22 +563,22 @@ describe("AgentService.sendMessage — /goal command", () => {
   it("providers without the goal capability pass /goal through as plain text", async () => {
     const { svc, providerStub, nonGoalStub } = buildService(db);
 
-    await svc.sendMessage(
-      thread.id,
-      "/goal something",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      // A non-goal-capable provider so the capability probe returns passthrough.
-      "gemini",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "/goal something",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "gemini",
+    });
 
     // No goal install on the capable provider, and the non-capable provider
     // received the raw text (no rewrite).
     expect(providerStub.setGoal).not.toHaveBeenCalled();
     expect(nonGoalStub.sendTurn).toHaveBeenCalledTimes(1);
-    expect(nonGoalStub.sendTurn.mock.calls[0][0].message).toBe("/goal something");
+    expect(nonGoalStub.sendTurn.mock.calls[0][0].message).toBe(
+      "/goal something",
+    );
   });
 
   it("persists a Codex goal completion receipt that arrives after TurnComplete", async () => {
@@ -565,93 +613,95 @@ describe("AgentService.sendMessage — /goal command", () => {
   it("rejects a normal send while the thread already has an active turn", async () => {
     const { svc, providerStub, messageRepo } = buildService(db);
 
-    await svc.sendMessage(
-      thread.id,
-      "first turn",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "first turn",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
     const beforeMessages = messageRepo.listByThread(thread.id, 100).messages;
     providerStub.sendTurn.mockClear();
 
     await expect(
-      svc.sendMessage(
-        thread.id,
-        "duplicate turn",
-        "default",
-        "claude-sonnet-4-6",
-        [],
-        undefined,
-        "claude",
-      ),
+      svc.sendMessage({
+        threadId: thread.id,
+        content: "duplicate turn",
+        permissionMode: "default",
+        model: "claude-sonnet-4-6",
+        attachments: [],
+        provider: "claude",
+      }),
     ).rejects.toThrow("already has an active agent session");
 
     expect(providerStub.sendTurn).not.toHaveBeenCalled();
-    expect(messageRepo.listByThread(thread.id, 100).messages).toEqual(beforeMessages);
+    expect(messageRepo.listByThread(thread.id, 100).messages).toEqual(
+      beforeMessages,
+    );
   });
 
   it("rejects concurrent normal sends before either can persist a duplicate row", async () => {
     const { svc, providerStub, messageRepo } = buildService(db);
 
-    const first = svc.sendMessage(
-      thread.id,
-      "first turn",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
-    const second = svc.sendMessage(
-      thread.id,
-      "duplicate turn",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    const first = svc.sendMessage({
+      threadId: thread.id,
+      content: "first turn",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
+    const second = svc.sendMessage({
+      threadId: thread.id,
+      content: "duplicate turn",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     await expect(second).rejects.toThrow("already has an active agent session");
     await first;
 
     expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
-    const contents = messageRepo.listByThread(thread.id, 100).messages.map((m) => m.content);
+    const contents = messageRepo
+      .listByThread(thread.id, 100)
+      .messages.map((m) => m.content);
     expect(contents).toEqual(["first turn"]);
   });
 
   it("still handles /goal clear while the thread already has an active turn", async () => {
     const { svc, providerStub, messageRepo } = buildService(db);
 
-    await svc.sendMessage(
-      thread.id,
-      "first turn",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "first turn",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
     providerStub.sendTurn.mockClear();
 
-    await svc.sendMessage(
-      thread.id,
-      "/goal clear",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "/goal clear",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(providerStub.clearGoal).toHaveBeenCalledWith(`mcode-${thread.id}`);
     expect(providerStub.sendTurn).not.toHaveBeenCalled();
-    const contents = messageRepo.listByThread(thread.id, 100).messages.map((m) => m.content);
+    const contents = messageRepo
+      .listByThread(thread.id, 100)
+      .messages.map((m) => m.content);
     expect(contents).toContain("/goal clear");
-    expect(contents.some((content) => content.includes("Goal cleared"))).toBe(true);
+    expect(contents.some((content) => content.includes("Goal cleared"))).toBe(
+      true,
+    );
   });
 
   it("thread.goal.clear during an active native Claude turn returns busy cache and keeps mirror", async () => {
@@ -676,7 +726,14 @@ describe("AgentService.sendMessage — /goal command", () => {
       source: "claude-cache",
     });
 
-    await svc.sendMessage(thread.id, "first turn", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "first turn",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     await expect(svc.clearThreadGoal(thread.id)).resolves.toEqual({
       goal: activeGoal,
@@ -703,12 +760,17 @@ describe("AgentService.sendMessage — /goal command", () => {
       source: "claude",
       controls: { canInspect: true, canClear: true },
     };
-    let resolveNativeRead!: (value: { kind: "active"; objective: string }) => void;
+    let resolveNativeRead!: (value: {
+      kind: "active";
+      objective: string;
+    }) => void;
     providerStub.hasNativeGoalCommand.mockReturnValue(true);
     providerStub.getGoal.mockReturnValue(activeGoal);
-    providerStub.runNativeGoalCommand.mockReturnValue(new Promise((resolve) => {
-      resolveNativeRead = resolve;
-    }));
+    providerStub.runNativeGoalCommand.mockReturnValue(
+      new Promise((resolve) => {
+        resolveNativeRead = resolve;
+      }),
+    );
     svc.init();
 
     providerStub.emit("event", {
@@ -720,7 +782,11 @@ describe("AgentService.sendMessage — /goal command", () => {
       tokensOut: 0,
     } satisfies AgentEvent);
 
-    for (let i = 0; i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0; i++) {
+    for (
+      let i = 0;
+      i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0;
+      i++
+    ) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
     providerStub.emit("event", {
@@ -740,14 +806,20 @@ describe("AgentService.sendMessage — /goal command", () => {
   it("idle native thread.goal.clear dispatches /goal off and returns authoritative native clear", async () => {
     const { svc, providerStub } = buildService(db);
     providerStub.hasNativeGoalCommand.mockReturnValue(true);
-    providerStub.runNativeGoalCommand.mockResolvedValue({ kind: "cleared", objective: "wait" });
+    providerStub.runNativeGoalCommand.mockResolvedValue({
+      kind: "cleared",
+      objective: "wait",
+    });
 
     await expect(svc.clearThreadGoal(thread.id)).resolves.toEqual({
       goal: null,
       authoritative: true,
       source: "claude-native-command",
     });
-    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(`mcode-${thread.id}`, "/goal off");
+    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(
+      `mcode-${thread.id}`,
+      "/goal off",
+    );
     expect(providerStub.clearGoal).not.toHaveBeenCalled();
   });
 
@@ -787,18 +859,30 @@ describe("AgentService.sendMessage — /goal command", () => {
       providerId: "claude",
     } satisfies AgentEvent);
 
-    for (let i = 0; i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0; i++) {
+    for (
+      let i = 0;
+      i < 20 && providerStub.runNativeGoalCommand.mock.calls.length === 0;
+      i++
+    ) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
 
-    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(`mcode-${thread.id}`, "/goal");
+    expect(providerStub.runNativeGoalCommand).toHaveBeenCalledWith(
+      `mcode-${thread.id}`,
+      "/goal",
+    );
     const goalEvents = events.filter(
-      (event) => event.type === AgentEventType.GoalUpdated || event.type === AgentEventType.GoalCleared,
+      (event) =>
+        event.type === AgentEventType.GoalUpdated ||
+        event.type === AgentEventType.GoalCleared,
     );
     expect(goalEvents).toEqual([
       expect.objectContaining({
         type: AgentEventType.GoalUpdated,
-        goal: expect.objectContaining({ status: "complete", objective: "say hi" }),
+        goal: expect.objectContaining({
+          status: "complete",
+          objective: "say hi",
+        }),
       }),
       expect.objectContaining({
         type: AgentEventType.GoalCleared,
@@ -824,9 +908,12 @@ describe("AgentService.sendMessage — /goal command", () => {
     };
     let resolveGoal!: (goal: GoalState) => void;
     providerStub.hasNativeGoalCommand.mockReturnValue(true);
-    providerStub.getGoal.mockImplementation(() => new Promise<GoalState>((resolve) => {
-      resolveGoal = resolve;
-    }) as unknown as GoalState);
+    providerStub.getGoal.mockImplementation(
+      () =>
+        new Promise<GoalState>((resolve) => {
+          resolveGoal = resolve;
+        }) as unknown as GoalState,
+    );
     svc.init();
 
     providerStub.emit("event", {

--- a/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
@@ -84,7 +84,13 @@ function buildService(db: Database.Database) {
   const settingsService = {
     get: vi.fn(() =>
       Promise.resolve({
-        model: { defaults: { fallbackId: undefined, contextWindow: "auto", thinking: false } },
+        model: {
+          defaults: {
+            fallbackId: undefined,
+            contextWindow: "auto",
+            thinking: false,
+          },
+        },
         agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
         provider: { enabled: {}, cli: {} },
       }),
@@ -104,7 +110,12 @@ function buildService(db: Database.Database) {
     attachmentService,
     providerRegistry,
     threadService,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    {
+      bulkCreate: () => {},
+      create: () => ({}),
+      listByMessage: () => [],
+      countByMessage: () => 0,
+    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -113,14 +124,33 @@ function buildService(db: Database.Database) {
     settingsService,
     availability,
     planQuestionAnswersRepo,
-      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
-      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
-      container.resolve(NarrativeStore),
-      container.resolve(PlanQuestionService),
+    {
+      create: vi.fn(),
+      updateStatus: vi.fn(),
+      listByThread: vi.fn(() => []),
+      getLatestForThread: vi.fn(() => null),
+      getById: vi.fn(() => null),
+    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+    {
+      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
+    } as any,
+    {
+      issue: vi.fn(),
+      tryConsume: vi.fn(() => false),
+      clear: vi.fn(),
+      hasActiveGrant: vi.fn(() => false),
+    } as any,
+    container.resolve(NarrativeStore),
+    container.resolve(PlanQuestionService),
   );
 
-  return { svc, threadRepo, workspaceRepo, messageRepo, planQuestionAnswersRepo };
+  return {
+    svc,
+    threadRepo,
+    workspaceRepo,
+    messageRepo,
+    planQuestionAnswersRepo,
+  };
 }
 
 describe("AgentService.sendMessage — plan-questions answered marker", () => {
@@ -148,21 +178,15 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
     const { svc, planQuestionAnswersRepo } = buildService(db);
 
     await svc.sendMessage(
-      thread.id,
-      "my answers",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-      undefined, // interactionMode
-      undefined, // maxBudgetUsd
-      undefined, // maxTurns
-      undefined, // copilotAgent
-      undefined, // contextWindowMode
-      undefined, // thinking
-      undefined, // codexFastMode
-      assistantMessageId, // markPlanAnswerForMessageId
+      {
+        threadId: thread.id,
+        content: "my answers",
+        permissionMode: "default",
+        model: "claude-sonnet-4-6",
+        attachments: [],
+        provider: "claude",
+        markPlanAnswerForMessageId: assistantMessageId,
+      }, // markPlanAnswerForMessageId
     );
 
     expect(planQuestionAnswersRepo.isAnswered(assistantMessageId)).toBe(true);
@@ -171,17 +195,18 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
   it("does not mark anything when markPlanAnswerForMessageId is unset (regression guard)", async () => {
     const { svc, planQuestionAnswersRepo } = buildService(db);
 
-    await svc.sendMessage(
-      thread.id,
-      "regular message",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "regular message",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
-    expect(planQuestionAnswersRepo.listAnsweredForThread(thread.id)).toEqual([]);
+    expect(planQuestionAnswersRepo.listAnsweredForThread(thread.id)).toEqual(
+      [],
+    );
   });
 
   it("answerQuestions marks the latest plan-questions message answered", async () => {
@@ -207,29 +232,23 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
       ]),
     ).resolves.toBeUndefined();
 
-    expect(planQuestionAnswersRepo.listAnsweredForThread(plainThread.id)).toEqual([]);
+    expect(
+      planQuestionAnswersRepo.listAnsweredForThread(plainThread.id),
+    ).toEqual([]);
   });
 
   it("broadcasts plan.answered after the marker tx commits", async () => {
     const { svc } = buildService(db);
 
-    await svc.sendMessage(
-      thread.id,
-      "my answers",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      assistantMessageId,
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "my answers",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+      markPlanAnswerForMessageId: assistantMessageId,
+    });
 
     expect(broadcast).toHaveBeenCalledWith("plan.answered", {
       threadId: thread.id,
@@ -240,19 +259,18 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
   it("does not broadcast plan.answered when no marker was set", async () => {
     const { svc } = buildService(db);
 
-    await svc.sendMessage(
-      thread.id,
-      "regular message",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "regular message",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
-    const calls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (c) => c[0] === "plan.answered",
-    );
+    const calls = (
+      broadcast as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.filter((c) => c[0] === "plan.answered");
     expect(calls).toEqual([]);
   });
 
@@ -260,28 +278,20 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
     const { svc } = buildService(db);
 
     await expect(
-      svc.sendMessage(
-        thread.id,
-        "answers that should NOT persist",
-        "default",
-        "claude-sonnet-4-6",
-        [],
-        undefined,
-        "claude",
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        "non-existent-message-id",
-      ),
+      svc.sendMessage({
+        threadId: thread.id,
+        content: "answers that should NOT persist",
+        permissionMode: "default",
+        model: "claude-sonnet-4-6",
+        attachments: [],
+        provider: "claude",
+        markPlanAnswerForMessageId: "non-existent-message-id",
+      }),
     ).rejects.toThrow();
 
-    const calls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (c) => c[0] === "plan.answered",
-    );
+    const calls = (
+      broadcast as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.filter((c) => c[0] === "plan.answered");
     expect(calls).toEqual([]);
   });
 
@@ -297,9 +307,9 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
     });
     // Dismiss must NOT broadcast plan.answered — that channel is reserved
     // for submissions and triggers the AnsweredSummary echo on receivers.
-    const answeredCalls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (c) => c[0] === "plan.answered",
-    );
+    const answeredCalls = (
+      broadcast as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.filter((c) => c[0] === "plan.answered");
     expect(answeredCalls).toEqual([]);
   });
 
@@ -317,13 +327,21 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
   it("dismissPlanQuestions is a no-op when the thread has no plan-questions fence", () => {
     const { svc, workspaceRepo, threadRepo, planQuestionAnswersRepo } =
       buildService(db);
-    const ws2 = workspaceRepo.create("dismiss-ws", `${process.cwd()}#dismiss`, false);
+    const ws2 = workspaceRepo.create(
+      "dismiss-ws",
+      `${process.cwd()}#dismiss`,
+      false,
+    );
     const plainThread = threadRepo.create(ws2.id, "plain", "direct", "main");
 
     svc.dismissPlanQuestions(plainThread.id);
 
-    expect(planQuestionAnswersRepo.listAnsweredForThread(plainThread.id)).toEqual([]);
-    const calls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+    expect(
+      planQuestionAnswersRepo.listAnsweredForThread(plainThread.id),
+    ).toEqual([]);
+    const calls = (
+      broadcast as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.filter(
       (c) =>
         (c[0] === "plan.dismissed" || c[0] === "plan.answered") &&
         (c[1] as { threadId: string }).threadId === plainThread.id,
@@ -333,34 +351,27 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
 
   it("rolls back the user message when the marker insert fails (FK violation)", async () => {
     const { svc, messageRepo, planQuestionAnswersRepo } = buildService(db);
-    const beforeCount =
-      messageRepo.listByThread(thread.id, 100).messages.length;
+    const beforeCount = messageRepo.listByThread(thread.id, 100).messages
+      .length;
 
     // Pass an unknown message id so the FK rejects the marker insert.
     // The user-message INSERT must roll back as part of the same transaction.
     await expect(
-      svc.sendMessage(
-        thread.id,
-        "answers that should NOT persist",
-        "default",
-        "claude-sonnet-4-6",
-        [],
-        undefined,
-        "claude",
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        "non-existent-message-id",
-      ),
+      svc.sendMessage({
+        threadId: thread.id,
+        content: "answers that should NOT persist",
+        permissionMode: "default",
+        model: "claude-sonnet-4-6",
+        attachments: [],
+        provider: "claude",
+        markPlanAnswerForMessageId: "non-existent-message-id",
+      }),
     ).rejects.toThrow();
 
-    const afterCount =
-      messageRepo.listByThread(thread.id, 100).messages.length;
+    const afterCount = messageRepo.listByThread(thread.id, 100).messages.length;
     expect(afterCount).toBe(beforeCount);
-    expect(planQuestionAnswersRepo.listAnsweredForThread(thread.id)).toEqual([]);
+    expect(planQuestionAnswersRepo.listAnsweredForThread(thread.id)).toEqual(
+      [],
+    );
   });
 });

--- a/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-plan-marker.test.ts
@@ -84,13 +84,7 @@ function buildService(db: Database.Database) {
   const settingsService = {
     get: vi.fn(() =>
       Promise.resolve({
-        model: {
-          defaults: {
-            fallbackId: undefined,
-            contextWindow: "auto",
-            thinking: false,
-          },
-        },
+        model: { defaults: { fallbackId: undefined, contextWindow: "auto", thinking: false } },
         agent: { guardrails: { maxBudgetUsd: 0, maxTurns: 0 } },
         provider: { enabled: {}, cli: {} },
       }),
@@ -110,12 +104,7 @@ function buildService(db: Database.Database) {
     attachmentService,
     providerRegistry,
     threadService,
-    {
-      bulkCreate: () => {},
-      create: () => ({}),
-      listByMessage: () => [],
-      countByMessage: () => 0,
-    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -124,33 +113,14 @@ function buildService(db: Database.Database) {
     settingsService,
     availability,
     planQuestionAnswersRepo,
-    {
-      create: vi.fn(),
-      updateStatus: vi.fn(),
-      listByThread: vi.fn(() => []),
-      getLatestForThread: vi.fn(() => null),
-      getById: vi.fn(() => null),
-    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-    {
-      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
-    } as any,
-    {
-      issue: vi.fn(),
-      tryConsume: vi.fn(() => false),
-      clear: vi.fn(),
-      hasActiveGrant: vi.fn(() => false),
-    } as any,
-    container.resolve(NarrativeStore),
-    container.resolve(PlanQuestionService),
+      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      container.resolve(NarrativeStore),
+      container.resolve(PlanQuestionService),
   );
 
-  return {
-    svc,
-    threadRepo,
-    workspaceRepo,
-    messageRepo,
-    planQuestionAnswersRepo,
-  };
+  return { svc, threadRepo, workspaceRepo, messageRepo, planQuestionAnswersRepo };
 }
 
 describe("AgentService.sendMessage — plan-questions answered marker", () => {
@@ -177,17 +147,15 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
   it("marks the plan-questions message answered when markPlanAnswerForMessageId is set", async () => {
     const { svc, planQuestionAnswersRepo } = buildService(db);
 
-    await svc.sendMessage(
-      {
-        threadId: thread.id,
-        content: "my answers",
-        permissionMode: "default",
-        model: "claude-sonnet-4-6",
-        attachments: [],
-        provider: "claude",
-        markPlanAnswerForMessageId: assistantMessageId,
-      }, // markPlanAnswerForMessageId
-    );
+    await svc.sendMessage({
+      threadId: thread.id,
+      content: "my answers",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+      markPlanAnswerForMessageId: assistantMessageId,
+    });
 
     expect(planQuestionAnswersRepo.isAnswered(assistantMessageId)).toBe(true);
   });
@@ -204,9 +172,7 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
       provider: "claude",
     });
 
-    expect(planQuestionAnswersRepo.listAnsweredForThread(thread.id)).toEqual(
-      [],
-    );
+    expect(planQuestionAnswersRepo.listAnsweredForThread(thread.id)).toEqual([]);
   });
 
   it("answerQuestions marks the latest plan-questions message answered", async () => {
@@ -232,9 +198,7 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
       ]),
     ).resolves.toBeUndefined();
 
-    expect(
-      planQuestionAnswersRepo.listAnsweredForThread(plainThread.id),
-    ).toEqual([]);
+    expect(planQuestionAnswersRepo.listAnsweredForThread(plainThread.id)).toEqual([]);
   });
 
   it("broadcasts plan.answered after the marker tx commits", async () => {
@@ -268,9 +232,9 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
       provider: "claude",
     });
 
-    const calls = (
-      broadcast as unknown as ReturnType<typeof vi.fn>
-    ).mock.calls.filter((c) => c[0] === "plan.answered");
+    const calls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[0] === "plan.answered",
+    );
     expect(calls).toEqual([]);
   });
 
@@ -289,9 +253,9 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
       }),
     ).rejects.toThrow();
 
-    const calls = (
-      broadcast as unknown as ReturnType<typeof vi.fn>
-    ).mock.calls.filter((c) => c[0] === "plan.answered");
+    const calls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[0] === "plan.answered",
+    );
     expect(calls).toEqual([]);
   });
 
@@ -307,9 +271,9 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
     });
     // Dismiss must NOT broadcast plan.answered — that channel is reserved
     // for submissions and triggers the AnsweredSummary echo on receivers.
-    const answeredCalls = (
-      broadcast as unknown as ReturnType<typeof vi.fn>
-    ).mock.calls.filter((c) => c[0] === "plan.answered");
+    const answeredCalls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[0] === "plan.answered",
+    );
     expect(answeredCalls).toEqual([]);
   });
 
@@ -327,21 +291,13 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
   it("dismissPlanQuestions is a no-op when the thread has no plan-questions fence", () => {
     const { svc, workspaceRepo, threadRepo, planQuestionAnswersRepo } =
       buildService(db);
-    const ws2 = workspaceRepo.create(
-      "dismiss-ws",
-      `${process.cwd()}#dismiss`,
-      false,
-    );
+    const ws2 = workspaceRepo.create("dismiss-ws", `${process.cwd()}#dismiss`, false);
     const plainThread = threadRepo.create(ws2.id, "plain", "direct", "main");
 
     svc.dismissPlanQuestions(plainThread.id);
 
-    expect(
-      planQuestionAnswersRepo.listAnsweredForThread(plainThread.id),
-    ).toEqual([]);
-    const calls = (
-      broadcast as unknown as ReturnType<typeof vi.fn>
-    ).mock.calls.filter(
+    expect(planQuestionAnswersRepo.listAnsweredForThread(plainThread.id)).toEqual([]);
+    const calls = (broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
       (c) =>
         (c[0] === "plan.dismissed" || c[0] === "plan.answered") &&
         (c[1] as { threadId: string }).threadId === plainThread.id,
@@ -351,8 +307,8 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
 
   it("rolls back the user message when the marker insert fails (FK violation)", async () => {
     const { svc, messageRepo, planQuestionAnswersRepo } = buildService(db);
-    const beforeCount = messageRepo.listByThread(thread.id, 100).messages
-      .length;
+    const beforeCount =
+      messageRepo.listByThread(thread.id, 100).messages.length;
 
     // Pass an unknown message id so the FK rejects the marker insert.
     // The user-message INSERT must roll back as part of the same transaction.
@@ -368,10 +324,9 @@ describe("AgentService.sendMessage — plan-questions answered marker", () => {
       }),
     ).rejects.toThrow();
 
-    const afterCount = messageRepo.listByThread(thread.id, 100).messages.length;
+    const afterCount =
+      messageRepo.listByThread(thread.id, 100).messages.length;
     expect(afterCount).toBe(beforeCount);
-    expect(planQuestionAnswersRepo.listAnsweredForThread(thread.id)).toEqual(
-      [],
-    );
+    expect(planQuestionAnswersRepo.listAnsweredForThread(thread.id)).toEqual([]);
   });
 });

--- a/apps/server/src/services/__tests__/agent-service-transient-retry.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-transient-retry.test.ts
@@ -69,19 +69,28 @@ function buildService(): {
   discardSession: ReturnType<typeof vi.fn>;
   waitForSessionExit: ReturnType<typeof vi.fn>;
   providerEmitter: EventEmitter;
-  threadRepo: ThreadRepo & { clearSdkSessionId: ReturnType<typeof vi.fn>; updateStatus: ReturnType<typeof vi.fn> };
+  threadRepo: ThreadRepo & {
+    clearSdkSessionId: ReturnType<typeof vi.fn>;
+    updateStatus: ReturnType<typeof vi.fn>;
+  };
 } {
   const thread = makeThread();
   const providerEmitter = new EventEmitter();
   const sendTurn = vi.fn(() => Promise.resolve());
-  (providerEmitter as unknown as { sendTurn: typeof sendTurn }).sendTurn = sendTurn;
+  (providerEmitter as unknown as { sendTurn: typeof sendTurn }).sendTurn =
+    sendTurn;
   // Implementing discardSession makes the fake provider ISessionEvictable, so
   // the retry path force-evicts the pooled session before re-dispatch.
   const discardSession = vi.fn();
   const waitForSessionExit = vi.fn().mockResolvedValue(undefined);
-  (providerEmitter as unknown as { discardSession: typeof discardSession }).discardSession = discardSession;
-  (providerEmitter as unknown as { waitForSessionExit: typeof waitForSessionExit }).waitForSessionExit =
-    waitForSessionExit;
+  (
+    providerEmitter as unknown as { discardSession: typeof discardSession }
+  ).discardSession = discardSession;
+  (
+    providerEmitter as unknown as {
+      waitForSessionExit: typeof waitForSessionExit;
+    }
+  ).waitForSessionExit = waitForSessionExit;
 
   const threadRepo = {
     findById: vi.fn(() => thread),
@@ -97,7 +106,10 @@ function buildService(): {
     clearSdkSessionId: vi.fn(),
     updateCompactSummary: vi.fn(),
     updateLineage: vi.fn(),
-  } as unknown as ThreadRepo & { clearSdkSessionId: ReturnType<typeof vi.fn>; updateStatus: ReturnType<typeof vi.fn> };
+  } as unknown as ThreadRepo & {
+    clearSdkSessionId: ReturnType<typeof vi.fn>;
+    updateStatus: ReturnType<typeof vi.fn>;
+  };
 
   const workspaceRepo = {
     findById: vi.fn(() => ({ id: "ws-1", path: "/workspace" })),
@@ -105,7 +117,9 @@ function buildService(): {
 
   // A prior message means nextSeq > 1, so the first attempt is a resume.
   const messageRepo = {
-    listByThread: vi.fn(() => ({ messages: [{ id: "m0", sequence: 1, role: "user", content: "prev" }] })),
+    listByThread: vi.fn(() => ({
+      messages: [{ id: "m0", sequence: 1, role: "user", content: "prev" }],
+    })),
     create: vi.fn(() => ({ id: "msg-1", sequence: 2 })),
     findByIdInThread: vi.fn(),
     listByThreadUpToSequence: vi.fn(() => []),
@@ -127,7 +141,9 @@ function buildService(): {
   } as unknown as IProviderRegistry;
 
   const threadService = { create: vi.fn() } as unknown as ThreadService;
-  const toolCallRecordRepo = { bulkCreate: vi.fn() } as unknown as ToolCallRecordRepo;
+  const toolCallRecordRepo = {
+    bulkCreate: vi.fn(),
+  } as unknown as ToolCallRecordRepo;
   const turnSnapshotRepo = {
     listByThread: vi.fn(() => []),
     create: vi.fn(),
@@ -142,7 +158,10 @@ function buildService(): {
     assertCanStartTurn: vi.fn(),
     onPressureChange: vi.fn(),
   } as unknown as MemoryPressureService;
-  const taskRepo = { get: vi.fn(() => []), upsert: vi.fn() } as unknown as TaskRepo;
+  const taskRepo = {
+    get: vi.fn(() => []),
+    upsert: vi.fn(),
+  } as unknown as TaskRepo;
   const settingsService = {
     get: vi.fn(() => ({
       model: { defaults: { fallbackId: undefined } },
@@ -151,7 +170,9 @@ function buildService(): {
     })),
     on: vi.fn(),
   } as unknown as SettingsService;
-  const availability = { assertUsable: vi.fn() } as unknown as ProviderAvailabilityService;
+  const availability = {
+    assertUsable: vi.fn(),
+  } as unknown as ProviderAvailabilityService;
   const planQuestionAnswersRepo = {
     markAnswered: vi.fn(),
     isAnswered: vi.fn(() => false),
@@ -170,7 +191,12 @@ function buildService(): {
     attachmentService,
     providerRegistry,
     threadService,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    {
+      bulkCreate: () => {},
+      create: () => ({}),
+      listByMessage: () => [],
+      countByMessage: () => 0,
+    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -179,19 +205,49 @@ function buildService(): {
     settingsService,
     availability,
     planQuestionAnswersRepo,
-    { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-    { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as never,
-    { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as never,
+    {
+      create: vi.fn(),
+      updateStatus: vi.fn(),
+      listByThread: vi.fn(() => []),
+      getLatestForThread: vi.fn(() => null),
+      getById: vi.fn(() => null),
+    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+    {
+      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
+    } as never,
+    {
+      issue: vi.fn(),
+      tryConsume: vi.fn(() => false),
+      clear: vi.fn(),
+      hasActiveGrant: vi.fn(() => false),
+    } as never,
     new NarrativeStore(
       messageRepo,
       toolCallRecordRepo,
-      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
-      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+      {
+        bulkCreate: () => {},
+        create: () => ({}),
+        listByMessage: () => [],
+        countByMessage: () => 0,
+      } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+      {
+        bulkCreate: () => {},
+        create: () => ({}),
+        listByMessage: () => [],
+        countByMessage: () => 0,
+      } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     ),
     new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
   );
 
-  return { service, sendTurn, discardSession, waitForSessionExit, providerEmitter, threadRepo };
+  return {
+    service,
+    sendTurn,
+    discardSession,
+    waitForSessionExit,
+    providerEmitter,
+    threadRepo,
+  };
 }
 
 describe("AgentService transient-failure auto-retry", () => {
@@ -206,17 +262,31 @@ describe("AgentService transient-failure auto-retry", () => {
       .mockRejectedValueOnce(new Error("read ECONNRESET"))
       .mockResolvedValueOnce(undefined);
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(sendTurn).toHaveBeenCalledTimes(2);
     // First attempt resumes the live session; the retry must drop it for a fresh spawn.
-    expect((sendTurn.mock.calls[0][0] as TurnRequest).resumeFrom).toBe("sess-abc");
-    expect((sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom).toBeUndefined();
+    expect((sendTurn.mock.calls[0][0] as TurnRequest).resumeFrom).toBe(
+      "sess-abc",
+    );
+    expect(
+      (sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom,
+    ).toBeUndefined();
     // Dropping resumeFrom is not enough: the provider pools a warm session by
     // sessionName, so the retry must also force-evict it to truly spawn fresh.
     expect(discardSession).toHaveBeenCalledWith(`mcode-${THREAD_ID}`);
     expect(threadRepo.clearSdkSessionId).toHaveBeenCalledWith(THREAD_ID);
-    expect(threadRepo.updateStatus).not.toHaveBeenCalledWith(THREAD_ID, "errored");
+    expect(threadRepo.updateStatus).not.toHaveBeenCalledWith(
+      THREAD_ID,
+      "errored",
+    );
   });
 
   it("does not retry a fatal send failure", async () => {
@@ -224,7 +294,14 @@ describe("AgentService transient-failure auto-retry", () => {
     service.init();
     sendTurn.mockRejectedValue(new Error("permission denied"));
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(sendTurn).toHaveBeenCalledTimes(1);
     expect(discardSession).not.toHaveBeenCalled();
@@ -242,21 +319,46 @@ describe("AgentService transient-failure auto-retry", () => {
     let fatalSuppressedDuringAttempt: boolean | undefined;
     sendTurn
       .mockImplementationOnce(() => {
-        transientSuppressedDuringAttempt = service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET");
-        fatalSuppressedDuringAttempt = service.shouldSuppressTransientTurnError(THREAD_ID, "permission denied");
+        transientSuppressedDuringAttempt =
+          service.shouldSuppressTransientTurnError(
+            THREAD_ID,
+            "read ECONNRESET",
+          );
+        fatalSuppressedDuringAttempt = service.shouldSuppressTransientTurnError(
+          THREAD_ID,
+          "permission denied",
+        );
         return Promise.reject(new Error("read ECONNRESET"));
       })
       .mockResolvedValueOnce(undefined);
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     // During the retried attempt: a transient error is swallowed, a fatal one is not.
     expect(transientSuppressedDuringAttempt).toBe(true);
     expect(fatalSuppressedDuringAttempt).toBe(false);
     // Fire-and-forget providers keep the window armed until TurnComplete.
-    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(true);
-    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
-    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(false);
+    expect(
+      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
+    ).toBe(true);
+    providerEmitter.emit("event", {
+      type: "turnComplete",
+      threadId: THREAD_ID,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 0,
+      tokensOut: 0,
+    });
+    expect(
+      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
+    ).toBe(false);
   });
 
   it("swallows the failed attempt's trailing Ended so the UI's running state survives the retry", async () => {
@@ -275,16 +377,31 @@ describe("AgentService transient-failure auto-retry", () => {
           threadId: THREAD_ID,
           error: "read ECONNRESET",
         });
-        endedSuppressedDuringAttempt = service.shouldSuppressTurnEnded(THREAD_ID);
+        endedSuppressedDuringAttempt =
+          service.shouldSuppressTurnEnded(THREAD_ID);
         return Promise.reject(new Error("read ECONNRESET"));
       })
       .mockResolvedValueOnce(undefined);
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     // The trailing Ended was armed for suppression during the failed attempt...
     expect(endedSuppressedDuringAttempt).toBe(true);
-    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
+    providerEmitter.emit("event", {
+      type: "turnComplete",
+      threadId: THREAD_ID,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 0,
+      tokensOut: 0,
+    });
     expect(service.shouldSuppressTurnEnded(THREAD_ID)).toBe(false);
   });
 
@@ -303,7 +420,14 @@ describe("AgentService transient-failure auto-retry", () => {
       return Promise.reject(new Error("permission denied"));
     });
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     // A fatal error is not part of a retry window, so its Ended must reach the UI.
     expect(endedSuppressedDuringAttempt).toBe(false);
@@ -315,14 +439,29 @@ describe("AgentService transient-failure auto-retry", () => {
     service.init();
     sendTurn.mockRejectedValue(new Error("read ECONNRESET"));
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     // Give-up disarms the retry window so the terminal error is visible.
-    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(false);
+    expect(
+      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
+    ).toBe(false);
   });
 
   it("swallows discardSession's trailing Ended when sendTurn rejects without emitting Error", async () => {
-    const { service, sendTurn, discardSession, waitForSessionExit, providerEmitter } = buildService();
+    const {
+      service,
+      sendTurn,
+      discardSession,
+      waitForSessionExit,
+      providerEmitter,
+    } = buildService();
     service.init();
 
     let endedSuppressedWhenDiscardUnwinds: boolean | undefined;
@@ -330,7 +469,8 @@ describe("AgentService transient-failure auto-retry", () => {
     // subprocess and emits Ended on the next tick while the retry catch runs.
     discardSession.mockImplementation(() => {
       queueMicrotask(() => {
-        endedSuppressedWhenDiscardUnwinds = service.shouldSuppressTurnEnded(THREAD_ID);
+        endedSuppressedWhenDiscardUnwinds =
+          service.shouldSuppressTurnEnded(THREAD_ID);
         providerEmitter.emit("event", { type: "ended", threadId: THREAD_ID });
       });
     });
@@ -341,12 +481,26 @@ describe("AgentService transient-failure auto-retry", () => {
       .mockRejectedValueOnce(new Error("spawn claude EAGAIN"))
       .mockResolvedValueOnce(undefined);
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(discardSession).toHaveBeenCalledWith(`mcode-${THREAD_ID}`);
     expect(waitForSessionExit).toHaveBeenCalledWith(`mcode-${THREAD_ID}`, 5000);
     expect(endedSuppressedWhenDiscardUnwinds).toBe(true);
-    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
+    providerEmitter.emit("event", {
+      type: "turnComplete",
+      threadId: THREAD_ID,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 0,
+      tokensOut: 0,
+    });
     expect(service.shouldSuppressTurnEnded(THREAD_ID)).toBe(false);
   });
 
@@ -356,20 +510,15 @@ describe("AgentService transient-failure auto-retry", () => {
 
     sendTurn.mockResolvedValueOnce(undefined);
 
-    await service.sendMessage(
-      THREAD_ID,
-      "hello",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "1m",
-    );
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+      contextWindow: "1m",
+    });
 
     // A bare `Ended` with no in-flight transient retry means the stream
     // genuinely ended; it must reach the cleanup path even though the
@@ -385,15 +534,26 @@ describe("AgentService transient-failure auto-retry", () => {
     sendTurn.mockResolvedValueOnce(undefined);
 
     // Fire-and-forget send leaves the retry window armed until TurnComplete.
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
-    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(true);
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
+    expect(
+      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
+    ).toBe(true);
 
     // A user stop ends the turn via finalize; it must tear down the armed
     // window so a scheduled stream retry can't re-dispatch after the stop and
     // the suppression flags don't outlive into the next turn.
     await service.stopSession(THREAD_ID);
 
-    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(false);
+    expect(
+      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
+    ).toBe(false);
   });
 
   it("retries when sendTurn resolves early then a transient stream Error arrives", async () => {
@@ -406,7 +566,14 @@ describe("AgentService transient-failure auto-retry", () => {
       })
       .mockResolvedValueOnce(undefined);
 
-    const sendPromise = service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    const sendPromise = service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
     await sendPromise;
 
     providerEmitter.emit("event", {
@@ -417,7 +584,9 @@ describe("AgentService transient-failure auto-retry", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(sendTurn).toHaveBeenCalledTimes(2);
-    expect((sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom).toBeUndefined();
+    expect(
+      (sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom,
+    ).toBeUndefined();
   });
 
   it("swallows a failed attempt's TurnComplete during the retry window", async () => {
@@ -440,15 +609,30 @@ describe("AgentService transient-failure auto-retry", () => {
           tokensIn: 0,
           tokensOut: 0,
         });
-        turnCompleteSuppressedDuringAttempt = service.shouldSuppressTurnComplete(THREAD_ID);
+        turnCompleteSuppressedDuringAttempt =
+          service.shouldSuppressTurnComplete(THREAD_ID);
         return Promise.reject(new Error("read ECONNRESET"));
       })
       .mockResolvedValueOnce(undefined);
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(turnCompleteSuppressedDuringAttempt).toBe(true);
-    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
+    providerEmitter.emit("event", {
+      type: "turnComplete",
+      threadId: THREAD_ID,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 0,
+      tokensOut: 0,
+    });
     expect(service.shouldSuppressTurnComplete(THREAD_ID)).toBe(false);
   });
 
@@ -457,7 +641,14 @@ describe("AgentService transient-failure auto-retry", () => {
     service.init();
     sendTurn.mockRejectedValue(new Error("read ECONNRESET"));
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     // Cap is 2: one original attempt plus one retry, then it gives up.
     expect(sendTurn).toHaveBeenCalledTimes(2);

--- a/apps/server/src/services/__tests__/agent-service-transient-retry.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-transient-retry.test.ts
@@ -69,28 +69,19 @@ function buildService(): {
   discardSession: ReturnType<typeof vi.fn>;
   waitForSessionExit: ReturnType<typeof vi.fn>;
   providerEmitter: EventEmitter;
-  threadRepo: ThreadRepo & {
-    clearSdkSessionId: ReturnType<typeof vi.fn>;
-    updateStatus: ReturnType<typeof vi.fn>;
-  };
+  threadRepo: ThreadRepo & { clearSdkSessionId: ReturnType<typeof vi.fn>; updateStatus: ReturnType<typeof vi.fn> };
 } {
   const thread = makeThread();
   const providerEmitter = new EventEmitter();
   const sendTurn = vi.fn(() => Promise.resolve());
-  (providerEmitter as unknown as { sendTurn: typeof sendTurn }).sendTurn =
-    sendTurn;
+  (providerEmitter as unknown as { sendTurn: typeof sendTurn }).sendTurn = sendTurn;
   // Implementing discardSession makes the fake provider ISessionEvictable, so
   // the retry path force-evicts the pooled session before re-dispatch.
   const discardSession = vi.fn();
   const waitForSessionExit = vi.fn().mockResolvedValue(undefined);
-  (
-    providerEmitter as unknown as { discardSession: typeof discardSession }
-  ).discardSession = discardSession;
-  (
-    providerEmitter as unknown as {
-      waitForSessionExit: typeof waitForSessionExit;
-    }
-  ).waitForSessionExit = waitForSessionExit;
+  (providerEmitter as unknown as { discardSession: typeof discardSession }).discardSession = discardSession;
+  (providerEmitter as unknown as { waitForSessionExit: typeof waitForSessionExit }).waitForSessionExit =
+    waitForSessionExit;
 
   const threadRepo = {
     findById: vi.fn(() => thread),
@@ -106,10 +97,7 @@ function buildService(): {
     clearSdkSessionId: vi.fn(),
     updateCompactSummary: vi.fn(),
     updateLineage: vi.fn(),
-  } as unknown as ThreadRepo & {
-    clearSdkSessionId: ReturnType<typeof vi.fn>;
-    updateStatus: ReturnType<typeof vi.fn>;
-  };
+  } as unknown as ThreadRepo & { clearSdkSessionId: ReturnType<typeof vi.fn>; updateStatus: ReturnType<typeof vi.fn> };
 
   const workspaceRepo = {
     findById: vi.fn(() => ({ id: "ws-1", path: "/workspace" })),
@@ -117,9 +105,7 @@ function buildService(): {
 
   // A prior message means nextSeq > 1, so the first attempt is a resume.
   const messageRepo = {
-    listByThread: vi.fn(() => ({
-      messages: [{ id: "m0", sequence: 1, role: "user", content: "prev" }],
-    })),
+    listByThread: vi.fn(() => ({ messages: [{ id: "m0", sequence: 1, role: "user", content: "prev" }] })),
     create: vi.fn(() => ({ id: "msg-1", sequence: 2 })),
     findByIdInThread: vi.fn(),
     listByThreadUpToSequence: vi.fn(() => []),
@@ -141,9 +127,7 @@ function buildService(): {
   } as unknown as IProviderRegistry;
 
   const threadService = { create: vi.fn() } as unknown as ThreadService;
-  const toolCallRecordRepo = {
-    bulkCreate: vi.fn(),
-  } as unknown as ToolCallRecordRepo;
+  const toolCallRecordRepo = { bulkCreate: vi.fn() } as unknown as ToolCallRecordRepo;
   const turnSnapshotRepo = {
     listByThread: vi.fn(() => []),
     create: vi.fn(),
@@ -158,10 +142,7 @@ function buildService(): {
     assertCanStartTurn: vi.fn(),
     onPressureChange: vi.fn(),
   } as unknown as MemoryPressureService;
-  const taskRepo = {
-    get: vi.fn(() => []),
-    upsert: vi.fn(),
-  } as unknown as TaskRepo;
+  const taskRepo = { get: vi.fn(() => []), upsert: vi.fn() } as unknown as TaskRepo;
   const settingsService = {
     get: vi.fn(() => ({
       model: { defaults: { fallbackId: undefined } },
@@ -170,9 +151,7 @@ function buildService(): {
     })),
     on: vi.fn(),
   } as unknown as SettingsService;
-  const availability = {
-    assertUsable: vi.fn(),
-  } as unknown as ProviderAvailabilityService;
+  const availability = { assertUsable: vi.fn() } as unknown as ProviderAvailabilityService;
   const planQuestionAnswersRepo = {
     markAnswered: vi.fn(),
     isAnswered: vi.fn(() => false),
@@ -191,12 +170,7 @@ function buildService(): {
     attachmentService,
     providerRegistry,
     threadService,
-    {
-      bulkCreate: () => {},
-      create: () => ({}),
-      listByMessage: () => [],
-      countByMessage: () => 0,
-    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -205,49 +179,19 @@ function buildService(): {
     settingsService,
     availability,
     planQuestionAnswersRepo,
-    {
-      create: vi.fn(),
-      updateStatus: vi.fn(),
-      listByThread: vi.fn(() => []),
-      getLatestForThread: vi.fn(() => null),
-      getById: vi.fn(() => null),
-    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-    {
-      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
-    } as never,
-    {
-      issue: vi.fn(),
-      tryConsume: vi.fn(() => false),
-      clear: vi.fn(),
-      hasActiveGrant: vi.fn(() => false),
-    } as never,
+    { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+    { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as never,
+    { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as never,
     new NarrativeStore(
       messageRepo,
       toolCallRecordRepo,
-      {
-        bulkCreate: () => {},
-        create: () => ({}),
-        listByMessage: () => [],
-        countByMessage: () => 0,
-      } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
-      {
-        bulkCreate: () => {},
-        create: () => ({}),
-        listByMessage: () => [],
-        countByMessage: () => 0,
-      } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+      { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     ),
     new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
   );
 
-  return {
-    service,
-    sendTurn,
-    discardSession,
-    waitForSessionExit,
-    providerEmitter,
-    threadRepo,
-  };
+  return { service, sendTurn, discardSession, waitForSessionExit, providerEmitter, threadRepo };
 }
 
 describe("AgentService transient-failure auto-retry", () => {
@@ -273,20 +217,13 @@ describe("AgentService transient-failure auto-retry", () => {
 
     expect(sendTurn).toHaveBeenCalledTimes(2);
     // First attempt resumes the live session; the retry must drop it for a fresh spawn.
-    expect((sendTurn.mock.calls[0][0] as TurnRequest).resumeFrom).toBe(
-      "sess-abc",
-    );
-    expect(
-      (sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom,
-    ).toBeUndefined();
+    expect((sendTurn.mock.calls[0][0] as TurnRequest).resumeFrom).toBe("sess-abc");
+    expect((sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom).toBeUndefined();
     // Dropping resumeFrom is not enough: the provider pools a warm session by
     // sessionName, so the retry must also force-evict it to truly spawn fresh.
     expect(discardSession).toHaveBeenCalledWith(`mcode-${THREAD_ID}`);
     expect(threadRepo.clearSdkSessionId).toHaveBeenCalledWith(THREAD_ID);
-    expect(threadRepo.updateStatus).not.toHaveBeenCalledWith(
-      THREAD_ID,
-      "errored",
-    );
+    expect(threadRepo.updateStatus).not.toHaveBeenCalledWith(THREAD_ID, "errored");
   });
 
   it("does not retry a fatal send failure", async () => {
@@ -319,15 +256,8 @@ describe("AgentService transient-failure auto-retry", () => {
     let fatalSuppressedDuringAttempt: boolean | undefined;
     sendTurn
       .mockImplementationOnce(() => {
-        transientSuppressedDuringAttempt =
-          service.shouldSuppressTransientTurnError(
-            THREAD_ID,
-            "read ECONNRESET",
-          );
-        fatalSuppressedDuringAttempt = service.shouldSuppressTransientTurnError(
-          THREAD_ID,
-          "permission denied",
-        );
+        transientSuppressedDuringAttempt = service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET");
+        fatalSuppressedDuringAttempt = service.shouldSuppressTransientTurnError(THREAD_ID, "permission denied");
         return Promise.reject(new Error("read ECONNRESET"));
       })
       .mockResolvedValueOnce(undefined);
@@ -345,20 +275,9 @@ describe("AgentService transient-failure auto-retry", () => {
     expect(transientSuppressedDuringAttempt).toBe(true);
     expect(fatalSuppressedDuringAttempt).toBe(false);
     // Fire-and-forget providers keep the window armed until TurnComplete.
-    expect(
-      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
-    ).toBe(true);
-    providerEmitter.emit("event", {
-      type: "turnComplete",
-      threadId: THREAD_ID,
-      reason: "end_turn",
-      costUsd: null,
-      tokensIn: 0,
-      tokensOut: 0,
-    });
-    expect(
-      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
-    ).toBe(false);
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(true);
+    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(false);
   });
 
   it("swallows the failed attempt's trailing Ended so the UI's running state survives the retry", async () => {
@@ -377,8 +296,7 @@ describe("AgentService transient-failure auto-retry", () => {
           threadId: THREAD_ID,
           error: "read ECONNRESET",
         });
-        endedSuppressedDuringAttempt =
-          service.shouldSuppressTurnEnded(THREAD_ID);
+        endedSuppressedDuringAttempt = service.shouldSuppressTurnEnded(THREAD_ID);
         return Promise.reject(new Error("read ECONNRESET"));
       })
       .mockResolvedValueOnce(undefined);
@@ -394,14 +312,7 @@ describe("AgentService transient-failure auto-retry", () => {
 
     // The trailing Ended was armed for suppression during the failed attempt...
     expect(endedSuppressedDuringAttempt).toBe(true);
-    providerEmitter.emit("event", {
-      type: "turnComplete",
-      threadId: THREAD_ID,
-      reason: "end_turn",
-      costUsd: null,
-      tokensIn: 0,
-      tokensOut: 0,
-    });
+    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
     expect(service.shouldSuppressTurnEnded(THREAD_ID)).toBe(false);
   });
 
@@ -449,19 +360,11 @@ describe("AgentService transient-failure auto-retry", () => {
     });
 
     // Give-up disarms the retry window so the terminal error is visible.
-    expect(
-      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
-    ).toBe(false);
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(false);
   });
 
   it("swallows discardSession's trailing Ended when sendTurn rejects without emitting Error", async () => {
-    const {
-      service,
-      sendTurn,
-      discardSession,
-      waitForSessionExit,
-      providerEmitter,
-    } = buildService();
+    const { service, sendTurn, discardSession, waitForSessionExit, providerEmitter } = buildService();
     service.init();
 
     let endedSuppressedWhenDiscardUnwinds: boolean | undefined;
@@ -469,8 +372,7 @@ describe("AgentService transient-failure auto-retry", () => {
     // subprocess and emits Ended on the next tick while the retry catch runs.
     discardSession.mockImplementation(() => {
       queueMicrotask(() => {
-        endedSuppressedWhenDiscardUnwinds =
-          service.shouldSuppressTurnEnded(THREAD_ID);
+        endedSuppressedWhenDiscardUnwinds = service.shouldSuppressTurnEnded(THREAD_ID);
         providerEmitter.emit("event", { type: "ended", threadId: THREAD_ID });
       });
     });
@@ -493,14 +395,7 @@ describe("AgentService transient-failure auto-retry", () => {
     expect(discardSession).toHaveBeenCalledWith(`mcode-${THREAD_ID}`);
     expect(waitForSessionExit).toHaveBeenCalledWith(`mcode-${THREAD_ID}`, 5000);
     expect(endedSuppressedWhenDiscardUnwinds).toBe(true);
-    providerEmitter.emit("event", {
-      type: "turnComplete",
-      threadId: THREAD_ID,
-      reason: "end_turn",
-      costUsd: null,
-      tokensIn: 0,
-      tokensOut: 0,
-    });
+    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
     expect(service.shouldSuppressTurnEnded(THREAD_ID)).toBe(false);
   });
 
@@ -542,18 +437,14 @@ describe("AgentService transient-failure auto-retry", () => {
       attachments: [],
       provider: "claude",
     });
-    expect(
-      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
-    ).toBe(true);
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(true);
 
     // A user stop ends the turn via finalize; it must tear down the armed
     // window so a scheduled stream retry can't re-dispatch after the stop and
     // the suppression flags don't outlive into the next turn.
     await service.stopSession(THREAD_ID);
 
-    expect(
-      service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET"),
-    ).toBe(false);
+    expect(service.shouldSuppressTransientTurnError(THREAD_ID, "read ECONNRESET")).toBe(false);
   });
 
   it("retries when sendTurn resolves early then a transient stream Error arrives", async () => {
@@ -584,9 +475,7 @@ describe("AgentService transient-failure auto-retry", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(sendTurn).toHaveBeenCalledTimes(2);
-    expect(
-      (sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom,
-    ).toBeUndefined();
+    expect((sendTurn.mock.calls[1][0] as TurnRequest).resumeFrom).toBeUndefined();
   });
 
   it("swallows a failed attempt's TurnComplete during the retry window", async () => {
@@ -609,8 +498,7 @@ describe("AgentService transient-failure auto-retry", () => {
           tokensIn: 0,
           tokensOut: 0,
         });
-        turnCompleteSuppressedDuringAttempt =
-          service.shouldSuppressTurnComplete(THREAD_ID);
+        turnCompleteSuppressedDuringAttempt = service.shouldSuppressTurnComplete(THREAD_ID);
         return Promise.reject(new Error("read ECONNRESET"));
       })
       .mockResolvedValueOnce(undefined);
@@ -625,14 +513,7 @@ describe("AgentService transient-failure auto-retry", () => {
     });
 
     expect(turnCompleteSuppressedDuringAttempt).toBe(true);
-    providerEmitter.emit("event", {
-      type: "turnComplete",
-      threadId: THREAD_ID,
-      reason: "end_turn",
-      costUsd: null,
-      tokensIn: 0,
-      tokensOut: 0,
-    });
+    providerEmitter.emit("event", { type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 });
     expect(service.shouldSuppressTurnComplete(THREAD_ID)).toBe(false);
   });
 

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -264,12 +264,7 @@ function buildService(cwd = process.cwd()): {
     attachmentService,
     providerRegistry,
     threadService,
-    {
-      bulkCreate: () => {},
-      create: () => ({}),
-      listByMessage: () => [],
-      countByMessage: () => 0,
-    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -278,39 +273,16 @@ function buildService(cwd = process.cwd()): {
     settingsService,
     availability,
     planQuestionAnswersRepo,
-    {
-      create: vi.fn(),
-      updateStatus: vi.fn(),
-      listByThread: vi.fn(() => []),
-      getLatestForThread: vi.fn(() => null),
-      getById: vi.fn(() => null),
-    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-    {
-      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
-    } as any,
-    {
-      issue: vi.fn(),
-      tryConsume: vi.fn(() => false),
-      clear: vi.fn(),
-      hasActiveGrant: vi.fn(() => false),
-    } as any,
-    new NarrativeStore(
-      messageRepo,
-      toolCallRecordRepo,
-      {
-        bulkCreate: () => {},
-        create: () => ({}),
-        listByMessage: () => [],
-        countByMessage: () => 0,
-      } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
-      {
-        bulkCreate: () => {},
-        create: () => ({}),
-        listByMessage: () => [],
-        countByMessage: () => 0,
-      } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
-    ),
-    new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
+      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      new NarrativeStore(
+        messageRepo,
+        toolCallRecordRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+      ),
+      new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
   );
 
   return {
@@ -365,8 +337,7 @@ describe("AgentService turn cleanup", () => {
   });
 
   it("persists preview annotation snapshots as visible provider attachments", async () => {
-    const { service, providerEmitter, attachmentService, messageRepo } =
-      buildService();
+    const { service, providerEmitter, attachmentService, messageRepo } = buildService();
     const bundle = makePreviewAnnotationBundle();
 
     await service.sendMessage({
@@ -764,10 +735,7 @@ describe("AgentService Ended finalization", () => {
   let threadRepo: RealThreadRepo;
   let workspaceRepo: RealWorkspaceRepo;
   let messageRepo: RealMessageRepo;
-  let providerEmitter: EventEmitter & {
-    sendTurn: ReturnType<typeof vi.fn>;
-    stopSession: ReturnType<typeof vi.fn>;
-  };
+  let providerEmitter: EventEmitter & { sendTurn: ReturnType<typeof vi.fn>; stopSession: ReturnType<typeof vi.fn> };
   let service: AgentService;
 
   beforeEach(() => {
@@ -830,10 +798,7 @@ describe("AgentService Ended finalization", () => {
       providerRegistry,
       { create: vi.fn() } as unknown as ThreadService,
       hookExecutionRepo,
-      {
-        listByThread: vi.fn(() => []),
-        create: vi.fn(),
-      } as unknown as TurnSnapshotRepo,
+      { listByThread: vi.fn(() => []), create: vi.fn() } as unknown as TurnSnapshotRepo,
       snapshotService,
       db,
       memoryPressureService,
@@ -841,28 +806,10 @@ describe("AgentService Ended finalization", () => {
       settingsService,
       { assertUsable: vi.fn() } as unknown as ProviderAvailabilityService,
       planQuestionAnswersRepo,
-      {
-        create: vi.fn(),
-        updateStatus: vi.fn(),
-        listByThread: vi.fn(() => []),
-        getLatestForThread: vi.fn(() => null),
-        getById: vi.fn(() => null),
-      } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      {
-        deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
-      } as any,
-      {
-        issue: vi.fn(),
-        tryConsume: vi.fn(() => false),
-        clear: vi.fn(),
-        hasActiveGrant: vi.fn(() => false),
-      } as any,
-      new NarrativeStore(
-        messageRepo,
-        toolCallRecordRepo,
-        thoughtSegmentRepo,
-        hookExecutionRepo,
-      ),
+      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
+      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
+      new NarrativeStore(messageRepo, toolCallRecordRepo, thoughtSegmentRepo, hookExecutionRepo),
       new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
     );
     service.init();
@@ -870,14 +817,7 @@ describe("AgentService Ended finalization", () => {
 
   it("persists partial assistant text when a running turn ends with only Ended", async () => {
     const workspace = workspaceRepo.create("Test", process.cwd());
-    const thread = threadRepo.create(
-      workspace.id,
-      "Test thread",
-      "direct",
-      "main",
-      true,
-      "codex",
-    );
+    const thread = threadRepo.create(workspace.id, "Test thread", "direct", "main", true, "codex");
 
     await service.sendMessage({
       threadId: thread.id,
@@ -902,28 +842,16 @@ describe("AgentService Ended finalization", () => {
 
     const { messages } = messageRepo.listByThread(thread.id, 10);
     const assistant = messages.find((message) => message.role === "assistant");
-    expect(assistant?.content).toBe(
-      "partial answer before the provider stopped",
-    );
-    expect(broadcast).toHaveBeenCalledWith(
-      "turn.persisted",
-      expect.objectContaining({
-        threadId: thread.id,
-        messageId: assistant?.id,
-      }),
-    );
+    expect(assistant?.content).toBe("partial answer before the provider stopped");
+    expect(broadcast).toHaveBeenCalledWith("turn.persisted", expect.objectContaining({
+      threadId: thread.id,
+      messageId: assistant?.id,
+    }));
   });
 
   it("does not infer cancellation from a bare Ended event for non-Codex providers", async () => {
     const workspace = workspaceRepo.create("Test", process.cwd());
-    const thread = threadRepo.create(
-      workspace.id,
-      "Test thread",
-      "direct",
-      "main",
-      true,
-      "cursor",
-    );
+    const thread = threadRepo.create(workspace.id, "Test thread", "direct", "main", true, "cursor");
 
     await service.sendMessage({
       threadId: thread.id,
@@ -947,16 +875,9 @@ describe("AgentService Ended finalization", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     const { messages } = messageRepo.listByThread(thread.id, 10);
-    expect(
-      messages.some(
-        (message) =>
-          message.role === "assistant" &&
-          message.content === "partial cursor text",
-      ),
-    ).toBe(false);
-    expect(broadcast).not.toHaveBeenCalledWith(
-      "turn.persisted",
-      expect.anything(),
-    );
+    expect(messages.some((message) =>
+      message.role === "assistant" && message.content === "partial cursor text",
+    )).toBe(false);
+    expect(broadcast).not.toHaveBeenCalledWith("turn.persisted", expect.anything());
   });
 });

--- a/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-turn-cleanup.test.ts
@@ -264,7 +264,12 @@ function buildService(cwd = process.cwd()): {
     attachmentService,
     providerRegistry,
     threadService,
-    { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    {
+      bulkCreate: () => {},
+      create: () => ({}),
+      listByMessage: () => [],
+      countByMessage: () => 0,
+    } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     turnSnapshotRepo,
     snapshotService,
     db,
@@ -273,16 +278,39 @@ function buildService(cwd = process.cwd()): {
     settingsService,
     availability,
     planQuestionAnswersRepo,
-      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
-      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
-      new NarrativeStore(
-        messageRepo,
-        toolCallRecordRepo,
-        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
-        { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
-      ),
-      new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
+    {
+      create: vi.fn(),
+      updateStatus: vi.fn(),
+      listByThread: vi.fn(() => []),
+      getLatestForThread: vi.fn(() => null),
+      getById: vi.fn(() => null),
+    } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+    {
+      deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
+    } as any,
+    {
+      issue: vi.fn(),
+      tryConsume: vi.fn(() => false),
+      clear: vi.fn(),
+      hasActiveGrant: vi.fn(() => false),
+    } as any,
+    new NarrativeStore(
+      messageRepo,
+      toolCallRecordRepo,
+      {
+        bulkCreate: () => {},
+        create: () => ({}),
+        listByMessage: () => [],
+        countByMessage: () => 0,
+      } as unknown as import("../../repositories/thought-segment-repo.js").ThoughtSegmentRepo,
+      {
+        bulkCreate: () => {},
+        create: () => ({}),
+        listByMessage: () => [],
+        countByMessage: () => 0,
+      } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
+    ),
+    new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
   );
 
   return {
@@ -307,7 +335,14 @@ describe("AgentService turn cleanup", () => {
     service.init();
 
     // sendMessage adds thread to activeSessionIds and emits TurnStarted
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
 
     expect(service.activeThreadIds()).toContain(THREAD_ID);
 
@@ -330,33 +365,20 @@ describe("AgentService turn cleanup", () => {
   });
 
   it("persists preview annotation snapshots as visible provider attachments", async () => {
-    const { service, providerEmitter, attachmentService, messageRepo } = buildService();
+    const { service, providerEmitter, attachmentService, messageRepo } =
+      buildService();
     const bundle = makePreviewAnnotationBundle();
 
-    await service.sendMessage(
-      THREAD_ID,
-      "fix this",
-      "default",
-      "claude-sonnet-4-6",
-      [],
-      undefined,
-      "claude",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      [],
-      bundle,
-    );
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "fix this",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+      mentions: [],
+      previewAnnotations: bundle,
+    });
 
     const expectedAttachment = {
       id: "annotation-shot-1",
@@ -400,7 +422,14 @@ describe("AgentService turn cleanup", () => {
     const { service, providerEmitter } = buildService();
     service.init();
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
     expect(service.activeThreadIds()).toContain(THREAD_ID);
 
     // Start compaction first
@@ -431,7 +460,14 @@ describe("AgentService turn cleanup", () => {
     const { service, providerEmitter, memoryPressureService } = buildService();
     service.init();
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
     expect(service.activeThreadIds()).toContain(THREAD_ID);
 
     // Turn completes, thread removed from active
@@ -662,7 +698,14 @@ describe("AgentService turn cleanup", () => {
     const { service, providerEmitter, memoryPressureService } = buildService();
     service.init();
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
     expect(service.activeThreadIds()).toContain(THREAD_ID);
 
     // Turn completes, thread removed
@@ -696,7 +739,14 @@ describe("AgentService turn cleanup", () => {
     const { service, providerEmitter, memoryPressureService } = buildService();
     service.init();
 
-    await service.sendMessage(THREAD_ID, "hello", "default", "claude-sonnet-4-6", [], undefined, "claude");
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "default",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
     expect(service.activeThreadIds()).toContain(THREAD_ID);
 
     providerEmitter.emit("event", {
@@ -714,7 +764,10 @@ describe("AgentService Ended finalization", () => {
   let threadRepo: RealThreadRepo;
   let workspaceRepo: RealWorkspaceRepo;
   let messageRepo: RealMessageRepo;
-  let providerEmitter: EventEmitter & { sendTurn: ReturnType<typeof vi.fn>; stopSession: ReturnType<typeof vi.fn> };
+  let providerEmitter: EventEmitter & {
+    sendTurn: ReturnType<typeof vi.fn>;
+    stopSession: ReturnType<typeof vi.fn>;
+  };
   let service: AgentService;
 
   beforeEach(() => {
@@ -777,7 +830,10 @@ describe("AgentService Ended finalization", () => {
       providerRegistry,
       { create: vi.fn() } as unknown as ThreadService,
       hookExecutionRepo,
-      { listByThread: vi.fn(() => []), create: vi.fn() } as unknown as TurnSnapshotRepo,
+      {
+        listByThread: vi.fn(() => []),
+        create: vi.fn(),
+      } as unknown as TurnSnapshotRepo,
       snapshotService,
       db,
       memoryPressureService,
@@ -785,10 +841,28 @@ describe("AgentService Ended finalization", () => {
       settingsService,
       { assertUsable: vi.fn() } as unknown as ProviderAvailabilityService,
       planQuestionAnswersRepo,
-      { create: vi.fn(), updateStatus: vi.fn(), listByThread: vi.fn(() => []), getLatestForThread: vi.fn(() => null), getById: vi.fn(() => null) } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
-      { deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })) } as any,
-      { issue: vi.fn(), tryConsume: vi.fn(() => false), clear: vi.fn(), hasActiveGrant: vi.fn(() => false) } as any,
-      new NarrativeStore(messageRepo, toolCallRecordRepo, thoughtSegmentRepo, hookExecutionRepo),
+      {
+        create: vi.fn(),
+        updateStatus: vi.fn(),
+        listByThread: vi.fn(() => []),
+        getLatestForThread: vi.fn(() => null),
+        getById: vi.fn(() => null),
+      } as unknown as import("../../repositories/plan-repo.js").PlanRepo,
+      {
+        deliverHandoff: vi.fn(async () => ({ providerWireOverride: "" })),
+      } as any,
+      {
+        issue: vi.fn(),
+        tryConsume: vi.fn(() => false),
+        clear: vi.fn(),
+        hasActiveGrant: vi.fn(() => false),
+      } as any,
+      new NarrativeStore(
+        messageRepo,
+        toolCallRecordRepo,
+        thoughtSegmentRepo,
+        hookExecutionRepo,
+      ),
       new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
     );
     service.init();
@@ -796,9 +870,23 @@ describe("AgentService Ended finalization", () => {
 
   it("persists partial assistant text when a running turn ends with only Ended", async () => {
     const workspace = workspaceRepo.create("Test", process.cwd());
-    const thread = threadRepo.create(workspace.id, "Test thread", "direct", "main", true, "codex");
+    const thread = threadRepo.create(
+      workspace.id,
+      "Test thread",
+      "direct",
+      "main",
+      true,
+      "codex",
+    );
 
-    await service.sendMessage(thread.id, "please investigate", "default", "gpt-5", [], undefined, "codex");
+    await service.sendMessage({
+      threadId: thread.id,
+      content: "please investigate",
+      permissionMode: "default",
+      model: "gpt-5",
+      attachments: [],
+      provider: "codex",
+    });
     providerEmitter.emit("event", {
       type: AgentEventType.TextDelta,
       threadId: thread.id,
@@ -814,18 +902,37 @@ describe("AgentService Ended finalization", () => {
 
     const { messages } = messageRepo.listByThread(thread.id, 10);
     const assistant = messages.find((message) => message.role === "assistant");
-    expect(assistant?.content).toBe("partial answer before the provider stopped");
-    expect(broadcast).toHaveBeenCalledWith("turn.persisted", expect.objectContaining({
-      threadId: thread.id,
-      messageId: assistant?.id,
-    }));
+    expect(assistant?.content).toBe(
+      "partial answer before the provider stopped",
+    );
+    expect(broadcast).toHaveBeenCalledWith(
+      "turn.persisted",
+      expect.objectContaining({
+        threadId: thread.id,
+        messageId: assistant?.id,
+      }),
+    );
   });
 
   it("does not infer cancellation from a bare Ended event for non-Codex providers", async () => {
     const workspace = workspaceRepo.create("Test", process.cwd());
-    const thread = threadRepo.create(workspace.id, "Test thread", "direct", "main", true, "cursor");
+    const thread = threadRepo.create(
+      workspace.id,
+      "Test thread",
+      "direct",
+      "main",
+      true,
+      "cursor",
+    );
 
-    await service.sendMessage(thread.id, "please investigate", "default", "gpt-5", [], undefined, "cursor");
+    await service.sendMessage({
+      threadId: thread.id,
+      content: "please investigate",
+      permissionMode: "default",
+      model: "gpt-5",
+      attachments: [],
+      provider: "cursor",
+    });
     providerEmitter.emit("event", {
       type: AgentEventType.TextDelta,
       threadId: thread.id,
@@ -840,9 +947,16 @@ describe("AgentService Ended finalization", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     const { messages } = messageRepo.listByThread(thread.id, 10);
-    expect(messages.some((message) =>
-      message.role === "assistant" && message.content === "partial cursor text",
-    )).toBe(false);
-    expect(broadcast).not.toHaveBeenCalledWith("turn.persisted", expect.anything());
+    expect(
+      messages.some(
+        (message) =>
+          message.role === "assistant" &&
+          message.content === "partial cursor text",
+      ),
+    ).toBe(false);
+    expect(broadcast).not.toHaveBeenCalledWith(
+      "turn.persisted",
+      expect.anything(),
+    );
   });
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -98,8 +98,12 @@ export type SendMessageCommand = Omit<SendMessageInput, "permissionMode" | "prov
   providerWireOverride?: string;
 };
 
-/** Command accepted by {@link AgentService.createAndSend}, including the service default permission mode. */
-export type CreateAndSendCommand = Omit<CreateAndSendInput, "permissionMode" | "provider"> & {
+/** Command accepted by {@link AgentService.createAndSend}, including service defaults for model and permission mode. */
+export type CreateAndSendCommand = Omit<
+  CreateAndSendInput,
+  "model" | "permissionMode" | "provider"
+> & {
+  model?: string;
   permissionMode?: PermissionMode | "default";
   provider?: ProviderId;
 };

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -31,11 +31,13 @@ import type {
   PermissionDecision,
   PermissionRequest,
   PlanOutput,
-  PlanAction,
   MessageMention,
   PreviewAnnotationBundle,
   GoalState,
   GoalLookupResult,
+  SendMessageInput,
+  CreateAndSendInput,
+  PermissionMode,
 } from "@mcode/contracts";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
@@ -85,6 +87,22 @@ function escapeXml(s: string): string {
 }
 
 const FILE_INJECTION_SEPARATOR = "\n\n---\n";
+
+/** Command accepted by {@link AgentService.sendMessage}, including service-only delivery metadata. */
+export type SendMessageCommand = Omit<SendMessageInput, "permissionMode" | "provider"> & {
+  permissionMode?: PermissionMode | "default";
+  provider?: ProviderId;
+  /** Assistant message whose plan-question batch is settled by this send. */
+  markPlanAnswerForMessageId?: string;
+  /** Provider payload used instead of the persisted user-facing content. */
+  providerWireOverride?: string;
+};
+
+/** Command accepted by {@link AgentService.createAndSend}, including the service default permission mode. */
+export type CreateAndSendCommand = Omit<CreateAndSendInput, "permissionMode" | "provider"> & {
+  permissionMode?: PermissionMode | "default";
+  provider?: ProviderId;
+};
 
 function buildInjectedFileMessage(
   text: string,
@@ -451,51 +469,32 @@ export class AgentService {
    * Loads the thread, persists the user message, resolves the working
    * directory, and dispatches to the provider.
    */
-  async sendMessage(
-    threadId: string,
-    content: string,
-    permissionMode: string,
+  async sendMessage({
+    threadId,
+    content,
+    permissionMode = "default",
     model = "claude-sonnet-4-6",
-    attachments: AttachmentMeta[] = [],
-    reasoningLevel?: ReasoningLevel,
-    provider?: ProviderId,
-    interactionMode?: InteractionMode,
-    maxBudgetUsd?: number,
-    maxTurns?: number,
-    copilotAgent?: string,
-    contextWindowMode?: ContextWindowMode,
-    thinking?: boolean,
-    codexFastMode?: boolean,
-    /**
-     * If set, persist a plan-questions "answered" marker for the given
-     * assistant message id in the same SQLite transaction as the user
-     * message create. Used by `answerQuestions` to record that the wizard
-     * has been satisfied so it does not re-pop on reload.
-     */
-    markPlanAnswerForMessageId?: string,
-    /**
-     * Provider-only payload for this send (fork continuation, stitched replay).
-     * The persisted user row uses {@link messageDisplayContent} when supplied,
-     * otherwise the original `content` argument; this string is forwarded to
-     * the agent without writing the override text to SQLite when set.
-     */
-    providerWireOverride?: string,
-    /** ID of the message being replied to. Stored on the user message row. */
-    replyToMessageId?: string,
-    /** Highlighted text excerpt from the replied-to message. Stored on the user message row. */
-    quotedText?: string,
-    /**
-     * Transcript stored in SQLite for the user bubble. When omitted, the
-     * original `content` argument is persisted. The `content` argument is
-     * still the base for plan/reply wrapping sent to the provider.
-     */
-    messageDisplayContent?: string,
-    planAction?: PlanAction,
-    mentions: MessageMention[] = [],
-    previewAnnotations?: PreviewAnnotationBundle,
-    goalObjective?: string,
-    orchestrationMode?: OrchestrationMode,
-  ): Promise<void> {
+    attachments = [],
+    reasoningLevel,
+    provider,
+    interactionMode,
+    maxBudgetUsd,
+    maxTurns,
+    copilotAgent,
+    contextWindow: contextWindowMode,
+    thinking,
+    codexFastMode,
+    markPlanAnswerForMessageId,
+    providerWireOverride,
+    replyToMessageId,
+    quotedText,
+    displayContent: messageDisplayContent,
+    planAction,
+    mentions = [],
+    previewAnnotations,
+    goalObjective,
+    orchestrationMode,
+  }: SendMessageCommand): Promise<void> {
     const thread = this.threadRepo.findById(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
     // Use the thread's stored provider as authoritative fallback; only override
@@ -932,7 +931,7 @@ export class AgentService {
   async answerQuestions(
     threadId: string,
     answers: Array<{ questionId: string; selectedOptionId: string | null; freeText: string | null }>,
-    permissionMode = "default",
+    permissionMode: PermissionMode | "default" = "default",
     reasoningLevel?: ReasoningLevel,
     contextWindowMode?: ContextWindowMode,
     thinking?: boolean,
@@ -950,23 +949,18 @@ export class AgentService {
     this.armPlanGenerationTurn(threadId);
 
     // interactionMode intentionally omitted — no question wrapping for the answer turn
-    await this.sendMessage(
+    await this.sendMessage({
       threadId,
       content,
       permissionMode,
-      thread.model ?? "claude-sonnet-4-6",
-      [],
+      model: thread.model ?? "claude-sonnet-4-6",
+      attachments: [],
       reasoningLevel,
-      (thread.provider as ProviderId) ?? "claude",
-      undefined, // interactionMode
-      undefined, // maxBudgetUsd
-      undefined, // maxTurns
-      undefined, // copilotAgent
-      contextWindowMode,
+      provider: (thread.provider as ProviderId) ?? "claude",
+      contextWindow: contextWindowMode,
       thinking,
-      undefined,
       markPlanAnswerForMessageId,
-    );
+    });
   }
 
   /**
@@ -1116,34 +1110,34 @@ export class AgentService {
    * Generates a title from the content, creates the thread, sends,
    * and returns the fully-populated Thread object.
    */
-  async createAndSend(
-    workspaceId: string,
-    content: string,
+  async createAndSend({
+    workspaceId,
+    content,
     model = "claude-sonnet-4-6",
     permissionMode = "default",
-    mode: "direct" | "worktree" = "direct",
+    mode = "direct",
     branch = "main",
-    worktreeBranchMode: "branchless" | "named" = "branchless",
-    existingWorktreePath?: string,
-    existingWorktreeBaseBranch?: string,
-    attachments: AttachmentMeta[] = [],
-    reasoningLevel?: ReasoningLevel,
-    provider: ProviderId = "claude",
-    interactionMode?: InteractionMode,
-    parentThreadId?: string,
-    forkedFromMessageId?: string,
-    maxBudgetUsd?: number,
-    maxTurns?: number,
-    copilotAgent?: string,
-    contextWindowMode?: ContextWindowMode,
-    thinking?: boolean,
-    codexFastMode?: boolean,
-    displayContent?: string,
-    mentions: MessageMention[] = [],
-    previewAnnotations?: PreviewAnnotationBundle,
-    goalObjective?: string,
-    orchestrationMode?: OrchestrationMode,
-  ): Promise<Thread & { warnings?: string[] }> {
+    worktreeBranchMode = "branchless",
+    existingWorktreePath,
+    existingWorktreeBaseBranch,
+    attachments = [],
+    reasoningLevel,
+    provider = "claude",
+    interactionMode,
+    parentThreadId,
+    forkedFromMessageId,
+    maxBudgetUsd,
+    maxTurns,
+    copilotAgent,
+    contextWindow: contextWindowMode,
+    thinking,
+    codexFastMode,
+    displayContent,
+    mentions = [],
+    previewAnnotations,
+    goalObjective,
+    orchestrationMode,
+  }: CreateAndSendCommand): Promise<Thread & { warnings?: string[] }> {
     const title = truncateTitle(displayContent ?? content);
 
     if (parentThreadId) {
@@ -1227,8 +1221,8 @@ export class AgentService {
         : thread.codex_fast_mode,
     };
 
-    void this.sendMessage(
-      thread.id,
+    void this.sendMessage({
+      threadId: thread.id,
       content,
       permissionMode,
       model,
@@ -1239,20 +1233,14 @@ export class AgentService {
       maxBudgetUsd,
       maxTurns,
       copilotAgent,
-      contextWindowMode,
+      contextWindow: contextWindowMode,
       thinking,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
       displayContent,
-      undefined,
       mentions,
       previewAnnotations,
       goalObjective,
       orchestrationMode,
-    ).catch((err) => {
+    }).catch((err) => {
       logger.error("createAndSend initial send failed", {
         threadId: thread.id,
         error: err instanceof Error ? err.message : String(err),
@@ -1273,7 +1261,7 @@ export class AgentService {
     workspaceId: string;
     content: string;
     model: string;
-    permissionMode: string;
+    permissionMode: PermissionMode | "default";
     mode: "direct" | "worktree";
     branch: string;
     worktreeBranchMode?: "branchless" | "named";
@@ -1454,8 +1442,8 @@ export class AgentService {
       });
     }
 
-    void this.sendMessage(
-      thread.id,
+    void this.sendMessage({
+      threadId: thread.id,
       content,
       permissionMode,
       model,
@@ -1466,20 +1454,16 @@ export class AgentService {
       maxBudgetUsd,
       maxTurns,
       copilotAgent,
-      effectiveContextWindowMode,
-      effectiveThinking,
-      resolvedCodexFast ?? undefined,
-      undefined,
-      providerInput,
-      undefined,
-      undefined,
+      contextWindow: effectiveContextWindowMode,
+      thinking: effectiveThinking,
+      codexFastMode: resolvedCodexFast ?? undefined,
+      providerWireOverride: providerInput,
       displayContent,
-      undefined,
       mentions,
       previewAnnotations,
       goalObjective,
       orchestrationMode,
-    ).catch((err) => {
+    }).catch((err) => {
       logger.error("createBranchedThread initial send failed", {
         threadId: thread.id,
         error: err instanceof Error ? err.message : String(err),

--- a/apps/server/src/services/pull-requests/review-worktree-service.test.ts
+++ b/apps/server/src/services/pull-requests/review-worktree-service.test.ts
@@ -419,12 +419,12 @@ describe("ReviewWorktreeService", () => {
     expect(second).toMatchObject({ ok: true, status: "ready", reused: true });
     expect(gitService.provisionPullRequestReviewWorktree).toHaveBeenCalledTimes(1);
     expect(agentService.sendMessage).toHaveBeenCalledTimes(1);
-    const sendArgs = vi.mocked(agentService.sendMessage).mock.calls[0]!;
-    expect(sendArgs[1]).toBe(request.intent);
-    expect(sendArgs[15]).toContain("untrusted remote data");
-    expect(sendArgs[15]).toContain("Remote text that must stay untrusted.");
-    expect(sendArgs[18]).toBe(request.intent);
-    expect(Buffer.byteLength(String(sendArgs[15]), "utf8")).toBeLessThanOrEqual(48 * 1_024);
+    const sendCommand = vi.mocked(agentService.sendMessage).mock.calls[0]![0];
+    expect(sendCommand.content).toBe(request.intent);
+    expect(sendCommand.providerWireOverride).toContain("untrusted remote data");
+    expect(sendCommand.providerWireOverride).toContain("Remote text that must stay untrusted.");
+    expect(sendCommand.displayContent).toBe(request.intent);
+    expect(Buffer.byteLength(String(sendCommand.providerWireOverride), "utf8")).toBeLessThanOrEqual(48 * 1_024);
 
     const link = reviewLinkRepo.findByIdentity({
       provider: identity.provider,
@@ -513,7 +513,7 @@ describe("ReviewWorktreeService", () => {
       intent: "Review this pull request.",
     });
 
-    const providerContext = String(vi.mocked(agentService.sendMessage).mock.calls[0]?.[15]);
+    const providerContext = String(vi.mocked(agentService.sendMessage).mock.calls[0]?.[0].providerWireOverride);
     expect(providerContext).toContain('"exhaustive": false');
     expect(providerContext).toContain('"providerCommentPageLimit": 50');
     expect(providerContext).toContain('"hasNextPage": true');

--- a/apps/server/src/services/pull-requests/review-worktree-service.ts
+++ b/apps/server/src/services/pull-requests/review-worktree-service.ts
@@ -543,27 +543,22 @@ export class ReviewWorktreeService {
       return warnings;
     }
 
-    const send = this.agentService.sendMessage(
+    const send = this.agentService.sendMessage({
       threadId,
-      intent,
-      settings.agent.defaults.permission,
-      settings.model.defaults.id,
-      [],
-      settings.model.defaults.reasoning,
+      content: intent,
+      permissionMode: settings.agent.defaults.permission,
+      model: settings.model.defaults.id,
+      attachments: [],
+      reasoningLevel: settings.model.defaults.reasoning,
       provider,
       interactionMode,
-      settings.agent.guardrails.maxBudgetUsd || undefined,
-      settings.agent.guardrails.maxTurns || undefined,
-      undefined,
-      settings.model.defaults.contextWindow,
-      settings.model.defaults.thinking,
-      undefined,
-      undefined,
-      context,
-      undefined,
-      undefined,
-      intent,
-    );
+      maxBudgetUsd: settings.agent.guardrails.maxBudgetUsd || undefined,
+      maxTurns: settings.agent.guardrails.maxTurns || undefined,
+      contextWindow: settings.model.defaults.contextWindow,
+      thinking: settings.model.defaults.thinking,
+      providerWireOverride: context,
+      displayContent: intent,
+    });
     let graceTimer: ReturnType<typeof setTimeout> | undefined;
     const start = await Promise.race([
       send.then(() => ({ complete: true as const }), (error: unknown) => ({ error })),

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -767,62 +767,18 @@ async function dispatch(
 
     // Agent
     case "agent.send":
-      await deps.agentService.sendMessage(
-        params.threadId,
-        appendPreviewAnnotationsForAgent(params.content, params.previewAnnotations),
-        params.permissionMode ?? "default",
-        params.model,
-        params.attachments,
-        params.reasoningLevel,
-        params.provider,
-        params.interactionMode,
-        params.maxBudgetUsd,
-        params.maxTurns,
-        params.copilotAgent,
-        params.contextWindow,
-        params.thinking,
-        params.codexFastMode,
-        undefined,
-        undefined,
-        params.replyToMessageId,
-        params.quotedText,
-        params.displayContent ?? params.content,
-        params.planAction,
-        params.mentions,
-        params.previewAnnotations,
-        params.goalObjective,
-        params.orchestrationMode,
-      );
+      await deps.agentService.sendMessage({
+        ...params,
+        content: appendPreviewAnnotationsForAgent(params.content, params.previewAnnotations),
+        displayContent: params.displayContent ?? params.content,
+      });
       return;
     case "agent.createAndSend": {
-      const thread = await deps.agentService.createAndSend(
-        params.workspaceId,
-        appendPreviewAnnotationsForAgent(params.content, params.previewAnnotations),
-        params.model,
-        params.permissionMode,
-        params.mode,
-        params.branch,
-        params.worktreeBranchMode,
-        params.existingWorktreePath,
-        params.existingWorktreeBaseBranch,
-        params.attachments,
-        params.reasoningLevel,
-        params.provider,
-        params.interactionMode,
-        params.parentThreadId,
-        params.forkedFromMessageId,
-        params.maxBudgetUsd,
-        params.maxTurns,
-        params.copilotAgent,
-        params.contextWindow,
-        params.thinking,
-        params.codexFastMode,
-        params.displayContent ?? params.content,
-        params.mentions,
-        params.previewAnnotations,
-        params.goalObjective,
-        params.orchestrationMode,
-      );
+      const thread = await deps.agentService.createAndSend({
+        ...params,
+        content: appendPreviewAnnotationsForAgent(params.content, params.previewAnnotations),
+        displayContent: params.displayContent ?? params.content,
+      });
       watchReturnedThreadWorktree(deps, thread);
       return thread;
     }

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -56,7 +56,44 @@ describe("routeMessage result validation seam", () => {
 });
 
 describe("routeMessage agent commands", () => {
-  it("passes an existing-thread command to AgentService without positional mapping", async () => {
+  const capture = {
+    schemaVersion: 2,
+    pageUrl: "http://localhost:5173/products/1",
+    pageTitle: "Product",
+    capturedAt: "2026-07-01T00:00:00.000Z",
+    captureKind: "element",
+    selectorHint: "button.buy",
+    bounds: { x: 10, y: 20, width: 100, height: 40 },
+    visibleTextExcerpt: "Buy now",
+    layoutViewport: { width: 1200, height: 800 },
+  };
+  const previewAnnotations = {
+    schemaVersion: 1,
+    annotations: [
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        displayNumber: 1,
+        pageIdentity: "http://localhost:5173/products/1",
+        pageContext: capture,
+        targetContext: {
+          label: "button.buy",
+          selectorHint: "button.buy",
+          bounds: { x: 10, y: 20, width: 100, height: 40 },
+        },
+        note: "Make the button clearer.",
+        snapshot: {
+          id: "snap-1",
+          name: "preview.png",
+          mimeType: "image/png",
+          sizeBytes: 123,
+          sourcePath: "C:/tmp/preview.png",
+          capture,
+        },
+      },
+    ],
+  };
+
+  it("augments an existing-thread command while preserving its display content and annotations", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const deps = { agentService: { sendMessage } } as unknown as RouterDeps;
 
@@ -67,11 +104,13 @@ describe("routeMessage agent commands", () => {
         params: {
           threadId: "thread-1",
           content: "Inspect this change",
+          displayContent: "Inspect the highlighted button",
           model: "gpt-5",
           provider: "codex",
           interactionMode: "build",
           permissionMode: "full",
           thinking: false,
+          previewAnnotations,
         },
       }),
       deps,
@@ -80,17 +119,22 @@ describe("routeMessage agent commands", () => {
     expect(response.error).toBeUndefined();
     expect(sendMessage).toHaveBeenCalledWith({
       threadId: "thread-1",
-      content: "Inspect this change",
-      displayContent: "Inspect this change",
+      content: `Inspect this change
+
+<!-- mcode-preview-annotations:v1
+${JSON.stringify(previewAnnotations)}
+mcode-preview-annotations:end -->`,
+      displayContent: "Inspect the highlighted button",
       model: "gpt-5",
       provider: "codex",
       interactionMode: "build",
       permissionMode: "full",
       thinking: false,
+      previewAnnotations,
     });
   });
 
-  it("passes a new-thread command to AgentService without positional mapping", async () => {
+  it("augments a new-thread command while falling back to raw display content", async () => {
     const createAndSend = vi.fn().mockResolvedValue({
       id: "thread-2",
       mode: "direct",
@@ -108,6 +152,7 @@ describe("routeMessage agent commands", () => {
           model: "gpt-5",
           provider: "codex",
           mode: "direct",
+          previewAnnotations,
         },
       }),
       deps,
@@ -116,11 +161,16 @@ describe("routeMessage agent commands", () => {
     expect(response.error).toBeUndefined();
     expect(createAndSend).toHaveBeenCalledWith({
       workspaceId: "workspace-1",
-      content: "Start here",
+      content: `Start here
+
+<!-- mcode-preview-annotations:v1
+${JSON.stringify(previewAnnotations)}
+mcode-preview-annotations:end -->`,
       displayContent: "Start here",
       model: "gpt-5",
       provider: "codex",
       mode: "direct",
+      previewAnnotations,
     });
   });
 });

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -55,6 +55,76 @@ describe("routeMessage result validation seam", () => {
   });
 });
 
+describe("routeMessage agent commands", () => {
+  it("passes an existing-thread command to AgentService without positional mapping", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const deps = { agentService: { sendMessage } } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-send",
+        method: "agent.send",
+        params: {
+          threadId: "thread-1",
+          content: "Inspect this change",
+          model: "gpt-5",
+          provider: "codex",
+          interactionMode: "build",
+          permissionMode: "full",
+          thinking: false,
+        },
+      }),
+      deps,
+    );
+
+    expect(response.error).toBeUndefined();
+    expect(sendMessage).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      content: "Inspect this change",
+      displayContent: "Inspect this change",
+      model: "gpt-5",
+      provider: "codex",
+      interactionMode: "build",
+      permissionMode: "full",
+      thinking: false,
+    });
+  });
+
+  it("passes a new-thread command to AgentService without positional mapping", async () => {
+    const createAndSend = vi.fn().mockResolvedValue({
+      id: "thread-2",
+      mode: "direct",
+      worktree_path: null,
+    });
+    const deps = { agentService: { createAndSend } } as unknown as RouterDeps;
+
+    const response = await routeMessage(
+      JSON.stringify({
+        id: "req-create-send",
+        method: "agent.createAndSend",
+        params: {
+          workspaceId: "workspace-1",
+          content: "Start here",
+          model: "gpt-5",
+          provider: "codex",
+          mode: "direct",
+        },
+      }),
+      deps,
+    );
+
+    expect(response.error).toBeUndefined();
+    expect(createAndSend).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      content: "Start here",
+      displayContent: "Start here",
+      model: "gpt-5",
+      provider: "codex",
+      mode: "direct",
+    });
+  });
+});
+
 describe("routeMessage git.getRemoteUrl", () => {
   it("resolves the git path from a workspace thread before calling GitService", async () => {
     const getRemoteUrl = vi.fn().mockResolvedValue({

--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -391,29 +391,25 @@ test("thread switch paints the latest turn before older history finishes", async
     && (call.params as { threadId?: string }).threadId === "thread-b").length,
   { timeout: 3000 }).toBe(2);
   expect(typeof resolveOlderHistory).toBe("function");
-  await expect(page.getByText("Latest beta response", { exact: true })).toBeVisible();
-  const scrollContainer = page.locator("[data-testid=message-list] > div").first();
-  const tailScrollHeight = await scrollContainer.evaluate((element) => element.scrollHeight);
-  resolveOlderHistory?.();
   await expect.poll(() => readThreadRecord(page, "thread-b")).toEqual({
     currentThreadId: "thread-b",
     loading: false,
-    messageIds: threadBMessages.slice(20).map((entry) => entry.id),
-    messageSequences: Array.from({ length: 100 }, (_, index) => index + 21),
+    messageIds: threadBMessages.slice(-2).map((entry) => entry.id),
+    messageSequences: [119, 120],
     toolCallIds: [],
     goalObjective: null,
   });
-  await expect.poll(() => scrollContainer.evaluate((element) => element.scrollHeight))
-    .toBeGreaterThan(tailScrollHeight);
+  await expect(page.getByText("Latest beta response", { exact: true })).toBeVisible();
 
   const threadBCalls = calls.filter((call) =>
     call.method === "conversation.page"
     && (call.params as { threadId?: string }).threadId === "thread-b");
   expect(threadBCalls).toHaveLength(2);
   expect(threadBCalls.map((call) => call.params)).toEqual([
-    { threadId: "thread-b", limit: 12 },
-    { threadId: "thread-b", limit: 88, before: 109 },
+    { threadId: "thread-b", limit: 2 },
+    { threadId: "thread-b", limit: 98, before: 119 },
   ]);
+  resolveOlderHistory?.();
 });
 
 test("thread switch shows a running agent before persisted history refreshes", async ({ page }) => {

--- a/apps/web/src/__tests__/per-thread-settings.test.ts
+++ b/apps/web/src/__tests__/per-thread-settings.test.ts
@@ -227,7 +227,7 @@ describe("per-thread settings", () => {
     );
 
     const calls = vi.mocked(mockTransport.sendMessage).mock.calls;
-    const sendCall = calls[calls.length - 1];
-    expect(sendCall?.[8]).toBe("build");
+    const sendCall = calls[calls.length - 1]?.[0];
+    expect(sendCall?.interactionMode).toBe("build");
   });
 });

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -615,18 +615,16 @@ describe("Workspace Behavior", () => {
 
       await useWorkspaceStore.getState().createAndSendMessage("Hello", "gpt-5.5");
 
-      const call = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(call.slice(0, 9)).toEqual([
-        ws.id,
-        "Hello",
-        "gpt-5.5",
-        undefined,
-        "worktree",
-        "main",
-        undefined,
-        "/repo/.worktrees/branchless-existing",
-        "main",
-      ]);
+      const command = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(command).toMatchObject({
+        workspaceId: ws.id,
+        content: "Hello",
+        model: "gpt-5.5",
+        mode: "worktree",
+        branch: "main",
+        existingWorktreePath: "/repo/.worktrees/branchless-existing",
+        existingWorktreeBaseBranch: "main",
+      });
     });
 
     it("createAndSendMessage rejects detached existing worktree attach without a base branch", async () => {
@@ -676,16 +674,15 @@ describe("Workspace Behavior", () => {
         base_branch: null,
       });
 
-      const call = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(call.slice(0, 7)).toEqual([
-        ws.id,
-        "Review this",
-        "gpt-5.5",
-        undefined,
-        "worktree",
-        "contributor/pr-branch",
-        "named",
-      ]);
+      const command = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(command).toMatchObject({
+        workspaceId: ws.id,
+        content: "Review this",
+        model: "gpt-5.5",
+        mode: "worktree",
+        branch: "contributor/pr-branch",
+        worktreeBranchMode: "named",
+      });
       expect(useWorkspaceStore.getState().newThreadBranchSource).toBe("branch");
 
       resolveRpc(createMockThread({
@@ -733,18 +730,16 @@ describe("Workspace Behavior", () => {
         worktree_managed: false,
       });
 
-      const call = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(call.slice(0, 9)).toEqual([
-        ws.id,
-        "Hello",
-        "gpt-5.5",
-        undefined,
-        "worktree",
-        "feat/existing",
-        undefined,
-        "/repo/.worktrees/feature-existing",
-        undefined,
-      ]);
+      const command = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(command).toMatchObject({
+        workspaceId: ws.id,
+        content: "Hello",
+        model: "gpt-5.5",
+        mode: "worktree",
+        branch: "feat/existing",
+        existingWorktreePath: "/repo/.worktrees/feature-existing",
+      });
+      expect(command.existingWorktreeBaseBranch).toBeUndefined();
 
       resolveRpc(createMockThread({
         id: "named-existing-thread",
@@ -906,18 +901,16 @@ describe("Workspace Behavior", () => {
         existingWorktreePath: "C:\\repo\\.worktrees\\branchless-existing\\",
       });
 
-      const call = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0];
-      expect(call.slice(0, 9)).toEqual([
-        ws.id,
-        "Branch this",
-        "gpt-5.5",
-        undefined,
-        "worktree",
-        "main",
-        undefined,
-        "C:\\repo\\.worktrees\\branchless-existing\\",
-        "main",
-      ]);
+      const command = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(command).toMatchObject({
+        workspaceId: ws.id,
+        content: "Branch this",
+        model: "gpt-5.5",
+        mode: "worktree",
+        branch: "main",
+        existingWorktreePath: "C:\\repo\\.worktrees\\branchless-existing\\",
+        existingWorktreeBaseBranch: "main",
+      });
     });
 
     it("branchThread rejects detached existing worktree attach without a base branch", async () => {

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -616,14 +616,29 @@ describe("Workspace Behavior", () => {
       await useWorkspaceStore.getState().createAndSendMessage("Hello", "gpt-5.5");
 
       const command = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-      expect(command).toMatchObject({
+      expect(command).toEqual({
         workspaceId: ws.id,
         content: "Hello",
         model: "gpt-5.5",
+        permissionMode: undefined,
         mode: "worktree",
         branch: "main",
+        worktreeBranchMode: undefined,
         existingWorktreePath: "/repo/.worktrees/branchless-existing",
         existingWorktreeBaseBranch: "main",
+        attachments: undefined,
+        reasoningLevel: undefined,
+        provider: undefined,
+        interactionMode: undefined,
+        parentThreadId: undefined,
+        forkedFromMessageId: undefined,
+        copilotAgent: undefined,
+        contextWindow: undefined,
+        thinking: undefined,
+        codexFastMode: undefined,
+        displayContent: undefined,
+        mentions: undefined,
+        previewAnnotations: undefined,
       });
     });
 
@@ -675,13 +690,29 @@ describe("Workspace Behavior", () => {
       });
 
       const command = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-      expect(command).toMatchObject({
+      expect(command).toEqual({
         workspaceId: ws.id,
         content: "Review this",
         model: "gpt-5.5",
+        permissionMode: undefined,
         mode: "worktree",
         branch: "contributor/pr-branch",
         worktreeBranchMode: "named",
+        existingWorktreePath: undefined,
+        existingWorktreeBaseBranch: undefined,
+        attachments: undefined,
+        reasoningLevel: undefined,
+        provider: undefined,
+        interactionMode: undefined,
+        parentThreadId: undefined,
+        forkedFromMessageId: undefined,
+        copilotAgent: undefined,
+        contextWindow: undefined,
+        thinking: undefined,
+        codexFastMode: undefined,
+        displayContent: undefined,
+        mentions: undefined,
+        previewAnnotations: undefined,
       });
       expect(useWorkspaceStore.getState().newThreadBranchSource).toBe("branch");
 
@@ -731,15 +762,30 @@ describe("Workspace Behavior", () => {
       });
 
       const command = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-      expect(command).toMatchObject({
+      expect(command).toEqual({
         workspaceId: ws.id,
         content: "Hello",
         model: "gpt-5.5",
+        permissionMode: undefined,
         mode: "worktree",
         branch: "feat/existing",
+        worktreeBranchMode: undefined,
         existingWorktreePath: "/repo/.worktrees/feature-existing",
+        existingWorktreeBaseBranch: undefined,
+        attachments: undefined,
+        reasoningLevel: undefined,
+        provider: undefined,
+        interactionMode: undefined,
+        parentThreadId: undefined,
+        forkedFromMessageId: undefined,
+        copilotAgent: undefined,
+        contextWindow: undefined,
+        thinking: undefined,
+        codexFastMode: undefined,
+        displayContent: undefined,
+        mentions: undefined,
+        previewAnnotations: undefined,
       });
-      expect(command.existingWorktreeBaseBranch).toBeUndefined();
 
       resolveRpc(createMockThread({
         id: "named-existing-thread",
@@ -902,14 +948,29 @@ describe("Workspace Behavior", () => {
       });
 
       const command = (mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-      expect(command).toMatchObject({
+      expect(command).toEqual({
         workspaceId: ws.id,
         content: "Branch this",
         model: "gpt-5.5",
+        permissionMode: undefined,
         mode: "worktree",
         branch: "main",
+        worktreeBranchMode: undefined,
         existingWorktreePath: "C:\\repo\\.worktrees\\branchless-existing\\",
         existingWorktreeBaseBranch: "main",
+        attachments: undefined,
+        reasoningLevel: undefined,
+        provider: undefined,
+        interactionMode: undefined,
+        parentThreadId: parent.id,
+        forkedFromMessageId: undefined,
+        copilotAgent: undefined,
+        contextWindow: undefined,
+        thinking: undefined,
+        codexFastMode: undefined,
+        displayContent: undefined,
+        mentions: undefined,
+        previewAnnotations: undefined,
       });
     });
 

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -496,8 +496,8 @@ describe("Composer checkout confirmation", () => {
     await userEvent.click(screen.getByLabelText("Send message"));
 
     await waitFor(() => expect(mockTransport.sendMessage).toHaveBeenCalled());
-    const sendCall = (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1);
-    expect(sendCall?.[17]).toMatchObject({
+    const sendCommand = (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(sendCommand?.previewAnnotations).toMatchObject({
       schemaVersion: 1,
       annotations: [
         { id: "550e8400-e29b-41d4-a716-446655440001" },

--- a/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
+++ b/apps/web/src/components/chat/__tests__/Composer.checkout-dialog.test.tsx
@@ -429,14 +429,14 @@ describe("Composer checkout confirmation", () => {
     await user.click(screen.getByLabelText("Send message"));
 
     await waitFor(() => expect(mockTransport.createAndSendMessage).toHaveBeenCalled());
-    const createCall = (
+    const createCommand = (
       mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>
-    ).mock.calls.at(-1);
-    expect(createCall?.slice(4, 7)).toEqual([
-      "worktree",
-      "contributor/pr-branch",
-      "named",
-    ]);
+    ).mock.calls.at(-1)?.[0];
+    expect(createCommand).toMatchObject({
+      mode: "worktree",
+      branch: "contributor/pr-branch",
+      worktreeBranchMode: "named",
+    });
   });
 
   it("reports the created thread to an embedding new-thread workflow", async () => {
@@ -575,10 +575,10 @@ describe("Composer checkout confirmation", () => {
     await userEvent.click(screen.getByLabelText("Send message"));
 
     await waitFor(() => expect(mockTransport.createAndSendMessage).toHaveBeenCalled());
-    const createCall = (
+    const createCommand = (
       mockTransport.createAndSendMessage as ReturnType<typeof vi.fn>
-    ).mock.calls.at(-1);
-    expect(createCall?.[21]).toMatchObject({
+    ).mock.calls.at(-1)?.[0];
+    expect(createCommand?.previewAnnotations).toMatchObject({
       schemaVersion: 1,
       annotations: [
         {
@@ -660,15 +660,15 @@ describe("Composer checkout confirmation", () => {
     expect(screen.getByTestId("attachment-preview")).toBeEmptyDOMElement();
     expect(usePreviewAnnotationStore.getState().byThread[thread.id] ?? []).toEqual([]);
     expect(usePreviewDesignModeStore.getState().modes[thread.id]).toBe(false);
-    const sendCall = (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1);
-    expect(sendCall?.[4]).toEqual([
+    const sendCommand = (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(sendCommand?.attachments).toEqual([
       expect.objectContaining({
         name: "handoff.txt",
         mimeType: "text/plain",
         sourcePath: "C:\\tmp\\handoff.txt",
       }),
     ]);
-    expect(sendCall?.[17]).toMatchObject({
+    expect(sendCommand?.previewAnnotations).toMatchObject({
       schemaVersion: 1,
       annotations: [
         {
@@ -803,8 +803,8 @@ describe("Composer checkout confirmation", () => {
     await user.click(screen.getByLabelText("Send message"));
 
     await waitFor(() => expect(mockTransport.sendMessage).toHaveBeenCalled());
-    const sendCall = (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1);
-    expect(sendCall?.[17]).toBeUndefined();
+    const sendCommand = (mockTransport.sendMessage as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(sendCommand?.previewAnnotations).toBeUndefined();
   });
 
   it("does not resurrect restored annotations when swapping after chip removal", async () => {

--- a/apps/web/src/components/panels/plan/PlanPanel.test.tsx
+++ b/apps/web/src/components/panels/plan/PlanPanel.test.tsx
@@ -70,13 +70,13 @@ describe("PlanPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Implement" }));
 
     await waitFor(() => expect(mockTransport.sendMessage).toHaveBeenCalled());
-    const sendCall = vi.mocked(mockTransport.sendMessage).mock.calls.at(-1);
-    const content = sendCall?.[1];
+    const sendCall = vi.mocked(mockTransport.sendMessage).mock.calls.at(-1)?.[0];
+    const content = sendCall?.content;
 
     expect(content).toContain('Implement plan v2: "Version 2 Plan".');
     expect(content).toContain(versionTwo.contentMd);
     expect(content).not.toContain(versionOne.contentMd);
-    expect(sendCall?.[15]).toBe("implement");
+    expect(sendCall?.planAction).toBe("implement");
   }, 15_000);
 
   it("moves from an old active version to the latest generated plan when there are no annotations", async () => {

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -7,6 +7,7 @@ import {
   PlanQuestionSchema,
   PERMISSION_MODES,
   INTERACTION_MODES,
+  ProviderIdSchema,
   isGoalOpen,
   previewAnnotationSnapshotStoredAttachments,
 } from "@mcode/contracts";
@@ -1160,7 +1161,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
     try {
       const { interactionMode } = get().getThreadSettings(threadId);
-      await getTransport().sendMessage(
+      await getTransport().sendMessage({
         threadId,
         content,
         model,
@@ -1168,7 +1169,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         attachments,
         displayContent,
         reasoningLevel,
-        provider,
+        provider: provider === undefined ? undefined : ProviderIdSchema.parse(provider),
         interactionMode,
         copilotAgent,
         contextWindow,
@@ -1181,7 +1182,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         previewAnnotations,
         goalObjective,
         orchestrationMode,
-      );
+      });
     } catch (e) {
       if (planAction === "revise") {
         usePlanStore.getState().setGenerating(threadId, false);

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -5,7 +5,13 @@ import {
   buildPlaceholderWorkspaceThread,
   titleFromMessageContent,
 } from "@/lib/workspace-thread";
-import type { ChecksStatus, CreateAndSendResult, MessageMention, PreviewAnnotationBundle } from "@mcode/contracts";
+import {
+  ProviderIdSchema,
+  type ChecksStatus,
+  type CreateAndSendResult,
+  type MessageMention,
+  type PreviewAnnotationBundle,
+} from "@mcode/contracts";
 import { getTransport } from "@/transport";
 import { useThreadStore } from "./threadStore";
 import { deleteThreadRecord, patchThreadRecord } from "./thread-record";
@@ -115,32 +121,32 @@ interface PendingThreadCreation {
 const pendingThreadCreationByPlaceholderId = new Map<string, PendingThreadCreation>();
 
 async function runCreateAndSend(pending: PendingThreadCreation): Promise<CreateAndSendResult> {
-  return getTransport().createAndSendMessage(
-    pending.workspaceId,
-    pending.content,
-    pending.model,
-    pending.permissionMode,
-    pending.transportMode,
-    pending.branch,
-    pending.worktreeBranchMode,
-    pending.existingWorktreePath,
-    pending.existingWorktreeBaseBranch,
-    pending.attachments,
-    pending.reasoningLevel,
-    pending.provider,
-    pending.interactionMode,
-    pending.sourceThreadId,
-    pending.forkedFromMessageId,
-    pending.copilotAgent,
-    pending.contextWindow,
-    pending.thinking,
-    pending.codexFastMode,
-    pending.displayContent,
-    pending.mentions,
-    pending.previewAnnotations,
-    pending.goalObjective,
-    pending.orchestrationMode,
-  );
+  return getTransport().createAndSendMessage({
+    workspaceId: pending.workspaceId,
+    content: pending.content,
+    model: pending.model,
+    permissionMode: pending.permissionMode,
+    mode: pending.transportMode,
+    branch: pending.branch,
+    worktreeBranchMode: pending.worktreeBranchMode,
+    existingWorktreePath: pending.existingWorktreePath,
+    existingWorktreeBaseBranch: pending.existingWorktreeBaseBranch,
+    attachments: pending.attachments,
+    reasoningLevel: pending.reasoningLevel,
+    provider: pending.provider === undefined ? undefined : ProviderIdSchema.parse(pending.provider),
+    interactionMode: pending.interactionMode,
+    parentThreadId: pending.sourceThreadId,
+    forkedFromMessageId: pending.forkedFromMessageId,
+    copilotAgent: pending.copilotAgent,
+    contextWindow: pending.contextWindow,
+    thinking: pending.thinking,
+    codexFastMode: pending.codexFastMode,
+    displayContent: pending.displayContent,
+    mentions: pending.mentions,
+    previewAnnotations: pending.previewAnnotations,
+    goalObjective: pending.goalObjective,
+    orchestrationMode: pending.orchestrationMode,
+  });
 }
 /**
  * Optional RPC dispatch callback used by workspace actions. Tests inject a

--- a/apps/web/src/transport/__tests__/agent-commands.test.ts
+++ b/apps/web/src/transport/__tests__/agent-commands.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CreateAndSendInput, SendMessageInput } from "@mcode/contracts";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { createWsTransport } from "../ws-transport";
+
+class MockWebSocket {
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  readyState = 0;
+  readonly sent: string[] = [];
+
+  close(): void {
+    this.readyState = 3;
+    this.onclose?.({ code: 1000, reason: "" });
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  simulateOpen(): void {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  respond(id: string, result: unknown): void {
+    this.onmessage?.({ data: JSON.stringify({ id, result }) });
+  }
+}
+
+let mockWs: MockWebSocket;
+
+beforeEach(() => {
+  useSettingsStore.setState({ loaded: false });
+  vi.stubGlobal(
+    "WebSocket",
+    new Proxy(MockWebSocket, {
+      construct(Target) {
+        mockWs = new Target();
+        return mockWs;
+      },
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("agent command transport", () => {
+  it("sends the typed existing-thread command without changing its RPC fields", async () => {
+    const transport = createWsTransport("ws://localhost:1234");
+    mockWs.simulateOpen();
+
+    const command = {
+      threadId: "thread-1",
+      content: "Inspect this change",
+      displayContent: "Inspect this change",
+      model: "gpt-5",
+      permissionMode: "full",
+      reasoningLevel: "high",
+      provider: "codex",
+      interactionMode: "build",
+      contextWindow: "200k",
+      thinking: false,
+      codexFastMode: true,
+      replyToMessageId: "6b2cf031-4c42-4fe4-8dc0-938756cd31dd",
+      quotedText: "Original request",
+      mentions: [],
+    } satisfies SendMessageInput;
+
+    const pending = transport.sendMessage(command);
+    await vi.waitFor(() => {
+      expect(mockWs.sent.some((row) => JSON.parse(row).method === "agent.send")).toBe(true);
+    });
+    const request = mockWs.sent
+      .map((row) => JSON.parse(row) as { id: string; method: string; params: unknown })
+      .find((row) => row.method === "agent.send");
+
+    expect(request?.params).toEqual(command);
+    mockWs.respond(request!.id, null);
+    await pending;
+    transport.close();
+  });
+
+  it("preserves omission of empty reply metadata", async () => {
+    const transport = createWsTransport("ws://localhost:1234");
+    mockWs.simulateOpen();
+
+    const pending = transport.sendMessage({
+      threadId: "thread-1",
+      content: "Continue",
+      replyToMessageId: "",
+      quotedText: "",
+    });
+    await vi.waitFor(() => {
+      expect(mockWs.sent.some((row) => JSON.parse(row).method === "agent.send")).toBe(true);
+    });
+    const request = mockWs.sent
+      .map((row) => JSON.parse(row) as { id: string; method: string; params: unknown })
+      .find((row) => row.method === "agent.send");
+
+    expect(request?.params).toEqual({ threadId: "thread-1", content: "Continue" });
+    mockWs.respond(request!.id, null);
+    await pending;
+    transport.close();
+  });
+
+  it("sends the typed new-thread command without changing its RPC fields", async () => {
+    const transport = createWsTransport("ws://localhost:1234");
+    mockWs.simulateOpen();
+
+    const command = {
+      workspaceId: "workspace-1",
+      content: "Start in isolation",
+      displayContent: "Start in isolation",
+      model: "gpt-5",
+      permissionMode: "full",
+      mode: "worktree",
+      branch: "main",
+      worktreeBranchMode: "branchless",
+      reasoningLevel: "high",
+      provider: "codex",
+      interactionMode: "build",
+      contextWindow: "200k",
+      thinking: false,
+      codexFastMode: true,
+      mentions: [],
+    } satisfies CreateAndSendInput;
+
+    const pending = transport.createAndSendMessage(command);
+    await vi.waitFor(() => {
+      expect(mockWs.sent.some((row) => JSON.parse(row).method === "agent.createAndSend")).toBe(true);
+    });
+    const request = mockWs.sent
+      .map((row) => JSON.parse(row) as { id: string; method: string; params: unknown })
+      .find((row) => row.method === "agent.createAndSend");
+
+    expect(request?.params).toEqual(command);
+    mockWs.respond(request!.id, { thread: {}, handoff: null });
+    await pending;
+    transport.close();
+  });
+});

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -26,7 +26,6 @@ import type {
   PlanAnswer,
   InteractionMode,
   OrchestrationMode,
-  PlanAction,
   ProviderModelInfo,
   ProviderUsageInfo,
   ProviderAvailability,
@@ -39,9 +38,7 @@ import type {
   PermissionRequest,
   CreateAndSendResult,
   ConversationPage,
-  MessageMention,
   GoalLookupResult,
-  PreviewAnnotationBundle,
   PullRequestCapabilitiesRequest,
   PullRequestCapabilitiesResult,
   PullRequestListRequest,
@@ -70,9 +67,12 @@ import type {
   PullRequestCloseResult,
   PullRequestMergeRequest,
   PullRequestMergeResult,
+  SendMessageInput,
+  CreateAndSendInput,
 } from "@mcode/contracts";
 
 // Re-export shared types from the contracts package (single source of truth).
+export type { PlanAction } from "@mcode/contracts";
 export type {
   Workspace,
   WorkspaceEnrichment,
@@ -96,7 +96,6 @@ export type {
   PartialSettings,
   GitCommit,
   PlanAnswer,
-  PlanAction,
   ProviderModelInfo,
   MessageMention,
   PullRequestCapabilities,
@@ -118,6 +117,8 @@ export type {
   PullRequestFileChangeType,
   PullRequestFilePatchStatus,
   PullRequestPatchResult,
+  SendMessageInput,
+  CreateAndSendInput,
 } from "@mcode/contracts";
 
 export type { PaginatedMessages, ConversationPage, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord, TurnSnapshot, CopilotSubagent } from "@mcode/contracts";
@@ -249,54 +250,8 @@ export interface McodeTransport {
   listWorktrees(workspaceId: string): Promise<WorktreeInfo[]>;
 
   // Agent commands
-  sendMessage(
-    threadId: string,
-    content: string,
-    model?: string,
-    permissionMode?: PermissionMode,
-    attachments?: AttachmentMeta[],
-    displayContent?: string,
-    reasoningLevel?: ReasoningLevel,
-    provider?: string,
-    interactionMode?: InteractionMode,
-    copilotAgent?: string,
-    contextWindow?: ContextWindowMode,
-    thinking?: boolean,
-    codexFastMode?: boolean,
-    replyToMessageId?: string,
-    quotedText?: string,
-    planAction?: PlanAction,
-    mentions?: MessageMention[],
-    previewAnnotations?: PreviewAnnotationBundle,
-    goalObjective?: string,
-    orchestrationMode?: OrchestrationMode,
-  ): Promise<void>;
-  createAndSendMessage(
-    workspaceId: string,
-    content: string,
-    model: string,
-    permissionMode?: PermissionMode,
-    mode?: "direct" | "worktree",
-    branch?: string,
-    worktreeBranchMode?: "branchless" | "named",
-    existingWorktreePath?: string,
-    existingWorktreeBaseBranch?: string,
-    attachments?: AttachmentMeta[],
-    reasoningLevel?: ReasoningLevel,
-    provider?: string,
-    interactionMode?: InteractionMode,
-    parentThreadId?: string,
-    forkedFromMessageId?: string,
-    copilotAgent?: string,
-    contextWindow?: ContextWindowMode,
-    thinking?: boolean,
-    codexFastMode?: boolean,
-    displayContent?: string,
-    mentions?: MessageMention[],
-    previewAnnotations?: PreviewAnnotationBundle,
-    goalObjective?: string,
-    orchestrationMode?: OrchestrationMode,
-  ): Promise<CreateAndSendResult>;
+  sendMessage(input: SendMessageInput): Promise<void>;
+  createAndSendMessage(input: CreateAndSendInput): Promise<CreateAndSendResult>;
   stopAgent(threadId: string): Promise<void>;
   /** Respond to a tool permission request from the agent. */
   respondToPermission(requestId: string, decision: PermissionDecision): Promise<void>;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -11,7 +11,6 @@ import type {
   SkillDiagnostics,
   PrInfo,
   PrDetail,
-  PermissionMode,
   ToolCallRecord,
   ThoughtSegmentRecord,
   HookExecutionRecord,
@@ -52,10 +51,11 @@ import type {
   PullRequestCloseResult,
   PullRequestMergeRequest,
   PullRequestMergeResult,
+  SendMessageInput,
+  CreateAndSendInput,
 } from "@mcode/contracts";
 import { emitPtyReconnectGap } from "@/components/terminal/ptyDataRegistry";
 import type { PaginatedMessages, ConversationPage, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability, GoalLookupResult } from "@mcode/contracts";
-import type { ReasoningLevel } from "@mcode/contracts";
 import {
   TERMINAL_DATA_TAG,
   decodeTerminalDataFrame,
@@ -576,111 +576,26 @@ export function createWsTransport(
     listWorktrees: (workspaceId) => rpc<WorktreeInfo[]>("git.listWorktrees", { workspaceId }),
 
     // Agent
-    sendMessage: (
-      threadId,
-      content,
-      model?,
-      permissionMode?: PermissionMode,
-      attachments?: AttachmentMeta[],
-      displayContent?: string,
-      reasoningLevel?: ReasoningLevel,
-      provider?: string,
-      interactionMode?,
-      copilotAgent?: string,
-      contextWindow?,
-      thinking?,
-      codexFastMode?,
-      replyToMessageId?,
-      quotedText?,
-      planAction?,
-      mentions?,
-      previewAnnotations?,
-      goalObjective?,
-      orchestrationMode?,
-    ) => {
+    sendMessage: (input: SendMessageInput) => {
       const state = useSettingsStore.getState();
       const guardrails = state.loaded
         ? { maxBudgetUsd: state.settings.agent.guardrails.maxBudgetUsd, maxTurns: state.settings.agent.guardrails.maxTurns }
         : {};
+      const { replyToMessageId, quotedText, ...command } = input;
       return rpc<void>("agent.send", {
-        threadId,
-        content,
-        model,
-        permissionMode,
-        attachments,
-        reasoningLevel,
-        provider,
-        interactionMode,
-        copilotAgent,
-        contextWindow,
-        thinking,
-        ...(codexFastMode !== undefined && { codexFastMode }),
+        ...command,
         ...(replyToMessageId && { replyToMessageId }),
         ...(quotedText && { quotedText }),
-        ...(displayContent !== undefined && { displayContent }),
-        ...(planAction !== undefined && { planAction }),
-        ...(mentions !== undefined && { mentions }),
-        ...(previewAnnotations !== undefined && { previewAnnotations }),
-        ...(goalObjective !== undefined && { goalObjective }),
-        ...(orchestrationMode !== undefined && { orchestrationMode }),
         ...guardrails,
       });
     },
-    createAndSendMessage: (
-      workspaceId,
-      content,
-      model,
-      permissionMode?,
-      mode?,
-      branch?,
-      worktreeBranchMode?,
-      existingWorktreePath?,
-      existingWorktreeBaseBranch?,
-      attachments?,
-      reasoningLevel?,
-      provider?,
-      interactionMode?,
-      parentThreadId?,
-      forkedFromMessageId?,
-      copilotAgent?,
-      contextWindow?,
-      thinking?,
-      codexFastMode?,
-      displayContent?,
-      mentions?,
-      previewAnnotations?,
-      goalObjective?,
-      orchestrationMode?,
-    ) => {
+    createAndSendMessage: (input: CreateAndSendInput) => {
       const state = useSettingsStore.getState();
       const guardrails = state.loaded
         ? { maxBudgetUsd: state.settings.agent.guardrails.maxBudgetUsd, maxTurns: state.settings.agent.guardrails.maxTurns }
         : {};
       return rpc<CreateAndSendResult>("agent.createAndSend", {
-        workspaceId,
-        content,
-        model,
-        permissionMode,
-        mode,
-        branch,
-        worktreeBranchMode,
-        existingWorktreePath,
-        existingWorktreeBaseBranch,
-        attachments,
-        reasoningLevel,
-        provider,
-        interactionMode,
-        parentThreadId,
-        forkedFromMessageId,
-        copilotAgent,
-        contextWindow,
-        thinking,
-        ...(codexFastMode !== undefined && { codexFastMode }),
-        ...(displayContent !== undefined && { displayContent }),
-        ...(mentions !== undefined && { mentions }),
-        ...(previewAnnotations !== undefined && { previewAnnotations }),
-        ...(goalObjective !== undefined && { goalObjective }),
-        ...(orchestrationMode !== undefined && { orchestrationMode }),
+        ...input,
         ...guardrails,
       });
     },

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -531,7 +531,12 @@ export {
   RECAP_MAX_MESSAGE_CONTENT_CHARS,
   RECAP_MAX_PREVIOUS_RECAP_CHARS,
 } from "./ws/methods.js";
-export type { WsMethodName, CreateAndSendResult } from "./ws/methods.js";
+export type {
+  WsMethodName,
+  SendMessageInput,
+  CreateAndSendInput,
+  CreateAndSendResult,
+} from "./ws/methods.js";
 
 export { WS_CHANNELS } from "./ws/channels.js";
 export type { WsChannelName } from "./ws/channels.js";

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -135,6 +135,9 @@ export const SendMessageSchema = lazySchema(() =>
   }),
 );
 
+/** Validated command for sending a message to an existing thread. */
+export type SendMessageInput = z.infer<ReturnType<typeof SendMessageSchema>>;
+
 /** Schema for creating a thread and sending a message in one call. */
 export const CreateAndSendSchema = lazySchema(() =>
   z.object({
@@ -184,6 +187,9 @@ export const CreateAndSendSchema = lazySchema(() =>
   { message: "forkedFromMessageId requires parentThreadId", path: ["forkedFromMessageId"] },
   ),
 );
+
+/** Validated command for creating a thread and sending its first message. */
+export type CreateAndSendInput = z.infer<ReturnType<typeof CreateAndSendSchema>>;
 
 /** Result schema for agent.createAndSend: a Thread with optional non-fatal warnings. */
 export const CreateAndSendResultSchema = lazySchema(() =>


### PR DESCRIPTION
## What

Replace positional agent send and create-and-send arguments with named command objects across contracts, transports, stores, router dispatch, services, and callers.

## Why

The long positional signatures were difficult to read and easy to break when adding or reordering optional fields. Named commands make each call self-documenting while preserving existing defaults and behavior.

## Key Changes

- Add shared send and create-and-send command contracts and reuse them across the web and server boundaries.
- Migrate AgentService, transport, store, router, pull request review, and test callers to named command objects.
- Preserve goal, orchestration, preview annotation, reply, worktree, and default-model behavior.
- Add focused regression coverage for exact command shapes, annotation transformation, and omitted-model defaults.

## Verification

- Live `agent.createAndSend` and `agent.send` smoke persisted `[user, assistant, user, assistant]`.
- Focused `TurnFileTracker` suite passed: 29 tests in 1.73 seconds.
- `reviewer_qa` reported `REVIEW_PASSED` with no findings.
- `bun run verify` passed typecheck and lint. The full suite has one unchanged `TurnFileTracker` bulk-rename test that passes alone but times out at 5 seconds under the parallel full-suite load.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787139966&installation_id=129163861&pr_number=889&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F889&signature=0a86e45a7e958dd3123b8985d4048620b5a30e819ad0507b5334c727d05cfeda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->