### PR TITLE
feat(web): polish thread overview

### DIFF
--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -140,6 +140,7 @@ import {
 import {
   getRepositoryFaviconUrl,
   getSafeRepositoryWebUrl,
+  getCiStatusRingStyle,
   getThreadOverviewCiDot,
   formatThreadOverviewSessionCost,
   formatThreadOverviewUsage,
@@ -1019,5 +1020,52 @@ describe("getThreadOverviewCiDot", () => {
       ),
     ).toBeNull();
     expect(getThreadOverviewCiDot(null, { ...baseChecks, aggregate: "passing" })).toBeNull();
+  });
+});
+
+describe("getCiStatusRingStyle", () => {
+  const completedRun = {
+    status: "completed" as const,
+    durationMs: 1,
+    startedAt: "2026-07-20T10:00:00.000Z",
+  };
+
+  it("renders all-passing checks as a hollow green ring", () => {
+    const style = getCiStatusRingStyle({
+      aggregate: "passing",
+      fetchedAt: 1,
+      runs: [
+        { ...completedRun, name: "Typecheck", conclusion: "success" },
+        { ...completedRun, name: "Tests", conclusion: "success" },
+      ],
+    });
+
+    expect(style.background).toBe(
+      "conic-gradient(var(--diff-add-strong) 0% 100%)",
+    );
+    expect(style.maskImage).toContain("transparent 42%");
+  });
+
+  it("allocates ring segments to failed, running, successful, and cancelled checks", () => {
+    const style = getCiStatusRingStyle({
+      aggregate: "failing",
+      fetchedAt: 1,
+      runs: [
+        { ...completedRun, name: "Lint", conclusion: "failure" },
+        {
+          name: "Build",
+          status: "in_progress",
+          conclusion: null,
+          durationMs: null,
+          startedAt: "2026-07-20T10:00:00.000Z",
+        },
+        { ...completedRun, name: "Tests", conclusion: "success" },
+        { ...completedRun, name: "Preview", conclusion: "cancelled" },
+      ],
+    });
+
+    expect(style.background).toBe(
+      "conic-gradient(var(--diff-remove-strong) 0% 25%, var(--primary) 25% 50%, var(--diff-add-strong) 50% 75%, var(--muted-foreground) 75% 100%)",
+    );
   });
 });

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -498,10 +498,13 @@ describe("HeaderActions - consolidated header", () => {
 
     const usageTrigger = screen.getByTestId("thread-overview-usage");
     const prAction = screen.getByTestId("thread-overview-pr");
+    const prSeparator = screen.getByTestId("thread-overview-pr-separator");
     const recap = screen.getByTestId("thread-overview-recap");
     expect(usageTrigger).toHaveAttribute("aria-label", "Usage, 5-hour 12%, weekly 47%");
     expect(usageTrigger).toHaveAttribute("aria-expanded", "true");
     expect(Boolean(usageTrigger.compareDocumentPosition(prAction) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    expect(Boolean(usageTrigger.compareDocumentPosition(prSeparator) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    expect(Boolean(prSeparator.compareDocumentPosition(prAction) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(Boolean(usageTrigger.compareDocumentPosition(recap) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(usageTrigger).toHaveTextContent("Usage");
     expect(usageTrigger).not.toHaveTextContent("5-hour 12%, weekly 47%");

--- a/apps/web/src/components/chat/HeaderActions.test.tsx
+++ b/apps/web/src/components/chat/HeaderActions.test.tsx
@@ -531,6 +531,39 @@ describe("HeaderActions - consolidated header", () => {
     expect(screen.queryByTestId("thread-overview-usage-popover")).not.toBeInTheDocument();
   });
 
+  it("emphasizes quota percentages when usage approaches or reaches the limit", () => {
+    seedThreadUsage("thread-1", {
+      providerId: "claude",
+      usageStatus: "ready",
+      quotaCategories: [
+        {
+          label: "5-hour limit",
+          used: 75,
+          total: 100,
+          remainingPercent: 0.25,
+          resetDate: "2099-07-07T14:14:00.000Z",
+          isUnlimited: false,
+        },
+        {
+          label: "Weekly limit",
+          used: 95,
+          total: 100,
+          remainingPercent: 0.05,
+          resetDate: "2099-07-07T14:14:00.000Z",
+          isUnlimited: false,
+        },
+      ],
+    });
+
+    renderHeaderActions(makeThread({ worktree_path: "/repo/worktrees/feat-x" }));
+
+    const values = screen.getAllByTestId("thread-overview-usage-value");
+    expect(values[0]).toHaveTextContent("75%");
+    expect(values[0]).toHaveClass("text-primary");
+    expect(values[1]).toHaveTextContent("95%");
+    expect(values[1]).toHaveClass("text-destructive");
+  });
+
   it("does not render Codex usage before provider quota data arrives", () => {
     renderHeaderActions(makeThread({ provider: "codex" }));
 

--- a/apps/web/src/components/chat/PrSplitButton.test.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.test.tsx
@@ -24,6 +24,21 @@ describe("PrSplitButton", () => {
     expect(screen.getByTestId("workspace-menu-open-pr")).toHaveTextContent("PR #42");
   });
 
+  it("uses machine typography for a generated PR number", () => {
+    render(
+      <PrSplitButton
+        pr={openPr}
+        label="PR #42"
+        machineLabel
+        onCreatePr={noop}
+        onOpenPr={noop}
+        primaryButtonTestId="workspace-menu-open-pr"
+      />,
+    );
+
+    expect(screen.getByText("PR #42")).toHaveClass("font-mono", "tabular-nums");
+  });
+
   it("calls onOpenPr from the popover action", () => {
     const onOpenPr = vi.fn();
     render(

--- a/apps/web/src/components/chat/PrSplitButton.tsx
+++ b/apps/web/src/components/chat/PrSplitButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronDown, GitPullRequest } from "lucide-react";
+import { ChevronDown, ExternalLink, GitPullRequest, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -10,6 +10,8 @@ interface PrSplitButtonProps {
   pr: { number: number; url: string; state: "OPEN" | "MERGED" | "CLOSED" | string };
   /** Primary row label, usually the PR title or PR number. */
   label: string;
+  /** Whether the primary label is generated repository data rather than prose. */
+  machineLabel?: boolean;
   /** Called when the user wants to open CreatePrDialog. */
   onCreatePr: () => void;
   /** Called with the PR URL when the user wants to open it in the browser or preview. */
@@ -47,6 +49,7 @@ function openPrLabel(pr: PrSplitButtonProps["pr"]): string {
 export function PrSplitButton({
   pr,
   label,
+  machineLabel = false,
   onCreatePr,
   onOpenPr,
   trailing,
@@ -73,10 +76,17 @@ export function PrSplitButton({
               )}
             >
               <span className="flex min-w-0 items-center gap-2">
-                <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
-                <span className="truncate text-xs font-medium">{label}</span>
+                <GitPullRequest className="size-3.5 shrink-0 text-muted-foreground" />
+                <span
+                  className={cn(
+                    "truncate text-xs font-medium",
+                    machineLabel && "font-mono tabular-nums",
+                  )}
+                >
+                  {label}
+                </span>
               </span>
-              <span className="flex shrink-0 items-center gap-1.5">
+              <span className="flex shrink-0 items-center gap-1">
                 {trailing ? (
                   <span
                     className="flex items-center"
@@ -99,7 +109,7 @@ export function PrSplitButton({
           }
         />
         <PopoverContent align="start" side="left" sideOffset={12} className="w-72 p-0">
-          <div data-testid="thread-overview-pr-popover" className="animate-popover-enter space-y-0.5 p-2">
+          <div data-testid="thread-overview-pr-popover" className="animate-popover-enter space-y-1 p-2">
             <Button
               variant="ghost"
               size="sm"
@@ -112,7 +122,7 @@ export function PrSplitButton({
                 onOpenPr(pr.url, event);
               }}
             >
-              <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+              <ExternalLink className="size-3.5 shrink-0 text-muted-foreground" />
               <span className="font-medium">{openPrLabel(pr)}</span>
             </Button>
             <Button
@@ -126,7 +136,7 @@ export function PrSplitButton({
                 onCreatePr();
               }}
             >
-              <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+              <Plus className="size-3.5 shrink-0 text-muted-foreground" />
               <span className="font-medium">Create new PR</span>
             </Button>
           </div>

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1242,12 +1242,12 @@ function ThreadOverviewPrActionRow({
           data-testid="workspace-menu-commit"
           className={cn(
             OVERVIEW_ROW_CLASS,
-            "cursor-pointer justify-start text-xs text-primary hover:bg-primary/10 hover:text-primary",
+            "cursor-pointer justify-start text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground",
           )}
           onClick={onCommitOrPush}
           title="Ask the agent to commit and push the changes"
         >
-          <GitPullRequest size={14} className="shrink-0 text-primary/80" />
+          <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
           <span className="font-medium">Commit or push</span>
         </Button>
       </div>
@@ -1263,13 +1263,13 @@ function ThreadOverviewPrActionRow({
         data-testid="workspace-menu-create-pr"
         className={cn(
           OVERVIEW_ROW_CLASS,
-          "cursor-pointer justify-start text-xs text-primary hover:bg-primary/10 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50",
+          "cursor-pointer justify-start text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50",
         )}
         onClick={onCreatePr}
         disabled={!hasCommitsAhead}
         title={hasCommitsAhead ? "Create pull request" : "Waiting for commits ahead of base branch"}
       >
-        <GitPullRequest size={14} className="shrink-0 text-primary/80" />
+        <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
         <span className="font-medium">Create PR</span>
       </Button>
     </div>

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1170,12 +1170,14 @@ function getCiStatusCircleStyle(checks: ChecksStatus): CSSProperties {
 
 function ThreadOverviewCiStatusCircle({ checks }: { checks: ChecksStatus }) {
   return (
-    <span
-      aria-hidden
-      data-testid="thread-overview-ci-status-circle"
-      className="size-3 shrink-0 rounded-full border border-border/70"
-      style={getCiStatusCircleStyle(checks)}
-    />
+    <span className="flex size-3.5 shrink-0 items-center justify-center">
+      <span
+        aria-hidden
+        data-testid="thread-overview-ci-status-circle"
+        className="size-1.5 rounded-full ring-1 ring-border/70"
+        style={getCiStatusCircleStyle(checks)}
+      />
+    </span>
   );
 }
 
@@ -1285,11 +1287,11 @@ function ThreadOverviewPrActiveRow({
             event.stopPropagation();
             setChecksOpen((open) => !open);
           }}
-          className="ml-6 flex h-6 w-[calc(100%-1.5rem)] cursor-pointer justify-between rounded-none border-transparent bg-transparent px-0 text-left text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent"
+          className="flex h-7 w-full cursor-pointer justify-between gap-3 border-transparent bg-transparent px-2 text-left text-muted-foreground hover:bg-muted/40 hover:text-foreground dark:hover:bg-muted/40"
         >
           <span className="flex min-w-0 items-center gap-2">
             <ThreadOverviewCiStatusCircle checks={checks} />
-            <span className="truncate text-xs">
+            <span className="truncate font-mono text-xs tabular-nums">
               {getCiOverviewSummaryLabel(checks)}
             </span>
           </span>
@@ -1307,9 +1309,10 @@ function ThreadOverviewPrActiveRow({
       status.label ? (
         <span
           data-testid="thread-overview-pr-status"
-          className="ml-6 inline-flex h-6 items-center rounded-md px-2 text-xs text-muted-foreground"
+          className="inline-flex h-7 w-full items-center gap-2 px-2 font-mono text-xs text-muted-foreground"
         >
-          {status.label}
+          <span aria-hidden className="size-3.5 shrink-0" />
+          <span className="truncate">{status.label}</span>
         </span>
       ) : null
     );
@@ -1319,6 +1322,7 @@ function ThreadOverviewPrActiveRow({
       <PrSplitButton
         pr={pr}
         label={rowLabel}
+        machineLabel={!detailText}
         onCreatePr={onCreatePr}
         onOpenPr={onOpenPr}
         primaryButtonTestId="workspace-menu-open-pr"
@@ -2044,16 +2048,21 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
             )}
 
             {canShowPrActions && (
-              <ThreadOverviewPrRow
-                pr={effectivePr}
-                hasCommitsAhead={hasCommitsAhead}
-                checks={checks}
-                openPrDetail={openPrDetail}
-                threadId={thread.id}
-                onCommitOrPush={handleCommitOrPush}
-                onCreatePr={() => setCreatePrOpen(true)}
-                onOpenPr={handleOpenPr}
-              />
+              <>
+                {usageSummary ? (
+                  <Separator data-testid="thread-overview-pr-separator" className="my-1.5" />
+                ) : null}
+                <ThreadOverviewPrRow
+                  pr={effectivePr}
+                  hasCommitsAhead={hasCommitsAhead}
+                  checks={checks}
+                  openPrDetail={openPrDetail}
+                  threadId={thread.id}
+                  onCommitOrPush={handleCommitOrPush}
+                  onCreatePr={() => setCreatePrOpen(true)}
+                  onOpenPr={handleOpenPr}
+                />
+              </>
             )}
 
             {sources.length > 0 && (

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -777,10 +777,7 @@ function ThreadOverviewRecapRow({
                   <RefreshCw
                     size={13}
                     aria-hidden
-                    className={cn(
-                      "transition-transform duration-200 ease-out group-active:rotate-45 motion-reduce:transition-none",
-                      isGenerating && "animate-spin motion-reduce:animate-none",
-                    )}
+                    className="transition-transform duration-200 ease-out group-active:rotate-45 motion-reduce:transition-none"
                   />
                 </Button>
               }

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -114,13 +114,13 @@ type LoadedBranchState =
   | { status: "error"; branches: GitBranchRecord[]; uncommittedFiles: number | null };
 type LoadStatus = "idle" | "loading" | "ready" | "error";
 type LocalCopyTarget = "path" | "branch";
-type CiSegmentName = "failing" | "running" | "passing" | "other";
+type CiSegmentName = "failing" | "running" | "passing" | "cancelled";
 
 const CI_SEGMENT_COLORS: Record<CiSegmentName, string> = {
   failing: "var(--diff-remove-strong)",
-  running: "#e7a90b",
+  running: "var(--primary)",
   passing: "var(--diff-add-strong)",
-  other: "var(--muted-foreground)",
+  cancelled: "var(--muted-foreground)",
 };
 
 /** Repository metadata rendered by the Overview Repository row. */
@@ -1143,18 +1143,25 @@ export function getPrRowDetail(
   return null;
 }
 
-function getCiStatusCircleStyle(checks: ChecksStatus): CSSProperties {
+/** Builds the segmented ring that summarizes CI run outcomes in the Overview. */
+export function getCiStatusRingStyle(checks: ChecksStatus): CSSProperties {
   const breakdown = getBreakdown(checks);
   const total = breakdown.total || 1;
   const segments = ([
     { name: "failing", count: breakdown.failing },
     { name: "running", count: breakdown.running },
     { name: "passing", count: breakdown.passing },
-    { name: "other", count: breakdown.other },
+    { name: "cancelled", count: breakdown.other },
   ] satisfies Array<{ name: CiSegmentName; count: number }>).filter((segment) => segment.count > 0);
 
+  const ringMask = "radial-gradient(circle, transparent 42%, black 46%)";
+
   if (segments.length === 0) {
-    return { background: "var(--muted)" };
+    return {
+      background: "var(--muted)",
+      maskImage: ringMask,
+      WebkitMaskImage: ringMask,
+    };
   }
 
   let cursor = 0;
@@ -1165,7 +1172,11 @@ function getCiStatusCircleStyle(checks: ChecksStatus): CSSProperties {
     return `${CI_SEGMENT_COLORS[segment.name]} ${start}% ${end}%`;
   });
 
-  return { background: `conic-gradient(${stops.join(", ")})` };
+  return {
+    background: `conic-gradient(${stops.join(", ")})`,
+    maskImage: ringMask,
+    WebkitMaskImage: ringMask,
+  };
 }
 
 function ThreadOverviewCiStatusCircle({ checks }: { checks: ChecksStatus }) {
@@ -1174,8 +1185,8 @@ function ThreadOverviewCiStatusCircle({ checks }: { checks: ChecksStatus }) {
       <span
         aria-hidden
         data-testid="thread-overview-ci-status-circle"
-        className="size-1.5 rounded-full ring-1 ring-border/70"
-        style={getCiStatusCircleStyle(checks)}
+        className="size-3.5 rounded-full"
+        style={getCiStatusRingStyle(checks)}
       />
     </span>
   );

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -664,31 +664,33 @@ function ThreadOverviewRepositoryRow({
   return (
     <div className="grid animate-thread-overview-row-reveal">
       <div className="min-h-0 overflow-hidden">
-        <Button
-          variant="ghost"
-          size="sm"
-          type="button"
-          onClick={onOpen}
+        <div
           data-testid="thread-overview-repository"
-          aria-label={`Open ${label} on remote`}
-          title={repository.webUrl ?? label}
-          className={cn(OVERVIEW_ROW_CLASS, "justify-between")}
+          className="flex w-full flex-col gap-1.5 px-2 py-1.5"
         >
-          <span className="flex min-w-0 items-center gap-2">
+          <span className="font-mono text-xs font-medium uppercase leading-tight tracking-[0.18em] text-muted-foreground">
+            REPOSITORY
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            onClick={onOpen}
+            data-testid="thread-overview-repository-link"
+            aria-label={`Open ${label} on remote`}
+            title={repository.webUrl ?? label}
+            className="-mx-1.5 h-7 min-w-0 justify-start gap-1.5 rounded-md px-1.5 text-left text-primary hover:bg-muted/50 hover:text-primary focus-visible:ring-inset"
+          >
             <SiteFavicon
               src={repository.faviconUrl}
               frameTestId="thread-overview-repository-favicon-frame"
               imageTestId="thread-overview-repository-favicon"
               fallback={<GitBranch size={14} className="shrink-0 text-muted-foreground" />}
             />
-            <span className="truncate text-xs font-medium text-primary">{label}</span>
-          </span>
-          <ExternalLink
-            size={12}
-            aria-hidden
-            className="shrink-0 text-muted-foreground transition-colors duration-150 group-hover:text-foreground/80"
-          />
-        </Button>
+            <span className="truncate text-xs font-medium">{label}</span>
+            <ExternalLink size={12} aria-hidden className="shrink-0 text-muted-foreground" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -212,6 +212,13 @@ function usageCategoryFillClass(category: QuotaCategory): string {
   return "bg-[var(--diff-add-strong)]";
 }
 
+function usageCategoryMetricClass(category: QuotaCategory): string {
+  const percent = usageCategoryPercent(category);
+  if (percent >= 90) return "text-destructive";
+  if (percent >= 70) return "text-primary";
+  return "text-foreground/80";
+}
+
 /**
  * Returns the Overview session-cost label only for provider-proven API-key billing.
  */
@@ -300,7 +307,7 @@ function ThreadOverviewUsageBars({
         className="flex h-8 w-full items-center justify-between gap-3 px-2 text-left"
       >
         <span className="flex min-w-0 items-center gap-2">
-          <Gauge size={14} aria-hidden className="shrink-0 text-muted-foreground" />
+          <Gauge aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />
           <span className="truncate text-xs font-medium">Usage</span>
         </span>
         <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
@@ -327,12 +334,12 @@ function ThreadOverviewUsageBars({
           className="h-8 w-full cursor-pointer justify-between gap-3 px-2 text-left"
         >
           <span className="flex min-w-0 items-center gap-2">
-            <Gauge size={14} aria-hidden className="shrink-0 text-muted-foreground" />
+            <Gauge aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="truncate text-xs font-medium">Usage</span>
           </span>
-          <span className="flex shrink-0 items-center gap-2">
+          <span className="flex min-w-0 shrink items-center gap-2">
             {!open ? (
-              <span className="font-mono text-xs tabular-nums text-muted-foreground">
+              <span className="min-w-0 truncate font-mono text-xs tabular-nums text-muted-foreground">
                 {summary}
               </span>
             ) : null}
@@ -353,63 +360,72 @@ function ThreadOverviewUsageBars({
           id={THREAD_OVERVIEW_USAGE_DETAILS_ID}
           data-testid="thread-overview-usage-details"
           aria-hidden={!open}
-          className="space-y-2.5 px-2 pb-2 pl-6 pt-1 text-muted-foreground"
+          className="flex gap-2 px-2 pb-2 pt-1 text-muted-foreground"
         >
-          {categories.map((category) => {
-            const percent = Math.min(Math.max(usageCategoryPercent(category), 0), 100);
-            const rounded = Math.round(percent);
-            const shortLabel = usageCategoryShortLabel(category.label);
-            const displayLabel = category.label.trim();
-            const resetText = formatUsageResetText(category.resetDate);
-            const progressDescription = resetText
-              ? `${shortLabel} usage ${rounded} percent. ${resetText}`
-              : `${shortLabel} usage ${rounded} percent`;
-            return (
-              <div key={category.label} className="space-y-1">
-                <div className="flex items-baseline justify-between gap-3">
-                  <span className="min-w-0 truncate text-xs text-foreground/80">{displayLabel}</span>
-                  <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
-                    {rounded}%
-                  </span>
-                </div>
-                <div
-                  role="progressbar"
-                  aria-label={progressDescription}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-valuenow={rounded}
-                  className="h-1 w-full overflow-hidden rounded-full bg-muted/60"
-                >
-                  <div
-                    className={cn(
-                      "h-full rounded-full transition-[width] duration-300 ease-out motion-reduce:transition-none",
-                      open && "animate-thread-overview-usage-fill",
-                      usageCategoryFillClass(category),
-                    )}
-                    style={{ width: `${percent}%` }}
-                  />
-                </div>
-                {resetText ? (
-                  <div className="font-mono text-xs tabular-nums text-muted-foreground/70">
-                    {resetText}
+          <span aria-hidden className="size-3.5 shrink-0" />
+          <div className="min-w-0 flex-1 space-y-3">
+            {categories.map((category) => {
+              const percent = Math.min(Math.max(usageCategoryPercent(category), 0), 100);
+              const rounded = Math.round(percent);
+              const shortLabel = usageCategoryShortLabel(category.label);
+              const displayLabel = category.label.trim();
+              const resetText = formatUsageResetText(category.resetDate);
+              const progressDescription = resetText
+                ? `${shortLabel} usage ${rounded} percent. ${resetText}`
+                : `${shortLabel} usage ${rounded} percent`;
+              return (
+                <div key={category.label} className="space-y-1">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="min-w-0 truncate text-xs text-foreground/80">{displayLabel}</span>
+                    <span
+                      data-testid="thread-overview-usage-value"
+                      className={cn(
+                        "shrink-0 font-mono text-xs font-medium tabular-nums",
+                        usageCategoryMetricClass(category),
+                      )}
+                    >
+                      {rounded}%
+                    </span>
                   </div>
-                ) : null}
+                  <div
+                    role="progressbar"
+                    aria-label={progressDescription}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={rounded}
+                    className="h-1 w-full overflow-hidden rounded-full bg-muted"
+                  >
+                    <div
+                      className={cn(
+                        "h-full rounded-full transition-[width] duration-300 ease-out motion-reduce:transition-none",
+                        open && "animate-thread-overview-usage-fill",
+                        usageCategoryFillClass(category),
+                      )}
+                      style={{ width: `${percent}%` }}
+                    />
+                  </div>
+                  {resetText ? (
+                    <div className="font-mono text-xs tabular-nums text-muted-foreground">
+                      {resetText}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+            {usageStatus === "stale" ? (
+              <div className="font-mono text-xs uppercase tracking-wider text-muted-foreground/60">
+                STALE
               </div>
-            );
-          })}
-          {usageStatus === "stale" ? (
-            <div className="font-mono text-xs uppercase tracking-wider text-muted-foreground/60">
-              STALE
-            </div>
-          ) : null}
-          {sessionCostSummary ? (
-            <div className="flex items-baseline justify-between gap-3 pt-0.5">
-              <span className="min-w-0 truncate text-xs text-foreground/80">Session cost</span>
-              <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
-                {sessionCostSummary}
-              </span>
-            </div>
-          ) : null}
+            ) : null}
+            {sessionCostSummary ? (
+              <div className="flex items-baseline justify-between gap-3 pt-1">
+                <span className="min-w-0 truncate text-xs text-foreground/80">Session cost</span>
+                <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                  {sessionCostSummary}
+                </span>
+              </div>
+            ) : null}
+          </div>
         </div>
       </AnimatedCollapsible>
     </Collapsible>

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -160,6 +160,9 @@ const EMPTY_REPOSITORY: ThreadOverviewRepository = {
   faviconUrl: null,
 };
 
+const OVERVIEW_ROW_CLASS =
+  "group h-8 w-full gap-3 px-2 text-left transition-[background-color,color,transform] duration-150 ease-out active:translate-y-px motion-reduce:transform-none";
+
 /**
  * Derives the active thread's compact CI signal for the Overview trigger.
  */
@@ -661,33 +664,31 @@ function ThreadOverviewRepositoryRow({
   return (
     <div className="grid animate-thread-overview-row-reveal">
       <div className="min-h-0 overflow-hidden">
-        <div
+        <Button
+          variant="ghost"
+          size="sm"
+          type="button"
+          onClick={onOpen}
           data-testid="thread-overview-repository"
-          className="flex w-full flex-col gap-1.5 px-2 py-1.5"
+          aria-label={`Open ${label} on remote`}
+          title={repository.webUrl ?? label}
+          className={cn(OVERVIEW_ROW_CLASS, "justify-between")}
         >
-          <span className="font-mono text-xs font-medium uppercase leading-tight tracking-[0.18em] text-muted-foreground">
-            REPOSITORY
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            type="button"
-            onClick={onOpen}
-            data-testid="thread-overview-repository-link"
-            aria-label={`Open ${label} on remote`}
-            title={repository.webUrl ?? label}
-            className="-mx-1.5 h-7 min-w-0 justify-start gap-1.5 rounded-md px-1.5 text-left text-primary hover:bg-muted/50 hover:text-primary focus-visible:ring-inset"
-          >
+          <span className="flex min-w-0 items-center gap-2">
             <SiteFavicon
               src={repository.faviconUrl}
               frameTestId="thread-overview-repository-favicon-frame"
               imageTestId="thread-overview-repository-favicon"
               fallback={<GitBranch size={14} className="shrink-0 text-muted-foreground" />}
             />
-            <span className="truncate text-xs font-medium">{label}</span>
-            <ExternalLink size={12} aria-hidden className="shrink-0 text-muted-foreground" />
-          </Button>
-        </div>
+            <span className="truncate text-xs font-medium text-primary">{label}</span>
+          </span>
+          <ExternalLink
+            size={12}
+            aria-hidden
+            className="shrink-0 text-muted-foreground transition-colors duration-150 group-hover:text-foreground/80"
+          />
+        </Button>
       </div>
     </div>
   );
@@ -769,9 +770,16 @@ function ThreadOverviewRecapRow({
                   aria-label={refreshLabel}
                   disabled={isGenerating}
                   onClick={onRefresh}
-                  className={cn("shrink-0", isGenerating && "text-muted-foreground/45")}
+                  className={cn("group shrink-0", isGenerating && "text-muted-foreground/45")}
                 >
-                  <RefreshCw size={13} aria-hidden />
+                  <RefreshCw
+                    size={13}
+                    aria-hidden
+                    className={cn(
+                      "transition-transform duration-200 ease-out group-active:rotate-45 motion-reduce:transition-none",
+                      isGenerating && "animate-spin motion-reduce:animate-none",
+                    )}
+                  />
                 </Button>
               }
             />
@@ -1088,8 +1096,8 @@ function ThreadOverviewSources({ sources, onOpen }: ThreadOverviewSourcesProps) 
 
   return (
     <div data-testid="thread-overview-sources" className="flex w-full flex-col gap-1.5 px-2 py-1.5">
-      <span className="font-mono text-xs font-medium uppercase leading-tight tracking-[0.18em] text-muted-foreground">
-        SOURCES
+      <span className="text-xs font-medium text-muted-foreground">
+        Sources
       </span>
       <div className="flex flex-wrap gap-1">
         {sources.map((source) => (
@@ -1232,11 +1240,14 @@ function ThreadOverviewPrActionRow({
           size="sm"
           type="button"
           data-testid="workspace-menu-commit"
-          className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-left text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground"
+          className={cn(
+            OVERVIEW_ROW_CLASS,
+            "cursor-pointer justify-start text-xs text-primary hover:bg-primary/10 hover:text-primary",
+          )}
           onClick={onCommitOrPush}
           title="Ask the agent to commit and push the changes"
         >
-          <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+          <GitPullRequest size={14} className="shrink-0 text-primary/80" />
           <span className="font-medium">Commit or push</span>
         </Button>
       </div>
@@ -1250,12 +1261,15 @@ function ThreadOverviewPrActionRow({
         size="sm"
         type="button"
         data-testid="workspace-menu-create-pr"
-        className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-left text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        className={cn(
+          OVERVIEW_ROW_CLASS,
+          "cursor-pointer justify-start text-xs text-primary hover:bg-primary/10 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50",
+        )}
         onClick={onCreatePr}
         disabled={!hasCommitsAhead}
         title={hasCommitsAhead ? "Create pull request" : "Waiting for commits ahead of base branch"}
       >
-        <GitPullRequest size={14} className="shrink-0 text-muted-foreground" />
+        <GitPullRequest size={14} className="shrink-0 text-primary/80" />
         <span className="font-medium">Create PR</span>
       </Button>
     </div>
@@ -1877,7 +1891,7 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
       aria-label={triggerStatus}
       data-testid="header-workspace-menu"
       className={cn(
-        "relative cursor-pointer text-foreground/70 hover:bg-muted/40 hover:text-foreground",
+        "relative cursor-pointer text-foreground/70 transition-[background-color,color,transform] duration-150 active:scale-95 motion-reduce:transform-none hover:bg-muted/40 hover:text-foreground",
         open && "bg-muted text-foreground",
       )}
     >
@@ -1897,17 +1911,28 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
   );
 
   const overviewBody = (
-    <div data-testid="thread-overview-body" className="animate-overview-enter p-1.5">
+    <div data-testid="thread-overview-body" className="animate-overview-enter">
+      <div
+        data-testid="thread-overview-masthead"
+        className="flex h-9 items-center bg-muted/20 px-3"
+      >
+        <span className="text-xs font-semibold text-foreground/90">Overview</span>
+      </div>
+      <Separator />
+      <div className="p-1.5">
             <Button
               variant="ghost"
               size="sm"
               onClick={openChanges}
               data-testid="workspace-menu-changes"
               aria-label={`Changes, ${changedFilesLabel(changeSummary.files)}`}
-              className="h-8 w-full cursor-pointer justify-between gap-3 px-2 text-left"
+              className={cn(OVERVIEW_ROW_CLASS, "cursor-pointer justify-between")}
             >
               <span className="flex min-w-0 items-center gap-2">
-                <Diff size={14} className="shrink-0 text-muted-foreground" />
+                <Diff
+                  size={14}
+                  className="shrink-0 text-muted-foreground transition-colors duration-150 group-hover:text-foreground/80"
+                />
                 <span className="truncate text-xs font-medium">Changes</span>
               </span>
               {isChangeSummaryLoading ? (
@@ -1946,10 +1971,13 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                 data-testid="thread-overview-plan"
                 onClick={openLatestPlan}
                 aria-label={`Plan, ${latestPlan.title}`}
-                className="h-8 w-full cursor-pointer justify-between gap-3 px-2 text-left"
+                className={cn(OVERVIEW_ROW_CLASS, "cursor-pointer justify-between")}
               >
                 <span className="flex min-w-0 items-center gap-2">
-                  <ListChecks size={14} className="shrink-0 text-muted-foreground" />
+                  <ListChecks
+                    size={14}
+                    className="shrink-0 text-muted-foreground transition-colors duration-150 group-hover:text-foreground/80"
+                  />
                   <span className="truncate text-xs font-medium">Plans</span>
                 </span>
                 <span className="min-w-0 max-w-[11rem] truncate text-xs text-muted-foreground">
@@ -1968,7 +1996,8 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                     data-testid="thread-overview-local"
                     aria-label={`${modeLabel}${dirPath ? `, ${dirPath}` : ""}`}
                     className={cn(
-                      "h-8 w-full justify-between gap-3 px-2 text-left",
+                      OVERVIEW_ROW_CLASS,
+                      "justify-between",
                       localOpen && "bg-muted text-foreground",
                     )}
                   >
@@ -1977,11 +2006,18 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                         size={14}
                         aria-hidden
                         data-testid="thread-overview-local-mode-icon"
-                        className="shrink-0 text-muted-foreground"
+                        className="shrink-0 text-muted-foreground transition-colors duration-150 group-hover:text-foreground/80"
                       />
                       <span className="truncate text-xs font-medium">{modeLabel}</span>
                     </span>
-                    <ChevronDown size={13} aria-hidden className="shrink-0 text-muted-foreground" />
+                    <ChevronDown
+                      size={13}
+                      aria-hidden
+                      className={cn(
+                        "shrink-0 text-muted-foreground transition-transform duration-150",
+                        localOpen && "rotate-180",
+                      )}
+                    />
                   </Button>
                 }
               />
@@ -2001,11 +2037,14 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                 size="sm"
                 type="button"
                 data-testid="thread-overview-create-branch"
-                className="h-8 w-full cursor-pointer justify-start gap-2 px-2 text-left text-xs text-foreground/75 hover:bg-muted/40 hover:text-foreground"
+                className={cn(
+                  OVERVIEW_ROW_CLASS,
+                  "cursor-pointer justify-start text-xs text-primary hover:bg-primary/10 hover:text-primary",
+                )}
                 onClick={() => setCreateBranchOpen(true)}
                 title="Create a branch in this worktree"
               >
-                <GitBranch size={14} className="shrink-0 text-muted-foreground" />
+                <GitBranch size={14} className="shrink-0 text-primary/80" />
                 <span className="font-medium">Create branch</span>
               </Button>
             ) : (
@@ -2018,15 +2057,26 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
                       type="button"
                       data-testid="workspace-menu-branch"
                       className={cn(
-                        "h-8 w-full justify-between gap-3 px-2 text-left",
+                        OVERVIEW_ROW_CLASS,
+                        "justify-between",
                         branchOpen && "bg-muted text-foreground",
                       )}
                     >
                       <span className="flex min-w-0 items-center gap-2">
-                        <GitBranch size={14} className="shrink-0 text-muted-foreground" />
+                        <GitBranch
+                          size={14}
+                          className="shrink-0 text-muted-foreground transition-colors duration-150 group-hover:text-foreground/80"
+                        />
                         <span className="truncate text-xs font-medium">{checkoutLabel}</span>
                       </span>
-                      <ChevronDown size={13} aria-hidden className="shrink-0 text-muted-foreground" />
+                      <ChevronDown
+                        size={13}
+                        aria-hidden
+                        className={cn(
+                          "shrink-0 text-muted-foreground transition-transform duration-150",
+                          branchOpen && "rotate-180",
+                        )}
+                      />
                     </Button>
                   }
                 />
@@ -2109,6 +2159,7 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
               error={threadRecap.error}
               onRefresh={() => void threadRecap.refresh()}
             />
+      </div>
     </div>
   );
 
@@ -2130,7 +2181,7 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
           sideOffset={18}
           alignOffset={-40}
           collisionPadding={8}
-          className="w-80 p-0"
+          className="w-80 overflow-hidden p-0"
         >
           {overviewBody}
         </PopoverContent>


### PR DESCRIPTION
## What
Polishes the thread Overview with clearer alignment, richer usage summaries, and a segmented circular CI indicator.

## Why
The PR status and usage sections felt misaligned and visually unfinished. CI state also needed to communicate mixed results instead of collapsing into a single status dot.

## Key Changes
- Align PR actions, status text, and check details to the overview grid.
- Show successful, failed, running, and cancelled checks in a segmented circular indicator.
- Refine usage summaries, quota thresholds, reset details, and collapsed presentation.
- Add restrained hover and disclosure motion while keeping Create PR neutral.

## Verification
- Live Playwright checks: 3 passed at desktop and compact widths.
- Focused Vitest checks: 62 passed.
- Full repository gate: typecheck passed, lint passed, and 2,368 frontend tests passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787142425&installation_id=129163861&pr_number=900&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F900&signature=cc58f71b8c44a14d0104d521f5b22d81349c1016cb5fe6ed9abaeca3e0d83cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->