### PR TITLE
fix(ui): polish home, sidebar, and model settings

### DIFF
--- a/apps/web/e2e/provider-toggle.spec.ts
+++ b/apps/web/e2e/provider-toggle.spec.ts
@@ -99,7 +99,9 @@ async function openProviderSettings(page: Page): Promise<void> {
   // separate "Provider" nav entry.
   await page.getByRole("button", { name: "Model", exact: true }).click();
   // Wait for the ProviderSection heading to confirm the section rendered.
-  await expect(page.getByRole("heading", { name: "Provider" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Providers", exact: true }),
+  ).toBeVisible();
 }
 
 /**
@@ -145,7 +147,7 @@ test.describe("provider toggle", () => {
 
   // ── Test 1: six switches + key badges visible ──────────────────────────────
 
-  test("renders six switches with badges", async ({ page }) => {
+  test("renders configurable switches with provider badges", async ({ page }) => {
     const availability = makeAvailabilityFixture();
 
     await mockWebSocketServer(page, {
@@ -156,9 +158,9 @@ test.describe("provider toggle", () => {
     await page.waitForLoadState("networkidle");
     await openProviderSettings(page);
 
-    // Each provider should have a switch
+    // Configurable providers should have switches.
     const switchIds: ProviderAvailability["id"][] = [
-      "claude", "codex", "copilot", "gemini", "cursor", "opencode",
+      "claude", "codex", "copilot",
     ];
     for (const id of switchIds) {
       await expect(page.getByTestId(`provider-switch-${id}`)).toBeVisible();
@@ -172,6 +174,11 @@ test.describe("provider toggle", () => {
 
     // Gemini should have a Coming soon badge
     await expect(page.getByTestId("provider-badge-gemini-comingsoon")).toBeVisible();
+    await expect(page.getByTestId("provider-badge-cursor-comingsoon")).toBeVisible();
+    await expect(page.getByTestId("provider-badge-opencode-comingsoon")).toBeVisible();
+    await expect(page.getByTestId("provider-switch-gemini")).toHaveCount(0);
+    await expect(page.getByTestId("provider-switch-cursor")).toHaveCount(0);
+    await expect(page.getByTestId("provider-switch-opencode")).toHaveCount(0);
 
     await page.screenshot({ path: SS("01-settings-default.png"), fullPage: false });
   });
@@ -304,7 +311,7 @@ test.describe("provider toggle", () => {
 
   // ── Test 5: coming-soon provider switch is disabled ───────────────────────
 
-  test("coming-soon provider switch is disabled", async ({ page }) => {
+  test("coming-soon providers are grouped without switches", async ({ page }) => {
     const availability = makeAvailabilityFixture();
 
     await mockWebSocketServer(page, {
@@ -315,10 +322,13 @@ test.describe("provider toggle", () => {
     await page.waitForLoadState("networkidle");
     await openProviderSettings(page);
 
-    // gemini is comingSoon=true, so its switch must be disabled
-    const geminiSwitch = page.getByTestId("provider-switch-gemini");
-    await expect(geminiSwitch).toBeVisible();
-    await expect(geminiSwitch).toBeDisabled();
+    await expect(page.getByTestId("coming-soon-providers")).toBeVisible();
+    await expect(page.getByTestId("provider-badge-gemini-comingsoon")).toBeVisible();
+    await expect(page.getByTestId("provider-badge-cursor-comingsoon")).toBeVisible();
+    await expect(page.getByTestId("provider-badge-opencode-comingsoon")).toBeVisible();
+    await expect(page.getByTestId("provider-switch-gemini")).toHaveCount(0);
+    await expect(page.getByTestId("provider-switch-cursor")).toHaveCount(0);
+    await expect(page.getByTestId("provider-switch-opencode")).toHaveCount(0);
 
     await page.screenshot({ path: SS("05-coming-soon-disabled.png"), fullPage: false });
   });

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -160,7 +160,7 @@ function NewThreadWelcome({
         </h1>
         <div
           data-testid="new-thread-starters"
-          className="grid w-full grid-cols-[repeat(auto-fit,minmax(18rem,1fr))] gap-2.5"
+          className="grid w-full grid-cols-[repeat(auto-fit,minmax(min(18rem,100%),1fr))] gap-2.5"
         >
           {NEW_THREAD_STARTERS.map(({ label, prompt, icon: Icon }) => (
             <Button
@@ -168,7 +168,7 @@ function NewThreadWelcome({
               type="button"
               variant="outline"
               onClick={() => onPromptSelect(prompt)}
-              className="group h-auto min-h-[10.8rem] flex-col items-start justify-between rounded-xl border-border/70 bg-transparent px-4 py-3.5 text-left shadow-none hover:border-primary/35 hover:bg-accent/45"
+              className="group h-auto min-h-24 flex-col items-start justify-between rounded-xl border-border/70 bg-transparent px-4 py-3.5 text-left shadow-none hover:border-primary/35 hover:bg-accent/45"
             >
               <Icon size={15} className="text-primary transition-transform duration-200 group-hover:-translate-y-0.5 motion-reduce:transform-none" aria-hidden />
               <span className="w-full max-w-[18ch] text-wrap text-[13px] font-medium leading-5 text-foreground/90">

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -128,7 +128,7 @@ function NewThreadWelcome({
       <div
         key={projectName ?? "projectless"}
         data-testid="new-thread-welcome"
-        className="animate-fade-up-in flex w-full max-w-3xl flex-col items-center gap-7 text-center"
+        className="animate-fade-up-in flex w-full max-w-[80rem] flex-col items-center gap-7 text-center"
       >
         <McodeLogo variant="newThread" markOnly />
         <h1
@@ -158,17 +158,20 @@ function NewThreadWelcome({
             "What should we work on?"
           )}
         </h1>
-        <div className="grid w-full grid-cols-1 gap-2.5 sm:grid-cols-2 lg:grid-cols-4">
+        <div
+          data-testid="new-thread-starters"
+          className="grid w-full grid-cols-[repeat(auto-fit,minmax(18rem,1fr))] gap-2.5"
+        >
           {NEW_THREAD_STARTERS.map(({ label, prompt, icon: Icon }) => (
             <Button
               key={label}
               type="button"
               variant="outline"
               onClick={() => onPromptSelect(prompt)}
-              className="group h-auto min-h-24 flex-col items-start justify-between rounded-xl border-border/70 bg-transparent px-4 py-3.5 text-left shadow-none hover:border-primary/35 hover:bg-accent/45"
+              className="group h-auto min-h-[10.8rem] flex-col items-start justify-between rounded-xl border-border/70 bg-transparent px-4 py-3.5 text-left shadow-none hover:border-primary/35 hover:bg-accent/45"
             >
               <Icon size={15} className="text-primary transition-transform duration-200 group-hover:-translate-y-0.5 motion-reduce:transform-none" aria-hidden />
-              <span className="max-w-32 text-wrap text-sm font-medium leading-5 text-foreground/90">
+              <span className="w-full max-w-[18ch] text-wrap text-[13px] font-medium leading-5 text-foreground/90">
                 {label}
               </span>
             </Button>

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -160,7 +160,7 @@ function NewThreadWelcome({
         </h1>
         <div
           data-testid="new-thread-starters"
-          className="grid w-full grid-cols-[repeat(auto-fit,minmax(min(18rem,100%),1fr))] gap-2.5"
+          className="grid w-full grid-cols-[repeat(auto-fit,minmax(min(18rem,100%),1fr))] gap-3"
         >
           {NEW_THREAD_STARTERS.map(({ label, prompt, icon: Icon }) => (
             <Button
@@ -168,10 +168,10 @@ function NewThreadWelcome({
               type="button"
               variant="outline"
               onClick={() => onPromptSelect(prompt)}
-              className="group h-auto min-h-24 flex-col items-start justify-between rounded-xl border-border/70 bg-transparent px-4 py-3.5 text-left shadow-none hover:border-primary/35 hover:bg-accent/45"
+              className="group h-auto min-h-24 flex-col items-start justify-between rounded-xl border-border/70 bg-transparent px-4 py-4 text-left shadow-none hover:border-primary/35 hover:bg-accent/45"
             >
-              <Icon size={15} className="text-primary transition-transform duration-200 group-hover:-translate-y-0.5 motion-reduce:transform-none" aria-hidden />
-              <span className="w-full max-w-[18ch] text-wrap text-[13px] font-medium leading-5 text-foreground/90">
+              <Icon className="size-4 text-primary transition-transform duration-200 group-hover:-translate-y-0.5 motion-reduce:transform-none" aria-hidden />
+              <span className="w-full max-w-[18ch] text-wrap text-sm font-medium leading-5 text-foreground/90">
                 {label}
               </span>
             </Button>

--- a/apps/web/src/components/settings/SettingRow.tsx
+++ b/apps/web/src/components/settings/SettingRow.tsx
@@ -13,21 +13,25 @@ interface SettingRowProps {
 
 /**
  * Responsive row layout for a single setting: label + hint on the left,
- * control slot on the right. Wraps to a stacked layout on narrow viewports.
+ * control slot on the right. Stacks the control below the label on narrow viewports.
  */
 export function SettingRow({ label, hint, children, className }: SettingRowProps) {
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center justify-between gap-x-6 gap-y-3 border-b border-border/50 px-1 py-4 last:border-b-0",
+        "grid gap-3 border-b border-border/50 px-1 py-4 last:border-b-0 min-[900px]:grid-cols-[minmax(0,1fr)_auto] min-[900px]:items-center min-[900px]:gap-x-8",
         className,
       )}
     >
-      <div className="min-w-[10rem]">
+      <div className="min-w-0">
         <span className="text-sm font-semibold text-foreground">{label}</span>
-        {hint && <p className="mt-1 text-xs text-muted-foreground">{hint}</p>}
+        {hint && (
+          <p className="mt-1 max-w-[62ch] text-xs leading-5 text-muted-foreground">
+            {hint}
+          </p>
+        )}
       </div>
-      <div className="shrink-0">{children}</div>
+      <div className="min-w-0 min-[900px]:justify-self-end">{children}</div>
     </div>
   );
 }

--- a/apps/web/src/components/settings/SettingRow.tsx
+++ b/apps/web/src/components/settings/SettingRow.tsx
@@ -13,7 +13,7 @@ interface SettingRowProps {
 
 /** Responsive grid shared by standard and provider-specific setting rows. */
 export const SETTING_ROW_GRID_CLASS =
-  "grid gap-3 min-[90rem]:grid-cols-[minmax(0,1fr)_auto] min-[90rem]:items-center min-[90rem]:gap-x-8";
+  "grid gap-3 min-[80rem]:grid-cols-[minmax(0,1fr)_auto] min-[80rem]:items-center min-[80rem]:gap-x-8";
 
 /**
  * Responsive row layout for a single setting: label + hint on the left,
@@ -36,7 +36,7 @@ export function SettingRow({ label, hint, children, className }: SettingRowProps
           </p>
         )}
       </div>
-      <div className="min-w-0 min-[90rem]:justify-self-end">{children}</div>
+      <div className="min-w-0 min-[80rem]:justify-self-end">{children}</div>
     </div>
   );
 }

--- a/apps/web/src/components/settings/SettingRow.tsx
+++ b/apps/web/src/components/settings/SettingRow.tsx
@@ -11,6 +11,10 @@ interface SettingRowProps {
   className?: string;
 }
 
+/** Responsive grid shared by standard and provider-specific setting rows. */
+export const SETTING_ROW_GRID_CLASS =
+  "grid gap-3 min-[90rem]:grid-cols-[minmax(0,1fr)_auto] min-[90rem]:items-center min-[90rem]:gap-x-8";
+
 /**
  * Responsive row layout for a single setting: label + hint on the left,
  * control slot on the right. Stacks the control below the label on narrow viewports.
@@ -19,19 +23,20 @@ export function SettingRow({ label, hint, children, className }: SettingRowProps
   return (
     <div
       className={cn(
-        "grid gap-3 border-b border-border/50 px-1 py-4 last:border-b-0 min-[900px]:grid-cols-[minmax(0,1fr)_auto] min-[900px]:items-center min-[900px]:gap-x-8",
+        SETTING_ROW_GRID_CLASS,
+        "border-b border-border/50 px-1 py-4 last:border-b-0",
         className,
       )}
     >
       <div className="min-w-0">
         <span className="text-sm font-semibold text-foreground">{label}</span>
         {hint && (
-          <p className="mt-1 max-w-[62ch] text-xs leading-5 text-muted-foreground">
+          <p className="mt-1 max-w-[62ch] text-xs text-muted-foreground">
             {hint}
           </p>
         )}
       </div>
-      <div className="min-w-0 min-[900px]:justify-self-end">{children}</div>
+      <div className="min-w-0 min-[90rem]:justify-self-end">{children}</div>
     </div>
   );
 }

--- a/apps/web/src/components/settings/SettingsGroup.tsx
+++ b/apps/web/src/components/settings/SettingsGroup.tsx
@@ -10,7 +10,7 @@ export interface SettingsGroupProps {
   children: ReactNode;
 }
 
-/** Renders a labeled settings group on a quiet tonal surface. */
+/** Renders a labeled settings group with divider-defined content. */
 export function SettingsGroup({
   title,
   description,
@@ -23,17 +23,17 @@ export function SettingsGroup({
       <div className="mb-3 px-1">
         <h2
           id={headingId}
-          className="text-base font-semibold tracking-tight text-foreground"
+          className="text-base leading-5 font-semibold tracking-tight text-foreground"
         >
           {title}
         </h2>
         {description && (
-          <p className="mt-1 max-w-[65ch] text-xs leading-5 text-muted-foreground">
+          <p className="mt-1 max-w-[65ch] text-xs text-muted-foreground">
             {description}
           </p>
         )}
       </div>
-      <div className="overflow-hidden rounded-xl border border-border/55 bg-card/30 px-4">
+      <div className="border-y border-border/50 px-2">
         {children}
       </div>
     </section>

--- a/apps/web/src/components/settings/SettingsGroup.tsx
+++ b/apps/web/src/components/settings/SettingsGroup.tsx
@@ -1,0 +1,41 @@
+import { useId, type ReactNode } from "react";
+
+/** Props for a visually grouped set of related settings. */
+export interface SettingsGroupProps {
+  /** Heading that identifies the settings group. */
+  title: string;
+  /** Short explanation of what the group controls. */
+  description?: string;
+  /** Setting rows rendered inside the group surface. */
+  children: ReactNode;
+}
+
+/** Renders a labeled settings group on a quiet tonal surface. */
+export function SettingsGroup({
+  title,
+  description,
+  children,
+}: SettingsGroupProps) {
+  const headingId = useId();
+
+  return (
+    <section aria-labelledby={headingId}>
+      <div className="mb-3 px-1">
+        <h2
+          id={headingId}
+          className="text-base font-semibold tracking-tight text-foreground"
+        >
+          {title}
+        </h2>
+        {description && (
+          <p className="mt-1 max-w-[65ch] text-xs leading-5 text-muted-foreground">
+            {description}
+          </p>
+        )}
+      </div>
+      <div className="overflow-hidden rounded-xl border border-border/55 bg-card/30 px-4">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/SettingsNav.tsx
+++ b/apps/web/src/components/settings/SettingsNav.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { NAV_GROUPS, type SettingsSection } from "./settings-nav";
 
 interface SettingsNavProps {
@@ -12,23 +13,25 @@ export function SettingsNav({ section, onSection }: SettingsNavProps) {
     <div className="py-4">
       {NAV_GROUPS.map((group) => (
         <div key={group.label} className="mb-5 px-2">
-          <p className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50">
+          <p className="mb-1 px-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             {group.label}
           </p>
           {group.items.map((item) => (
-            <button
+            <Button
               key={item.id}
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => onSection(item.id)}
               className={cn(
-                "flex w-full rounded px-3 py-1.5 text-left text-sm font-medium transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring/50",
+                "w-full justify-start rounded-md px-3 text-left font-medium",
                 section === item.id
-                  ? "bg-primary/10 text-foreground font-semibold"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/40",
+                  ? "bg-primary/10 font-semibold text-foreground hover:bg-primary/10"
+                  : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
               )}
             >
               {item.label}
-            </button>
+            </Button>
           ))}
         </div>
       ))}

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/lib/model-registry";
 import { SettingRow } from "../SettingRow";
 import { SegControl } from "../SegControl";
-import { SectionHeading } from "../SectionHeading";
+import { SettingsGroup } from "../SettingsGroup";
 import { SearchableGroupedPicker } from "../SearchableGroupedPicker";
 import { SettingsProviderPicker } from "../SettingsProviderPicker";
 import { Switch } from "@/components/ui/switch";
@@ -388,12 +388,27 @@ export function ModelSection() {
   };
 
   return (
-    <div>
-      <ProviderSection />
+    <div
+      data-testid="model-settings-section"
+      className="mx-auto w-full max-w-[88rem] pb-10"
+    >
+      <header className="mb-8 border-b border-border/45 px-1 pb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+          Models &amp; providers
+        </h1>
+        <p className="mt-2 max-w-[65ch] text-sm leading-6 text-muted-foreground">
+          Configure the providers and model defaults used across new threads and
+          utility tasks.
+        </p>
+      </header>
 
-      <div className="mt-8">
-      <SectionHeading>Model</SectionHeading>
-      <div>
+      <div className="space-y-8">
+        <ProviderSection />
+
+        <SettingsGroup
+          title="Model defaults"
+          description="Defaults applied when you start a new thread."
+        >
       <SettingRow
         label="Provider"
         configKey="model.defaults.provider"
@@ -523,12 +538,12 @@ export function ModelSection() {
           />
         </SettingRow>
       )}
-      </div>
-      </div>
+        </SettingsGroup>
 
-      <div className="mt-8">
-        <SectionHeading>Utility Model</SectionHeading>
-        <div>
+        <SettingsGroup
+          title="Utility model"
+          description="Provider and model for lightweight tasks such as PR drafts and diff summaries."
+        >
           <SettingRow
             label="Provider"
             configKey="model.utility.provider"
@@ -570,12 +585,12 @@ export function ModelSection() {
               </div>
             )}
           </SettingRow>
-        </div>
-      </div>
+        </SettingsGroup>
 
-      <div className="mt-8">
-        <SectionHeading>AI Features</SectionHeading>
-        <div>
+        <SettingsGroup
+          title="AI features"
+          description="Optional model-powered features."
+        >
           <SettingRow
             label="Diff summary"
             configKey="diffSummary.enabled"
@@ -586,9 +601,8 @@ export function ModelSection() {
               onCheckedChange={(v) => update({ diffSummary: { enabled: v } })}
             />
           </SettingRow>
-        </div>
+        </SettingsGroup>
       </div>
-
     </div>
   );
 }

--- a/apps/web/src/components/settings/sections/ModelSection.tsx
+++ b/apps/web/src/components/settings/sections/ModelSection.tsx
@@ -393,10 +393,10 @@ export function ModelSection() {
       className="mx-auto w-full max-w-[88rem] pb-10"
     >
       <header className="mb-8 border-b border-border/45 px-1 pb-6">
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="text-2xl leading-7 font-semibold tracking-tight text-foreground">
           Models &amp; providers
         </h1>
-        <p className="mt-2 max-w-[65ch] text-sm leading-6 text-muted-foreground">
+        <p className="mt-2 max-w-[65ch] text-sm leading-4 text-muted-foreground">
           Configure the providers and model defaults used across new threads and
           utility tasks.
         </p>

--- a/apps/web/src/components/settings/sections/ProviderSection.tsx
+++ b/apps/web/src/components/settings/sections/ProviderSection.tsx
@@ -129,7 +129,7 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
   const hint = hintFor(row, isLastEnabled);
 
   const controls = (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 min-[80rem]:min-w-[9.2rem] min-[80rem]:justify-end">
       {row.beta && (
         <Tooltip>
           <TooltipTrigger>

--- a/apps/web/src/components/settings/sections/ProviderSection.tsx
+++ b/apps/web/src/components/settings/sections/ProviderSection.tsx
@@ -33,6 +33,8 @@ export function ProviderSection() {
   const settings = useSettingsStore((s) => s.settings);
   const update = useSettingsStore((s) => s.update);
   const [pendingDisable, setPendingDisable] = useState<ProviderId | null>(null);
+  const availableProviders = providers.filter((provider) => !provider.comingSoon);
+  const comingSoonProviders = providers.filter((provider) => provider.comingSoon);
 
   // Count how many adapter-backed providers are currently enabled, so we can
   // prevent the user from disabling the last one.
@@ -61,7 +63,7 @@ export function ProviderSection() {
         title="Providers"
         description="Enable providers and configure their CLI paths."
       >
-        {providers.map((p) => (
+        {availableProviders.map((p) => (
           <ProviderRow
             key={p.id}
             row={p}
@@ -75,6 +77,18 @@ export function ProviderSection() {
             }
           />
         ))}
+        {comingSoonProviders.length > 0 && (
+          <div data-testid="coming-soon-providers" className="py-4">
+            <h3 className="px-1 text-xs font-semibold text-muted-foreground">
+              Coming soon
+            </h3>
+            <div className="mt-2 space-y-0.5">
+              {comingSoonProviders.map((provider) => (
+                <ComingSoonProviderRow key={provider.id} row={provider} />
+              ))}
+            </div>
+          </div>
+        )}
       </SettingsGroup>
       {pendingDisable && (
         <ConfirmDisableDialog
@@ -106,10 +120,10 @@ interface ProviderRowProps {
  * Single provider row with a disclosure for editable CLI path configuration.
  */
 function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }: ProviderRowProps) {
-  // Coming-soon and adapter-less providers cannot be toggled; the last enabled
-  // provider also blocks toggling to prevent an unusable state.
-  const switchDisabled = row.comingSoon || !row.hasAdapter || isLastEnabled;
-  const canConfigure = !row.comingSoon && onCliPathChange != null;
+  // Adapter-less providers cannot be toggled; the last enabled provider also
+  // blocks toggling to prevent an unusable state.
+  const switchDisabled = !row.hasAdapter || isLastEnabled;
+  const canConfigure = onCliPathChange != null;
   const [isConfigOpen, setIsConfigOpen] = useState(row.beta);
   const label = labelFor(row.id);
   const hint = hintFor(row, isLastEnabled);
@@ -127,11 +141,6 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
             This provider is in early phase. Expect bugs or incomplete features.
           </TooltipContent>
         </Tooltip>
-      )}
-      {row.comingSoon && (
-        <Badge variant="outline" data-testid={`provider-badge-${row.id}-comingsoon`}>
-          Coming soon
-        </Badge>
       )}
       {row.enabled && row.cli.status === "not_found" && (
         <Tooltip>
@@ -165,8 +174,12 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
   }
 
   return (
-    <Collapsible open={isConfigOpen} onOpenChange={setIsConfigOpen}>
-      <div className="border-b border-border/50 px-1 py-4 last:border-b-0">
+    <Collapsible
+      open={isConfigOpen}
+      onOpenChange={setIsConfigOpen}
+      className="border-b border-border/50 last:border-b-0"
+    >
+      <div className="px-1 py-4">
         <div className={SETTING_ROW_GRID_CLASS}>
           <CollapsibleTrigger asChild>
             <Button
@@ -175,7 +188,7 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
               size="sm"
               data-testid={`provider-config-trigger-${row.id}`}
               aria-label={`${isConfigOpen ? "Hide" : "Show"} ${label} configuration`}
-              className="-ml-2 h-auto w-full min-w-0 items-start justify-between gap-4 rounded-md px-2 py-1 text-left hover:bg-accent/60"
+              className="-ml-2 h-auto w-full min-w-0 items-start justify-between gap-4 rounded-md px-2 py-1 text-left hover:bg-accent/60 aria-expanded:bg-transparent dark:aria-expanded:bg-transparent"
             >
               <span className="flex min-w-0 flex-col items-start">
                 <span className="text-sm font-semibold text-foreground">{label}</span>
@@ -217,6 +230,24 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
   );
 }
 
+/** Displays a non-interactive provider that is not available yet. */
+function ComingSoonProviderRow({ row }: { row: ProviderAvailability }) {
+  return (
+    <div className="flex items-center justify-between gap-4 px-1 py-2.5">
+      <span className="text-sm font-medium text-foreground/75">
+        {labelFor(row.id)}
+      </span>
+      <Badge
+        variant="outline"
+        size="sm"
+        data-testid={`provider-badge-${row.id}-comingsoon`}
+      >
+        Coming soon
+      </Badge>
+    </div>
+  );
+}
+
 /** Returns the human-readable display name for a provider ID. */
 function labelFor(id: ProviderId): string {
   if (id === "copilot") return "GitHub Copilot";
@@ -226,7 +257,6 @@ function labelFor(id: ProviderId): string {
 /** Returns the hint text shown below the provider label. */
 function hintFor(row: ProviderAvailability, isLastEnabled: boolean): string {
   if (isLastEnabled) return "At least one provider must be enabled.";
-  if (row.comingSoon) return "Adapter not available yet.";
   if (row.enabled && row.cli.status === "not_found") {
     return `CLI not found${row.cli.configuredPath ? ` at ${row.cli.configuredPath}` : ""}.`;
   }

--- a/apps/web/src/components/settings/sections/ProviderSection.tsx
+++ b/apps/web/src/components/settings/sections/ProviderSection.tsx
@@ -3,7 +3,7 @@ import { ChevronDown } from "lucide-react";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import { SettingRow } from "../SettingRow";
-import { SectionHeading } from "../SectionHeading";
+import { SettingsGroup } from "../SettingsGroup";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -57,8 +57,10 @@ export function ProviderSection() {
 
   return (
     <div>
-      <SectionHeading>Provider</SectionHeading>
-      <div>
+      <SettingsGroup
+        title="Providers"
+        description="Enable providers and configure their CLI paths."
+      >
         {providers.map((p) => (
           <ProviderRow
             key={p.id}
@@ -73,7 +75,7 @@ export function ProviderSection() {
             }
           />
         ))}
-      </div>
+      </SettingsGroup>
       {pendingDisable && (
         <ConfirmDisableDialog
           providerId={pendingDisable}
@@ -165,7 +167,7 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
   return (
     <Collapsible open={isConfigOpen} onOpenChange={setIsConfigOpen}>
       <div className="border-b border-border/50 px-1 py-4 last:border-b-0">
-        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+        <div className="grid gap-3 min-[900px]:grid-cols-[minmax(0,1fr)_auto] min-[900px]:items-center min-[900px]:gap-x-8">
           <CollapsibleTrigger asChild>
             <Button
               type="button"
@@ -173,7 +175,7 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
               size="sm"
               data-testid={`provider-config-trigger-${row.id}`}
               aria-label={`${isConfigOpen ? "Hide" : "Show"} ${label} configuration`}
-              className="-ml-2 h-auto min-w-[10rem] flex-1 items-start justify-between gap-4 rounded-md px-2 py-1 text-left hover:bg-accent/60"
+              className="-ml-2 h-auto w-full min-w-0 items-start justify-between gap-4 rounded-md px-2 py-1 text-left hover:bg-accent/60"
             >
               <span className="flex min-w-0 flex-col items-start">
                 <span className="text-sm font-semibold text-foreground">{label}</span>
@@ -191,7 +193,7 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
           {controls}
         </div>
         <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down motion-reduce:animate-none">
-          <div className="mt-3 flex flex-wrap items-center justify-between gap-x-6 gap-y-3 border-t border-border/40 pt-3 pl-2">
+          <div className="mt-3 grid gap-3 border-t border-border/40 pt-3 pl-2 min-[900px]:grid-cols-[minmax(0,1fr)_auto] min-[900px]:items-center min-[900px]:gap-x-8">
             <label htmlFor={`provider-cli-path-${row.id}`} className="text-sm font-medium text-foreground">
               {label} CLI path
             </label>

--- a/apps/web/src/components/settings/sections/ProviderSection.tsx
+++ b/apps/web/src/components/settings/sections/ProviderSection.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
-import { SettingRow } from "../SettingRow";
+import { SettingRow, SETTING_ROW_GRID_CLASS } from "../SettingRow";
 import { SettingsGroup } from "../SettingsGroup";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -167,7 +167,7 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
   return (
     <Collapsible open={isConfigOpen} onOpenChange={setIsConfigOpen}>
       <div className="border-b border-border/50 px-1 py-4 last:border-b-0">
-        <div className="grid gap-3 min-[900px]:grid-cols-[minmax(0,1fr)_auto] min-[900px]:items-center min-[900px]:gap-x-8">
+        <div className={SETTING_ROW_GRID_CLASS}>
           <CollapsibleTrigger asChild>
             <Button
               type="button"
@@ -193,7 +193,12 @@ function ProviderRow({ row, isLastEnabled, onToggle, cliPath, onCliPathChange }:
           {controls}
         </div>
         <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down motion-reduce:animate-none">
-          <div className="mt-3 grid gap-3 border-t border-border/40 pt-3 pl-2 min-[900px]:grid-cols-[minmax(0,1fr)_auto] min-[900px]:items-center min-[900px]:gap-x-8">
+          <div
+            className={cn(
+              SETTING_ROW_GRID_CLASS,
+              "mt-3 border-t border-border/40 pt-3 pl-2",
+            )}
+          >
             <label htmlFor={`provider-cli-path-${row.id}`} className="text-sm font-medium text-foreground">
               {label} CLI path
             </label>

--- a/apps/web/src/components/settings/sections/ProviderSection.tsx
+++ b/apps/web/src/components/settings/sections/ProviderSection.tsx
@@ -238,8 +238,7 @@ function ComingSoonProviderRow({ row }: { row: ProviderAvailability }) {
         {labelFor(row.id)}
       </span>
       <Badge
-        variant="outline"
-        size="sm"
+        variant="secondary"
         data-testid={`provider-badge-${row.id}-comingsoon`}
       >
         Coming soon

--- a/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
+++ b/apps/web/src/components/settings/sections/__tests__/ModelSection.test.tsx
@@ -101,6 +101,22 @@ describe("ModelSection reasoning options", () => {
     vi.clearAllMocks();
   });
 
+  it("groups provider and model controls under a clear page hierarchy", () => {
+    renderWithModel("claude", "claude-opus-4-7");
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Models & providers" }),
+    ).toBeInTheDocument();
+    for (const name of [
+      "Providers",
+      "Model defaults",
+      "Utility model",
+      "AI features",
+    ]) {
+      expect(screen.getByRole("region", { name })).toBeInTheDocument();
+    }
+  });
+
   it("renders reasoning options in order: Low, Medium, High, X-High, Max for Claude Opus 4.7", () => {
     renderWithModel("claude", "claude-opus-4-7");
 

--- a/apps/web/src/components/settings/sections/__tests__/ProviderSection.test.tsx
+++ b/apps/web/src/components/settings/sections/__tests__/ProviderSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useProviderAvailabilityStore } from "@/stores/providerAvailabilityStore";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -73,16 +73,34 @@ beforeEach(() => {
 });
 
 describe("ProviderSection", () => {
-  it("renders one switch per provider", () => {
+  it("renders switches only for available providers", () => {
     render(<ProviderSection />);
     const switches = screen.getAllByRole("switch");
-    expect(switches).toHaveLength(6);
+    expect(switches).toHaveLength(3);
+    expect(screen.queryByTestId("provider-switch-gemini")).not.toBeInTheDocument();
   });
 
-  it("renders the Beta badge for copilot and Coming soon for gemini/cursor/opencode", () => {
+  it("renders the Beta badge for copilot and Coming soon badges for planned providers", () => {
     render(<ProviderSection />);
     expect(screen.getByTestId("provider-badge-copilot-beta")).toBeInTheDocument();
     expect(screen.getByTestId("provider-badge-gemini-comingsoon")).toBeInTheDocument();
+    expect(screen.getByTestId("provider-badge-cursor-comingsoon")).toBeInTheDocument();
+    expect(screen.getByTestId("provider-badge-opencode-comingsoon")).toBeInTheDocument();
+  });
+
+  it("groups planned providers after available providers without adapter copy", () => {
+    render(<ProviderSection />);
+
+    const comingSoon = screen.getByTestId("coming-soon-providers");
+    expect(within(comingSoon).getByText("Gemini")).toBeInTheDocument();
+    expect(within(comingSoon).getByText("Cursor")).toBeInTheDocument();
+    expect(within(comingSoon).getByText("Opencode")).toBeInTheDocument();
+    expect(screen.queryByText("Adapter not available yet.")).not.toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId("provider-config-trigger-copilot")
+        .compareDocumentPosition(comingSoon) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("renders a CLI-not-found badge when enabled and status='not_found'", () => {
@@ -90,9 +108,10 @@ describe("ProviderSection", () => {
     expect(screen.getByTestId("provider-badge-codex-cli-missing")).toBeInTheDocument();
   });
 
-  it("disables the switch for coming-soon providers", () => {
+  it("does not render controls for coming-soon providers", () => {
     render(<ProviderSection />);
-    expect(screen.getByTestId("provider-switch-gemini")).toBeDisabled();
+    expect(screen.queryByTestId("provider-switch-gemini")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("provider-config-trigger-gemini")).not.toBeInTheDocument();
   });
 
   it("keeps stable provider configuration collapsed and opens Beta configuration by default", () => {
@@ -123,6 +142,15 @@ describe("ProviderSection", () => {
     await user.click(screen.getByTestId("provider-config-trigger-claude"));
 
     expect(screen.getByTestId("provider-cli-path-claude")).toBeVisible();
+  });
+
+  it("keeps expanded provider triggers visually neutral", () => {
+    render(<ProviderSection />);
+
+    expect(screen.getByTestId("provider-config-trigger-copilot")).toHaveClass(
+      "aria-expanded:bg-transparent",
+      "dark:aria-expanded:bg-transparent",
+    );
   });
 
   it("does not expose a disclosure trigger for coming-soon providers", () => {

--- a/apps/web/src/components/settings/sections/__tests__/ProviderSection.test.tsx
+++ b/apps/web/src/components/settings/sections/__tests__/ProviderSection.test.tsx
@@ -83,9 +83,18 @@ describe("ProviderSection", () => {
   it("renders the Beta badge for copilot and Coming soon badges for planned providers", () => {
     render(<ProviderSection />);
     expect(screen.getByTestId("provider-badge-copilot-beta")).toBeInTheDocument();
-    expect(screen.getByTestId("provider-badge-gemini-comingsoon")).toBeInTheDocument();
-    expect(screen.getByTestId("provider-badge-cursor-comingsoon")).toBeInTheDocument();
-    expect(screen.getByTestId("provider-badge-opencode-comingsoon")).toBeInTheDocument();
+    expect(screen.getByTestId("provider-badge-gemini-comingsoon")).toHaveAttribute(
+      "variant",
+      "secondary",
+    );
+    expect(screen.getByTestId("provider-badge-cursor-comingsoon")).toHaveAttribute(
+      "variant",
+      "secondary",
+    );
+    expect(screen.getByTestId("provider-badge-opencode-comingsoon")).toHaveAttribute(
+      "variant",
+      "secondary",
+    );
   });
 
   it("groups planned providers after available providers without adapter copy", () => {

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -301,11 +301,13 @@ describe("ProjectTree thread interactions", () => {
 
     const row = screen.getByRole("button", { name: /My Thread/i });
     const provider = screen.getByLabelText("Provider, Claude");
-    const providerLeft = Number.parseFloat(provider.style.left);
+    const leadingIcons = provider.parentElement;
+    const leadingIconsWidth = Number.parseFloat(leadingIcons?.style.width ?? "");
     const titleLeft = Number.parseFloat(row.style.paddingLeft);
 
     expect(provider).toHaveClass("-mt-px");
-    expect(titleLeft - (providerLeft + 16)).toBe(4);
+    expect(leadingIcons).toHaveClass("left-0.5");
+    expect(titleLeft - (2 + leadingIconsWidth)).toBe(4);
   });
 
   it("offers Explorer and rename actions from the project menu", () => {
@@ -704,6 +706,9 @@ describe("ProjectTree PR-ability gating by mode", () => {
     const indicator = screen.getByTestId("thread-pr-indicator-thread-1");
     expect(indicator).toHaveAttribute("aria-label", "PR #42, open");
     expect(indicator).toHaveClass("-mt-px");
+    const leadingIcons = indicator.parentElement;
+    expect(leadingIcons).toHaveClass("gap-1");
+    expect(within(leadingIcons!).getByLabelText(/^Provider,/)).toBeInTheDocument();
     expect(screen.queryByText("#42")).toBeNull();
   });
 

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1749,7 +1749,7 @@ const ProjectNode = memo(function ProjectNode({
           onClick={handleCreateThreadClick}
           className="opacity-0 text-muted-foreground hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
         >
-          <SquarePen className="size-[1.2rem]" />
+          <SquarePen className="size-[1.4rem]" />
         </Button>
       </div>
 

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1670,7 +1670,7 @@ const ProjectNode = memo(function ProjectNode({
             event.stopPropagation();
             handleToggle();
           }}
-          className="size-6 shrink-0 text-muted-foreground opacity-0 transition-opacity hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
+          className="size-6 shrink-0 text-muted-foreground opacity-0 transition-opacity hover:bg-transparent hover:text-muted-foreground dark:hover:bg-transparent group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
         >
           <ChevronRight
             size={14}
@@ -1747,9 +1747,9 @@ const ProjectNode = memo(function ProjectNode({
           title={`New thread in ${workspace.name}`}
           onKeyDown={(event) => event.stopPropagation()}
           onClick={handleCreateThreadClick}
-          className="opacity-0 text-muted-foreground hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
+          className="size-6 opacity-0 text-muted-foreground hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
         >
-          <SquarePen size={12} />
+          <SquarePen size={11} className="size-[1.1rem]" />
         </Button>
       </div>
 

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1075,7 +1075,7 @@ const ThreadPrIndicator = memo(function ThreadPrIndicator({
       title={label}
       aria-label={label}
       data-testid={`thread-pr-indicator-${threadId}`}
-      className="absolute left-1.5 top-1/2 -mt-px flex h-4 w-4 -translate-y-1/2 items-center justify-center"
+      className="-mt-px flex h-4 w-4 items-center justify-center"
     >
       <span className="relative flex size-4 items-center justify-center">
         <PrIcon
@@ -1302,25 +1302,29 @@ function VirtualizedThreadList({
             )}
             style={{ paddingLeft: `${42 + depth * 12}px` }}
           >
-            {prable && thread.pr_number != null ? (
-              <ThreadPrIndicator
-                threadId={thread.id}
-                prNumber={thread.pr_number}
-                prStatus={thread.pr_status}
-                checks={checks}
-                showCi={showPrCi}
-              />
-            ) : null}
             <span
-              aria-label={`Provider, ${providerMeta.label}`}
-              className={cn(
-                "absolute top-1/2 -mt-px flex h-4 w-4 -translate-y-1/2 items-center justify-center",
-                providerMeta.color,
-                scaffoldDim,
-              )}
-              style={{ left: `${22 + depth * 12}px` }}
+              className="absolute left-0.5 top-1/2 flex -translate-y-1/2 items-center justify-end gap-1"
+              style={{ width: `${36 + depth * 12}px` }}
             >
-              <RowProviderIcon size={12} />
+              {prable && thread.pr_number != null ? (
+                <ThreadPrIndicator
+                  threadId={thread.id}
+                  prNumber={thread.pr_number}
+                  prStatus={thread.pr_status}
+                  checks={checks}
+                  showCi={showPrCi}
+                />
+              ) : null}
+              <span
+                aria-label={`Provider, ${providerMeta.label}`}
+                className={cn(
+                  "-mt-px flex h-4 w-4 items-center justify-center",
+                  providerMeta.color,
+                  scaffoldDim,
+                )}
+              >
+                <RowProviderIcon size={12} />
+              </span>
             </span>
             <div
               className={cn(

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -29,6 +29,7 @@ import {
   MoreHorizontal,
   Pencil,
   Plus,
+  SquarePen,
 } from "lucide-react";
 import {
   Tooltip,
@@ -1739,25 +1740,17 @@ const ProjectNode = memo(function ProjectNode({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label={`New thread in ${workspace.name}`}
-                onKeyDown={(event) => event.stopPropagation()}
-                onClick={handleCreateThreadClick}
-                className="rounded-md text-muted-foreground opacity-0 hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
-              >
-                <Plus size={15} aria-hidden />
-              </Button>
-            }
-          />
-          <TooltipContent side="right" className="text-xs">
-            New thread
-          </TooltipContent>
-        </Tooltip>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label={`New thread in ${workspace.name}`}
+          title={`New thread in ${workspace.name}`}
+          onKeyDown={(event) => event.stopPropagation()}
+          onClick={handleCreateThreadClick}
+          className="opacity-0 text-muted-foreground hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
+        >
+          <SquarePen size={12} />
+        </Button>
       </div>
 
       {/* Threads (when expanded) — indented, no guide rail. */}

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -29,7 +29,6 @@ import {
   MoreHorizontal,
   Pencil,
   Plus,
-  SquarePen,
 } from "lucide-react";
 import {
   Tooltip,
@@ -1740,17 +1739,25 @@ const ProjectNode = memo(function ProjectNode({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          aria-label={`New thread in ${workspace.name}`}
-          title={`New thread in ${workspace.name}`}
-          onKeyDown={(event) => event.stopPropagation()}
-          onClick={handleCreateThreadClick}
-          className="opacity-0 text-muted-foreground hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
-        >
-          <SquarePen size={13} />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label={`New thread in ${workspace.name}`}
+                onKeyDown={(event) => event.stopPropagation()}
+                onClick={handleCreateThreadClick}
+                className="rounded-md text-muted-foreground opacity-0 hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
+              >
+                <Plus size={15} aria-hidden />
+              </Button>
+            }
+          />
+          <TooltipContent side="right" className="text-xs">
+            New thread
+          </TooltipContent>
+        </Tooltip>
       </div>
 
       {/* Threads (when expanded) — indented, no guide rail. */}

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1747,9 +1747,9 @@ const ProjectNode = memo(function ProjectNode({
           title={`New thread in ${workspace.name}`}
           onKeyDown={(event) => event.stopPropagation()}
           onClick={handleCreateThreadClick}
-          className="size-6 opacity-0 text-muted-foreground hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
+          className="opacity-0 text-muted-foreground hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
         >
-          <SquarePen size={11} className="size-[1.1rem]" />
+          <SquarePen className="size-[1rem]" />
         </Button>
       </div>
 

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1749,7 +1749,7 @@ const ProjectNode = memo(function ProjectNode({
           onClick={handleCreateThreadClick}
           className="opacity-0 text-muted-foreground hover:bg-background/60 hover:text-foreground group-hover/ws:opacity-100 group-focus-within/ws:opacity-100 focus:opacity-100"
         >
-          <SquarePen className="size-[1rem]" />
+          <SquarePen className="size-[1.2rem]" />
         </Button>
       </div>
 


### PR DESCRIPTION
## What

Polish the new-thread home, project tree, and Model settings page while preserving the existing visual language.

## Why

The annotated UI review identified cramped status icons, inconsistent action sizing, narrow starter cards, and weak settings hierarchy.

## Key Changes

- Keep the existing project new-thread icon and tune its size, spacing, and hover behavior.
- Add a consistent 4px gap between pull-request and provider status icons without shifting thread titles.
- Make starter cards wider and responsive across desktop and compact layouts.
- Reorganize Model settings into clearer provider, model-default, utility-model, and AI-feature groups.
- Keep expanded provider rows neutral and group unavailable providers last with consistent badges.
- Refine settings navigation spacing and control alignment.
- Align provider E2E coverage with the redesigned headings and unavailable-provider rows.

## Verification

- Focused sidebar and settings tests: 35 passed.
- Provider settings E2E spec: 7 passed.
- Live browser verification: 4px PR/provider gap and zero console errors.
- GitHub CI: title, typecheck, lint, unit tests, build, and all four E2E shards passed.