### PR TITLE
fix(chat): restore nested shell narration

### DIFF
--- a/apps/server/drizzle/0022_foamy_black_crow.sql
+++ b/apps/server/drizzle/0022_foamy_black_crow.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tool_call_records` ADD `exit_code` integer;

--- a/apps/server/drizzle/meta/0022_snapshot.json
+++ b/apps/server/drizzle/meta/0022_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "4acf7c52-baa4-46d4-bf21-62802ee2dee0",
-  "prevId": "23190214-504d-4b55-bb8e-f2c92be7ae45",
+  "id": "c07c1316-2b12-4757-ad6b-e534e07c1215",
+  "prevId": "11007ec1-331f-4923-98a3-e5d23ef44582",
   "tables": {
     "cleanup_jobs": {
       "name": "cleanup_jobs",
@@ -1430,6 +1430,13 @@
           "notNull": false,
           "autoincrement": false
         },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
         "status": {
           "name": "status",
           "type": "text",
@@ -1542,6 +1549,14 @@
           "notNull": true,
           "autoincrement": false,
           "default": "'[]'"
+        },
+        "file_effects": {
+          "name": "file_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"revision\":0,\"fileCount\":0,\"additions\":0,\"deletions\":0,\"effects\":[]}'"
         },
         "worktree_path": {
           "name": "worktree_path",

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1784398924316,
       "tag": "0021_bright_vargas",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1784554548886,
+      "tag": "0022_foamy_black_crow",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/__tests__/tool-call-record-repo.test.ts
+++ b/apps/server/src/__tests__/tool-call-record-repo.test.ts
@@ -115,6 +115,21 @@ describe("ToolCallRecordRepo", () => {
     expect(records[0]!.exit_code).toBe(1);
   });
 
+  it("preserves a successful exit code of zero", () => {
+    const record = repo.create({
+      messageId,
+      toolName: "Bash",
+      inputSummary: "git status",
+      outputSummary: "",
+      exitCode: 0,
+      status: "completed",
+      sortOrder: 0,
+    });
+
+    expect(record.exit_code).toBe(0);
+    expect(repo.listByMessage(messageId)[0]!.exit_code).toBe(0);
+  });
+
   it("bulkCreate inserts multiple records in a transaction", () => {
     const inputs: CreateToolCallRecordInput[] = [
       {

--- a/apps/server/src/__tests__/tool-call-record-repo.test.ts
+++ b/apps/server/src/__tests__/tool-call-record-repo.test.ts
@@ -59,6 +59,7 @@ describe("V7 migration", () => {
       "output_truncated",
       "output_total_bytes",
       "output_artifact_path",
+      "exit_code",
     ]));
 
     db.close();
@@ -86,6 +87,7 @@ describe("ToolCallRecordRepo", () => {
       outputTruncated: true,
       outputTotalBytes: 300_000,
       outputArtifactPath: "C:\\mcode\\artifacts\\tool-output\\thread\\tool.txt",
+      exitCode: 1,
       status: "completed",
       sortOrder: 0,
     };
@@ -100,6 +102,7 @@ describe("ToolCallRecordRepo", () => {
     expect(record.output_truncated).toBe(1);
     expect(record.output_total_bytes).toBe(300_000);
     expect(record.output_artifact_path).toBe("C:\\mcode\\artifacts\\tool-output\\thread\\tool.txt");
+    expect(record.exit_code).toBe(1);
     expect(record.status).toBe("completed");
     expect(record.sort_order).toBe(0);
     expect(record.parent_tool_call_id).toBeNull();
@@ -109,6 +112,7 @@ describe("ToolCallRecordRepo", () => {
     expect(records).toHaveLength(1);
     expect(records[0]!.id).toBe(record.id);
     expect(records[0]!.output_truncated).toBe(1);
+    expect(records[0]!.exit_code).toBe(1);
   });
 
   it("bulkCreate inserts multiple records in a transaction", () => {

--- a/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
@@ -266,6 +266,7 @@ describe("CodexEventMapper", () => {
         toolCallId: "cmd-live",
         output: "hi\n",
         isError: false,
+        exitCode: 0,
       },
     ]);
   });
@@ -326,7 +327,7 @@ describe("CodexEventMapper", () => {
           id: "cmd-known",
           command: "echo hi",
           aggregatedOutput: "hi\n",
-          exitCode: 0,
+          exitCode: 1,
         },
       },
     });
@@ -337,7 +338,8 @@ describe("CodexEventMapper", () => {
         threadId: "test-thread",
         toolCallId: "cmd-known",
         output: "hi\n",
-        isError: false,
+        isError: true,
+        exitCode: 1,
       },
     ]);
   });
@@ -417,6 +419,7 @@ describe("CodexEventMapper", () => {
         toolCallId: "cmd-fallback",
         output: "/repo\n",
         isError: false,
+        exitCode: 0,
       },
     ]);
   });

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -192,6 +192,7 @@ export class CodexEventMapper {
     toolCallId: string;
     output: string | BoundedToolOutputBuffer | undefined;
     isError: boolean;
+    exitCode?: number;
     toolInput?: Record<string, unknown>;
     fallback?: string;
   }): AgentEvent {
@@ -202,6 +203,7 @@ export class CodexEventMapper {
       toolCallId: args.toolCallId,
       output: bounded.output,
       isError: args.isError,
+      ...(args.exitCode !== undefined ? { exitCode: args.exitCode } : {}),
       ...(bounded.outputTruncated
         ? {
             outputTruncated: true,
@@ -1235,6 +1237,9 @@ export class CodexEventMapper {
       const toolResultEvent = this.toolResultEvent({
         toolCallId,
         isError: item.exitCode != null && item.exitCode !== 0,
+        ...(typeof item.exitCode === "number" && Number.isInteger(item.exitCode)
+          ? { exitCode: item.exitCode }
+          : {}),
         output: bufferedOutput,
         fallback: textOut,
       });

--- a/apps/server/src/repositories/tool-call-record-repo.ts
+++ b/apps/server/src/repositories/tool-call-record-repo.ts
@@ -19,6 +19,7 @@ interface ToolCallRecordRow {
   output_truncated: number;
   output_total_bytes: number | null;
   output_artifact_path: string | null;
+  exit_code: number | null;
   status: string;
   started_at: string;
   completed_at: string | null;
@@ -36,6 +37,7 @@ export interface CreateToolCallRecordInput {
   outputTruncated?: boolean;
   outputTotalBytes?: number;
   outputArtifactPath?: string;
+  exitCode?: number;
   status: ToolCallStatus;
   sortOrder: number;
   parentToolCallId?: string;
@@ -52,6 +54,7 @@ function rowToToolCallRecord(row: ToolCallRecordRow): ToolCallRecord {
     output_truncated: row.output_truncated,
     output_total_bytes: row.output_total_bytes,
     output_artifact_path: row.output_artifact_path,
+    exit_code: row.exit_code,
     status: row.status as ToolCallStatus,
     started_at: row.started_at,
     completed_at: row.completed_at,
@@ -60,7 +63,7 @@ function rowToToolCallRecord(row: ToolCallRecordRow): ToolCallRecord {
 }
 
 const TOOL_CALL_RECORD_COLUMNS =
-  "id, message_id, parent_tool_call_id, tool_name, input_summary, output_summary, output_truncated, output_total_bytes, output_artifact_path, status, started_at, completed_at, sort_order";
+  "id, message_id, parent_tool_call_id, tool_name, input_summary, output_summary, output_truncated, output_total_bytes, output_artifact_path, exit_code, status, started_at, completed_at, sort_order";
 
 /** Repository for tool call record creation and retrieval against SQLite. */
 @injectable()
@@ -72,7 +75,7 @@ export class ToolCallRecordRepo {
 
   constructor(@inject("Database") private readonly db: Database.Database) {
     this.stmtInsert = db.prepare(
-      "INSERT OR IGNORE INTO tool_call_records (id, message_id, parent_tool_call_id, tool_name, input_summary, output_summary, output_truncated, output_total_bytes, output_artifact_path, status, started_at, completed_at, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "INSERT OR IGNORE INTO tool_call_records (id, message_id, parent_tool_call_id, tool_name, input_summary, output_summary, output_truncated, output_total_bytes, output_artifact_path, exit_code, status, started_at, completed_at, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     );
     this.stmtListByMessage = db.prepare(
       `SELECT ${TOOL_CALL_RECORD_COLUMNS} FROM tool_call_records WHERE message_id = ? ORDER BY sort_order ASC`,
@@ -101,6 +104,7 @@ export class ToolCallRecordRepo {
       input.outputTruncated === true ? 1 : 0,
       input.outputTotalBytes ?? null,
       input.outputArtifactPath ?? null,
+      input.exitCode ?? null,
       input.status,
       now,
       completedAt,
@@ -117,6 +121,7 @@ export class ToolCallRecordRepo {
       output_truncated: input.outputTruncated === true ? 1 : 0,
       output_total_bytes: input.outputTotalBytes ?? null,
       output_artifact_path: input.outputArtifactPath ?? null,
+      exit_code: input.exitCode ?? null,
       status: input.status,
       started_at: now,
       completed_at: completedAt,
@@ -140,6 +145,7 @@ export class ToolCallRecordRepo {
           item.outputTruncated === true ? 1 : 0,
           item.outputTotalBytes ?? null,
           item.outputArtifactPath ?? null,
+          item.exitCode ?? null,
           item.status,
           now,
           completedAt,

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -11,7 +11,10 @@ import type { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import type { MessageRepo } from "../../repositories/message-repo.js";
 import type { GitService } from "../git-service.js";
 import type { AttachmentService } from "../attachment-service.js";
-import type { ToolCallRecordRepo } from "../../repositories/tool-call-record-repo.js";
+import type {
+  ToolCallRecordRepo,
+  CreateToolCallRecordInput,
+} from "../../repositories/tool-call-record-repo.js";
 import type { ThoughtSegmentRepo, CreateThoughtSegmentInput } from "../../repositories/thought-segment-repo.js";
 import type { HookExecutionRepo, CreateHookExecutionInput } from "../../repositories/hook-execution-repo.js";
 import type { TurnSnapshotRepo } from "../../repositories/turn-snapshot-repo.js";
@@ -264,6 +267,40 @@ describe("AgentService narrative persistence", () => {
     });
 
     expect(taskAppend).not.toHaveBeenCalled();
+  });
+
+  it("persists a shell exit code from its tool result", async () => {
+    const { providerEmitter, toolBulk } = build();
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolUse,
+      threadId: THREAD_ID,
+      toolCallId: "shell-failed",
+      toolName: "command_execution",
+      toolInput: { command: "exit 1" },
+    });
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolResult,
+      threadId: THREAD_ID,
+      toolCallId: "shell-failed",
+      output: "",
+      isError: true,
+      exitCode: 1,
+    });
+    providerEmitter.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: THREAD_ID,
+      tokensIn: 0,
+      tokensOut: 0,
+      contextWindow: 0,
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(toolBulk).toHaveBeenCalledOnce();
+    const toolCalls: CreateToolCallRecordInput[] = toolBulk.mock.calls[0][0];
+    expect(toolCalls[0].exitCode).toBe(1);
   });
 
   it("applies a TaskUpdate status transition to the persisted task by harness id", () => {

--- a/apps/server/src/services/__tests__/narrative-store.test.ts
+++ b/apps/server/src/services/__tests__/narrative-store.test.ts
@@ -269,6 +269,7 @@ describe("NarrativeStore write seam (server-side traps)", () => {
         outputTruncated: true,
         outputTotalBytes: 300_000,
         outputArtifactPath: "C:\\mcode\\artifacts\\tool-output\\thread\\tool.txt",
+        exitCode: 1,
       });
       store.persistNarrative(THREAD, "m1", "", "completed");
 
@@ -276,6 +277,7 @@ describe("NarrativeStore write seam (server-side traps)", () => {
       expect(tools[0].output_truncated).toBe(1);
       expect(tools[0].output_total_bytes).toBe(300_000);
       expect(tools[0].output_artifact_path).toBe("C:\\mcode\\artifacts\\tool-output\\thread\\tool.txt");
+      expect(tools[0].exit_code).toBe(1);
     });
 
     it("clears the whole stack on the final Message event", () => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -2508,6 +2508,7 @@ export class AgentService {
               ...(event.outputTruncated === true ? { outputTruncated: true } : {}),
               ...(event.outputTotalBytes != null ? { outputTotalBytes: event.outputTotalBytes } : {}),
               ...(event.outputArtifactPath ? { outputArtifactPath: event.outputArtifactPath } : {}),
+              ...(event.exitCode !== undefined ? { exitCode: event.exitCode } : {}),
             },
           );
           // Persist a just-created task now that the harness has assigned its id.

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -420,6 +420,7 @@ export class NarrativeStore {
       outputTruncated?: boolean;
       outputTotalBytes?: number;
       outputArtifactPath?: string;
+      exitCode?: number;
     },
   ): void {
     const stack = this.agentCallStack.get(threadId) ?? [];
@@ -441,11 +442,15 @@ export class NarrativeStore {
         buffer[i].outputTruncated = outputMeta?.outputTruncated === true;
         delete buffer[i].outputTotalBytes;
         delete buffer[i].outputArtifactPath;
+        delete buffer[i].exitCode;
         if (outputMeta?.outputTotalBytes != null) {
           buffer[i].outputTotalBytes = outputMeta.outputTotalBytes;
         }
         if (outputMeta?.outputArtifactPath) {
           buffer[i].outputArtifactPath = outputMeta.outputArtifactPath;
+        }
+        if (outputMeta?.exitCode !== undefined) {
+          buffer[i].exitCode = outputMeta.exitCode;
         }
         buffer[i].status = isError ? "failed" : "completed";
         if (toolInput && Object.keys(toolInput).length > 0) {

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -223,6 +223,9 @@ export function applySchemaPatches(db: Database.Database): void {
   if (toolCols.length > 0 && !toolCols.includes("output_artifact_path")) {
     addToolCallColumn("output_artifact_path TEXT");
   }
+  if (toolCols.length > 0 && !toolCols.includes("exit_code")) {
+    addToolCallColumn("exit_code INTEGER");
+  }
 
   const messageCols = (
     db.prepare("PRAGMA table_info(messages)").all() as Array<{ name: string }>

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -186,6 +186,7 @@ export const toolCallRecords = sqliteTable(
     outputTruncated: integer("output_truncated").notNull().default(0),
     outputTotalBytes: integer("output_total_bytes"),
     outputArtifactPath: text("output_artifact_path"),
+    exitCode: integer("exit_code"),
     status: text("status").notNull().default("running"),
     startedAt: text("started_at").notNull().default(timestampDefault),
     completedAt: text("completed_at"),

--- a/apps/web/e2e/tool-output-truncation.spec.ts
+++ b/apps/web/e2e/tool-output-truncation.spec.ts
@@ -3,6 +3,7 @@ import { getDefaultSettings } from "@mcode/contracts";
 import { interceptZustandStores, mockWebSocketServer } from "./helpers/e2e-helpers";
 
 const now = new Date().toISOString();
+const completedAt = new Date(Date.parse(now) + 15_000).toISOString();
 const WORKSPACE_ID = "ws-tool-output-truncation";
 const THREAD_ID = "thread-tool-output-truncation";
 const ASSISTANT_ID = "assistant-tool-output-truncation";
@@ -93,7 +94,7 @@ function truncatedToolRecord() {
     output_artifact_path: ARTIFACT_PATH,
     status: "completed" as const,
     started_at: now,
-    completed_at: now,
+    completed_at: completedAt,
     sort_order: 0,
   };
 }
@@ -140,13 +141,16 @@ async function dispatchAgentEvent(page: Page, event: unknown) {
   }, { threadId: THREAD_ID, agentEvent: event });
 }
 
-async function expectTruncationNotice(page: Page, total: string) {
-  const summary = page.getByRole("button", { name: /Ran command/ });
+async function expectTruncationNotice(page: Page, total: string, duration?: string) {
+  const summary = page.getByRole("button", { name: /Ran 1 command/ });
   if (await summary.getAttribute("aria-expanded") !== "true") {
     await summary.click();
   }
 
   const command = page.getByRole("button", { name: /Ran command/ });
+  if (duration) {
+    await expect(command).toContainText(`in ${duration}`);
+  }
   if (await command.getAttribute("aria-expanded") !== "true") {
     await command.click();
   }
@@ -187,14 +191,21 @@ test.describe("tool output truncation", () => {
   });
 
   test("keeps truncation notice after persisted narrative reload", async ({ page }) => {
+    const browserErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") browserErrors.push(message.text());
+    });
+    page.on("pageerror", (error) => browserErrors.push(error.message));
+
     await setupApp(page, [userMessage(), assistantMessage()]);
 
-    await expectTruncationNotice(page, "350 KB total");
+    await expectTruncationNotice(page, "350 KB total", "15s");
 
     await page.reload();
     await page.waitForSelector("[data-testid='thread-item']");
     await page.getByTestId("thread-item").first().click();
 
-    await expectTruncationNotice(page, "350 KB total");
+    await expectTruncationNotice(page, "350 KB total", "15s");
+    expect(browserErrors).toEqual([]);
   });
 });

--- a/apps/web/e2e/tool-output-truncation.spec.ts
+++ b/apps/web/e2e/tool-output-truncation.spec.ts
@@ -99,7 +99,25 @@ function truncatedToolRecord() {
   };
 }
 
-async function setupApp(page: Page, messages: Array<ReturnType<typeof userMessage> | ReturnType<typeof assistantMessage>>) {
+function failedToolRecord() {
+  return {
+    ...truncatedToolRecord(),
+    id: "tool-failed",
+    input_summary: "git pull --ff-only origin main",
+    output_summary: "fatal: Not possible to fast-forward, aborting.",
+    output_truncated: 0,
+    output_total_bytes: null,
+    output_artifact_path: null,
+    exit_code: 1,
+    status: "failed" as const,
+  };
+}
+
+async function setupApp(
+  page: Page,
+  messages: Array<ReturnType<typeof userMessage> | ReturnType<typeof assistantMessage>>,
+  toolRecords = [truncatedToolRecord()],
+) {
   await page.addInitScript((workspaceId: string) => {
     localStorage.setItem("mcode-expanded-projects", JSON.stringify({ [workspaceId]: true }));
   }, WORKSPACE_ID);
@@ -113,7 +131,7 @@ async function setupApp(page: Page, messages: Array<ReturnType<typeof userMessag
     "narrative.list": (params?: unknown) => {
       const messageId = (params as { messageId?: string } | undefined)?.messageId;
       return messageId === ASSISTANT_ID
-        ? { tools: [truncatedToolRecord()], thoughts: [], hooks: [] }
+        ? { tools: toolRecords, thoughts: [], hooks: [] }
         : { tools: [], thoughts: [], hooks: [] };
     },
     "settings.get": getDefaultSettings(),
@@ -207,5 +225,17 @@ test.describe("tool output truncation", () => {
 
     await expectTruncationNotice(page, "350 KB total", "15s");
     expect(browserErrors).toEqual([]);
+  });
+
+  test("shows a persisted shell exit code in the panel footer", async ({ page }) => {
+    await setupApp(page, [userMessage(), assistantMessage()], [failedToolRecord()]);
+
+    await page.getByRole("button", { name: /Ran 1 command/ }).click();
+    await page.getByRole("button", { name: /Ran command/ }).click();
+
+    const panel = page.getByRole("region", { name: "Shell output" });
+    await expect(panel.getByText("exit code 1")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Ran command/ })).not.toContainText("errored");
+    await expect(panel.getByText("errored")).toHaveCount(0);
   });
 });

--- a/apps/web/e2e/tool-output-truncation.spec.ts
+++ b/apps/web/e2e/tool-output-truncation.spec.ts
@@ -146,6 +146,11 @@ async function expectTruncationNotice(page: Page, total: string) {
     await summary.click();
   }
 
+  const command = page.getByRole("button", { name: /Ran command/ });
+  if (await command.getAttribute("aria-expanded") !== "true") {
+    await command.click();
+  }
+
   const notice = page.getByText(/Output truncated/).first();
   await expect(notice).toBeVisible();
   await expect(notice).toContainText(total);

--- a/apps/web/src/__tests__/tool-call-matching.test.ts
+++ b/apps/web/src/__tests__/tool-call-matching.test.ts
@@ -48,7 +48,7 @@ describe("Tool Call Matching", () => {
 
     useThreadStore.getState().handleAgentEvent("thread-1", {
       method: "session.toolResult",
-      params: { toolCallId: "tc2", output: "done", isError: false },
+      params: { toolCallId: "tc2", output: "done", isError: true, exitCode: 1 },
     });
     vi.runAllTimers();
 
@@ -56,6 +56,7 @@ describe("Tool Call Matching", () => {
     expect(calls[0].isComplete).toBe(false); // tc1 untouched
     expect(calls[1].isComplete).toBe(true);
     expect(calls[1].output).toBe("done");
+    expect(calls[1].exitCode).toBe(1);
   });
 
   it("tool result with non-matching ID falls back to first incomplete", () => {

--- a/apps/web/src/components/chat/narrative/HookRow.tsx
+++ b/apps/web/src/components/chat/narrative/HookRow.tsx
@@ -4,7 +4,6 @@ import { AnimatedCollapsible } from "@/components/ui/animated-collapsible";
 import type { HookExecution } from "@/transport/types";
 import { NarrativeSummaryLine } from "./ToolSummaryLine";
 import { getHookOutputLines } from "@/components/chat/hook-output";
-import { NARRATIVE_TOOL_ROW, narrativeToolDetailClass } from "./narrative-layout";
 
 interface HookRowProps {
   /** The hook execution to display. */
@@ -69,7 +68,7 @@ export function HookRow({ hook }: HookRowProps) {
         expandable={hasOutput}
         icon={isRunning ? (
           <span aria-label="running" className="flex w-3 h-3 items-center justify-center shrink-0">
-            <span className="size-1.5 rounded-full bg-primary animate-pulse" />
+            <span className="size-1.5 animate-pulse rounded-full bg-primary" />
           </span>
         ) : isBlocked ? (
           <span aria-label="blocked" className="flex w-3 h-3 items-center justify-center shrink-0">
@@ -81,11 +80,11 @@ export function HookRow({ hook }: HookRowProps) {
           </span>
         )}
         badge={isRunning ? (
-          <span className="font-mono text-xs font-medium px-1.5 py-px rounded-sm bg-primary/15 text-primary shrink-0">
+          <span className="shrink-0 rounded-sm bg-primary/15 px-1.5 py-px font-mono text-xs font-medium text-primary">
             running
           </span>
         ) : isBlocked ? (
-          <span className="font-mono text-xs font-medium px-1.5 py-px rounded-sm bg-[var(--diff-remove)]/15 text-[var(--diff-remove)] shrink-0">
+          <span className="shrink-0 rounded-sm bg-[var(--diff-remove)]/15 px-1.5 py-px font-mono text-xs font-medium text-[var(--diff-remove)]">
             blocked
           </span>
         ) : undefined}
@@ -98,14 +97,14 @@ export function HookRow({ hook }: HookRowProps) {
 
         {/* Trigger label */}
         {hook.toolName && (
-          <span className="min-w-0 truncate font-mono text-xs text-muted-foreground/50">
+          <span className="min-w-0 truncate font-mono text-xs text-muted-foreground/65">
             on {hook.toolName}
           </span>
         )}
 
         {/* Duration or elapsed timer - hide for sub-5ms instant hooks */}
         {(isRunning || (hook.durationMs != null && hook.durationMs >= 5)) && (
-          <span className="font-mono text-xs tabular-nums text-muted-foreground/50 shrink-0">
+          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground/65">
             {isRunning ? `${elapsedSeconds}s` : formatDuration(hook.durationMs!)}
           </span>
         )}
@@ -113,31 +112,23 @@ export function HookRow({ hook }: HookRowProps) {
 
       {hasOutput && (
         <AnimatedCollapsible open={open}>
-          <ul className="min-w-0 max-w-full pl-6 mt-0.5 space-y-0.5 pb-1">
+          <pre className="mt-1 ml-6 max-h-64 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/60 bg-muted/25 px-3 py-2 font-mono text-sm leading-5 [overflow-wrap:anywhere]">
             {fullLines.map((line, index) => (
-              <li key={`${index}-${line}`} className="flex min-w-0 max-w-full flex-col gap-0.5">
-                <div className={`${NARRATIVE_TOOL_ROW} text-sm`}>
-                  <Webhook className="w-[14px] h-[14px] text-muted-foreground/75 shrink-0" />
-                  <span className="text-foreground/65 font-medium shrink-0">
-                    Hook detail
-                  </span>
-                  <span
-                    className={
-                      isBlocked || (hasPassed && hook.exitCode !== 0)
-                        ? `${narrativeToolDetailClass("md")} text-[var(--diff-remove)]`
-                        : narrativeToolDetailClass("md")
-                    }
-                    title={line}
-                  >
-                    {line}
-                    {isRunning && index === fullLines.length - 1 && (
-                      <span aria-hidden="true" className="typing-cursor" />
-                    )}
-                  </span>
-                </div>
-              </li>
+              <span
+                key={`${index}-${line}`}
+                className={
+                  isBlocked || (hasPassed && hook.exitCode !== 0)
+                    ? "block text-sm text-[var(--diff-remove)]"
+                    : "block text-sm text-foreground/75"
+                }
+              >
+                {line}
+                {isRunning && index === fullLines.length - 1 && (
+                  <span aria-hidden="true" className="typing-cursor" />
+                )}
+              </span>
             ))}
-          </ul>
+          </pre>
         </AnimatedCollapsible>
       )}
     </div>

--- a/apps/web/src/components/chat/narrative/NarrativeFlow.tsx
+++ b/apps/web/src/components/chat/narrative/NarrativeFlow.tsx
@@ -45,7 +45,7 @@ function marginClassForItem(item: NarrativeItem, index: number): string {
       return "mt-3";
     case "tool-group":
     case "hook":
-      return "mt-0";
+      return "mt-1";
     case "subagent":
       return "mt-1";
     case "active-tool":

--- a/apps/web/src/components/chat/narrative/NarrativeIndicator.tsx
+++ b/apps/web/src/components/chat/narrative/NarrativeIndicator.tsx
@@ -107,12 +107,12 @@ export function NarrativeIndicator({
   return (
     <div
       className={cn(
-        "flex items-center gap-2 px-4 py-2 mt-1.5",
+        "mt-2 flex items-center gap-2 px-4 py-2",
         phase === "exiting" && "narrative-indicator-exit",
       )}
       data-state={phase}
     >
-      <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <span className="flex items-center gap-2 text-sm text-muted-foreground">
         {/* When sub-agents are dispatched, the stacked-layers icon (with its
             float + per-layer ripple) becomes the "agent working" mark — more
             semantic than a generic dot because it mirrors the same glyph used

--- a/apps/web/src/components/chat/narrative/PersistedNarrative.tsx
+++ b/apps/web/src/components/chat/narrative/PersistedNarrative.tsx
@@ -7,7 +7,10 @@ import { ThoughtBlock } from "./ThoughtBlock";
 import { ToolSummaryLine } from "./ToolSummaryLine";
 import { HookRow } from "./HookRow";
 import { SubagentRow } from "./SubagentRow";
-import { buildPersistedNarrativeItems } from "./build-persisted-narrative";
+import {
+  buildPersistedNarrativeItems,
+  recordToToolCall,
+} from "./build-persisted-narrative";
 
 /** Props for `PersistedNarrative`. */
 export interface PersistedNarrativeProps {
@@ -119,20 +122,7 @@ export function PersistedNarrative({ messageId, messageContent }: PersistedNarra
       };
     }
     const built = buildPersistedNarrativeItems({ ...records, messageContent });
-    const liveTools: ToolCall[] = records.tools.map((r) => ({
-      id: r.id,
-      toolName: r.tool_name,
-      toolInput: {},
-      output: r.output_summary || null,
-      isError: r.status === "failed",
-      isComplete:
-        r.status === "completed" || r.status === "failed" || r.status === "cancelled",
-      ...(r.output_truncated === 1 ? { outputTruncated: true } : {}),
-      ...(typeof r.output_total_bytes === "number" ? { outputTotalBytes: r.output_total_bytes } : {}),
-      ...(r.output_artifact_path ? { outputArtifactPath: r.output_artifact_path } : {}),
-      parentToolCallId: r.parent_tool_call_id ?? undefined,
-      startedAt: Date.parse(r.started_at) || 0,
-    }));
+    const liveTools: ToolCall[] = records.tools.map(recordToToolCall);
     return { items: built, allToolCalls: liveTools };
   }, [records, messageContent]);
 

--- a/apps/web/src/components/chat/narrative/PersistedNarrative.tsx
+++ b/apps/web/src/components/chat/narrative/PersistedNarrative.tsx
@@ -32,6 +32,8 @@ function marginClassForItem(item: NarrativeItem, index: number): string {
   switch (item.type) {
     case "thought":
       return "mt-3";
+    case "tool-group":
+    case "hook":
     case "subagent":
       return "mt-1";
     default:

--- a/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
+++ b/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
@@ -71,6 +71,13 @@ export function ShellToolCallRow({ toolCall }: ShellToolCallRowProps) {
   const duration = toolCall.isComplete ? formatToolDuration(toolCall.durationMs) : null;
   const isRunning = !toolCall.isComplete && !toolCall.isError;
   const isCancelled = !toolCall.isComplete && toolCall.isError;
+  const failureLabel = toolCall.isError
+    ? typeof toolCall.exitCode === "number" && Number.isInteger(toolCall.exitCode)
+      ? `exit code ${toolCall.exitCode}`
+      : isCancelled
+        ? "cancelled"
+        : "failed"
+    : null;
 
   return (
     <div className="min-w-0 max-w-full">
@@ -103,11 +110,6 @@ export function ShellToolCallRow({ toolCall }: ShellToolCallRowProps) {
         <span className={narrativeToolDetailClass("md")} title={command || undefined}>
           {detail}
         </span>
-        {toolCall.isError && (
-          <Badge variant="destructive" size="sm" className="rounded-sm font-mono">
-            {isCancelled ? "cancelled" : "errored"}
-          </Badge>
-        )}
         <ChevronRight
           className={`h-3 w-3 shrink-0 text-muted-foreground/45 transition-transform duration-150 motion-reduce:transition-none ${
             open ? "rotate-90" : ""
@@ -150,6 +152,14 @@ export function ShellToolCallRow({ toolCall }: ShellToolCallRowProps) {
               >
                 {toolCall.output}
               </pre>
+            )}
+
+            {failureLabel && (
+              <footer className="mt-2 flex justify-end">
+                <Badge variant="destructive" size="sm" className="rounded-sm font-mono">
+                  {failureLabel}
+                </Badge>
+              </footer>
             )}
           </div>
         </section>

--- a/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
+++ b/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
@@ -1,7 +1,6 @@
 import { useId, useState } from "react";
 import { ChevronRight, Terminal } from "lucide-react";
 import { AnimatedCollapsible } from "@/components/ui/animated-collapsible";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatDuration } from "@/lib/time";
 import type { ToolCall } from "@/transport/types";
@@ -156,9 +155,9 @@ export function ShellToolCallRow({ toolCall }: ShellToolCallRowProps) {
 
             {failureLabel && (
               <footer className="mt-2 flex justify-end">
-                <Badge variant="destructive" size="sm" className="rounded-sm font-mono">
+                <span className="font-mono text-xs tabular-nums text-muted-foreground/70">
                   {failureLabel}
-                </Badge>
+                </span>
               </footer>
             )}
           </div>

--- a/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
+++ b/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
@@ -1,6 +1,8 @@
 import { useId, useState } from "react";
 import { ChevronRight, Terminal } from "lucide-react";
 import { AnimatedCollapsible } from "@/components/ui/animated-collapsible";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { formatDuration } from "@/lib/time";
 import type { ToolCall } from "@/transport/types";
 import { NARRATIVE_TOOL_ROW, narrativeToolDetailClass } from "./narrative-layout";
@@ -72,10 +74,12 @@ export function ShellToolCallRow({ toolCall }: ShellToolCallRowProps) {
 
   return (
     <div className="min-w-0 max-w-full">
-      <button
+      <Button
         type="button"
+        variant="ghost"
+        size="sm"
         onClick={() => setOpen((current) => !current)}
-        className={`${NARRATIVE_TOOL_ROW} w-full rounded-md py-1 text-left transition-colors duration-150 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none`}
+        className={`${NARRATIVE_TOOL_ROW} h-auto w-full justify-start rounded-md px-0 py-1 text-left font-normal transition-colors duration-150 hover:bg-muted/30 aria-expanded:bg-transparent active:translate-y-0 motion-reduce:transition-none dark:hover:bg-muted/30 dark:aria-expanded:bg-transparent`}
         aria-expanded={open}
         aria-controls={panelId}
       >
@@ -100,16 +104,16 @@ export function ShellToolCallRow({ toolCall }: ShellToolCallRowProps) {
           {detail}
         </span>
         {toolCall.isError && (
-          <span className="shrink-0 rounded-sm bg-[var(--diff-remove)]/15 px-1.5 py-px font-mono text-xs font-medium text-[var(--diff-remove)]">
+          <Badge variant="destructive" size="sm" className="rounded-sm font-mono">
             {isCancelled ? "cancelled" : "errored"}
-          </span>
+          </Badge>
         )}
         <ChevronRight
           className={`h-3 w-3 shrink-0 text-muted-foreground/45 transition-transform duration-150 motion-reduce:transition-none ${
             open ? "rotate-90" : ""
           }`}
         />
-      </button>
+      </Button>
 
       <AnimatedCollapsible open={open}>
         <section

--- a/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
+++ b/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
@@ -1,0 +1,155 @@
+import { useId, useState } from "react";
+import { ChevronRight, Terminal } from "lucide-react";
+import { AnimatedCollapsible } from "@/components/ui/animated-collapsible";
+import { formatDuration } from "@/lib/time";
+import type { ToolCall } from "@/transport/types";
+import { NARRATIVE_TOOL_ROW, narrativeToolDetailClass } from "./narrative-layout";
+import { ToolOutputTruncationNotice } from "./ToolOutputTruncationNotice";
+
+interface ShellToolCallRowProps {
+  /** Shell invocation rendered as a nested narrative row. */
+  toolCall: ToolCall;
+}
+
+/** Extracts a shell command from live input or a persisted provider summary. */
+function extractCommand(toolCall: ToolCall): string {
+  const direct = toolCall.toolInput.command;
+  if (typeof direct === "string" && direct.trim().length > 0) return direct;
+
+  const summary = toolCall.toolInput._summary ?? toolCall.toolInput.summary;
+  if (typeof summary !== "string") return "";
+
+  const trimmed = summary.trim();
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        "command" in parsed &&
+        typeof parsed.command === "string"
+      ) {
+        return parsed.command;
+      }
+    } catch {
+      // Some older persisted summaries were truncated mid-JSON.
+    }
+  }
+
+  const legacyPrefix = '{"command":"';
+  if (trimmed.startsWith(legacyPrefix)) {
+    const escapedCommand = trimmed.slice(legacyPrefix.length).replace(/"}$/, "");
+    const escapedSlash = "\u0000";
+    return escapedCommand
+      .replace(/\\\\/g, escapedSlash)
+      .replace(/\\"/g, '"')
+      .replace(/\\n/g, "\n")
+      .replace(/\\r/g, "\r")
+      .replace(/\\t/g, "\t")
+      .replace(/\\\//g, "/")
+      .split(escapedSlash)
+      .join("\\");
+  }
+
+  return summary;
+}
+
+/** Formats a completed tool duration for the compact child-row label. */
+function formatToolDuration(durationMs: number | undefined): string | null {
+  if (durationMs == null || !Number.isFinite(durationMs) || durationMs < 0) return null;
+  return formatDuration(Math.max(1, Math.round(durationMs / 1000)));
+}
+
+/** Renders a nested shell call that reveals a terminal-style command transcript. */
+export function ShellToolCallRow({ toolCall }: ShellToolCallRowProps) {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+  const command = extractCommand(toolCall);
+  const detail = command.replace(/\s+/g, " ").trim() || "Command unavailable";
+  const duration = toolCall.isComplete ? formatToolDuration(toolCall.durationMs) : null;
+  const isRunning = !toolCall.isComplete && !toolCall.isError;
+  const isCancelled = !toolCall.isComplete && toolCall.isError;
+
+  return (
+    <div className="min-w-0 max-w-full">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className={`${NARRATIVE_TOOL_ROW} w-full rounded-md py-1 text-left transition-colors duration-150 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none`}
+        aria-expanded={open}
+        aria-controls={panelId}
+      >
+        <Terminal
+          className={`h-3.5 w-3.5 shrink-0 ${
+            toolCall.isError
+              ? "text-[var(--diff-remove)]"
+              : isRunning
+                ? "text-primary"
+                : "text-muted-foreground/70"
+          }`}
+        />
+        <span className="shrink-0 text-sm font-medium text-foreground/75">
+          {isRunning ? "Running command" : "Ran command"}
+        </span>
+        {duration && (
+          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground/65">
+            in {duration}
+          </span>
+        )}
+        <span className={narrativeToolDetailClass("md")} title={command || undefined}>
+          {detail}
+        </span>
+        {toolCall.isError && (
+          <span className="shrink-0 rounded-sm bg-[var(--diff-remove)]/15 px-1.5 py-px font-mono text-xs font-medium text-[var(--diff-remove)]">
+            {isCancelled ? "cancelled" : "errored"}
+          </span>
+        )}
+        <ChevronRight
+          className={`h-3 w-3 shrink-0 text-muted-foreground/45 transition-transform duration-150 motion-reduce:transition-none ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+      </button>
+
+      <AnimatedCollapsible open={open}>
+        <section
+          id={panelId}
+          aria-label="Shell output"
+          className="mt-1 min-w-0 max-w-full overflow-hidden rounded-lg border border-border/60 bg-muted/25"
+        >
+          <header className="border-b border-border/50 px-3 py-2 text-sm font-medium text-foreground/75">
+            Shell
+          </header>
+          <div className="min-w-0 px-3 py-3 font-mono text-xs leading-5">
+            <div className="flex min-w-0 items-start gap-2">
+              <span aria-hidden="true" className="select-none text-muted-foreground/70">
+                $
+              </span>
+              <code className="min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-xs leading-5 text-foreground/85 [overflow-wrap:anywhere]">
+                {command || "Command unavailable"}
+              </code>
+            </div>
+
+            {toolCall.outputTruncated === true && (
+              <div className="mt-2">
+                <ToolOutputTruncationNotice toolCall={toolCall} />
+              </div>
+            )}
+
+            {toolCall.output && (
+              <pre
+                className={`mt-2 max-h-64 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 [overflow-wrap:anywhere] ${
+                  toolCall.isError
+                    ? "text-[var(--diff-remove)]"
+                    : "text-foreground/75"
+                }`}
+              >
+                {toolCall.output}
+              </pre>
+            )}
+          </div>
+        </section>
+      </AnimatedCollapsible>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
+++ b/apps/web/src/components/chat/narrative/ShellToolCallRow.tsx
@@ -57,8 +57,8 @@ function extractCommand(toolCall: ToolCall): string {
 
 /** Formats a completed tool duration for the compact child-row label. */
 function formatToolDuration(durationMs: number | undefined): string | null {
-  if (durationMs == null || !Number.isFinite(durationMs) || durationMs < 0) return null;
-  return formatDuration(Math.max(1, Math.round(durationMs / 1000)));
+  if (durationMs == null || !Number.isFinite(durationMs) || durationMs < 1000) return null;
+  return formatDuration(Math.round(durationMs / 1000));
 }
 
 /** Renders a nested shell call that reveals a terminal-style command transcript. */
@@ -68,14 +68,14 @@ export function ShellToolCallRow({ toolCall }: ShellToolCallRowProps) {
   const command = extractCommand(toolCall);
   const detail = command.replace(/\s+/g, " ").trim() || "Command unavailable";
   const duration = toolCall.isComplete ? formatToolDuration(toolCall.durationMs) : null;
-  const isRunning = !toolCall.isComplete && !toolCall.isError;
-  const isCancelled = !toolCall.isComplete && toolCall.isError;
-  const failureLabel = toolCall.isError
+  const isCancelled = toolCall.isCancelled === true || (!toolCall.isComplete && toolCall.isError);
+  const isRunning = !toolCall.isComplete && !toolCall.isError && !isCancelled;
+  const failureLabel = isCancelled
+    ? "cancelled"
+    : toolCall.isError
     ? typeof toolCall.exitCode === "number" && Number.isInteger(toolCall.exitCode)
       ? `exit code ${toolCall.exitCode}`
-      : isCancelled
-        ? "cancelled"
-        : "failed"
+      : "failed"
     : null;
 
   return (

--- a/apps/web/src/components/chat/narrative/SubagentRow.tsx
+++ b/apps/web/src/components/chat/narrative/SubagentRow.tsx
@@ -259,17 +259,18 @@ function ExpandableSubagentRow({
             }
 
             const canonicalName = resolveToolName(tc.toolName);
-            const Icon = TOOL_ICONS[canonicalName] ?? DEFAULT_ICON;
-            const label = TOOL_LABELS[canonicalName] ?? tc.toolName;
-            const detail = extractToolInputDetail(tc);
 
-            if (resolveToolName(tc.toolName) === "Bash") {
+            if (canonicalName === "Bash") {
               return (
                 <li key={tc.id} className="min-w-0 max-w-full list-none">
                   <ShellToolCallRow toolCall={tc} />
                 </li>
               );
             }
+
+            const Icon = TOOL_ICONS[canonicalName] ?? DEFAULT_ICON;
+            const label = TOOL_LABELS[canonicalName] ?? tc.toolName;
+            const detail = extractToolInputDetail(tc);
 
             return (
               <li key={tc.id} className={`${NARRATIVE_TOOL_ROW} py-1 text-sm`}>

--- a/apps/web/src/components/chat/narrative/SubagentRow.tsx
+++ b/apps/web/src/components/chat/narrative/SubagentRow.tsx
@@ -19,6 +19,7 @@ import { ToolOutputTruncationNotice } from "./ToolOutputTruncationNotice";
 import { EntityIcon } from "../EntityToken";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ShellToolCallRow } from "./ShellToolCallRow";
 
 interface SubagentRowProps {
   toolCall: ToolCall;
@@ -42,7 +43,7 @@ interface DelegationTagsProps {
 function DelegationTags({ tags }: DelegationTagsProps) {
   if (tags.length === 0) return null;
   return (
-    <span className="flex items-center gap-1 shrink-0">
+    <span className="flex shrink-0 items-center gap-1">
       {tags.map((tag) => (
         <Badge
           key={tag}
@@ -80,7 +81,7 @@ export function SubagentRow({ toolCall, children, hooks, allToolCalls, depth = 0
   if (!hasChildren && !finalOutput) {
     return (
       <div
-        className="flex w-full min-w-0 max-w-full items-center gap-1.5 overflow-hidden px-2 py-1 text-sm"
+        className="flex w-full min-w-0 max-w-full items-center gap-2 overflow-hidden px-2 py-1 text-sm"
         data-testid="subagent-flat-row"
       >
         <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted/65 ring-1 ring-inset ring-border/60">
@@ -211,7 +212,7 @@ function ExpandableSubagentRow({
         <DelegationTags tags={delegationTags} />
 
         {metaText && (
-          <span className="font-mono text-xs text-muted-foreground/50 shrink-0">
+          <span className="shrink-0 font-mono text-xs text-muted-foreground/65">
             {!isRunning ? `· ${metaText}` : metaText}
           </span>
         )}
@@ -238,17 +239,8 @@ function ExpandableSubagentRow({
           </div>
         )}
         {children.length > 0 && (
-          /* Mini-timeline: a hairline rail emerges inside the expanded sub-agent
-              because the children are a nested group that the eye benefits from
-              tracking as one unit. The rail aligns with the parent's stacked-
-              layers icon (centred at ~x=15), so it reads as "these calls belong
-              to this sub-agent" rather than a generic indent. */
-          <div className="relative min-w-0 max-w-full pl-7 mt-0.5 pb-1">
-            <div
-              className="absolute left-[14px] top-1 bottom-2 w-px bg-border/50 pointer-events-none"
-              aria-hidden
-            />
-            <ul className="min-w-0 max-w-full space-y-px max-h-64 overflow-y-auto overflow-x-hidden">
+          <div className="mt-1 min-w-0 max-w-full pb-2 pl-6">
+            <ul className="max-h-64 min-w-0 max-w-full space-y-1 overflow-y-auto overflow-x-hidden">
             {visibleChildren.map((tc, idx) => {
               const isActive = idx === lastIncompleteIdx;
 
@@ -271,8 +263,16 @@ function ExpandableSubagentRow({
             const label = TOOL_LABELS[canonicalName] ?? tc.toolName;
             const detail = extractToolInputDetail(tc);
 
+            if (resolveToolName(tc.toolName) === "Bash") {
+              return (
+                <li key={tc.id} className="min-w-0 max-w-full list-none">
+                  <ShellToolCallRow toolCall={tc} />
+                </li>
+              );
+            }
+
             return (
-              <li key={tc.id} className={`${NARRATIVE_TOOL_ROW} py-px text-sm`}>
+              <li key={tc.id} className={`${NARRATIVE_TOOL_ROW} py-1 text-sm`}>
                 <Icon className={`w-3 h-3 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground/50"}`} />
                 <span className={`shrink-0 ${isActive ? "text-foreground" : "text-muted-foreground/70"}`}>{label}</span>
                 <span className={narrativeToolDetailClass("sm")} title={detail}>
@@ -293,7 +293,7 @@ function ExpandableSubagentRow({
             variant="ghost"
             size="sm"
             onClick={() => setShowAll((o) => !o)}
-            className="h-auto items-center gap-1 rounded-md pl-7 pb-1 text-xs text-muted-foreground/50 hover:text-muted-foreground/70 transition-colors"
+            className="h-auto items-center gap-1 rounded-md pb-1 pl-7 font-mono text-xs text-muted-foreground/55 transition-colors hover:text-muted-foreground/75"
           >
             <ChevronDown className={`h-2.5 w-2.5 shrink-0 transition-transform duration-150 ${showAll ? "rotate-180" : ""}`} />
             {showAll ? "Show less" : `Show all ${children.length}`}

--- a/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
+++ b/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
@@ -15,7 +15,7 @@ import type { ToolGroup } from "./types";
 import { extractToolInputDetail } from "./tool-detail";
 import { NARRATIVE_TOOL_ROW, narrativeToolDetailClass } from "./narrative-layout";
 import { ToolOutputTruncationNotice } from "./ToolOutputTruncationNotice";
-import { CommandExecutionCard } from "./CommandExecutionCard";
+import { ShellToolCallRow } from "./ShellToolCallRow";
 
 interface ToolSummaryLineProps {
   /** The group of consecutive tool calls to summarize. */
@@ -58,7 +58,7 @@ export function NarrativeSummaryLine({
       type="button"
       onClick={onToggle}
       disabled={disabled}
-      className={`${NARRATIVE_TOOL_ROW} w-full px-2 py-1 text-left rounded-md transition-colors duration-100 text-sm ${
+      className={`${NARRATIVE_TOOL_ROW} w-full rounded-md px-2 py-1 text-left text-sm transition-colors duration-100 ${
         disabled ? "cursor-default" : "hover:bg-muted/30"
       }`}
       aria-expanded={expandable ? open : undefined}
@@ -106,7 +106,7 @@ function StatusBadge({ status }: StatusBadgeProps) {
   };
   return (
     <span
-      className={`font-mono text-xs font-medium px-1.5 py-px rounded-sm ${styles[status]}`}
+      className={`rounded-sm px-1.5 py-px font-mono text-xs font-medium ${styles[status]}`}
     >
       {status}
     </span>
@@ -128,19 +128,6 @@ export function ToolSummaryLine({
 }: ToolSummaryLineProps) {
   const [open, setOpen] = useState(false);
 
-  if (
-    group.calls.length > 0 &&
-    group.calls.every((call) => isShellTool(call.toolName))
-  ) {
-    return (
-      <div className="flex min-w-0 max-w-full flex-col gap-1 py-0.5">
-        {group.calls.map((toolCall) => (
-          <CommandExecutionCard key={toolCall.id} toolCall={toolCall} />
-        ))}
-      </div>
-    );
-  }
-
   const firstCall = group.calls[0];
   const LeadingIcon = firstCall
     ? (TOOL_ICONS[resolveToolName(firstCall.toolName)] ?? DEFAULT_ICON)
@@ -160,17 +147,17 @@ export function ToolSummaryLine({
       <NarrativeSummaryLine
         open={open}
         onToggle={() => setOpen((prev) => !prev)}
-        icon={<LeadingIcon className="w-3 h-3 shrink-0 text-muted-foreground/40" />}
+        icon={<LeadingIcon className="h-3 w-3 shrink-0 text-muted-foreground/55" />}
         badge={worstBadge ? <StatusBadge status={worstBadge} /> : undefined}
       >
-        <span className="text-muted-foreground/60 flex-1 min-w-0 truncate">
+        <span className="min-w-0 flex-1 truncate font-medium text-foreground/75">
           {summaryText}
         </span>
       </NarrativeSummaryLine>
 
       {/* Expanded detail list */}
       <AnimatedCollapsible open={open}>
-        <ul className="min-w-0 max-w-full pl-6 mt-0.5 space-y-0.5 pb-1">
+        <ul className="mt-1 min-w-0 max-w-full space-y-1 pb-2 pl-6">
           {group.calls.map((tc) => {
             const canonicalName = resolveToolName(tc.toolName);
             const Icon = TOOL_ICONS[canonicalName] ?? DEFAULT_ICON;
@@ -180,14 +167,14 @@ export function ToolSummaryLine({
 
             if (isShellTool(tc.toolName)) {
               return (
-                <li key={tc.id} className="min-w-0 max-w-full py-0.5">
-                  <CommandExecutionCard toolCall={tc} />
+                <li key={tc.id} className="min-w-0 max-w-full">
+                  <ShellToolCallRow toolCall={tc} />
                 </li>
               );
             }
 
             return (
-              <li key={tc.id} className="flex min-w-0 max-w-full flex-col gap-0.5">
+              <li key={tc.id} className="flex min-w-0 max-w-full flex-col gap-1 py-1">
                 {/* Row: icon + label + detail + badge */}
                 <div className={`${NARRATIVE_TOOL_ROW} text-sm`}>
                   <Icon className="w-[14px] h-[14px] text-muted-foreground/75 shrink-0" />

--- a/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
+++ b/apps/web/src/components/chat/narrative/ToolSummaryLine.tsx
@@ -83,7 +83,7 @@ export function NarrativeSummaryLine({
  */
 function getCallStatus(tc: ToolCall): "completed" | "errored" | "cancelled" {
   if (tc.isError) return "errored";
-  if (!tc.isComplete) return "cancelled";
+  if (tc.isCancelled || !tc.isComplete) return "cancelled";
   return "completed";
 }
 
@@ -160,10 +160,6 @@ export function ToolSummaryLine({
         <ul className="mt-1 min-w-0 max-w-full space-y-1 pb-2 pl-6">
           {group.calls.map((tc) => {
             const canonicalName = resolveToolName(tc.toolName);
-            const Icon = TOOL_ICONS[canonicalName] ?? DEFAULT_ICON;
-            const label = TOOL_LABELS[canonicalName] ?? tc.toolName;
-            const detail = extractToolInputDetail(tc);
-            const status = getCallStatus(tc);
 
             if (isShellTool(tc.toolName)) {
               return (
@@ -172,6 +168,11 @@ export function ToolSummaryLine({
                 </li>
               );
             }
+
+            const Icon = TOOL_ICONS[canonicalName] ?? DEFAULT_ICON;
+            const label = TOOL_LABELS[canonicalName] ?? tc.toolName;
+            const detail = extractToolInputDetail(tc);
+            const status = getCallStatus(tc);
 
             return (
               <li key={tc.id} className="flex min-w-0 max-w-full flex-col gap-1 py-1">

--- a/apps/web/src/components/chat/narrative/TurnFooter.tsx
+++ b/apps/web/src/components/chat/narrative/TurnFooter.tsx
@@ -49,7 +49,7 @@ export function TurnFooter({ counts, durationMs }: TurnFooterProps) {
   if (parts.length === 0 && durationMs == null) return null;
 
   return (
-    <div className="mt-2 flex items-baseline gap-3 pl-[18px] font-mono uppercase text-xs tracking-[0.08em] text-muted-foreground/45">
+    <div className="mt-2 flex items-baseline gap-3 pl-4 font-mono uppercase text-xs tracking-[0.08em] text-muted-foreground/45">
       {parts.length > 0 && <span>{parts.join(" · ")}</span>}
       <span className="flex-1 h-px bg-border/40" aria-hidden="true" />
       <span className="tabular-nums">{formatDuration(durationMs)}</span>

--- a/apps/web/src/components/chat/narrative/__tests__/SubagentRow.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/SubagentRow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { SubagentRow } from "../SubagentRow";
 import type { ToolCall } from "@/transport/types";
 
@@ -92,5 +92,34 @@ describe("SubagentRow", () => {
     );
 
     expect(screen.getByText(/Output truncated/).textContent).toContain("512 KB total");
+  });
+
+  it("keeps shell calls nested under a subagent and expands their transcript", () => {
+    const child: ToolCall = {
+      id: "shell-1",
+      toolName: "Shell",
+      toolInput: { command: "git status --short" },
+      output: " M file.ts",
+      isError: false,
+      isComplete: true,
+      durationMs: 2_000,
+      startedAt: 1,
+      parentToolCallId: "agent-1",
+    };
+
+    render(<SubagentRow toolCall={mkAgent({})} children={[child]} hooks={[]} />);
+
+    const parent = screen.getByRole("button", { name: /Read detection module/ });
+    fireEvent.click(parent);
+
+    const command = screen.getByRole("button", { name: /Ran command/ });
+    expect(command).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("region", { name: "Shell output" })).toBeNull();
+
+    fireEvent.click(command);
+
+    expect(screen.getByRole("region", { name: "Shell output" })).toBeTruthy();
+    expect(screen.getAllByText("git status --short")).toHaveLength(2);
+    expect(screen.getByText("M file.ts", { exact: false })).toBeTruthy();
   });
 });

--- a/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
@@ -256,4 +256,32 @@ describe("narrative tool row layout classes", () => {
     expect(notice.textContent).toContain("full output saved");
     expect(notice.className).toContain("text-xs");
   });
+
+  it("shows a failed shell exit code at the bottom right of the expanded panel", () => {
+    const group: ToolGroup = {
+      calls: [
+        makeBashCall({
+          id: "tc-failed",
+          output: "fatal: remote failed",
+          isComplete: true,
+          isError: true,
+          exitCode: 1,
+        }),
+      ],
+    };
+
+    render(
+      <ToolSummaryLine group={group} hasError={true} hasCancelled={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/ }));
+    const child = screen.getByRole("button", { name: /Ran command/ });
+    expect(child).not.toHaveTextContent("errored");
+    fireEvent.click(child);
+
+    const panel = screen.getByRole("region", { name: "Shell output" });
+    const badge = screen.getByText("exit code 1");
+    expect(panel).toContainElement(badge);
+    expect(badge.closest("footer")).toHaveClass("justify-end");
+  });
 });

--- a/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
@@ -181,6 +181,29 @@ describe("narrative tool row layout classes", () => {
     }
   });
 
+  it("does not round a sub-second shell duration up to one second", () => {
+    const group: ToolGroup = {
+      calls: [makeBashCall({ isComplete: true, durationMs: 500 })],
+    };
+
+    render(<ToolSummaryLine group={group} hasError={false} hasCancelled={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/ }));
+    expect(screen.getByRole("button", { name: /Ran command/ })).not.toHaveTextContent("in 1s");
+  });
+
+  it("shows cancelled for a persisted cancelled shell call", () => {
+    const group: ToolGroup = {
+      calls: [makeBashCall({ isComplete: true, isCancelled: true })],
+    };
+
+    render(<ToolSummaryLine group={group} hasError={false} hasCancelled />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Ran command/ }));
+    expect(screen.getAllByText("cancelled")).toHaveLength(2);
+  });
+
   it("normalizes older persisted Codex command summaries before display", () => {
     const group: ToolGroup = {
       calls: [

--- a/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
@@ -5,8 +5,9 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { ActiveToolRow } from "../ActiveToolRow";
 import { ToolSummaryLine } from "../ToolSummaryLine";
+import { buildPersistedNarrativeItems } from "../build-persisted-narrative";
 import { buildToolSummaryText, isShellTool, resolveToolName } from "../../tool-renderers/constants";
-import type { ToolCall } from "@/transport/types";
+import type { ToolCall, ToolCallRecord } from "@/transport/types";
 import type { ToolGroup } from "../types";
 
 /** Long unbroken path + git add, matching real overflow reports. */
@@ -105,6 +106,40 @@ describe("narrative tool row layout classes", () => {
     expect(screen.getByText("Shell")).toBeTruthy();
     expect(container.querySelector("code")?.textContent).toBe(LONG_SHELL_COMMAND);
     expect(screen.getByText("command output")).toBeTruthy();
+  });
+
+  it("ToolSummaryLine renders duration hydrated from a persisted shell call", () => {
+    const persisted: ToolCallRecord = {
+      id: "tc-persisted",
+      message_id: "message-1",
+      parent_tool_call_id: null,
+      tool_name: "Shell",
+      input_summary: JSON.stringify({ command: LONG_SHELL_COMMAND }),
+      output_summary: "command output",
+      status: "completed",
+      started_at: "2026-05-15T10:00:00Z",
+      completed_at: "2026-05-15T10:00:15Z",
+      sort_order: 1,
+    };
+    const items = buildPersistedNarrativeItems({
+      tools: [persisted],
+      thoughts: [],
+      hooks: [],
+    });
+
+    expect(items[0].type).toBe("tool-group");
+    if (items[0].type !== "tool-group") return;
+
+    render(
+      <ToolSummaryLine group={items[0].group} hasError={false} hasCancelled={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/ }));
+    expect(screen.getByRole("button", { name: /Ran command/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.getByText("in 15s")).toBeTruthy();
   });
 
   it("ToolSummaryLine maps command_execution to terminal icon via Bash alias", () => {

--- a/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
@@ -257,7 +257,7 @@ describe("narrative tool row layout classes", () => {
     expect(notice.className).toContain("text-xs");
   });
 
-  it("shows a failed shell exit code at the bottom right of the expanded panel", () => {
+  it("shows a plain shell exit code at the bottom right of the expanded panel", () => {
     const group: ToolGroup = {
       calls: [
         makeBashCall({
@@ -280,8 +280,9 @@ describe("narrative tool row layout classes", () => {
     fireEvent.click(child);
 
     const panel = screen.getByRole("region", { name: "Shell output" });
-    const badge = screen.getByText("exit code 1");
-    expect(panel).toContainElement(badge);
-    expect(badge.closest("footer")).toHaveClass("justify-end");
+    const exitCode = screen.getByText("exit code 1");
+    expect(panel).toContainElement(exitCode);
+    expect(exitCode).toHaveClass("text-muted-foreground/70");
+    expect(exitCode.closest("footer")).toHaveClass("justify-end");
   });
 });

--- a/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
+++ b/apps/web/src/components/chat/narrative/__tests__/tool-row-overflow.test.tsx
@@ -69,13 +69,14 @@ describe("narrative tool row layout classes", () => {
     expect(command?.className).toContain("overflow-wrap");
   });
 
-  it("ToolSummaryLine gives a completed shell command its own disclosure", () => {
+  it("ToolSummaryLine keeps shell calls nested and reveals a shell transcript", () => {
     const group: ToolGroup = {
       calls: [
         makeBashCall({
           id: "tc-1",
           isComplete: true,
           output: "command output",
+          durationMs: 15_000,
         }),
       ],
     };
@@ -86,15 +87,24 @@ describe("narrative tool row layout classes", () => {
       </div>,
     );
 
-    const button = screen.getByRole("button", { name: /Ran command/ });
+    const summary = screen.getByRole("button", { name: /Ran 1 command/ });
     expect(screen.getAllByRole("button")).toHaveLength(1);
-    fireEvent.click(button);
+    fireEvent.click(summary);
 
+    const child = screen.getByRole("button", { name: /Ran command/ });
+    expect(child).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByText("in 15s")).toBeTruthy();
+    expect(screen.queryByRole("region", { name: "Shell output" })).toBeNull();
+
+    fireEvent.click(child);
+
+    const detail = screen.getByTitle(LONG_SHELL_COMMAND);
+    expect(detail.className).toContain("truncate");
+    expect(detail.closest("li")?.className).toContain("min-w-0");
+    expect(screen.getByRole("region", { name: "Shell output" })).toBeTruthy();
+    expect(screen.getByText("Shell")).toBeTruthy();
     expect(container.querySelector("code")?.textContent).toBe(LONG_SHELL_COMMAND);
-    expect(screen.queryByText("Output")).toBeNull();
     expect(screen.getByText("command output")).toBeTruthy();
-    expect(container.querySelector("code")?.className).toContain("text-xs");
-    expect(container.querySelector("pre")?.className).toContain("text-xs");
   });
 
   it("ToolSummaryLine maps command_execution to terminal icon via Bash alias", () => {
@@ -114,6 +124,7 @@ describe("narrative tool row layout classes", () => {
       </div>,
     );
 
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/ }));
     fireEvent.click(screen.getByRole("button", { name: /Ran command/ }));
     expect(container.querySelector(".lucide-terminal")).toBeTruthy();
     expect(screen.getByText("Ran command")).toBeTruthy();
@@ -151,6 +162,7 @@ describe("narrative tool row layout classes", () => {
       <ToolSummaryLine group={group} hasError={false} hasCancelled={false} />,
     );
 
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/ }));
     fireEvent.click(screen.getByRole("button", { name: /Ran command/ }));
     expect(container.querySelector("code")?.textContent).toBe(LONG_SHELL_COMMAND);
     expect(container.textContent).not.toContain('{"command"');
@@ -173,6 +185,7 @@ describe("narrative tool row layout classes", () => {
       <ToolSummaryLine group={group} hasError={false} hasCancelled={false} />,
     );
 
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/ }));
     fireEvent.click(screen.getByRole("button", { name: /Ran command/ }));
     const command = container.querySelector("code")?.textContent ?? "";
     expect(command).toMatch(/^cd "C:\\Users\\cjnwo/);
@@ -200,6 +213,7 @@ describe("narrative tool row layout classes", () => {
       </div>,
     );
 
+    fireEvent.click(screen.getByRole("button", { name: /Ran 1 command/ }));
     fireEvent.click(screen.getByRole("button", { name: /Ran command/ }));
 
     const notice = screen.getByText(/Output truncated/);

--- a/apps/web/src/components/chat/narrative/build-narrative.ts
+++ b/apps/web/src/components/chat/narrative/build-narrative.ts
@@ -81,7 +81,10 @@ export function filterThoughtsMatchingAssistantBody(
 
 /** Returns true if any call in a group has output containing "cancelled". */
 function hasCancelledCall(calls: readonly ToolCall[]): boolean {
-  return calls.some((tc) => typeof tc.output === "string" && tc.output.toLowerCase().includes("cancelled"));
+  return calls.some(
+    (tc) => tc.isCancelled === true
+      || (typeof tc.output === "string" && tc.output.toLowerCase().includes("cancelled")),
+  );
 }
 
 /** A unified timeline event - everything that happens during a turn, sorted by startedAt. */

--- a/apps/web/src/components/chat/narrative/build-persisted-narrative.test.ts
+++ b/apps/web/src/components/chat/narrative/build-persisted-narrative.test.ts
@@ -110,6 +110,19 @@ describe("buildPersistedNarrativeItems", () => {
     }
   });
 
+  it("hydrates a persisted shell exit code onto the rendered tool call", () => {
+    const items = buildPersistedNarrativeItems({
+      tools: [makeTool({ tool_name: "Bash", status: "failed", exit_code: 1 })],
+      thoughts: [],
+      hooks: [],
+    });
+
+    expect(items[0].type).toBe("tool-group");
+    if (items[0].type === "tool-group") {
+      expect(items[0].group.calls[0].exitCode).toBe(1);
+    }
+  });
+
   it.each([
     ["a positive interval", "2026-05-15T10:00:00Z", "2026-05-15T10:00:15Z", 15_000],
     ["a zero interval", "2026-05-15T10:00:00Z", "2026-05-15T10:00:00Z", 0],

--- a/apps/web/src/components/chat/narrative/build-persisted-narrative.test.ts
+++ b/apps/web/src/components/chat/narrative/build-persisted-narrative.test.ts
@@ -123,6 +123,20 @@ describe("buildPersistedNarrativeItems", () => {
     }
   });
 
+  it("preserves an explicit persisted cancellation status", () => {
+    const items = buildPersistedNarrativeItems({
+      tools: [makeTool({ tool_name: "Bash", status: "cancelled" })],
+      thoughts: [],
+      hooks: [],
+    });
+
+    expect(items[0].type).toBe("tool-group");
+    if (items[0].type === "tool-group") {
+      expect(items[0].hasCancelled).toBe(true);
+      expect(items[0].group.calls[0].isCancelled).toBe(true);
+    }
+  });
+
   it.each([
     ["a positive interval", "2026-05-15T10:00:00Z", "2026-05-15T10:00:15Z", 15_000],
     ["a zero interval", "2026-05-15T10:00:00Z", "2026-05-15T10:00:00Z", 0],

--- a/apps/web/src/components/chat/narrative/build-persisted-narrative.test.ts
+++ b/apps/web/src/components/chat/narrative/build-persisted-narrative.test.ts
@@ -110,6 +110,40 @@ describe("buildPersistedNarrativeItems", () => {
     }
   });
 
+  it.each([
+    ["a positive interval", "2026-05-15T10:00:00Z", "2026-05-15T10:00:15Z", 15_000],
+    ["a zero interval", "2026-05-15T10:00:00Z", "2026-05-15T10:00:00Z", 0],
+  ])("hydrates %s as a completed tool duration", (_label, startedAt, completedAt, expected) => {
+    const items = buildPersistedNarrativeItems({
+      tools: [makeTool({ started_at: startedAt, completed_at: completedAt })],
+      thoughts: [],
+      hooks: [],
+    });
+
+    expect(items[0].type).toBe("tool-group");
+    if (items[0].type === "tool-group") {
+      expect(items[0].group.calls[0].durationMs).toBe(expected);
+    }
+  });
+
+  it.each([
+    ["missing completion", "2026-05-15T10:00:00Z", null],
+    ["invalid start", "not-a-date", "2026-05-15T10:00:15Z"],
+    ["invalid completion", "2026-05-15T10:00:00Z", "not-a-date"],
+    ["reversed timestamps", "2026-05-15T10:00:15Z", "2026-05-15T10:00:00Z"],
+  ])("omits duration for %s", (_label, startedAt, completedAt) => {
+    const items = buildPersistedNarrativeItems({
+      tools: [makeTool({ started_at: startedAt, completed_at: completedAt })],
+      thoughts: [],
+      hooks: [],
+    });
+
+    expect(items[0].type).toBe("tool-group");
+    if (items[0].type === "tool-group") {
+      expect(items[0].group.calls[0].durationMs).toBeUndefined();
+    }
+  });
+
   it("hooks-only: emits a hook row per record", () => {
     const items = buildPersistedNarrativeItems({
       tools: [],

--- a/apps/web/src/components/chat/narrative/build-persisted-narrative.ts
+++ b/apps/web/src/components/chat/narrative/build-persisted-narrative.ts
@@ -28,8 +28,24 @@ function isoToMs(s: string | null | undefined): number {
   return Number.isFinite(t) ? t : 0;
 }
 
+/** Derive a valid elapsed duration from persisted lifecycle timestamps. */
+function persistedDurationMs(
+  startedAt: string | null | undefined,
+  completedAt: string | null | undefined,
+): number | undefined {
+  if (!startedAt || !completedAt) return undefined;
+
+  const start = Date.parse(startedAt);
+  const end = Date.parse(completedAt);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return undefined;
+
+  return end - start;
+}
+
 /** Map a persisted tool record to the live `ToolCall` shape used by row components. */
 function recordToToolCall(r: ToolCallRecord): ToolCall {
+  const durationMs = persistedDurationMs(r.started_at, r.completed_at);
+
   return {
     id: r.id,
     toolName: r.tool_name,
@@ -42,6 +58,7 @@ function recordToToolCall(r: ToolCallRecord): ToolCall {
     ...(r.output_truncated === 1 ? { outputTruncated: true } : {}),
     ...(typeof r.output_total_bytes === "number" ? { outputTotalBytes: r.output_total_bytes } : {}),
     ...(r.output_artifact_path ? { outputArtifactPath: r.output_artifact_path } : {}),
+    ...(durationMs === undefined ? {} : { durationMs }),
     parentToolCallId: r.parent_tool_call_id ?? undefined,
     startedAt: isoToMs(r.started_at),
   };

--- a/apps/web/src/components/chat/narrative/build-persisted-narrative.ts
+++ b/apps/web/src/components/chat/narrative/build-persisted-narrative.ts
@@ -43,7 +43,7 @@ function persistedDurationMs(
 }
 
 /** Map a persisted tool record to the live `ToolCall` shape used by row components. */
-function recordToToolCall(r: ToolCallRecord): ToolCall {
+export function recordToToolCall(r: ToolCallRecord): ToolCall {
   const durationMs = persistedDurationMs(r.started_at, r.completed_at);
 
   return {
@@ -55,6 +55,7 @@ function recordToToolCall(r: ToolCallRecord): ToolCall {
     output: r.output_summary || null,
     isError: r.status === "failed",
     isComplete: r.status === "completed" || r.status === "failed" || r.status === "cancelled",
+    ...(r.status === "cancelled" ? { isCancelled: true } : {}),
     ...(r.output_truncated === 1 ? { outputTruncated: true } : {}),
     ...(typeof r.output_total_bytes === "number" ? { outputTotalBytes: r.output_total_bytes } : {}),
     ...(r.output_artifact_path ? { outputArtifactPath: r.output_artifact_path } : {}),
@@ -226,7 +227,8 @@ export function buildPersistedNarrativeItems(
       group: { calls: pendingGroup.slice() },
       hasError: pendingGroup.some((c) => c.isError),
       hasCancelled: pendingGroup.some(
-        (c) => typeof c.output === "string" && c.output.toLowerCase().includes("cancelled"),
+        (c) => c.isCancelled === true
+          || (typeof c.output === "string" && c.output.toLowerCase().includes("cancelled")),
       ),
     });
     pendingGroup.length = 0;

--- a/apps/web/src/components/chat/narrative/build-persisted-narrative.ts
+++ b/apps/web/src/components/chat/narrative/build-persisted-narrative.ts
@@ -59,6 +59,7 @@ function recordToToolCall(r: ToolCallRecord): ToolCall {
     ...(typeof r.output_total_bytes === "number" ? { outputTotalBytes: r.output_total_bytes } : {}),
     ...(r.output_artifact_path ? { outputArtifactPath: r.output_artifact_path } : {}),
     ...(durationMs === undefined ? {} : { durationMs }),
+    ...(typeof r.exit_code === "number" ? { exitCode: r.exit_code } : {}),
     parentToolCallId: r.parent_tool_call_id ?? undefined,
     startedAt: isoToMs(r.started_at),
   };

--- a/apps/web/src/components/chat/narrative/narrative-layout.ts
+++ b/apps/web/src/components/chat/narrative/narrative-layout.ts
@@ -8,7 +8,7 @@
 
 /** Constrains a horizontal tool/meta row inside the virtualized chat column. */
 export const NARRATIVE_TOOL_ROW =
-  "flex min-w-0 max-w-full items-center gap-1.5 overflow-hidden";
+  "flex min-w-0 max-w-full items-center gap-2 overflow-hidden";
 
 /**
  * Monospace detail text (path, command, pattern) with ellipsis when truncated.
@@ -19,6 +19,6 @@ export function narrativeToolDetailClass(size: "sm" | "md"): string {
   const tone =
     size === "md"
       ? "text-sm text-muted-foreground/80"
-      : "text-sm text-muted-foreground/50";
+      : "text-xs text-muted-foreground/65";
   return `font-mono ${tone} truncate flex-1 min-w-0 [overflow-wrap:anywhere]`;
 }

--- a/apps/web/src/components/ui/animated-collapsible.tsx
+++ b/apps/web/src/components/ui/animated-collapsible.tsx
@@ -29,7 +29,13 @@ export function AnimatedCollapsible({
         className,
       )}
     >
-      <div className="min-h-0 overflow-hidden">{children}</div>
+      <div
+        className="min-h-0 overflow-hidden"
+        aria-hidden={!open}
+        inert={!open}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -2268,6 +2268,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const toolCallId = (params.toolCallId as string) || "";
       const output = (params.output as string) || "";
       const isError = (params.isError as boolean) || false;
+      const exitCode =
+        typeof params.exitCode === "number" && Number.isInteger(params.exitCode)
+          ? params.exitCode
+          : undefined;
       const outputTruncated = params.outputTruncated === true;
       const outputTotalBytes =
         typeof params.outputTotalBytes === "number" && Number.isFinite(params.outputTotalBytes)
@@ -2334,6 +2338,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             ...(outputTotalBytes != null ? { outputTotalBytes } : {}),
             ...(outputArtifactPath ? { outputArtifactPath } : {}),
             ...(durationMs != null ? { durationMs } : {}),
+            ...(exitCode !== undefined ? { exitCode } : {}),
           };
         };
         const updated = hasIdMatch

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -140,6 +140,8 @@ export interface ToolCall {
   output: string | null;
   isError: boolean;
   isComplete: boolean;
+  /** True when a persisted tool call ended through cancellation. */
+  isCancelled?: boolean;
   /** True when the live output preview omits middle bytes from the full output. */
   outputTruncated?: boolean;
   /** UTF-8 byte count for the full output when the server bounded the preview. */

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -154,6 +154,8 @@ export interface ToolCall {
   startedAt?: number;
   /** Wall-clock duration when the tool call completed (ms). */
   durationMs?: number;
+  /** Process exit code reported for a completed shell command. */
+  exitCode?: number;
 }
 
 /** Ephemeral hook execution state tracked during a session. Not persisted to DB. */

--- a/packages/contracts/src/__tests__/agent-event.test.ts
+++ b/packages/contracts/src/__tests__/agent-event.test.ts
@@ -44,11 +44,15 @@ describe("AgentEventSchema", () => {
       threadId: "thread-1",
       toolCallId: "agent-1",
       output: "done",
-      isError: false,
+      isError: true,
+      exitCode: 1,
       toolInput: { model: "gpt-5.5", reasoningEffort: "high" },
     });
 
     expect(result.success).toBe(true);
+    if (result.success && result.data.type === "toolResult") {
+      expect(result.data.exitCode).toBe(1);
+    }
   });
 });
 

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -95,6 +95,8 @@ export const AgentEventSchema = lazySchema(() =>
       toolCallId: z.string(),
       output: z.string(),
       isError: z.boolean(),
+      /** Process exit code when the provider reports one for a shell command. */
+      exitCode: z.number().int().optional(),
       /** True when the output preview omits middle bytes from the full output. */
       outputTruncated: z.boolean().optional(),
       /** UTF-8 byte count for the full tool output before preview bounding. */

--- a/packages/contracts/src/models/tool-call-record.ts
+++ b/packages/contracts/src/models/tool-call-record.ts
@@ -17,6 +17,7 @@ export const ToolCallRecordSchema = z.object({
   output_truncated: z.number().int().optional(),
   output_total_bytes: z.number().nullable().optional(),
   output_artifact_path: z.string().nullable().optional(),
+  exit_code: z.number().int().nullable().optional(),
   status: ToolCallStatusSchema,
   started_at: z.string(),
   completed_at: z.string().nullable(),


### PR DESCRIPTION
## What

Restore grouped shell-command narration with expandable terminal output.

## Why

The command display flattened child commands into top-level cards, removing useful nesting and making tool narration harder to scan.

## Key Changes

- Restore command groups with expandable nested shell rows
- Improve narration spacing and preserve compact long-command handling
- Persist command duration and exit codes across reloads
- Show exit codes as quiet metadata in expanded Shell panels

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787147509&installation_id=129163861&pr_number=902&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F902&signature=652a9a03a4eaa0d056350d639bb8c0cd9f61630a3f80099ad53fe8d24ffb9b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell command results now retain and display process exit codes, including failures.
  * Persisted tool-call history now shows command durations when timing data is available.
  * Shell output is presented in expandable, accessible transcript panels.

* **Bug Fixes**
  * Improved restoration of command duration, output, truncation notices, and failure details after reload.
  * Refined narrative spacing, styling, and collapsed-content accessibility.

* **Tests**
  * Added coverage for exit-code persistence, duration hydration, shell output expansion, and reload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->