### PR TITLE
feat: serve Codex Skills from a lazy app-server catalog

### DIFF
--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -41,6 +41,10 @@ import { GithubService } from "./services/github-service";
 import { FileService } from "./services/file-service";
 import { ConfigService } from "./services/config-service";
 import { SkillService } from "./services/skill-service";
+import {
+  CodexCatalogClientFactory,
+  CodexCatalogService,
+} from "./services/codex-catalog-service";
 import { TerminalService } from "./services/terminal-service";
 import { AttachmentService } from "./services/attachment-service";
 import { HandoffStorage } from "./services/handoff/handoff-storage.js";
@@ -352,6 +356,16 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register(
     SkillService,
     { useClass: SkillService },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    CodexCatalogClientFactory,
+    { useClass: CodexCatalogClientFactory },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    CodexCatalogService,
+    { useClass: CodexCatalogService },
     { lifecycle: Lifecycle.Singleton },
   );
   container.register(

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -27,6 +27,7 @@ import { GithubService } from "./services/github-service";
 import { FileService } from "./services/file-service";
 import { ConfigService } from "./services/config-service";
 import { SkillService } from "./services/skill-service";
+import { CodexCatalogService } from "./services/codex-catalog-service";
 import { TerminalService } from "./services/terminal-service";
 import { MessageRepo } from "./repositories/message-repo";
 import { ThreadRepo } from "./repositories/thread-repo";
@@ -220,6 +221,7 @@ const reviewWorktreeService = container.resolve(ReviewWorktreeService);
 const fileService = container.resolve(FileService);
 const configService = container.resolve(ConfigService);
 const skillService = container.resolve(SkillService);
+const codexCatalogService = container.resolve(CodexCatalogService);
 const terminalService = container.resolve(TerminalService);
 const messageRepo = container.resolve(MessageRepo);
 const threadRepo = container.resolve(ThreadRepo);
@@ -611,6 +613,7 @@ const { httpServer, wss } = createWsServer({
   fileService,
   configService,
   skillService,
+  codexCatalogService,
   terminalService,
   messageRepo,
   toolCallRecordRepo,

--- a/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
@@ -600,4 +600,25 @@ describe("CodexAppServer.start (failed handshake teardown)", () => {
 
     expect(fatal).not.toHaveBeenCalledWith(expect.stringContaining("Codex app-server exited unexpectedly"));
   }, 10_000);
+
+  it("initializes a catalog-only connection without creating a thread", async () => {
+    const methods: string[] = [];
+    harnessFakeServer((req): Record<string, unknown> => {
+      if (req.method) methods.push(req.method);
+      return { result: {} };
+    });
+    const server = new CodexAppServer({
+      cliPath: "codex",
+      workingDirectory: "/tmp",
+      catalogOnly: true,
+      getSpawnEnv: () => ({}),
+    });
+
+    await server.start();
+
+    expect(methods).toContain("initialize");
+    expect(methods).not.toContain("model/list");
+    expect(methods).not.toContain("thread/start");
+    await server.kill();
+  }, 10_000);
 });

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { homedir, tmpdir } from "os";
+import { tmpdir } from "os";
 import { join } from "path";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 
@@ -52,13 +52,27 @@ import { AgentEventType } from "@mcode/contracts";
 import type { AgentEvent } from "@mcode/contracts";
 import { stubEnvService } from "../../../__tests__/stub-env-service.js";
 
-function makeProvider(skillList: (...args: unknown[]) => unknown[] = vi.fn(() => [])): CodexProvider {
+function makeProvider(
+  skillList: (...args: unknown[]) => unknown[] = vi.fn(() => []),
+  catalogService: {
+    currentSkills: (cwd?: string) => unknown[];
+    refresh: (cwd?: string) => Promise<{ skills: unknown[] }>;
+    onSkillsChanged: (handler: () => void) => () => void;
+    shutdown: () => Promise<void>;
+  } = {
+    currentSkills: vi.fn(() => []),
+    refresh: vi.fn(async () => ({ skills: [] })),
+    onSkillsChanged: vi.fn(() => () => undefined),
+    shutdown: vi.fn(async () => undefined),
+  },
+): CodexProvider {
   return new CodexProvider(
     { get: async () => ({ provider: { cli: { codex: "codex" } } }) } as never,
     { assign: vi.fn(), isWindowsJob: false } as never,
     stubEnvService() as never,
     { list: skillList } as never,
     { persistGeneratedImageFromPath: vi.fn() } as never,
+    catalogService as never,
   );
 }
 
@@ -114,6 +128,44 @@ describe("CodexProvider first turn on new session", () => {
     });
 
     await ended;
+  });
+
+  it("starts the first turn from cached Skills without waiting for catalog I/O", async () => {
+    const nativeSkill = {
+      name: "review",
+      description: "Review changes",
+      kind: "skill" as const,
+      source: "project" as const,
+      providers: ["codex"],
+      nativeName: "review",
+      path: "C:/repo/.codex/skills/review/SKILL.md",
+    };
+    const currentSkills = vi.fn(() => [nativeSkill]);
+    const refresh = vi.fn(() => new Promise<{ skills: unknown[] }>(() => undefined));
+    const list = vi.fn((_cwd, _providerId, skills) => skills as unknown[]);
+    const provider = makeProvider(list, {
+      currentSkills,
+      refresh,
+      onSkillsChanged: vi.fn(() => () => undefined),
+      shutdown: vi.fn(async () => undefined),
+    });
+
+    await provider.sendTurn({
+      sessionId: "mcode-catalog-independent",
+      threadId: "catalog-independent",
+      message: "hello",
+      cwd: "C:/repo",
+      model: "gpt-5.4",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "auto",
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(sendTurnMock).toHaveBeenCalledTimes(1);
+    expect(currentSkills).toHaveBeenCalledWith("C:/repo");
+    expect(list).toHaveBeenCalledWith("C:/repo", "codex", [nativeSkill]);
+    expect(refresh).not.toHaveBeenCalled();
   });
 
   it("maps proactive orchestration to Ultra only on supported Codex models", async () => {
@@ -404,69 +456,30 @@ describe("CodexProvider first turn on new session", () => {
     expect(sendTurnMock.mock.calls[0][0]).toEqual([{ type: "text", text: "/goal clear" }]);
   });
 
-  it("lists enabled native Codex skills from a live app-server session", async () => {
+  it("lists native Codex Skills through the catalog service", async () => {
     const cwd = process.cwd();
-    const skillPath = join(
-      homedir(),
-      ".codex",
-      "plugins",
-      "cache",
-      "openai-bundled",
-      "browser",
-      "1.0.0",
-      "skills",
-      "control-in-app-browser",
-      "SKILL.md",
-    );
-    listSkillsMock.mockResolvedValueOnce({
-      data: [{
-        cwd,
-        errors: [],
-        skills: [
-          {
-            name: "control-in-app-browser",
-            description: "Long browser description",
-            shortDescription: "Short browser description",
-            enabled: true,
-            path: skillPath,
-            scope: "system",
-            interface: null,
-          },
-          {
-            name: "disabled",
-            description: "Hidden",
-            enabled: false,
-            path: join(cwd, ".codex", "skills", "disabled", "SKILL.md"),
-            scope: "repo",
-          },
-        ],
-      }],
-    });
-    const provider = makeProvider();
-
-    await provider.sendTurn({
-      sessionId: "mcode-native-skills",
-      threadId: "native-skills",
-      message: "hello",
-      cwd,
-      model: "gpt-5.4",
-      interactionMode: "build",
-      providerOptions: {},
-      permissionMode: "auto",
+    const nativeSkill = {
+      name: "control-in-app-browser",
+      description: "Short browser description",
+      kind: "skill" as const,
+      source: "plugin" as const,
+      providers: ["codex"],
+      nativeName: "control-in-app-browser",
+      path: "C:/codex/skills/control-in-app-browser/SKILL.md",
+    };
+    const refresh = vi.fn(async () => ({ skills: [nativeSkill] }));
+    const provider = makeProvider(undefined, {
+      currentSkills: vi.fn(() => []),
+      refresh,
+      onSkillsChanged: vi.fn(() => () => undefined),
+      shutdown: vi.fn(async () => undefined),
     });
 
     const skills = await provider.listSkills(cwd);
 
-    expect(listSkillsMock).toHaveBeenCalledWith([cwd]);
-    expect(skills).toEqual([{
-      name: "control-in-app-browser",
-      description: "Short browser description",
-      kind: "skill",
-      source: "plugin",
-      providers: ["codex"],
-      nativeName: "control-in-app-browser",
-      path: skillPath,
-    }]);
+    expect(refresh).toHaveBeenCalledWith(cwd);
+    expect(skills).toEqual([nativeSkill]);
+    expect(listSkillsMock).not.toHaveBeenCalled();
   });
 
   it("runs side-channel handoff turns at low effort", async () => {

--- a/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
@@ -60,6 +60,12 @@ describe("CodexProvider permission flow", () => {
       stubEnvService() as never,
       { list: vi.fn(() => []) } as never,
       { persistGeneratedImageFromPath: vi.fn() } as never,
+      {
+        currentSkills: vi.fn(() => []),
+        refresh: vi.fn(async () => ({ skills: [] })),
+        onSkillsChanged: vi.fn(() => () => undefined),
+        shutdown: vi.fn(async () => undefined),
+      } as never,
     );
     // Pre-register a session entry so drain logic has something to iterate.
     seedSession(provider, sessionId, threadId, {

--- a/apps/server/src/providers/codex/__tests__/codex-provider-subagent-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-subagent-turn.test.ts
@@ -79,6 +79,12 @@ function makeProvider(): CodexProvider {
     stubEnvService() as never,
     { list: vi.fn(() => []) } as never,
     { persistGeneratedImageFromPath: vi.fn() } as never,
+    {
+      currentSkills: vi.fn(() => []),
+      refresh: vi.fn(async () => ({ skills: [] })),
+      onSkillsChanged: vi.fn(() => () => undefined),
+      shutdown: vi.fn(async () => undefined),
+    } as never,
   );
 }
 

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -91,6 +91,8 @@ export interface CodexAppServerOptions {
   getSpawnEnv?: () => Record<string, string>;
   /** Config overrides passed to `codex app-server` as repeated `-c key=value`. */
   configOverrides?: readonly string[];
+  /** Completes the handshake after initialization without creating a thread. */
+  catalogOnly?: boolean;
 }
 
 /**
@@ -817,12 +819,14 @@ export class CodexAppServer extends EventEmitter {
 
   /** Runs interrupt, RPC dispose, and process termination once per server instance. */
   private async performKill(): Promise<void> {
-    if (this.rpc) {
+    if (this.rpc && this.threadId) {
       try {
         await this.rpc.sendRequest("turn/interrupt", { threadId: this.threadId }, 3000);
       } catch {
         // best effort - ignore
       }
+    }
+    if (this.rpc) {
       this.rpc.dispose();
     }
 
@@ -1085,6 +1089,8 @@ export class CodexAppServer extends EventEmitter {
 
     // Step 2: initialized notification (no response expected)
     this.rpc.sendNotification("initialized", {});
+
+    if (this.options.catalogOnly) return;
 
     // Step 3: model/list (best-effort)
     try {

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -21,7 +21,8 @@ import { AttachmentService } from "../../services/attachment-service.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import type { MemoryPressureLevel } from "../../services/memory-pressure-service.js";
 import { CleanForker } from "../../services/handoff/session-forker.js";
-import { SkillService, codexPluginNameFromSkillPath } from "../../services/skill-service.js";
+import { SkillService } from "../../services/skill-service.js";
+import { CodexCatalogService } from "../../services/codex-catalog-service.js";
 import type {
   IAgentProvider,
   IGoalCapable,
@@ -54,7 +55,6 @@ import type {
   CodexRateLimitWindow,
   CodexRateLimitsPayload,
   CodexTurnOptions,
-  CodexSkillMetadata,
   CompletedItem,
   ThreadGoal,
 } from "./codex-types.js";
@@ -363,32 +363,6 @@ async function resolveCodexSlashInvocation(
   return { text: message };
 }
 
-/** Maps Codex native skill scope into Mcode's source labels. */
-function codexSkillSource(skill: CodexSkillMetadata): SkillInfo["source"] {
-  if (codexPluginNameFromSkillPath(skill.path)) return "plugin";
-  if (skill.scope === "user") return "user";
-  if (skill.scope === "repo") return "project";
-  return "agent";
-}
-
-/** Picks the concise display description from Codex native metadata. */
-function codexSkillDescription(skill: CodexSkillMetadata): string {
-  return skill.interface?.shortDescription ?? skill.shortDescription ?? skill.description ?? "";
-}
-
-/** Converts native Codex skill metadata into the shared slash-menu shape. */
-function mapNativeCodexSkill(skill: CodexSkillMetadata): SkillInfo {
-  return {
-    name: skill.name,
-    description: codexSkillDescription(skill),
-    kind: "skill",
-    source: codexSkillSource(skill),
-    providers: ["codex"],
-    nativeName: skill.name,
-    path: skill.path,
-  };
-}
-
 /** Return the generated image path from an app-server imageGeneration item. */
 export function generatedImagePathFromCodexItem(item: CompletedItem | undefined): string | null {
   if (!item || item.type !== "imageGeneration") return null;
@@ -487,6 +461,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     @inject(EnvService) private readonly envService: EnvService,
     @inject(SkillService) private readonly skillService: SkillService,
     @inject(AttachmentService) private readonly attachmentService: AttachmentService,
+    @inject(CodexCatalogService) private readonly codexCatalogService: CodexCatalogService,
   ) {
     super();
     this.runtime = new SessionRuntime<CodexSessionState>(this, {
@@ -799,7 +774,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     } = req;
     const codexFastMode = req.providerOptions.fastMode;
 
-    const nativeSkills = await this.listSkills(cwd);
+    const nativeSkills = this.codexCatalogService.currentSkills(cwd);
     const skillCatalog = this.skillService.list(cwd, "codex", nativeSkills);
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
     let input: TurnInputPart[];
@@ -975,9 +950,6 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
 
     server.on("notification", (notification) => {
       const n = notification as { method?: string; params?: Record<string, unknown> };
-      if (n.method === "skills/changed") {
-        this.emit("skills_changed");
-      }
       if (n.method === "account/rateLimits/updated") {
         this.applyUsageSnapshot(n.params, threadId);
       }
@@ -1263,34 +1235,14 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     }
   }
 
-  /** Lists native Codex skills from an already-running app-server session. */
+  /** Lists native Codex Skills through the provider-wide catalog connection. */
   async listSkills(cwd?: string): Promise<SkillInfo[]> {
-    for (const sessionId of this.liveSessionIds) {
-      const state = this.runtime.get(sessionId);
-      if (!state?.server.isAlive) continue;
-      if (cwd && state.cwd !== cwd) continue;
-
-      try {
-        const result = await state.server.listSkills(cwd ? [cwd] : undefined);
-        const entry = cwd
-          ? result.data.find((item) => item.cwd === cwd) ?? result.data[0]
-          : result.data[0];
-        return (entry?.skills ?? [])
-          .filter((skill) => skill.enabled)
-          .map(mapNativeCodexSkill);
-      } catch (err) {
-        logger.warn("Codex native skills/list failed; falling back to disk scan", {
-          sessionId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
-    return [];
+    return (await this.codexCatalogService.refresh(cwd)).skills;
   }
 
   /** Subscribes to native Codex skill catalog invalidations. */
   onSkillsChanged(handler: () => void): void {
-    this.on("skills_changed", handler);
+    this.codexCatalogService.onSkillsChanged(() => handler());
   }
 
   /** Apply a queued native goal to the app-server before dispatching a turn. */
@@ -1688,6 +1640,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     this.drainPending(() => true);
     void this.runtime.shutdown().catch((err: unknown) => {
       logger.warn("Codex runtime shutdown failed", { error: String(err) });
+    });
+    void this.codexCatalogService.shutdown().catch((err: unknown) => {
+      logger.warn("Codex catalog shutdown failed", { error: String(err) });
     });
     this.sdkSessionIds.clear();
     this.pendingSpawnTurns.clear();

--- a/apps/server/src/services/__tests__/codex-catalog-service.test.ts
+++ b/apps/server/src/services/__tests__/codex-catalog-service.test.ts
@@ -1,0 +1,233 @@
+import "reflect-metadata";
+import { EventEmitter } from "events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodexCatalogService } from "../codex-catalog-service.js";
+import type { SkillsListResult } from "../../providers/codex/codex-types.js";
+
+class ControlledCatalogClient extends EventEmitter {
+  isAlive = true;
+  readonly start = vi.fn(async () => undefined);
+  readonly kill = vi.fn(async () => {
+    this.isAlive = false;
+  });
+  readonly listSkills = vi.fn(async (cwds?: string[]): Promise<SkillsListResult> => {
+    const cwd = cwds?.[0] ?? "";
+    return {
+      data: [{
+        cwd,
+        errors: [],
+        skills: [
+          {
+            name: "review",
+            description: "Global review",
+            enabled: true,
+            path: "C:/users/test/.codex/skills/review/SKILL.md",
+            scope: "user",
+          },
+          {
+            name: "review",
+            description: `Project review for ${cwd}`,
+            enabled: true,
+            path: `${cwd}/.codex/skills/review/SKILL.md`,
+            scope: "repo",
+          },
+        ],
+      }],
+    };
+  });
+}
+
+describe("CodexCatalogService", () => {
+  const services: CodexCatalogService[] = [];
+
+  function createService(
+    client: ControlledCatalogClient,
+    create: () => ControlledCatalogClient = () => client,
+  ): CodexCatalogService {
+    const service = new CodexCatalogService(
+      { get: () => ({ provider: { cli: { codex: "codex" } } }) } as never,
+      { isWindowsJob: false } as never,
+      { getEnv: () => ({}) } as never,
+      { create } as never,
+    );
+    services.push(service);
+    return service;
+  }
+
+  afterEach(async () => {
+    await Promise.all(services.splice(0).map((service) => service.shutdown()));
+    vi.useRealTimers();
+  });
+
+  it("uses one lazy app-server connection for distinct working-directory catalogs", async () => {
+    const client = new ControlledCatalogClient();
+    const create = vi.fn(() => client);
+    const service = createService(client, create);
+
+    expect(create).not.toHaveBeenCalled();
+
+    const first = await service.refresh("C:/workspaces/one");
+    const second = await service.refresh("C:/workspaces/two");
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(client.start).toHaveBeenCalledTimes(1);
+    expect(client.listSkills.mock.calls).toEqual([
+      [["C:/workspaces/one"], false],
+      [["C:/workspaces/two"], false],
+    ]);
+    expect(first.skills.map((skill) => skill.path)).toEqual([
+      "C:/users/test/.codex/skills/review/SKILL.md",
+      "C:/workspaces/one/.codex/skills/review/SKILL.md",
+    ]);
+    expect(second.skills.map((skill) => skill.path)).toEqual([
+      "C:/users/test/.codex/skills/review/SKILL.md",
+      "C:/workspaces/two/.codex/skills/review/SKILL.md",
+    ]);
+  });
+
+  it("reconciles the affected context after skills/changed", async () => {
+    const client = new ControlledCatalogClient();
+    const service = createService(client);
+    const cwd = "C:/workspaces/one";
+    await service.refresh(cwd);
+    client.listSkills.mockResolvedValueOnce({
+      data: [{
+        cwd,
+        errors: [],
+        skills: [{
+          name: "ship",
+          description: "Ship changes",
+          enabled: true,
+          path: `${cwd}/.codex/skills/ship/SKILL.md`,
+          scope: "repo",
+        }],
+      }],
+    });
+    const changed = new Promise<string | undefined>((resolve) => {
+      service.onSkillsChanged(resolve);
+    });
+
+    client.emit("notification", { method: "skills/changed", params: { cwd } });
+
+    await expect(changed).resolves.toBe(cwd);
+    expect(client.listSkills).toHaveBeenLastCalledWith([cwd], true);
+    expect(service.currentSkills(cwd).map((skill) => skill.name)).toEqual(["ship"]);
+  });
+
+  it("releases the catalog connection after 60 seconds without a request", async () => {
+    vi.useFakeTimers();
+    const client = new ControlledCatalogClient();
+    const service = createService(client);
+    await service.refresh("C:/workspaces/one");
+
+    await vi.advanceTimersByTimeAsync(60_001);
+
+    expect(client.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the context snapshot and scopes diagnostics after a provider failure", async () => {
+    const client = new ControlledCatalogClient();
+    const service = createService(client);
+    const cwd = "C:/workspaces/one";
+    const first = await service.refresh(cwd);
+    client.listSkills.mockRejectedValueOnce(new Error("provider unavailable"));
+
+    const failed = await service.refresh(cwd);
+
+    expect(failed.skills).toEqual(first.skills);
+    expect(failed.freshness).toMatchObject({ status: "stale" });
+    expect(failed.diagnostics).toEqual([{
+      severity: "warning",
+      code: "source-unavailable",
+      message: "Codex Skills are temporarily unavailable for this catalog context.",
+    }]);
+  });
+
+  it("isolates invalid native metadata while retaining valid Skills", async () => {
+    const client = new ControlledCatalogClient();
+    const cwd = "C:/workspaces/one";
+    client.listSkills.mockResolvedValueOnce({
+      data: [{
+        cwd,
+        errors: [],
+        skills: [
+          { name: "invalid", description: "Invalid", enabled: true, path: null, scope: "repo" },
+          {
+            name: "ship",
+            description: "Ship changes",
+            enabled: true,
+            path: `${cwd}/.codex/skills/ship/SKILL.md`,
+            scope: "repo",
+          },
+        ],
+      }],
+    } as never);
+    const service = createService(client);
+
+    const result = await service.refresh(cwd);
+
+    expect(result.skills.map((skill) => skill.name)).toEqual(["ship"]);
+    expect(result.diagnostics).toContainEqual({
+      severity: "warning",
+      code: "partial-result",
+      message: "Some Codex Skills were omitted because their metadata was invalid.",
+    });
+  });
+
+  it("does not cache a different cwd when the requested context is omitted", async () => {
+    const client = new ControlledCatalogClient();
+    client.listSkills.mockResolvedValueOnce({
+      data: [{
+        cwd: "C:/workspaces/other",
+        errors: [],
+        skills: [{
+          name: "other",
+          description: "Other workspace",
+          enabled: true,
+          path: "C:/workspaces/other/.codex/skills/other/SKILL.md",
+          scope: "repo",
+        }],
+      }],
+    });
+    const service = createService(client);
+
+    const result = await service.refresh("C:/workspaces/requested");
+
+    expect(result.skills).toEqual([]);
+    expect(result.freshness.status).toBe("stale");
+    expect(service.currentSkills("C:/workspaces/requested")).toEqual([]);
+  });
+
+  it("ignores malformed skills/changed notifications", async () => {
+    const client = new ControlledCatalogClient();
+    const service = createService(client);
+    await service.refresh("C:/workspaces/one");
+
+    expect(() => client.emit("notification", null)).not.toThrow();
+    client.emit("notification", {
+      method: "skills/changed",
+      params: { cwds: ["x".repeat(4_097)] },
+    });
+    await Promise.resolve();
+
+    expect(client.listSkills).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts the oldest catalog context when the context limit is reached", async () => {
+    const client = new ControlledCatalogClient();
+    const service = createService(client);
+    for (let index = 0; index < 65; index += 1) {
+      await service.refresh(`C:/workspaces/${index}`);
+    }
+    client.listSkills.mockClear();
+
+    client.emit("notification", {
+      method: "skills/changed",
+      params: { cwd: "C:/workspaces/0" },
+    });
+    await Promise.resolve();
+
+    expect(client.listSkills).not.toHaveBeenCalled();
+    expect(service.currentSkills("C:/workspaces/0")).toEqual([]);
+  });
+});

--- a/apps/server/src/services/codex-catalog-service.ts
+++ b/apps/server/src/services/codex-catalog-service.ts
@@ -1,0 +1,354 @@
+import { EventEmitter } from "events";
+import { inject, injectable } from "tsyringe";
+import type {
+  ProviderCatalogDiagnostic,
+  ProviderCatalogFreshness,
+  SkillInfo,
+} from "@mcode/contracts";
+import {
+  PROVIDER_CATALOG_MAX_ENTRIES,
+  SkillInfoSchema,
+} from "@mcode/contracts";
+import { logger } from "@mcode/shared";
+import { CodexAppServer, type CodexAppServerOptions } from "../providers/codex/codex-app-server.js";
+import type {
+  SkillsListResult,
+} from "../providers/codex/codex-types.js";
+import { codexPluginNameFromSkillPath } from "./skill-service.js";
+import { SettingsService } from "./settings-service.js";
+import { EnvService } from "./env-service.js";
+import type { JobObject } from "./job-object.js";
+
+const CODEX_CATALOG_IDLE_TTL_MS = 60_000;
+const CODEX_CATALOG_MAX_CONTEXTS = 64;
+const CODEX_CATALOG_MAX_CWD_LENGTH = 4_096;
+
+/** Result of refreshing native Codex Skills for one working-directory context. */
+export interface CodexCatalogRefreshResult {
+  readonly skills: SkillInfo[];
+  readonly diagnostics: ProviderCatalogDiagnostic[];
+  readonly freshness: ProviderCatalogFreshness;
+}
+
+/** Minimal app-server surface used by the provider-wide catalog connection. */
+export interface CodexCatalogClient extends EventEmitter {
+  readonly isAlive: boolean;
+  start(): Promise<void>;
+  listSkills(cwds?: string[], forceReload?: boolean): Promise<SkillsListResult>;
+  kill(): Promise<void>;
+}
+
+/** Creates the external app-server client used by {@link CodexCatalogService}. */
+@injectable()
+export class CodexCatalogClientFactory {
+  /** Creates one catalog-only Codex app-server client. */
+  create(options: CodexAppServerOptions): CodexCatalogClient {
+    return new CodexAppServer(options);
+  }
+}
+
+function catalogKey(cwd?: string): string {
+  return cwd ?? "";
+}
+
+function skillSource(path: string, scope: string): SkillInfo["source"] {
+  if (codexPluginNameFromSkillPath(path)) return "plugin";
+  if (scope === "user") return "user";
+  if (scope === "repo") return "project";
+  return "agent";
+}
+
+function mapSkill(skill: unknown): SkillInfo | undefined {
+  if (!skill || typeof skill !== "object") return undefined;
+  const value = skill as Record<string, unknown>;
+  if (value.enabled !== true || typeof value.name !== "string" || typeof value.path !== "string") {
+    return undefined;
+  }
+  const interfaceValue = value.interface && typeof value.interface === "object"
+    ? value.interface as Record<string, unknown>
+    : undefined;
+  const description = [
+    interfaceValue?.shortDescription,
+    value.shortDescription,
+    value.description,
+  ].find((candidate): candidate is string => typeof candidate === "string") ?? "";
+  const scope = typeof value.scope === "string" ? value.scope : "";
+  const parsed = SkillInfoSchema().safeParse({
+    name: value.name,
+    description,
+    kind: "skill",
+    source: skillSource(value.path, scope),
+    providers: ["codex"],
+    nativeName: value.name,
+    path: value.path,
+  });
+  return parsed.success ? parsed.data : undefined;
+}
+
+function boundedDiagnosticMessage(message: string): string {
+  const normalized = message.replace(/[\u0000-\u001f\u007f]/g, " ").trim();
+  return normalized.slice(0, 900) || "Codex did not provide a diagnostic message.";
+}
+
+function reconcileSkills(rawSkills: unknown): {
+  skills: SkillInfo[];
+  invalidMetadata: boolean;
+  entryLimitReached: boolean;
+} {
+  if (!Array.isArray(rawSkills)) {
+    return { skills: [], invalidMetadata: true, entryLimitReached: false };
+  }
+  const byPath = new Map<string, SkillInfo>();
+  let invalidMetadata = false;
+  for (const rawSkill of rawSkills.slice(0, PROVIDER_CATALOG_MAX_ENTRIES)) {
+    if (
+      rawSkill &&
+      typeof rawSkill === "object" &&
+      (rawSkill as Record<string, unknown>).enabled === false
+    ) {
+      continue;
+    }
+    const skill = mapSkill(rawSkill);
+    if (skill?.path) byPath.set(skill.path, skill);
+    else invalidMetadata = true;
+  }
+  return {
+    skills: [...byPath.values()],
+    invalidMetadata,
+    entryLimitReached: rawSkills.length > PROVIDER_CATALOG_MAX_ENTRIES,
+  };
+}
+
+function upstreamDiagnostics(rawErrors: unknown): ProviderCatalogDiagnostic[] {
+  if (!Array.isArray(rawErrors)) return [];
+  return rawErrors.slice(0, 90).flatMap((error) => {
+    const message = error && typeof error === "object"
+      ? (error as Record<string, unknown>).message
+      : undefined;
+    return typeof message === "string"
+      ? [{
+          severity: "warning" as const,
+          code: "discovery-error" as const,
+          message: boundedDiagnosticMessage(message),
+        }]
+      : [];
+  });
+}
+
+/** Owns one lazy, thread-independent Codex app-server connection for Skill catalogs. */
+@injectable()
+export class CodexCatalogService {
+  private client: CodexCatalogClient | null = null;
+  private startPromise: Promise<CodexCatalogClient> | null = null;
+  private readonly snapshots = new Map<string, CodexCatalogRefreshResult>();
+  private readonly requestedContexts = new Map<string, string | undefined>();
+  private readonly skillsChangedHandlers = new Set<(cwd?: string) => void>();
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    @inject(SettingsService) private readonly settingsService: SettingsService,
+    @inject("JobObject") private readonly jobObject: JobObject,
+    @inject(EnvService) private readonly envService: EnvService,
+    @inject(CodexCatalogClientFactory) private readonly clientFactory: CodexCatalogClientFactory,
+  ) {}
+
+  /** Refreshes the complete native Skill list for one working-directory context. */
+  async refresh(cwd?: string): Promise<CodexCatalogRefreshResult> {
+    this.rememberContext(cwd);
+    this.armIdleTimer();
+    return this.refreshContext(cwd, false);
+  }
+
+  /** Subscribes to completed background refreshes triggered by skills/changed. */
+  onSkillsChanged(handler: (cwd?: string) => void): () => void {
+    this.skillsChangedHandlers.add(handler);
+    return () => this.skillsChangedHandlers.delete(handler);
+  }
+
+  /** Returns the last complete Skill list without starting or waiting for catalog work. */
+  currentSkills(cwd?: string): SkillInfo[] {
+    return this.snapshots.get(catalogKey(cwd))?.skills ?? [];
+  }
+
+  /** Stops the catalog process and clears in-flight connection state. */
+  async shutdown(): Promise<void> {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+    const client = this.client;
+    this.client = null;
+    this.startPromise = null;
+    await client?.kill();
+  }
+
+  private async refreshContext(
+    cwd: string | undefined,
+    forceReload: boolean,
+  ): Promise<CodexCatalogRefreshResult> {
+    try {
+      const client = await this.acquireClient(cwd);
+      const result = await client.listSkills(cwd ? [cwd] : undefined, forceReload);
+      const rawData = Array.isArray((result as { data?: unknown }).data)
+        ? (result as { data: unknown[] }).data
+        : [];
+      const data = (cwd
+        ? rawData.find((item) => (
+            item && typeof item === "object" && (item as Record<string, unknown>).cwd === cwd
+          ))
+        : rawData[0]) as Record<string, unknown> | undefined;
+      if (!data) {
+        throw new Error("Codex skills/list omitted the requested catalog context.");
+      }
+      const reconciled = reconcileSkills(data?.skills);
+      const diagnostics = upstreamDiagnostics(data?.errors);
+      if (reconciled.invalidMetadata) {
+        diagnostics.push({
+          severity: "warning",
+          code: "partial-result",
+          message: "Some Codex Skills were omitted because their metadata was invalid.",
+        });
+      }
+      if (reconciled.entryLimitReached) {
+        diagnostics.push({
+          severity: "warning",
+          code: "partial-result",
+          message: `Codex Skills were capped at ${PROVIDER_CATALOG_MAX_ENTRIES} entries.`,
+        });
+      }
+      const fetchedAt = new Date().toISOString();
+      const snapshot: CodexCatalogRefreshResult = {
+        skills: reconciled.skills,
+        diagnostics,
+        freshness: { status: "fresh", fetchedAt },
+      };
+      this.snapshots.set(catalogKey(cwd), snapshot);
+      return snapshot;
+    } catch (error) {
+      const previous = this.snapshots.get(catalogKey(cwd));
+      const fetchedAt = previous?.freshness.fetchedAt ?? new Date().toISOString();
+      logger.warn("Codex catalog refresh failed", {
+        cwd,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        skills: previous?.skills ?? [],
+        diagnostics: [{
+          severity: "warning",
+          code: "source-unavailable",
+          message: "Codex Skills are temporarily unavailable for this catalog context.",
+        }],
+        freshness: {
+          status: "stale",
+          fetchedAt,
+          reason: "Codex Skill discovery failed.",
+        },
+      };
+    }
+  }
+
+  private async acquireClient(cwd?: string): Promise<CodexCatalogClient> {
+    if (this.client?.isAlive) return this.client;
+    if (this.startPromise) return this.startPromise;
+
+    const settings = this.settingsService.get();
+    const client = this.clientFactory.create({
+      cliPath: settings.provider.cli.codex || "codex",
+      workingDirectory: cwd ?? process.cwd(),
+      approvalPolicy: "never",
+      catalogOnly: true,
+      jobObject: this.jobObject,
+      getSpawnEnv: () => this.envService.getEnv(),
+    });
+    this.client = client;
+    client.on("notification", (notification: unknown) => {
+      this.handleNotification(notification);
+    });
+    this.startPromise = client.start().then(() => client);
+    try {
+      return await this.startPromise;
+    } catch (error) {
+      if (this.client === client) this.client = null;
+      await client.kill().catch(() => undefined);
+      throw error;
+    } finally {
+      this.startPromise = null;
+    }
+  }
+
+  private armIdleTimer(): void {
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      void this.evictIdleClient();
+    }, CODEX_CATALOG_IDLE_TTL_MS);
+    this.idleTimer.unref?.();
+  }
+
+  private async evictIdleClient(): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    this.startPromise = null;
+    await client?.kill();
+  }
+
+  private rememberContext(cwd?: string): void {
+    const key = catalogKey(cwd);
+    this.requestedContexts.delete(key);
+    this.requestedContexts.set(key, cwd);
+
+    const snapshot = this.snapshots.get(key);
+    if (snapshot) {
+      this.snapshots.delete(key);
+      this.snapshots.set(key, snapshot);
+    }
+
+    while (this.requestedContexts.size > CODEX_CATALOG_MAX_CONTEXTS) {
+      const oldestKey = this.requestedContexts.keys().next().value as string | undefined;
+      if (oldestKey === undefined) break;
+      this.requestedContexts.delete(oldestKey);
+      this.snapshots.delete(oldestKey);
+    }
+  }
+
+  private handleNotification(notification: unknown): void {
+    if (!notification || typeof notification !== "object") return;
+    const value = notification as { method?: unknown; params?: unknown };
+    if (value.method !== "skills/changed") return;
+
+    const params = value.params && typeof value.params === "object"
+      ? value.params as { cwd?: unknown; cwds?: unknown }
+      : undefined;
+    const isValidCwd = (cwd: unknown): cwd is string => (
+      typeof cwd === "string" && cwd.length > 0 && cwd.length <= CODEX_CATALOG_MAX_CWD_LENGTH
+    );
+    const signaledCwds = [...new Set([
+      ...(isValidCwd(params?.cwd) ? [params.cwd] : []),
+      ...(Array.isArray(params?.cwds) ? params.cwds.filter(isValidCwd) : []),
+    ])].slice(0, CODEX_CATALOG_MAX_CONTEXTS);
+    const hasExplicitContexts = params?.cwd !== undefined || params?.cwds !== undefined;
+    if (hasExplicitContexts && signaledCwds.length === 0) return;
+    const contexts = signaledCwds.length > 0
+      ? signaledCwds
+          .map((cwd) => this.requestedContexts.get(catalogKey(cwd)))
+          .filter((cwd): cwd is string => cwd !== undefined)
+      : [...this.requestedContexts.values()];
+
+    void this.refreshChangedContexts(contexts);
+  }
+
+  private async refreshChangedContexts(contexts: readonly (string | undefined)[]): Promise<void> {
+    for (const cwd of contexts.slice(0, CODEX_CATALOG_MAX_CONTEXTS)) {
+      await this.refreshContext(cwd, true);
+      for (const handler of this.skillsChangedHandlers) {
+        try {
+          handler(cwd);
+        } catch (error) {
+          logger.debug("Codex catalog skills-changed subscriber failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+  }
+}

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -168,19 +168,17 @@ describe("SkillService", () => {
       expect(skill!.providers).toEqual(["claude"]);
     });
 
-    it("tags skills from ~/.codex/skills with providers=['codex']", () => {
+    it("does not expose Codex Skills from the filesystem fallback", () => {
       const skillDir = join(fakeHome, ".codex", "skills", "codex-skill");
       mkdirSync(skillDir, { recursive: true });
       writeMd(join(skillDir, "SKILL.md"), { description: "Codex skill" });
 
       const items = new SkillService().list(undefined, "codex");
 
-      const skill = items.find((i) => i.name === "codex-skill");
-      expect(skill).toBeDefined();
-      expect(skill!.providers).toEqual(["codex"]);
+      expect(items.find((i) => i.name === "codex-skill")).toBeUndefined();
     });
 
-    it("scans Codex plugin cache skills with plugin prefixes", () => {
+    it("does not scan Codex plugin cache Skills", () => {
       const skillDir = join(
         fakeHome,
         ".codex",
@@ -197,16 +195,10 @@ describe("SkillService", () => {
       writeMd(skillPath, { name: "audit", description: "Run audit checks" });
 
       const items = new SkillService().list(undefined, "codex");
-      expect(items.find((i) => i.name === "impeccable:audit")).toMatchObject({
-        kind: "skill",
-        source: "plugin",
-        nativeName: "audit",
-        path: skillPath,
-        providers: ["codex"],
-      });
+      expect(items.find((i) => i.name === "impeccable:audit")).toBeUndefined();
     });
 
-    it("scans bundled Codex runtime plugin skills", () => {
+    it("does not scan bundled Codex runtime plugin Skills", () => {
       const skillDir = join(
         fakeHome,
         ".cache",
@@ -223,15 +215,10 @@ describe("SkillService", () => {
       writeMd(join(skillDir, "SKILL.md"), { name: "documents", description: "Edit documents" });
 
       const items = new SkillService().list(undefined, "codex");
-      expect(items.find((i) => i.name === "documents:documents")).toMatchObject({
-        kind: "skill",
-        source: "plugin",
-        nativeName: "documents",
-        providers: ["codex"],
-      });
+      expect(items.find((i) => i.name === "documents:documents")).toBeUndefined();
     });
 
-    it("lets native Codex catalog entries override disk fallback duplicates", () => {
+    it("uses native Codex catalog entries instead of disk fallback duplicates", () => {
       const skillDir = join(
         fakeHome,
         ".codex",
@@ -265,6 +252,31 @@ describe("SkillService", () => {
       });
     });
 
+    it("keeps same-name native Codex Skills distinct by path", () => {
+      const nativeSkills = [
+        {
+          name: "review",
+          description: "Global review",
+          kind: "skill" as const,
+          source: "user" as const,
+          providers: ["codex"],
+          path: "C:/users/test/.codex/skills/review/SKILL.md",
+        },
+        {
+          name: "review",
+          description: "Project review",
+          kind: "skill" as const,
+          source: "project" as const,
+          providers: ["codex"],
+          path: "C:/repo/.codex/skills/review/SKILL.md",
+        },
+      ];
+
+      const items = new SkillService().list("C:/repo", "codex", nativeSkills);
+
+      expect(items.filter((item) => item.name === "review")).toEqual(nativeSkills);
+    });
+
     it("extracts Codex plugin names from cache and runtime skill paths", () => {
       const cacheSkillPath = join(
         fakeHome,
@@ -296,7 +308,7 @@ describe("SkillService", () => {
       expect(codexPluginNameFromSkillPath(runtimeSkillPath, fakeHome)).toBe("documents");
     });
 
-    it("tags skills from ~/.agents/skills with providers=['codex'] only", () => {
+    it("leaves ~/.agents/skills discovery to the native Codex catalog", () => {
       const skillDir = join(fakeHome, ".agents", "skills", "shared-skill");
       mkdirSync(skillDir, { recursive: true });
       writeMd(join(skillDir, "SKILL.md"), { description: "Shared skill" });
@@ -304,7 +316,7 @@ describe("SkillService", () => {
       const svc = new SkillService();
 
       const codexItems = svc.list(undefined, "codex");
-      expect(codexItems.find((i) => i.name === "shared-skill")).toBeDefined();
+      expect(codexItems.find((i) => i.name === "shared-skill")).toBeUndefined();
 
       svc.invalidate();
       const copilotItems = svc.list(undefined, "copilot");
@@ -332,7 +344,7 @@ describe("SkillService", () => {
 
       svc.invalidate();
       const codexItems = svc.list(undefined, "codex");
-      expect(codexItems.find((i) => i.name === "codex-only")).toBeDefined();
+      expect(codexItems.find((i) => i.name === "codex-only")).toBeUndefined();
       expect(codexItems.find((i) => i.name === "claude-only")).toBeUndefined();
     });
 
@@ -348,7 +360,7 @@ describe("SkillService", () => {
       const items = new SkillService().list();
 
       expect(items.find((i) => i.name === "claude-skill")).toBeDefined();
-      expect(items.find((i) => i.name === "codex-skill")).toBeDefined();
+      expect(items.find((i) => i.name === "codex-skill")).toBeUndefined();
       expect(items.every((i) => Array.isArray(i.providers))).toBe(true);
     });
 
@@ -372,14 +384,10 @@ describe("SkillService", () => {
       }
     });
 
-    it("allows same name across different providers", () => {
+    it("allows a native Codex Skill to share a name with a Claude Skill", () => {
       const claudeSkillDir = join(fakeHome, ".claude", "skills", "deploy");
       mkdirSync(claudeSkillDir, { recursive: true });
       writeMd(join(claudeSkillDir, "SKILL.md"), { description: "Claude deploy" });
-
-      const codexSkillDir = join(fakeHome, ".codex", "skills", "deploy");
-      mkdirSync(codexSkillDir, { recursive: true });
-      writeMd(join(codexSkillDir, "SKILL.md"), { description: "Codex deploy" });
 
       const svc = new SkillService();
 
@@ -388,9 +396,16 @@ describe("SkillService", () => {
       expect(claudeDeploy!.description).toBe("Claude deploy");
 
       svc.invalidate();
-      const codexItems = svc.list(undefined, "codex");
+      const codexItems = svc.list(undefined, "codex", [{
+        name: "deploy",
+        description: "Native Codex deploy",
+        kind: "skill",
+        source: "user",
+        providers: ["codex"],
+        path: "C:/codex/skills/deploy/SKILL.md",
+      }]);
       const codexDeploy = codexItems.find((i) => i.name === "deploy");
-      expect(codexDeploy!.description).toBe("Codex deploy");
+      expect(codexDeploy!.description).toBe("Native Codex deploy");
     });
 
     it("tags prompts from ~/.codex/prompts as Codex prompt commands", () => {

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -2,9 +2,8 @@
  * Skill and command scanning service.
  * Walks user, project, agent, and plugin directories looking for both
  * `skills/` (each subdirectory is a skill), provider command directories, and
- * Codex's `prompts/` directory. Mirrors Claude Code's native discovery,
- * extended to cover Codex and Copilot provider directories, plus Cursor
- * `.cursor/skills` and commands.
+ * Codex's deprecated `prompts/` directory. Native Codex Skills come only from
+ * app-server `skills/list` and enter through the `nativeItems` boundary.
  */
 
 import { injectable } from "tsyringe";
@@ -197,53 +196,6 @@ function scanPluginMarketplaceDir(ctx: ScanContext, marketplacesDir: string, pro
   }
 }
 
-/**
- * Scan one Codex plugin install directory. Codex plugins can ship plain
- * `skills/` trees, and contributor-authored plugins may also carry provider
- * subtrees used by the Codex CLI.
- */
-function scanCodexPluginVersionDir(
-  ctx: ScanContext,
-  versionDir: string,
-  pluginName: string,
-  providers: string[],
-): void {
-  for (const sub of ["", ".codex", ".agents"]) {
-    const base = sub ? join(versionDir, sub) : versionDir;
-    scanSkillsDir(ctx, join(base, "skills"), pluginName, "plugin", providers);
-  }
-}
-
-/** Walk Codex plugin cache: cache/<marketplace>/<plugin>/<version>/. */
-function scanCodexPluginCacheDir(ctx: ScanContext, cacheDir: string, providers: string[]): void {
-  for (const mp of scanDir(ctx, cacheDir)) {
-    if (!mp.isDirectory()) continue;
-    const mpDir = join(cacheDir, mp.name);
-    for (const plugin of scanDir(ctx, mpDir)) {
-      if (!plugin.isDirectory()) continue;
-      const pluginDir = join(mpDir, plugin.name);
-      const versions = scanDir(ctx, pluginDir)
-        .filter((e) => e.isDirectory())
-        .map((e) => e.name)
-        .sort(VERSION_COLLATOR.compare);
-      if (versions.length === 0) continue;
-      scanCodexPluginVersionDir(ctx, join(pluginDir, versions[versions.length - 1]), plugin.name, providers);
-    }
-  }
-}
-
-/** Walk bundled Codex runtime plugins: runtime/plugins/<marketplace>/plugins/<plugin>/. */
-function scanCodexRuntimePluginsDir(ctx: ScanContext, runtimePluginsDir: string, providers: string[]): void {
-  for (const marketplace of scanDir(ctx, runtimePluginsDir)) {
-    if (!marketplace.isDirectory()) continue;
-    const pluginsDir = join(runtimePluginsDir, marketplace.name, "plugins");
-    for (const plugin of scanDir(ctx, pluginsDir)) {
-      if (!plugin.isDirectory()) continue;
-      scanCodexPluginVersionDir(ctx, join(pluginsDir, plugin.name), plugin.name, providers);
-    }
-  }
-}
-
 function pathSegmentsUnder(root: string, filePath: string): string[] | null {
   const rootNorm = root.replace(/\\/g, "/").replace(/\/+$/, "");
   const fileNorm = filePath.replace(/\\/g, "/");
@@ -364,8 +316,7 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
     { path: join(claudeDir, "commands"), source: "user", providers: ["claude"], kind: "commands" },
     { path: join(claudeDir, ".agents", "skills"), source: "agent", providers: ["claude"], kind: "skills" },
 
-    // Codex ecosystem
-    { path: join(codexDir, "skills"), source: "user", providers: ["codex"], kind: "skills" },
+    // Codex custom prompt compatibility
     { path: join(codexDir, "prompts"), source: "user", providers: ["codex"], kind: "commands", prefix: "prompts" },
 
     // Copilot ecosystem
@@ -376,8 +327,7 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
     { path: join(cursorDir, "skills"), source: "user", providers: ["cursor"], kind: "skills" },
     { path: join(cursorDir, "commands"), source: "user", providers: ["cursor"], kind: "commands" },
 
-    // Cross-provider (.agents at home root — visible to Codex but not Claude or Copilot)
-    { path: join(agentsDir, "skills"), source: "agent", providers: ["codex"], kind: "skills" },
+    // Codex command compatibility
     { path: join(agentsDir, "commands"), source: "agent", providers: ["codex"], kind: "commands" },
 
     // Copilot user-level agents (OS-native config path)
@@ -390,11 +340,7 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
       { path: join(cwd, ".claude", "skills"), source: "project", providers: ["claude"], kind: "skills" },
       { path: join(cwd, ".claude", "commands"), source: "project", providers: ["claude"], kind: "commands" },
 
-      // Codex project-level
-      { path: join(cwd, ".codex", "skills"), source: "project", providers: ["codex"], kind: "skills" },
-
-      // Cross-provider project-level
-      { path: join(cwd, ".agents", "skills"), source: "project", providers: ["codex"], kind: "skills" },
+      // Codex command compatibility
       { path: join(cwd, ".agents", "commands"), source: "project", providers: ["codex"], kind: "commands" },
 
       // Copilot project-level agents
@@ -486,6 +432,9 @@ export class SkillService {
     const nativeFiltered = providerId
       ? nativeItems.filter((s) => s.providers.includes(providerId))
       : nativeItems;
+    if (providerId === "codex") {
+      return [...seen.values(), ...nativeFiltered];
+    }
     for (const item of nativeFiltered) {
       const nativeKeys = new Set([item.name, item.nativeName].filter((key): key is string => !!key));
       for (const [key, existing] of seen) {
@@ -502,7 +451,6 @@ export class SkillService {
   private scan(cwd?: string): { items: SkillInfo[]; diag: SkillDiagnostics } {
     const home = homedir();
     const claudeDir = join(home, ".claude");
-    const codexDir = join(home, ".codex");
     const cursorDir = join(home, ".cursor");
     const ctx: ScanContext = {
       out: [],
@@ -526,10 +474,6 @@ export class SkillService {
     // Cursor plugin installs (mtime-selected hash dirs under ~/.cursor/plugins)
     scanCursorPluginCacheDir(ctx, join(cursorDir, "plugins", "cache"), ["cursor"]);
     scanCursorPluginCacheDir(ctx, join(cursorDir, "plugins", "local"), ["cursor"]);
-
-    // Codex plugin installs (pre-session fallback only; native catalog wins once a session exists)
-    scanCodexPluginCacheDir(ctx, join(codexDir, "plugins", "cache"), ["codex"]);
-    scanCodexRuntimePluginsDir(ctx, join(home, ".cache", "codex-runtimes", "codex-primary-runtime", "plugins"), ["codex"]);
 
     return { items: ctx.out, diag: ctx.diag };
   }

--- a/apps/server/src/transport/provider-catalog.ts
+++ b/apps/server/src/transport/provider-catalog.ts
@@ -14,6 +14,7 @@ import {
   type ProviderCapabilityEntry,
   type ProviderCatalogContext,
   type ProviderCatalogDiagnostic,
+  type ProviderCatalogFreshness,
   type ProviderCatalogSnapshot,
   type SettingsProviderId,
   type SkillInfo,
@@ -43,6 +44,8 @@ export interface BuildProviderCatalogSnapshotInput {
   readonly context: ProviderCatalogContext;
   readonly skills: readonly SkillInfo[];
   readonly agentDiscovery?: BoundedCodexAgentDiscovery;
+  readonly diagnostics?: readonly ProviderCatalogDiagnostic[];
+  readonly freshness?: ProviderCatalogFreshness;
   readonly fetchedAt?: string;
 }
 
@@ -145,7 +148,7 @@ function toProviderCapabilityEntry(
   if (item.kind === "skill") {
     return {
       kind: "skill",
-      identity: { providerId, kind: "skill", nativeId: item.nativeName ?? item.name },
+      identity: { providerId, kind: "skill", nativeId: item.path ?? item.nativeName ?? item.name },
       name: item.name,
       description: item.description,
       source: item.source,
@@ -205,7 +208,7 @@ function parseSelectableAgent(
 export function buildProviderCatalogSnapshot(
   input: BuildProviderCatalogSnapshotInput,
 ): ProviderCatalogSnapshot {
-  const diagnostics: ProviderCatalogDiagnostic[] = [];
+  const diagnostics: ProviderCatalogDiagnostic[] = [...(input.diagnostics ?? [])];
   let invalidItemOmitted = false;
   const entries: ProviderCapabilityEntry[] = [];
   for (const item of input.skills.slice(0, PROVIDER_CATALOG_MAX_ENTRIES)) {
@@ -248,7 +251,10 @@ export function buildProviderCatalogSnapshot(
   return ProviderCatalogSnapshotSchema().parse({
     providerId: input.providerId,
     context: input.context,
-    freshness: { status: "fresh", fetchedAt: input.fetchedAt ?? new Date().toISOString() },
+    freshness: input.freshness ?? {
+      status: "fresh",
+      fetchedAt: input.fetchedAt ?? new Date().toISOString(),
+    },
     diagnostics,
     entries,
     selectableAgents,

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -34,6 +34,7 @@ import type { GithubService } from "../services/github-service";
 import type { FileService } from "../services/file-service";
 import type { ConfigService } from "../services/config-service";
 import type { SkillService } from "../services/skill-service";
+import type { CodexCatalogService } from "../services/codex-catalog-service";
 import type { TerminalService } from "../services/terminal-service";
 import type { MessageRepo } from "../repositories/message-repo";
 import type { ToolCallRecordRepo } from "../repositories/tool-call-record-repo";
@@ -220,6 +221,8 @@ export interface RouterDeps {
   fileService: FileService;
   configService: ConfigService;
   skillService: SkillService;
+  /** Owns the thread-independent Codex app-server catalog connection. */
+  codexCatalogService: CodexCatalogService;
   terminalService: TerminalService;
   messageRepo: MessageRepo;
   toolCallRecordRepo: ToolCallRecordRepo;
@@ -995,11 +998,13 @@ async function dispatch(
     case "provider.catalog": {
       const { cwd, context: catalogContext } = resolveProviderCatalogContext(deps, params);
       let nativeSkills;
+      let diagnostics;
+      let freshness;
       if (params.providerId === "codex") {
-        const provider = deps.providerRegistry.resolve("codex");
-        nativeSkills = isSkillCatalogCapable(provider)
-          ? await provider.listSkills(cwd)
-          : undefined;
+        const catalog = await deps.codexCatalogService.refresh(cwd);
+        nativeSkills = catalog.skills;
+        diagnostics = catalog.diagnostics;
+        freshness = catalog.freshness;
       }
       const skills = deps.skillService.list(cwd, params.providerId, nativeSkills);
       const agentDiscovery = params.providerId === "codex"
@@ -1015,6 +1020,8 @@ async function dispatch(
         context: catalogContext,
         skills,
         ...(agentDiscovery ? { agentDiscovery } : {}),
+        ...(diagnostics ? { diagnostics } : {}),
+        ...(freshness ? { freshness } : {}),
       });
     }
     case "skill.diagnose":

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -1,6 +1,9 @@
+import "reflect-metadata";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
 import type { WebSocket } from "ws";
 import { routeMessage, type RouterDeps } from "./ws-router.js";
+import { CodexCatalogService } from "../services/codex-catalog-service.js";
 import { _resetForTest, addClient } from "./push.js";
 import {
   RECAP_MAX_MESSAGE_CONTENT_CHARS,
@@ -56,69 +59,152 @@ describe("routeMessage result validation seam", () => {
 });
 
 describe("routeMessage provider.catalog", () => {
-  it("returns mapped capabilities and separate Codex agents for the requested thread context", async () => {
-    const list = vi.fn().mockReturnValue([
-      {
-        name: "review",
-        description: "Review changes",
-        kind: "skill",
-        source: "plugin",
-        providers: ["codex"],
-        nativeName: "review",
-        path: "C:/repo/.codex/skills/review/SKILL.md",
-      },
+  it("discovers path-scoped Codex Skills before a thread exists", async () => {
+    let catalogVersion = 1;
+    const client = Object.assign(new EventEmitter(), {
+      isAlive: true,
+      start: vi.fn(async () => undefined),
+      kill: vi.fn(async () => undefined),
+      listSkills: vi.fn(async (cwds?: string[]) => {
+        const cwd = cwds?.[0] ?? "";
+        const projectSkill = catalogVersion === 1 ? "review" : "ship";
+        return {
+        data: [{
+          cwd,
+          errors: [],
+          skills: [
+            {
+              name: "review",
+              description: "Review global changes",
+              enabled: true,
+              scope: "user",
+              path: "C:/users/test/.codex/skills/review/SKILL.md",
+            },
+            {
+              name: projectSkill,
+              description: `${projectSkill} project changes`,
+              enabled: true,
+              scope: "repo",
+              path: `${cwd}/.codex/skills/${projectSkill}/SKILL.md`,
+            },
+          ],
+        }],
+        };
+      }),
+    });
+    const create = vi.fn(() => client);
+    const codexCatalogService = new CodexCatalogService(
+      { get: () => ({ provider: { cli: { codex: "codex" } } }) } as never,
+      { isWindowsJob: false } as never,
+      { getEnv: () => ({}) } as never,
+      { create } as never,
+    );
+    const refresh = vi.spyOn(codexCatalogService, "refresh");
+    const list = vi.fn().mockImplementation((_cwd, _providerId, discoveredSkills = []) => [
+      ...discoveredSkills,
       {
         name: "prompts:release",
         description: "Prepare a release",
-        kind: "command",
-        source: "user",
+        kind: "command" as const,
+        source: "user" as const,
         providers: ["codex"],
         nativeName: "release",
         path: "C:/users/test/.codex/prompts/release.md",
       },
     ]);
+    const threadLookup = vi.fn();
     const deps = {
       workspaceService: {
-        findById: vi.fn().mockReturnValue({ id: "workspace-1", path: "C:/repo" }),
+        findById: vi.fn((workspaceId: string) => ({
+          id: workspaceId,
+          path: workspaceId === "workspace-2" ? "C:/other" : "C:/repo",
+        })),
       },
-      threadRepo: {
-        findById: vi.fn().mockReturnValue({
-          id: "thread-1",
-          workspace_id: "workspace-1",
-          mode: "direct",
-          worktree_path: null,
-        }),
-      },
-      gitService: { resolveWorkingDir: vi.fn().mockReturnValue("C:/repo") },
-      providerRegistry: { resolve: vi.fn().mockReturnValue({ listSkills: vi.fn().mockResolvedValue([]) }) },
+      threadRepo: { findById: threadLookup },
+      codexCatalogService,
       skillService: { list },
     } as unknown as RouterDeps;
 
     const response = await routeMessage(JSON.stringify({
       id: "catalog-1",
       method: "provider.catalog",
-      params: { providerId: "codex", workspaceId: "workspace-1", threadId: "thread-1" },
+      params: { providerId: "codex", workspaceId: "workspace-1" },
     }), deps);
 
     expect(response.error).toBeUndefined();
     expect(response.result).toMatchObject({
       providerId: "codex",
-      context: { scope: "workspace", workspaceId: "workspace-1", threadId: "thread-1" },
+      context: { scope: "workspace", workspaceId: "workspace-1" },
       freshness: { status: "fresh" },
       diagnostics: [],
       entries: [
-        { kind: "skill", identity: { providerId: "codex", kind: "skill", nativeId: "review" } },
+        {
+          kind: "skill",
+          identity: {
+            providerId: "codex",
+            kind: "skill",
+            nativeId: "C:/users/test/.codex/skills/review/SKILL.md",
+          },
+        },
+        {
+          kind: "skill",
+          identity: {
+            providerId: "codex",
+            kind: "skill",
+            nativeId: "C:/repo/.codex/skills/review/SKILL.md",
+          },
+        },
         {
           kind: "customPrompt",
           identity: { providerId: "codex", kind: "customPrompt", nativeId: "release" },
         },
       ],
     });
-    expect(list).toHaveBeenCalledWith("C:/repo", "codex", undefined);
+    expect(refresh).toHaveBeenCalledWith("C:/repo");
+    expect(threadLookup).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(client.start).toHaveBeenCalledTimes(1);
+    expect(client.listSkills).toHaveBeenCalledWith(["C:/repo"], false);
+    expect(list).toHaveBeenCalledWith(
+      "C:/repo",
+      "codex",
+      expect.arrayContaining([
+        expect.objectContaining({ path: "C:/users/test/.codex/skills/review/SKILL.md" }),
+        expect.objectContaining({ path: "C:/repo/.codex/skills/review/SKILL.md" }),
+      ]),
+    );
     expect((response.result as {
       selectableAgents: Array<{ providerId: string; nativeId: string }>;
     }).selectableAgents.every((agent) => agent.providerId === "codex" && agent.nativeId.length > 0))
       .toBe(true);
+
+    const otherWorkspaceResponse = await routeMessage(JSON.stringify({
+      id: "catalog-2",
+      method: "provider.catalog",
+      params: { providerId: "codex", workspaceId: "workspace-2" },
+    }), deps);
+    expect(otherWorkspaceResponse.error).toBeUndefined();
+    expect(client.listSkills).toHaveBeenLastCalledWith(["C:/other"], false);
+    expect((otherWorkspaceResponse.result as { entries: Array<{ identity: { nativeId: string } }> })
+      .entries.some((entry) => entry.identity.nativeId.startsWith("C:/other/"))).toBe(true);
+
+    catalogVersion = 2;
+    const refreshed = new Promise<string | undefined>((resolve) => {
+      codexCatalogService.onSkillsChanged(resolve);
+    });
+    client.emit("notification", { method: "skills/changed", params: { cwd: "C:/repo" } });
+    await expect(refreshed).resolves.toBe("C:/repo");
+    expect(client.listSkills).toHaveBeenCalledWith(["C:/repo"], true);
+
+    const refreshedResponse = await routeMessage(JSON.stringify({
+      id: "catalog-3",
+      method: "provider.catalog",
+      params: { providerId: "codex", workspaceId: "workspace-1" },
+    }), deps);
+    expect((refreshedResponse.result as { entries: Array<{ name: string }> }).entries)
+      .toEqual(expect.arrayContaining([expect.objectContaining({ name: "ship" })]));
+    expect(create).toHaveBeenCalledTimes(1);
+    await codexCatalogService.shutdown();
   });
 
   it("rejects unknown providers and oversized contexts before dispatch", async () => {


### PR DESCRIPTION
## What
Serve Codex Skills from one lazy provider-wide app-server catalog before thread creation.

## Why
Mcode needs provider-authoritative Skill discovery without starting or coupling to a thread app-server.

## Key Changes
- Add a lazy catalog-only Codex app-server connection with 60-second idle eviction and bounded per-cwd snapshots.
- Fetch full Skill lists for the effective working directory, preserve provider-native path identities, and reconcile `skills/changed` in the background.
- Remove the Codex filesystem Skill fallback while retaining deprecated custom prompts.
- Add controlled WebSocket and provider tests for pre-thread discovery, cwd scoping, refresh, thread independence, and failure diagnostics.

Closes #892

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787154828&installation_model_id=20477&pr_number=904&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F904&signature=4497961af9548442ad11397dbc13528cdca100f6b55e681eda9add8b91429144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex skill catalog support with workspace-specific discovery and refresh handling.
  * Catalog results now include freshness status and diagnostics when discovery is incomplete.
  * Codex skills can load from cached catalog data without waiting for a live session.
  * Catalog updates are reflected automatically when skills change.

* **Bug Fixes**
  * Prevented duplicate skills with the same name but different paths from being merged.
  * Improved handling of invalid metadata and catalog refresh failures.
  * Avoided unnecessary thread creation during catalog-only operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->