### PR TITLE
feat(catalog): persist and reconcile provider snapshots

### DIFF
--- a/apps/server/drizzle/0023_grey_wildside.sql
+++ b/apps/server/drizzle/0023_grey_wildside.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `provider_catalog_snapshots` (
+	`context_key` text PRIMARY KEY NOT NULL,
+	`provider_id` text NOT NULL,
+	`workspace_id` text,
+	`cwd` text,
+	`snapshot_json` text NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_provider_catalog_snapshots_workspace` ON `provider_catalog_snapshots` (`workspace_id`);--> statement-breakpoint
+CREATE INDEX `idx_provider_catalog_snapshots_provider` ON `provider_catalog_snapshots` (`provider_id`);

--- a/apps/server/drizzle/0023_grey_wildside.sql
+++ b/apps/server/drizzle/0023_grey_wildside.sql
@@ -4,7 +4,8 @@ CREATE TABLE `provider_catalog_snapshots` (
 	`workspace_id` text,
 	`cwd` text,
 	`snapshot_json` text NOT NULL,
-	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
 CREATE INDEX `idx_provider_catalog_snapshots_workspace` ON `provider_catalog_snapshots` (`workspace_id`);--> statement-breakpoint

--- a/apps/server/drizzle/meta/0023_snapshot.json
+++ b/apps/server/drizzle/meta/0023_snapshot.json
@@ -721,7 +721,21 @@
           "isUnique": false
         }
       },
-      "foreignKeys": {},
+      "foreignKeys": {
+        "provider_catalog_snapshots_workspace_id_workspaces_id_fk": {
+          "name": "provider_catalog_snapshots_workspace_id_workspaces_id_fk",
+          "tableFrom": "provider_catalog_snapshots",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}

--- a/apps/server/drizzle/meta/0023_snapshot.json
+++ b/apps/server/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,1845 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "69f53c81-494b-4416-8853-976d9976cfc8",
+  "prevId": "c07c1316-2b12-4757-ad6b-e534e07c1215",
+  "tables": {
+    "cleanup_jobs": {
+      "name": "cleanup_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cleanup_jobs_thread_id_unique": {
+          "name": "cleanup_jobs_thread_id_unique",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cleanup_jobs_retry": {
+          "name": "idx_cleanup_jobs_retry",
+          "columns": [
+            "next_retry_at",
+            "attempts",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diff_summaries": {
+      "name": "diff_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_turn_id": {
+          "name": "last_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_diff_summaries_thread": {
+          "name": "idx_diff_summaries_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "diff_summaries_thread_id_threads_id_fk": {
+          "name": "diff_summaries_thread_id_threads_id_fk",
+          "tableFrom": "diff_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_executions": {
+      "name": "hook_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hook_name": {
+          "name": "hook_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "did_block": {
+          "name": "did_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_hook_executions_message": {
+          "name": "idx_hook_executions_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hook_executions_message_id_messages_id_fk": {
+          "name": "hook_executions_message_id_messages_id_fk",
+          "tableFrom": "hook_executions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_annotations": {
+          "name": "preview_annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quoted_text": {
+          "name": "quoted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_messages_thread": {
+          "name": "idx_messages_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_sequence": {
+          "name": "idx_messages_sequence",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_reply_to_message_id_messages_id_fk": {
+          "name": "messages_reply_to_message_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "reply_to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_question_answers": {
+      "name": "plan_question_answers",
+      "columns": {
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_question_answers_thread": {
+          "name": "idx_plan_question_answers_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_question_answers_assistant_message_id_messages_id_fk": {
+          "name": "plan_question_answers_assistant_message_id_messages_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_question_answers_thread_id_threads_id_fk": {
+          "name": "plan_question_answers_thread_id_threads_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plans_thread": {
+          "name": "idx_plans_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plans_thread_version": {
+          "name": "idx_plans_thread_version",
+          "columns": [
+            "thread_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plans_thread_id_threads_id_fk": {
+          "name": "plans_thread_id_threads_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_message_id_messages_id_fk": {
+          "name": "plans_message_id_messages_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_catalog_snapshots": {
+      "name": "provider_catalog_snapshots",
+      "columns": {
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_provider_catalog_snapshots_workspace": {
+          "name": "idx_provider_catalog_snapshots_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_provider_catalog_snapshots_provider": {
+          "name": "idx_provider_catalog_snapshots_provider",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_cache": {
+      "name": "provider_model_cache",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_request_review_links": {
+      "name": "pull_request_review_links",
+      "columns": {
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_node_id": {
+          "name": "repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_state": {
+          "name": "pr_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "head_repository_node_id": {
+          "name": "head_repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_owner": {
+          "name": "head_repository_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_name": {
+          "name": "head_repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_oid": {
+          "name": "head_oid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_branch": {
+          "name": "local_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_remote": {
+          "name": "push_remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_ref": {
+          "name": "push_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "managed_remote_name": {
+          "name": "managed_remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_thread_id": {
+          "name": "primary_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_pull_request_review_links_identity": {
+          "name": "idx_pull_request_review_links_identity",
+          "columns": [
+            "provider",
+            "repository_node_id",
+            "pull_request_number"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_primary_thread": {
+          "name": "idx_pull_request_review_links_primary_thread",
+          "columns": [
+            "primary_thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_workspace": {
+          "name": "idx_pull_request_review_links_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pull_request_review_links_worktree_path": {
+          "name": "idx_pull_request_review_links_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_request_review_links_workspace_id_workspaces_id_fk": {
+          "name": "pull_request_review_links_workspace_id_workspaces_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pull_request_review_links_primary_thread_id_threads_id_fk": {
+          "name": "pull_request_review_links_primary_thread_id_threads_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "primary_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thought_segments": {
+      "name": "thought_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_final_response": {
+          "name": "is_final_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_thought_segments_message": {
+          "name": "idx_thought_segments_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thought_segments_message_id_messages_id_fk": {
+          "name": "thought_segments_message_id_messages_id_fk",
+          "tableFrom": "thought_segments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tasks": {
+      "name": "thread_tasks",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_json": {
+          "name": "tasks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tasks_thread_id_threads_id_fk": {
+          "name": "thread_tasks_thread_id_threads_id_fk",
+          "tableFrom": "thread_tasks",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkout_state": {
+          "name": "checkout_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'named'"
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_tokens": {
+          "name": "last_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interaction_mode": {
+          "name": "interaction_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "orchestration_mode": {
+          "name": "orchestration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_message_id": {
+          "name": "forked_from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_compact_summary": {
+          "name": "last_compact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "copilot_agent": {
+          "name": "copilot_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window_mode": {
+          "name": "context_window_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codex_fast_mode": {
+          "name": "codex_fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_open_in_app": {
+          "name": "default_open_in_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file_changes": {
+          "name": "has_file_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_threads_workspace": {
+          "name": "idx_threads_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_deleted": {
+          "name": "idx_threads_workspace_deleted",
+          "columns": [
+            "workspace_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_recency": {
+          "name": "idx_threads_workspace_recency",
+          "columns": [
+            "workspace_id",
+            "\"updated_at\" desc"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_status": {
+          "name": "idx_threads_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_parent_thread_id": {
+          "name": "idx_threads_parent_thread_id",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_forked_from_message_id": {
+          "name": "idx_threads_forked_from_message_id",
+          "columns": [
+            "forked_from_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_workspace_id_workspaces_id_fk": {
+          "name": "threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_call_records": {
+      "name": "tool_call_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_truncated": {
+          "name": "output_truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_total_bytes": {
+          "name": "output_total_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_artifact_path": {
+          "name": "output_artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tool_call_records_message": {
+          "name": "idx_tool_call_records_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tool_call_records_parent": {
+          "name": "idx_tool_call_records_parent",
+          "columns": [
+            "parent_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_call_records_message_id_messages_id_fk": {
+          "name": "tool_call_records_message_id_messages_id_fk",
+          "tableFrom": "tool_call_records",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turn_snapshots": {
+      "name": "turn_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_before": {
+          "name": "ref_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_after": {
+          "name": "ref_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "file_effects": {
+          "name": "file_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"revision\":0,\"fileCount\":0,\"additions\":0,\"deletions\":0,\"effects\":[]}'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_turn_snapshots_message": {
+          "name": "idx_turn_snapshots_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_turn_snapshots_thread": {
+          "name": "idx_turn_snapshots_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "turn_snapshots_message_id_messages_id_fk": {
+          "name": "turn_snapshots_message_id_messages_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_snapshots_thread_id_threads_id_fk": {
+          "name": "turn_snapshots_thread_id_threads_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_path_unique": {
+          "name": "workspaces_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspaces_sort_order": {
+          "name": "idx_workspaces_sort_order",
+          "columns": [
+            "\"sort_order\" asc"
+          ],
+          "isUnique": false
+        },
+        "idx_workspaces_pinned_last_opened": {
+          "name": "idx_workspaces_pinned_last_opened",
+          "columns": [
+            "\"pinned\" desc",
+            "\"last_opened_at\" desc"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_threads_workspace_recency": {
+        "columns": {
+          "\"updated_at\" desc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_sort_order": {
+        "columns": {
+          "\"sort_order\" asc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_pinned_last_opened": {
+        "columns": {
+          "\"pinned\" desc": {
+            "isExpression": true
+          },
+          "\"last_opened_at\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1784554548886,
       "tag": "0022_foamy_black_crow",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1784563485483,
+      "tag": "0023_grey_wildside",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -22,6 +22,7 @@ import { ModelCacheRepo } from "./repositories/model-cache-repo";
 import { PlanQuestionAnswersRepo } from "./repositories/plan-question-answers-repo";
 import { PlanRepo } from "./repositories/plan-repo";
 import { PullRequestReviewLinkRepo } from "./repositories/pull-request-review-link-repo";
+import { ProviderCatalogSnapshotRepo } from "./repositories/provider-catalog-snapshot-repo";
 
 // Providers
 import { ClaudeProvider } from "./providers/claude/claude-provider";
@@ -45,6 +46,7 @@ import {
   CodexCatalogClientFactory,
   CodexCatalogService,
 } from "./services/codex-catalog-service";
+import { ProviderCatalogService } from "./services/provider-catalog-service";
 import { TerminalService } from "./services/terminal-service";
 import { AttachmentService } from "./services/attachment-service";
 import { HandoffStorage } from "./services/handoff/handoff-storage.js";
@@ -220,6 +222,11 @@ export function setupContainer(mcodeDir: string): typeof container {
     { useClass: PullRequestReviewLinkRepo },
     { lifecycle: Lifecycle.Singleton },
   );
+  container.register(
+    ProviderCatalogSnapshotRepo,
+    { useClass: ProviderCatalogSnapshotRepo },
+    { lifecycle: Lifecycle.Singleton },
+  );
 
   // Providers
   container.register(
@@ -366,6 +373,11 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register(
     CodexCatalogService,
     { useClass: CodexCatalogService },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    ProviderCatalogService,
+    { useClass: ProviderCatalogService },
     { lifecycle: Lifecycle.Singleton },
   );
   container.register(

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -28,6 +28,7 @@ import { FileService } from "./services/file-service";
 import { ConfigService } from "./services/config-service";
 import { SkillService } from "./services/skill-service";
 import { CodexCatalogService } from "./services/codex-catalog-service";
+import { ProviderCatalogService } from "./services/provider-catalog-service";
 import { TerminalService } from "./services/terminal-service";
 import { MessageRepo } from "./repositories/message-repo";
 import { ThreadRepo } from "./repositories/thread-repo";
@@ -222,6 +223,7 @@ const fileService = container.resolve(FileService);
 const configService = container.resolve(ConfigService);
 const skillService = container.resolve(SkillService);
 const codexCatalogService = container.resolve(CodexCatalogService);
+const providerCatalogService = container.resolve(ProviderCatalogService);
 const terminalService = container.resolve(TerminalService);
 const messageRepo = container.resolve(MessageRepo);
 const threadRepo = container.resolve(ThreadRepo);
@@ -600,6 +602,14 @@ for (const provider of providerRegistry.resolveAll()) {
   });
 }
 
+providerCatalogService.onChanged((change) => {
+  broadcast("provider.catalogChanged", change);
+  portPush.send("provider.catalogChanged", change);
+});
+codexCatalogService.onSkillsChanged((cwd) => {
+  providerCatalogService.refreshKnownContexts("codex", cwd);
+});
+
 // Create and start HTTP + WS server
 const { httpServer, wss } = createWsServer({
   workspaceService,
@@ -614,6 +624,7 @@ const { httpServer, wss } = createWsServer({
   configService,
   skillService,
   codexCatalogService,
+  providerCatalogService,
   terminalService,
   messageRepo,
   toolCallRecordRepo,

--- a/apps/server/src/repositories/provider-catalog-snapshot-repo.test.ts
+++ b/apps/server/src/repositories/provider-catalog-snapshot-repo.test.ts
@@ -1,0 +1,63 @@
+import "reflect-metadata";
+import { afterEach, describe, expect, it } from "vitest";
+import type Database from "better-sqlite3";
+import type { ProviderCatalogSnapshot } from "@mcode/contracts";
+import { openMemoryDatabase } from "../store/database.js";
+import { ProviderCatalogSnapshotRepo } from "./provider-catalog-snapshot-repo.js";
+
+const SNAPSHOT: ProviderCatalogSnapshot = {
+  providerId: "codex",
+  context: { scope: "workspace", workspaceId: "workspace-1" },
+  freshness: { status: "fresh", fetchedAt: "2026-07-20T12:00:00.000Z" },
+  diagnostics: [],
+  entries: [{
+    kind: "skill",
+    identity: { providerId: "codex", kind: "skill", nativeId: "review" },
+    name: "review",
+    description: "Review changes",
+    source: "user",
+  }],
+  selectableAgents: [],
+};
+
+describe("ProviderCatalogSnapshotRepo", () => {
+  let db: Database.Database | undefined;
+
+  afterEach(() => db?.close());
+
+  it("persists snapshots by provider and realized catalog context", () => {
+    db = openMemoryDatabase();
+    const firstProcess = new ProviderCatalogSnapshotRepo(db);
+    firstProcess.upsert("codex:workspace:workspace-1:C:/repo", "workspace-1", "C:/repo", SNAPSHOT);
+
+    const restartedProcess = new ProviderCatalogSnapshotRepo(db);
+
+    expect(restartedProcess.get("codex:workspace:workspace-1:C:/repo")).toEqual(SNAPSHOT);
+    expect(restartedProcess.get("codex:workspace:workspace-2:C:/other")).toBeNull();
+  });
+
+  it("rejects malformed persisted payloads without affecting other contexts", () => {
+    db = openMemoryDatabase();
+    const repo = new ProviderCatalogSnapshotRepo(db);
+    repo.upsert("valid", "workspace-1", "C:/repo", SNAPSHOT);
+    db.prepare(`
+      INSERT INTO provider_catalog_snapshots
+        (context_key, provider_id, workspace_id, cwd, snapshot_json)
+      VALUES (?, ?, ?, ?, ?)
+    `).run("invalid", "codex", "workspace-2", "C:/other", "{}");
+
+    expect(repo.get("invalid")).toBeNull();
+    expect(repo.get("valid")).toEqual(SNAPSHOT);
+  });
+
+  it("does not expire an otherwise valid snapshot because of its age", () => {
+    db = openMemoryDatabase();
+    const repo = new ProviderCatalogSnapshotRepo(db);
+    repo.upsert("old", "workspace-1", "C:/repo", SNAPSHOT);
+    db.prepare(
+      "UPDATE provider_catalog_snapshots SET updated_at = ? WHERE context_key = ?",
+    ).run("2000-01-01T00:00:00.000Z", "old");
+
+    expect(repo.get("old")).toEqual(SNAPSHOT);
+  });
+});

--- a/apps/server/src/repositories/provider-catalog-snapshot-repo.test.ts
+++ b/apps/server/src/repositories/provider-catalog-snapshot-repo.test.ts
@@ -25,8 +25,18 @@ describe("ProviderCatalogSnapshotRepo", () => {
 
   afterEach(() => db?.close());
 
+  function openCatalogDatabase(): Database.Database {
+    const database = openMemoryDatabase();
+    const insertWorkspace = database.prepare(
+      "INSERT INTO workspaces (id, name, path) VALUES (?, ?, ?)",
+    );
+    insertWorkspace.run("workspace-1", "Workspace 1", "C:/repo");
+    insertWorkspace.run("workspace-2", "Workspace 2", "C:/other");
+    return database;
+  }
+
   it("persists snapshots by provider and realized catalog context", () => {
-    db = openMemoryDatabase();
+    db = openCatalogDatabase();
     const firstProcess = new ProviderCatalogSnapshotRepo(db);
     firstProcess.upsert("codex:workspace:workspace-1:C:/repo", "workspace-1", "C:/repo", SNAPSHOT);
 
@@ -37,7 +47,7 @@ describe("ProviderCatalogSnapshotRepo", () => {
   });
 
   it("rejects malformed persisted payloads without affecting other contexts", () => {
-    db = openMemoryDatabase();
+    db = openCatalogDatabase();
     const repo = new ProviderCatalogSnapshotRepo(db);
     repo.upsert("valid", "workspace-1", "C:/repo", SNAPSHOT);
     db.prepare(`
@@ -51,7 +61,7 @@ describe("ProviderCatalogSnapshotRepo", () => {
   });
 
   it("does not expire an otherwise valid snapshot because of its age", () => {
-    db = openMemoryDatabase();
+    db = openCatalogDatabase();
     const repo = new ProviderCatalogSnapshotRepo(db);
     repo.upsert("old", "workspace-1", "C:/repo", SNAPSHOT);
     db.prepare(
@@ -59,5 +69,31 @@ describe("ProviderCatalogSnapshotRepo", () => {
     ).run("2000-01-01T00:00:00.000Z", "old");
 
     expect(repo.get("old")).toEqual(SNAPSHOT);
+  });
+
+  it("deletes workspace snapshots when their workspace is deleted", () => {
+    db = openCatalogDatabase();
+    const repo = new ProviderCatalogSnapshotRepo(db);
+    repo.upsert("workspace-snapshot", "workspace-1", "C:/repo", SNAPSHOT);
+
+    db.prepare("DELETE FROM workspaces WHERE id = ?").run("workspace-1");
+
+    expect(repo.get("workspace-snapshot")).toBeNull();
+  });
+
+  it("does not recreate a snapshot after its workspace is deleted", () => {
+    db = openCatalogDatabase();
+    const repo = new ProviderCatalogSnapshotRepo(db);
+    db.prepare("DELETE FROM workspaces WHERE id = ?").run("workspace-1");
+
+    const persisted = repo.upsert(
+      "deleted-workspace",
+      "workspace-1",
+      "C:/repo",
+      SNAPSHOT,
+    );
+
+    expect(persisted).toBe(false);
+    expect(repo.get("deleted-workspace")).toBeNull();
   });
 });

--- a/apps/server/src/repositories/provider-catalog-snapshot-repo.ts
+++ b/apps/server/src/repositories/provider-catalog-snapshot-repo.ts
@@ -35,19 +35,20 @@ export class ProviderCatalogSnapshotRepo {
     }
   }
 
-  /** Inserts or replaces a validated snapshot without applying an age limit. */
+  /** Inserts or replaces a validated snapshot when its workspace still exists. */
   upsert(
     contextKey: string,
     workspaceId: string | undefined,
     cwd: string | undefined,
     snapshot: ProviderCatalogSnapshot,
-  ): void {
+  ): boolean {
     const validated = ProviderCatalogSnapshotSchema().parse(snapshot);
-    this.db.transaction(() => {
-      this.db.prepare(`
+    return this.db.transaction(() => {
+      const result = this.db.prepare(`
         INSERT INTO provider_catalog_snapshots
           (context_key, provider_id, workspace_id, cwd, snapshot_json, updated_at)
-        VALUES (?, ?, ?, ?, ?, datetime('now'))
+        SELECT ?, ?, ?, ?, ?, datetime('now')
+        WHERE ? IS NULL OR EXISTS (SELECT 1 FROM workspaces WHERE id = ?)
         ON CONFLICT(context_key) DO UPDATE SET
           provider_id = excluded.provider_id,
           workspace_id = excluded.workspace_id,
@@ -60,7 +61,10 @@ export class ProviderCatalogSnapshotRepo {
         workspaceId ?? null,
         cwd ?? null,
         JSON.stringify(validated),
+        workspaceId ?? null,
+        workspaceId ?? null,
       );
+      if (result.changes === 0) return false;
       this.db.prepare(`
         DELETE FROM provider_catalog_snapshots
         WHERE context_key IN (
@@ -71,6 +75,7 @@ export class ProviderCatalogSnapshotRepo {
           LIMIT -1 OFFSET ?
         )
       `).run(validated.providerId, MAX_PERSISTED_CONTEXTS_PER_PROVIDER);
+      return true;
     })();
   }
 }

--- a/apps/server/src/repositories/provider-catalog-snapshot-repo.ts
+++ b/apps/server/src/repositories/provider-catalog-snapshot-repo.ts
@@ -1,0 +1,76 @@
+import { inject, injectable } from "tsyringe";
+import type Database from "better-sqlite3";
+import {
+  ProviderCatalogSnapshotSchema,
+  type ProviderCatalogSnapshot,
+} from "@mcode/contracts";
+import { logger } from "@mcode/shared";
+
+interface ProviderCatalogSnapshotRow {
+  snapshot_json: string;
+}
+
+const MAX_PERSISTED_CONTEXTS_PER_PROVIDER = 512;
+
+/** Persists bounded provider catalog snapshots by realized discovery context. */
+@injectable()
+export class ProviderCatalogSnapshotRepo {
+  constructor(@inject("Database") private readonly db: Database.Database) {}
+
+  /** Returns one validated snapshot, or null when the row is absent or corrupt. */
+  get(contextKey: string): ProviderCatalogSnapshot | null {
+    const row = this.db.prepare(
+      "SELECT snapshot_json FROM provider_catalog_snapshots WHERE context_key = ?",
+    ).get(contextKey) as ProviderCatalogSnapshotRow | undefined;
+    if (!row) return null;
+
+    try {
+      return ProviderCatalogSnapshotSchema().parse(JSON.parse(row.snapshot_json));
+    } catch (error) {
+      logger.warn("Ignoring invalid provider catalog snapshot", {
+        contextKey,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /** Inserts or replaces a validated snapshot without applying an age limit. */
+  upsert(
+    contextKey: string,
+    workspaceId: string | undefined,
+    cwd: string | undefined,
+    snapshot: ProviderCatalogSnapshot,
+  ): void {
+    const validated = ProviderCatalogSnapshotSchema().parse(snapshot);
+    this.db.transaction(() => {
+      this.db.prepare(`
+        INSERT INTO provider_catalog_snapshots
+          (context_key, provider_id, workspace_id, cwd, snapshot_json, updated_at)
+        VALUES (?, ?, ?, ?, ?, datetime('now'))
+        ON CONFLICT(context_key) DO UPDATE SET
+          provider_id = excluded.provider_id,
+          workspace_id = excluded.workspace_id,
+          cwd = excluded.cwd,
+          snapshot_json = excluded.snapshot_json,
+          updated_at = excluded.updated_at
+      `).run(
+        contextKey,
+        validated.providerId,
+        workspaceId ?? null,
+        cwd ?? null,
+        JSON.stringify(validated),
+      );
+      this.db.prepare(`
+        DELETE FROM provider_catalog_snapshots
+        WHERE context_key IN (
+          SELECT context_key
+          FROM provider_catalog_snapshots
+          WHERE provider_id = ?
+          ORDER BY updated_at DESC, context_key DESC
+          LIMIT -1 OFFSET ?
+        )
+      `).run(validated.providerId, MAX_PERSISTED_CONTEXTS_PER_PROVIDER);
+    })();
+  }
+}

--- a/apps/server/src/services/__tests__/codex-catalog-service.test.ts
+++ b/apps/server/src/services/__tests__/codex-catalog-service.test.ts
@@ -125,6 +125,42 @@ describe("CodexCatalogService", () => {
     expect(client.kill).toHaveBeenCalledTimes(1);
   });
 
+  it("starts a new connection after eviction while retaining the context snapshot", async () => {
+    vi.useFakeTimers();
+    const firstClient = new ControlledCatalogClient();
+    const secondClient = new ControlledCatalogClient();
+    const create = vi.fn()
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const service = createService(firstClient, create);
+    const cwd = "C:/workspaces/one";
+    const first = await service.refresh(cwd);
+
+    await vi.advanceTimersByTimeAsync(60_001);
+    const restarted = await service.refresh(cwd);
+
+    expect(firstClient.kill).toHaveBeenCalledTimes(1);
+    expect(secondClient.start).toHaveBeenCalledTimes(1);
+    expect(secondClient.listSkills).toHaveBeenCalledWith([cwd], false);
+    expect(restarted.skills).toEqual(first.skills);
+  });
+
+  it("does not extend the request idle deadline for provider change signals", async () => {
+    vi.useFakeTimers();
+    const client = new ControlledCatalogClient();
+    const service = createService(client);
+    const cwd = "C:/workspaces/one";
+    await service.refresh(cwd);
+    await vi.advanceTimersByTimeAsync(30_000);
+    const changed = new Promise<string | undefined>((resolve) => service.onSkillsChanged(resolve));
+
+    client.emit("notification", { method: "skills/changed", params: { cwd } });
+    await changed;
+    await vi.advanceTimersByTimeAsync(30_001);
+
+    expect(client.kill).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves the context snapshot and scopes diagnostics after a provider failure", async () => {
     const client = new ControlledCatalogClient();
     const service = createService(client);

--- a/apps/server/src/services/codex-catalog-service.ts
+++ b/apps/server/src/services/codex-catalog-service.ts
@@ -170,6 +170,11 @@ export class CodexCatalogService {
     return this.snapshots.get(catalogKey(cwd))?.skills ?? [];
   }
 
+  /** Returns the last complete refresh result without touching the connection idle deadline. */
+  currentSnapshot(cwd?: string): CodexCatalogRefreshResult | undefined {
+    return this.snapshots.get(catalogKey(cwd));
+  }
+
   /** Stops the catalog process and clears in-flight connection state. */
   async shutdown(): Promise<void> {
     if (this.idleTimer) {
@@ -231,7 +236,7 @@ export class CodexCatalogService {
         cwd,
         error: error instanceof Error ? error.message : String(error),
       });
-      return {
+      const snapshot: CodexCatalogRefreshResult = {
         skills: previous?.skills ?? [],
         diagnostics: [{
           severity: "warning",
@@ -244,6 +249,8 @@ export class CodexCatalogService {
           reason: "Codex Skill discovery failed.",
         },
       };
+      this.snapshots.set(catalogKey(cwd), snapshot);
+      return snapshot;
     }
   }
 

--- a/apps/server/src/services/provider-catalog-service.test.ts
+++ b/apps/server/src/services/provider-catalog-service.test.ts
@@ -1,0 +1,149 @@
+import "reflect-metadata";
+import { afterEach, describe, expect, it } from "vitest";
+import type Database from "better-sqlite3";
+import type {
+  ProviderCatalogChange,
+  ProviderCatalogRequest,
+  ProviderCatalogSnapshot,
+} from "@mcode/contracts";
+import { openMemoryDatabase } from "../store/database.js";
+import { ProviderCatalogSnapshotRepo } from "../repositories/provider-catalog-snapshot-repo.js";
+import {
+  ProviderCatalogService,
+  providerCatalogContextKey,
+} from "./provider-catalog-service.js";
+
+const REQUEST: ProviderCatalogRequest = {
+  providerId: "codex",
+  workspaceId: "workspace-1",
+};
+const CACHED: ProviderCatalogSnapshot = {
+  providerId: "codex",
+  context: { scope: "workspace", workspaceId: "workspace-1" },
+  freshness: { status: "fresh", fetchedAt: "2026-07-20T12:00:00.000Z" },
+  diagnostics: [],
+  entries: [{
+    kind: "skill",
+    identity: { providerId: "codex", kind: "skill", nativeId: "review" },
+    name: "review",
+    description: "Review changes",
+    source: "user",
+  }],
+  selectableAgents: [],
+};
+
+describe("ProviderCatalogService", () => {
+  let db: Database.Database | undefined;
+
+  afterEach(() => db?.close());
+
+  function createService(): {
+    repo: ProviderCatalogSnapshotRepo;
+    service: ProviderCatalogService;
+  } {
+    db = openMemoryDatabase();
+    const repo = new ProviderCatalogSnapshotRepo(db);
+    return { repo, service: new ProviderCatalogService(repo) };
+  }
+
+  it("returns a stale persisted snapshot before background refresh completes", async () => {
+    const { repo, service } = createService();
+    const key = providerCatalogContextKey(REQUEST, "C:/repo");
+    repo.upsert(key, "workspace-1", "C:/repo", CACHED);
+    let finishRefresh!: (snapshot: ProviderCatalogSnapshot) => void;
+    const refresh = new Promise<ProviderCatalogSnapshot>((resolve) => { finishRefresh = resolve; });
+
+    const immediate = service.request({
+      request: REQUEST,
+      context: CACHED.context,
+      cwd: "C:/repo",
+      refresh: () => refresh,
+    });
+
+    expect(immediate.entries).toEqual(CACHED.entries);
+    expect(immediate.freshness).toMatchObject({ status: "stale" });
+
+    const changed = new Promise<ProviderCatalogChange>((resolve) => service.onChanged(resolve));
+    finishRefresh({
+      ...CACHED,
+      freshness: { status: "fresh", fetchedAt: "2026-07-20T13:00:00.000Z" },
+      entries: [
+        { ...CACHED.entries[0], description: "Review the current changes" },
+        {
+          kind: "skill",
+          identity: { providerId: "codex", kind: "skill", nativeId: "ship" },
+          name: "ship",
+          description: "Ship changes",
+          source: "project",
+        },
+      ],
+    });
+
+    await expect(changed).resolves.toMatchObject({
+      request: REQUEST,
+      additions: [expect.objectContaining({ name: "ship" })],
+      updates: [expect.objectContaining({ name: "review" })],
+      removals: [],
+      freshness: { status: "fresh" },
+    });
+    expect(repo.get(key)?.entries).toHaveLength(2);
+  });
+
+  it("retains cached entries and records a scoped diagnostic after refresh failure", async () => {
+    const { repo, service } = createService();
+    const key = providerCatalogContextKey(REQUEST, "C:/repo");
+    repo.upsert(key, "workspace-1", "C:/repo", CACHED);
+    const changed = new Promise<ProviderCatalogChange>((resolve) => service.onChanged(resolve));
+
+    service.request({
+      request: REQUEST,
+      context: CACHED.context,
+      cwd: "C:/repo",
+      refresh: async () => ({
+        ...CACHED,
+        entries: [],
+        freshness: {
+          status: "stale",
+          fetchedAt: CACHED.freshness.fetchedAt,
+          reason: "Codex Skill discovery failed.",
+        },
+        diagnostics: [{
+          severity: "warning",
+          code: "source-unavailable",
+          message: "Codex Skills are temporarily unavailable for this catalog context.",
+        }],
+      }),
+    });
+
+    await expect(changed).resolves.toMatchObject({
+      additions: [],
+      updates: [],
+      removals: [],
+      diagnostics: [expect.objectContaining({ code: "source-unavailable" })],
+    });
+    expect(repo.get(key)?.entries).toEqual(CACHED.entries);
+  });
+
+  it("uses the workspace snapshot provisionally for a realized worktree context", () => {
+    const { repo, service } = createService();
+    const workspaceKey = providerCatalogContextKey(REQUEST, "C:/repo");
+    repo.upsert(workspaceKey, "workspace-1", "C:/repo", CACHED);
+    const worktreeRequest = { ...REQUEST, threadId: "thread-1" };
+
+    const immediate = service.request({
+      request: worktreeRequest,
+      context: { scope: "workspace", workspaceId: "workspace-1", threadId: "thread-1" },
+      cwd: "C:/repo/.worktrees/thread-1",
+      fallbackCwd: "C:/repo",
+      refresh: () => new Promise(() => undefined),
+    });
+
+    expect(immediate.context).toEqual({
+      scope: "workspace",
+      workspaceId: "workspace-1",
+      threadId: "thread-1",
+    });
+    expect(immediate.entries).toEqual(CACHED.entries);
+    expect(immediate.freshness.status).toBe("stale");
+  });
+});

--- a/apps/server/src/services/provider-catalog-service.test.ts
+++ b/apps/server/src/services/provider-catalog-service.test.ts
@@ -234,11 +234,12 @@ describe("ProviderCatalogService", () => {
       finishRefresh = resolve;
     }));
     const changes: ProviderCatalogChange[] = [];
+    const immediate: ProviderCatalogSnapshot[] = [];
     service.onChanged((change) => changes.push(change));
 
     for (let index = 0; index < 65; index += 1) {
       const request = { ...REQUEST, threadId: `thread-${index}` };
-      service.request({
+      immediate.push(service.request({
         request,
         context: {
           scope: "workspace",
@@ -247,22 +248,30 @@ describe("ProviderCatalogService", () => {
         },
         cwd: "C:/repo",
         refresh,
-      });
+      }));
     }
+    expect(immediate[64]).toMatchObject({
+      diagnostics: [expect.objectContaining({
+        code: "source-unavailable",
+        message: expect.stringContaining("capacity"),
+      })],
+      freshness: { status: "stale", reason: expect.stringContaining("capacity") },
+    });
     await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
     finishRefresh(CACHED);
 
     await vi.waitFor(() => expect(changes).toHaveLength(64));
-    expect(changes.some((change) => change.request.threadId === "thread-0")).toBe(false);
-    expect(changes.some((change) => change.request.threadId === "thread-64")).toBe(true);
+    expect(changes.some((change) => change.request.threadId === "thread-0")).toBe(true);
+    expect(changes.some((change) => change.request.threadId === "thread-64")).toBe(false);
   });
 
   it("bounds concurrent physical catalog refreshes", async () => {
     const { service } = createService();
     const refresh = vi.fn(() => new Promise<ProviderCatalogSnapshot>(() => undefined));
+    const immediate: ProviderCatalogSnapshot[] = [];
 
     for (let index = 0; index < 65; index += 1) {
-      service.request({
+      immediate.push(service.request({
         request: { ...REQUEST, threadId: `thread-${index}` },
         context: {
           scope: "workspace",
@@ -271,9 +280,13 @@ describe("ProviderCatalogService", () => {
         },
         cwd: `C:/repo-${index}`,
         refresh,
-      });
+      }));
     }
 
     await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(64));
+    expect(immediate[64]).toMatchObject({
+      diagnostics: [expect.objectContaining({ code: "source-unavailable" })],
+      freshness: { status: "stale", reason: expect.stringContaining("capacity") },
+    });
   });
 });

--- a/apps/server/src/services/provider-catalog-service.test.ts
+++ b/apps/server/src/services/provider-catalog-service.test.ts
@@ -289,4 +289,41 @@ describe("ProviderCatalogService", () => {
       freshness: { status: "stale", reason: expect.stringContaining("capacity") },
     });
   });
+
+  it("admits a new context after evicting the oldest completed context", async () => {
+    const { service } = createService();
+    const refresh = vi.fn(async () => CACHED);
+    const changes: ProviderCatalogChange[] = [];
+    service.onChanged((change) => changes.push(change));
+
+    for (let index = 0; index < 64; index += 1) {
+      service.request({
+        request: { ...REQUEST, threadId: `thread-${index}` },
+        context: {
+          scope: "workspace",
+          workspaceId: "workspace-1",
+          threadId: `thread-${index}`,
+        },
+        cwd: `C:/repo-${index}`,
+        refresh,
+      });
+    }
+    await vi.waitFor(() => expect(changes).toHaveLength(64));
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+
+    const next = service.request({
+      request: { ...REQUEST, threadId: "thread-64" },
+      context: {
+        scope: "workspace",
+        workspaceId: "workspace-1",
+        threadId: "thread-64",
+      },
+      cwd: "C:/repo-64",
+      refresh,
+    });
+
+    expect(next.diagnostics).toEqual([]);
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(65));
+    await vi.waitFor(() => expect(changes).toHaveLength(65));
+  });
 });

--- a/apps/server/src/services/provider-catalog-service.test.ts
+++ b/apps/server/src/services/provider-catalog-service.test.ts
@@ -42,6 +42,8 @@ describe("ProviderCatalogService", () => {
     service: ProviderCatalogService;
   } {
     db = openMemoryDatabase();
+    db.prepare("INSERT INTO workspaces (id, name, path) VALUES (?, ?, ?)")
+      .run("workspace-1", "Workspace 1", "C:/repo");
     const repo = new ProviderCatalogSnapshotRepo(db);
     return { repo, service: new ProviderCatalogService(repo) };
   }
@@ -122,6 +124,32 @@ describe("ProviderCatalogService", () => {
       diagnostics: [expect.objectContaining({ code: "source-unavailable" })],
     });
     expect(repo.get(key)?.entries).toEqual(CACHED.entries);
+  });
+
+  it("drops a delayed refresh after its workspace is deleted", async () => {
+    const { repo, service } = createService();
+    const key = providerCatalogContextKey(REQUEST, "C:/repo");
+    let finishRefresh!: (snapshot: ProviderCatalogSnapshot) => void;
+    const refresh = new Promise<ProviderCatalogSnapshot>((resolve) => {
+      finishRefresh = resolve;
+    });
+    const persist = vi.spyOn(repo, "upsert");
+    const changes: ProviderCatalogChange[] = [];
+    service.onChanged((change) => changes.push(change));
+
+    service.request({
+      request: REQUEST,
+      context: CACHED.context,
+      cwd: "C:/repo",
+      refresh: () => refresh,
+    });
+    db?.prepare("DELETE FROM workspaces WHERE id = ?").run("workspace-1");
+    finishRefresh(CACHED);
+
+    await vi.waitFor(() => expect(persist).toHaveBeenCalledOnce());
+    expect(persist.mock.results[0]?.value).toBe(false);
+    expect(repo.get(key)).toBeNull();
+    expect(changes).toEqual([]);
   });
 
   it("uses the workspace snapshot provisionally for a realized worktree context", () => {

--- a/apps/server/src/services/provider-catalog-service.test.ts
+++ b/apps/server/src/services/provider-catalog-service.test.ts
@@ -226,4 +226,54 @@ describe("ProviderCatalogService", () => {
       expect.objectContaining({ description: "Review after notification" }),
     ]);
   });
+
+  it("bounds logical subscribers attached to one physical refresh", async () => {
+    const { service } = createService();
+    let finishRefresh!: (snapshot: ProviderCatalogSnapshot) => void;
+    const refresh = vi.fn(() => new Promise<ProviderCatalogSnapshot>((resolve) => {
+      finishRefresh = resolve;
+    }));
+    const changes: ProviderCatalogChange[] = [];
+    service.onChanged((change) => changes.push(change));
+
+    for (let index = 0; index < 65; index += 1) {
+      const request = { ...REQUEST, threadId: `thread-${index}` };
+      service.request({
+        request,
+        context: {
+          scope: "workspace",
+          workspaceId: "workspace-1",
+          threadId: request.threadId,
+        },
+        cwd: "C:/repo",
+        refresh,
+      });
+    }
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+    finishRefresh(CACHED);
+
+    await vi.waitFor(() => expect(changes).toHaveLength(64));
+    expect(changes.some((change) => change.request.threadId === "thread-0")).toBe(false);
+    expect(changes.some((change) => change.request.threadId === "thread-64")).toBe(true);
+  });
+
+  it("bounds concurrent physical catalog refreshes", async () => {
+    const { service } = createService();
+    const refresh = vi.fn(() => new Promise<ProviderCatalogSnapshot>(() => undefined));
+
+    for (let index = 0; index < 65; index += 1) {
+      service.request({
+        request: { ...REQUEST, threadId: `thread-${index}` },
+        context: {
+          scope: "workspace",
+          workspaceId: "workspace-1",
+          threadId: `thread-${index}`,
+        },
+        cwd: `C:/repo-${index}`,
+        refresh,
+      });
+    }
+
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(64));
+  });
 });

--- a/apps/server/src/services/provider-catalog-service.test.ts
+++ b/apps/server/src/services/provider-catalog-service.test.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type Database from "better-sqlite3";
 import type {
   ProviderCatalogChange,
@@ -145,5 +145,85 @@ describe("ProviderCatalogService", () => {
     });
     expect(immediate.entries).toEqual(CACHED.entries);
     expect(immediate.freshness.status).toBe("stale");
+  });
+
+  it("tracks every logical request sharing one persisted checkout", async () => {
+    const { repo, service } = createService();
+    const key = providerCatalogContextKey(REQUEST, "C:/repo");
+    repo.upsert(key, "workspace-1", "C:/repo", CACHED);
+    const changes: ProviderCatalogChange[] = [];
+    service.onChanged((change) => changes.push(change));
+    const firstRequest = { ...REQUEST, threadId: "thread-1" };
+    const secondRequest = { ...REQUEST, threadId: "thread-2" };
+    const initialRefreshes: Array<ReturnType<typeof vi.fn>> = [];
+    const cacheRefreshes: Array<ReturnType<typeof vi.fn>> = [];
+
+    for (const request of [firstRequest, secondRequest]) {
+      const refresh = vi.fn(async () => CACHED);
+      const refreshFromCache = vi.fn(async () => ({
+        ...CACHED,
+        freshness: { status: "fresh" as const, fetchedAt: "2026-07-20T14:00:00.000Z" },
+      }));
+      initialRefreshes.push(refresh);
+      cacheRefreshes.push(refreshFromCache);
+      service.request({
+        request,
+        context: {
+          scope: "workspace",
+          workspaceId: "workspace-1",
+          threadId: request.threadId,
+        },
+        cwd: "C:/repo",
+        refresh,
+        refreshFromCache,
+      });
+    }
+    await vi.waitFor(() => expect(changes).toHaveLength(2));
+    expect(initialRefreshes.reduce((total, refresh) => total + refresh.mock.calls.length, 0))
+      .toBe(1);
+    changes.length = 0;
+
+    service.refreshKnownContexts("codex", "C:/repo");
+
+    await vi.waitFor(() => expect(changes).toHaveLength(2));
+    expect(changes.map((change) => change.request.threadId).sort()).toEqual([
+      "thread-1",
+      "thread-2",
+    ]);
+    expect(cacheRefreshes.reduce((total, refresh) => total + refresh.mock.calls.length, 0))
+      .toBe(1);
+  });
+
+  it("queues a native change received during an active refresh", async () => {
+    const { repo, service } = createService();
+    const key = providerCatalogContextKey(REQUEST, "C:/repo");
+    repo.upsert(key, "workspace-1", "C:/repo", CACHED);
+    let finishRefresh!: (snapshot: ProviderCatalogSnapshot) => void;
+    const initialRefresh = new Promise<ProviderCatalogSnapshot>((resolve) => {
+      finishRefresh = resolve;
+    });
+    const refreshFromCache = vi.fn(async () => ({
+      ...CACHED,
+      entries: [{ ...CACHED.entries[0], description: "Review after notification" }],
+      freshness: { status: "fresh" as const, fetchedAt: "2026-07-20T14:00:00.000Z" },
+    }));
+    const changes: ProviderCatalogChange[] = [];
+    service.onChanged((change) => changes.push(change));
+
+    service.request({
+      request: REQUEST,
+      context: CACHED.context,
+      cwd: "C:/repo",
+      refresh: () => initialRefresh,
+      refreshFromCache,
+    });
+    service.refreshKnownContexts("codex", "C:/repo");
+    finishRefresh(CACHED);
+
+    await vi.waitFor(() => expect(changes).toHaveLength(2));
+    expect(refreshFromCache).toHaveBeenCalledTimes(1);
+    expect(changes[1]?.updates).toEqual([
+      expect.objectContaining({ description: "Review after notification" }),
+    ]);
   });
 });

--- a/apps/server/src/services/provider-catalog-service.ts
+++ b/apps/server/src/services/provider-catalog-service.ts
@@ -22,6 +22,17 @@ export interface ProviderCatalogLoadInput {
 
 const MAX_TRACKED_CATALOG_CONTEXTS = 64;
 
+interface CatalogRefreshSubscriber {
+  readonly visible: ProviderCatalogSnapshot;
+  readonly input: ProviderCatalogLoadInput;
+}
+
+interface CatalogRefreshJob {
+  readonly refresh: () => Promise<ProviderCatalogSnapshot>;
+  readonly subscribers: Map<string, CatalogRefreshSubscriber>;
+  readonly pendingSubscribers: Map<string, CatalogRefreshSubscriber>;
+}
+
 function capabilityIdentity(entry: ProviderCapabilityEntry): string {
   const { providerId, kind, nativeId } = entry.identity;
   return JSON.stringify([providerId, kind, nativeId]);
@@ -43,6 +54,18 @@ export function providerCatalogContextKey(
   return JSON.stringify([
     request.providerId,
     request.workspaceId ?? null,
+    cwd?.replace(/\\/g, "/") ?? null,
+  ]);
+}
+
+function providerCatalogRequestKey(
+  request: ProviderCatalogRequest,
+  cwd?: string,
+): string {
+  return JSON.stringify([
+    request.providerId,
+    request.workspaceId ?? null,
+    request.threadId ?? null,
     cwd?.replace(/\\/g, "/") ?? null,
   ]);
 }
@@ -122,7 +145,7 @@ function catalogChange(
 /** Coordinates persisted snapshots, background refresh, and incremental catalog changes. */
 @injectable()
 export class ProviderCatalogService {
-  private readonly inflight = new Map<string, Promise<void>>();
+  private readonly inflight = new Map<string, CatalogRefreshJob>();
   private readonly trackedContexts = new Map<string, ProviderCatalogLoadInput>();
   private readonly changedHandlers = new Set<(change: ProviderCatalogChange) => void>();
 
@@ -133,16 +156,17 @@ export class ProviderCatalogService {
 
   /** Returns cached state immediately and starts one background refresh for the context. */
   request(input: ProviderCatalogLoadInput): ProviderCatalogSnapshot {
-    const key = providerCatalogContextKey(input.request, input.cwd);
+    const persistenceKey = providerCatalogContextKey(input.request, input.cwd);
+    const requestKey = providerCatalogRequestKey(input.request, input.cwd);
     const fallbackRequest = { ...input.request, threadId: undefined };
     const fallbackKey = input.fallbackCwd === undefined
       ? undefined
       : providerCatalogContextKey(fallbackRequest, input.fallbackCwd);
-    const persisted = this.snapshotRepo.get(key)
-      ?? (fallbackKey && fallbackKey !== key ? this.snapshotRepo.get(fallbackKey) : null);
+    const persisted = this.snapshotRepo.get(persistenceKey)
+      ?? (fallbackKey && fallbackKey !== persistenceKey ? this.snapshotRepo.get(fallbackKey) : null);
     const visible = staleSnapshot(persisted, input.request, input.context);
-    this.rememberContext(key, input);
-    this.scheduleRefresh(key, visible, input);
+    this.rememberContext(requestKey, input);
+    this.scheduleRefresh(requestKey, persistenceKey, visible, input, false);
     return visible;
   }
 
@@ -154,7 +178,8 @@ export class ProviderCatalogService {
 
   /** Reconciles requested contexts after a provider-native background change signal. */
   refreshKnownContexts(providerId: string, cwd?: string): void {
-    for (const [key, input] of this.trackedContexts) {
+    const queueByPersistenceKey = new Map<string, boolean>();
+    for (const [requestKey, input] of this.trackedContexts) {
       if (
         input.request.providerId !== providerId
         || input.cwd !== cwd
@@ -162,9 +187,19 @@ export class ProviderCatalogService {
       ) {
         continue;
       }
-      const persisted = this.snapshotRepo.get(key);
+      const persistenceKey = providerCatalogContextKey(input.request, input.cwd);
+      const queueIfInflight = queueByPersistenceKey.get(persistenceKey)
+        ?? this.inflight.has(persistenceKey);
+      queueByPersistenceKey.set(persistenceKey, queueIfInflight);
+      const persisted = this.snapshotRepo.get(persistenceKey);
       const visible = staleSnapshot(persisted, input.request, input.context);
-      this.scheduleRefresh(key, visible, { ...input, refresh: input.refreshFromCache });
+      this.scheduleRefresh(
+        requestKey,
+        persistenceKey,
+        visible,
+        { ...input, refresh: input.refreshFromCache },
+        queueIfInflight,
+      );
     }
   }
 
@@ -179,37 +214,70 @@ export class ProviderCatalogService {
   }
 
   private scheduleRefresh(
-    key: string,
+    requestKey: string,
+    persistenceKey: string,
     visible: ProviderCatalogSnapshot,
     input: ProviderCatalogLoadInput,
+    queueIfInflight: boolean,
   ): void {
-    if (this.inflight.has(key)) return;
-    const refresh = new Promise<void>((resolve) => {
+    const subscriber = { visible, input } satisfies CatalogRefreshSubscriber;
+    const currentJob = this.inflight.get(persistenceKey);
+    if (currentJob) {
+      const subscribers = queueIfInflight
+        ? currentJob.pendingSubscribers
+        : currentJob.subscribers;
+      subscribers.set(requestKey, subscriber);
+      return;
+    }
+    const job: CatalogRefreshJob = {
+      refresh: input.refresh,
+      subscribers: new Map([[requestKey, subscriber]]),
+      pendingSubscribers: new Map(),
+    };
+    this.inflight.set(persistenceKey, job);
+    void new Promise<void>((resolve) => {
       setImmediate(() => {
-        void this.refresh(key, visible, input).finally(resolve);
+        void this.refresh(persistenceKey, job).finally(resolve);
       });
     }).finally(() => {
-      this.inflight.delete(key);
+      this.inflight.delete(persistenceKey);
+      for (const [pendingRequestKey, pending] of job.pendingSubscribers) {
+        const persisted = this.snapshotRepo.get(persistenceKey);
+        const pendingVisible = staleSnapshot(
+          persisted,
+          pending.input.request,
+          pending.input.context,
+        );
+        this.scheduleRefresh(
+          pendingRequestKey,
+          persistenceKey,
+          pendingVisible,
+          pending.input,
+          false,
+        );
+      }
     });
-    this.inflight.set(key, refresh);
   }
 
   private async refresh(
-    key: string,
-    visible: ProviderCatalogSnapshot,
-    input: ProviderCatalogLoadInput,
+    persistenceKey: string,
+    job: CatalogRefreshJob,
   ): Promise<void> {
     let refreshed: ProviderCatalogSnapshot;
     try {
-      refreshed = await input.refresh();
+      refreshed = await job.refresh();
     } catch (error) {
+      const firstSubscriber = job.subscribers.values().next().value as
+        | CatalogRefreshSubscriber
+        | undefined;
+      if (!firstSubscriber) return;
       logger.warn("Provider catalog background refresh failed", {
-        providerId: input.request.providerId,
-        workspaceId: input.request.workspaceId,
+        providerId: firstSubscriber.input.request.providerId,
+        workspaceId: firstSubscriber.input.request.workspaceId,
         error: error instanceof Error ? error.message : String(error),
       });
       refreshed = {
-        ...visible,
+        ...firstSubscriber.visible,
         diagnostics: [{
           severity: "warning",
           code: "source-unavailable",
@@ -217,28 +285,39 @@ export class ProviderCatalogService {
         }],
         freshness: {
           status: "stale",
-          fetchedAt: visible.freshness.fetchedAt,
+          fetchedAt: firstSubscriber.visible.freshness.fetchedAt,
           reason: "Provider catalog refresh failed.",
         },
       };
     }
 
-    const next = refreshed.freshness.status === "fresh"
-      ? { ...refreshed, context: input.context }
-      : {
-          ...visible,
-          diagnostics: refreshed.diagnostics,
-          freshness: refreshed.freshness,
-        };
-    this.snapshotRepo.upsert(key, input.request.workspaceId, input.cwd, next);
-    const change = catalogChange(input.request, visible, next);
-    for (const handler of this.changedHandlers) {
-      try {
-        handler(change);
-      } catch (error) {
-        logger.debug("Provider catalog change subscriber failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
+    let persisted = false;
+    for (const { visible, input } of job.subscribers.values()) {
+      const next = refreshed.freshness.status === "fresh"
+        ? { ...refreshed, context: input.context }
+        : {
+            ...visible,
+            diagnostics: refreshed.diagnostics,
+            freshness: refreshed.freshness,
+          };
+      if (!persisted) {
+        this.snapshotRepo.upsert(
+          persistenceKey,
+          input.request.workspaceId,
+          input.cwd,
+          next,
+        );
+        persisted = true;
+      }
+      const change = catalogChange(input.request, visible, next);
+      for (const handler of this.changedHandlers) {
+        try {
+          handler(change);
+        } catch (error) {
+          logger.debug("Provider catalog change subscriber failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
     }
   }

--- a/apps/server/src/services/provider-catalog-service.ts
+++ b/apps/server/src/services/provider-catalog-service.ts
@@ -93,6 +93,22 @@ function staleSnapshot(
   };
 }
 
+function capacitySnapshot(snapshot: ProviderCatalogSnapshot): ProviderCatalogSnapshot {
+  return {
+    ...snapshot,
+    diagnostics: [{
+      severity: "warning",
+      code: "source-unavailable",
+      message: "Provider catalog refresh capacity is full for this context. Try again shortly.",
+    }],
+    freshness: {
+      status: "stale",
+      fetchedAt: snapshot.freshness.fetchedAt,
+      reason: "Provider catalog refresh capacity is full.",
+    },
+  };
+}
+
 function reconcileEntries(
   previous: ProviderCatalogSnapshot,
   next: ProviderCatalogSnapshot,
@@ -166,8 +182,10 @@ export class ProviderCatalogService {
     const persisted = this.snapshotRepo.get(persistenceKey)
       ?? (fallbackKey && fallbackKey !== persistenceKey ? this.snapshotRepo.get(fallbackKey) : null);
     const visible = staleSnapshot(persisted, input.request, input.context);
-    this.rememberContext(requestKey, input);
-    this.scheduleRefresh(requestKey, persistenceKey, visible, input, false);
+    if (!this.rememberContext(requestKey, input)) return capacitySnapshot(visible);
+    if (!this.scheduleRefresh(requestKey, persistenceKey, visible, input, false)) {
+      return capacitySnapshot(visible);
+    }
     return visible;
   }
 
@@ -194,28 +212,27 @@ export class ProviderCatalogService {
       queueByPersistenceKey.set(persistenceKey, queueIfInflight);
       const persisted = this.snapshotRepo.get(persistenceKey);
       const visible = staleSnapshot(persisted, input.request, input.context);
-      this.scheduleRefresh(
+      const scheduled = this.scheduleRefresh(
         requestKey,
         persistenceKey,
         visible,
         { ...input, refresh: input.refreshFromCache },
         queueIfInflight,
       );
+      if (!scheduled) this.emitChange(catalogChange(input.request, visible, capacitySnapshot(visible)));
     }
   }
 
-  private rememberContext(key: string, input: ProviderCatalogLoadInput): void {
+  private rememberContext(key: string, input: ProviderCatalogLoadInput): boolean {
+    if (
+      !this.trackedContexts.has(key)
+      && this.trackedContexts.size >= MAX_TRACKED_CATALOG_CONTEXTS
+    ) {
+      return false;
+    }
     this.trackedContexts.delete(key);
     this.trackedContexts.set(key, input);
-    while (this.trackedContexts.size > MAX_TRACKED_CATALOG_CONTEXTS) {
-      const oldest = this.trackedContexts.keys().next().value as string | undefined;
-      if (oldest === undefined) break;
-      this.trackedContexts.delete(oldest);
-      for (const job of this.inflight.values()) {
-        job.subscribers.delete(oldest);
-        job.pendingSubscribers.delete(oldest);
-      }
-    }
+    return true;
   }
 
   private scheduleRefresh(
@@ -224,7 +241,7 @@ export class ProviderCatalogService {
     visible: ProviderCatalogSnapshot,
     input: ProviderCatalogLoadInput,
     queueIfInflight: boolean,
-  ): void {
+  ): boolean {
     const subscriber = { visible, input } satisfies CatalogRefreshSubscriber;
     const currentJob = this.inflight.get(persistenceKey);
     if (currentJob) {
@@ -232,9 +249,9 @@ export class ProviderCatalogService {
         ? currentJob.pendingSubscribers
         : currentJob.subscribers;
       subscribers.set(requestKey, subscriber);
-      return;
+      return true;
     }
-    if (this.inflight.size >= MAX_INFLIGHT_CATALOG_REFRESHES) return;
+    if (this.inflight.size >= MAX_INFLIGHT_CATALOG_REFRESHES) return false;
     const job: CatalogRefreshJob = {
       refresh: input.refresh,
       subscribers: new Map([[requestKey, subscriber]]),
@@ -263,6 +280,19 @@ export class ProviderCatalogService {
         );
       }
     });
+    return true;
+  }
+
+  private emitChange(change: ProviderCatalogChange): void {
+    for (const handler of this.changedHandlers) {
+      try {
+        handler(change);
+      } catch (error) {
+        logger.debug("Provider catalog change subscriber failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 
   private async refresh(
@@ -316,15 +346,7 @@ export class ProviderCatalogService {
         persisted = true;
       }
       const change = catalogChange(input.request, visible, next);
-      for (const handler of this.changedHandlers) {
-        try {
-          handler(change);
-        } catch (error) {
-          logger.debug("Provider catalog change subscriber failed", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
+      this.emitChange(change);
     }
   }
 }

--- a/apps/server/src/services/provider-catalog-service.ts
+++ b/apps/server/src/services/provider-catalog-service.ts
@@ -21,6 +21,7 @@ export interface ProviderCatalogLoadInput {
 }
 
 const MAX_TRACKED_CATALOG_CONTEXTS = 64;
+const MAX_INFLIGHT_CATALOG_REFRESHES = 64;
 
 interface CatalogRefreshSubscriber {
   readonly visible: ProviderCatalogSnapshot;
@@ -210,6 +211,10 @@ export class ProviderCatalogService {
       const oldest = this.trackedContexts.keys().next().value as string | undefined;
       if (oldest === undefined) break;
       this.trackedContexts.delete(oldest);
+      for (const job of this.inflight.values()) {
+        job.subscribers.delete(oldest);
+        job.pendingSubscribers.delete(oldest);
+      }
     }
   }
 
@@ -229,6 +234,7 @@ export class ProviderCatalogService {
       subscribers.set(requestKey, subscriber);
       return;
     }
+    if (this.inflight.size >= MAX_INFLIGHT_CATALOG_REFRESHES) return;
     const job: CatalogRefreshJob = {
       refresh: input.refresh,
       subscribers: new Map([[requestKey, subscriber]]),

--- a/apps/server/src/services/provider-catalog-service.ts
+++ b/apps/server/src/services/provider-catalog-service.ts
@@ -228,7 +228,18 @@ export class ProviderCatalogService {
       !this.trackedContexts.has(key)
       && this.trackedContexts.size >= MAX_TRACKED_CATALOG_CONTEXTS
     ) {
-      return false;
+      let oldestInactive: string | undefined;
+      for (const candidate of this.trackedContexts.keys()) {
+        const active = [...this.inflight.values()].some((job) => (
+          job.subscribers.has(candidate) || job.pendingSubscribers.has(candidate)
+        ));
+        if (!active) {
+          oldestInactive = candidate;
+          break;
+        }
+      }
+      if (oldestInactive === undefined) return false;
+      this.trackedContexts.delete(oldestInactive);
     }
     this.trackedContexts.delete(key);
     this.trackedContexts.set(key, input);

--- a/apps/server/src/services/provider-catalog-service.ts
+++ b/apps/server/src/services/provider-catalog-service.ts
@@ -1,0 +1,245 @@
+import { inject, injectable } from "tsyringe";
+import type {
+  ProviderCapabilityEntry,
+  ProviderCatalogChange,
+  ProviderCatalogContext,
+  ProviderCatalogRequest,
+  ProviderCatalogSnapshot,
+  SelectableProviderAgent,
+} from "@mcode/contracts";
+import { logger } from "@mcode/shared";
+import { ProviderCatalogSnapshotRepo } from "../repositories/provider-catalog-snapshot-repo.js";
+
+/** Inputs for one stale-while-revalidate provider catalog request. */
+export interface ProviderCatalogLoadInput {
+  readonly request: ProviderCatalogRequest;
+  readonly context: ProviderCatalogContext;
+  readonly cwd?: string;
+  readonly fallbackCwd?: string;
+  readonly refresh: () => Promise<ProviderCatalogSnapshot>;
+  readonly refreshFromCache?: () => Promise<ProviderCatalogSnapshot>;
+}
+
+const MAX_TRACKED_CATALOG_CONTEXTS = 64;
+
+function capabilityIdentity(entry: ProviderCapabilityEntry): string {
+  const { providerId, kind, nativeId } = entry.identity;
+  return JSON.stringify([providerId, kind, nativeId]);
+}
+
+function agentIdentity(agent: SelectableProviderAgent): string {
+  return JSON.stringify([agent.providerId, agent.nativeId]);
+}
+
+function equal(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/** Builds a stable persistence key for a provider and realized working directory. */
+export function providerCatalogContextKey(
+  request: ProviderCatalogRequest,
+  cwd?: string,
+): string {
+  return JSON.stringify([
+    request.providerId,
+    request.workspaceId ?? null,
+    cwd?.replace(/\\/g, "/") ?? null,
+  ]);
+}
+
+function staleSnapshot(
+  snapshot: ProviderCatalogSnapshot | null,
+  request: ProviderCatalogRequest,
+  context: ProviderCatalogContext,
+): ProviderCatalogSnapshot {
+  const fetchedAt = snapshot?.freshness.fetchedAt ?? new Date().toISOString();
+  return {
+    providerId: request.providerId,
+    context,
+    freshness: {
+      status: "stale",
+      fetchedAt,
+      reason: snapshot
+        ? "Refreshing the last confirmed provider catalog."
+        : "The provider catalog has not been confirmed yet.",
+    },
+    diagnostics: snapshot?.diagnostics ?? [],
+    entries: snapshot?.entries ?? [],
+    selectableAgents: snapshot?.selectableAgents ?? [],
+  };
+}
+
+function reconcileEntries(
+  previous: ProviderCatalogSnapshot,
+  next: ProviderCatalogSnapshot,
+): Pick<ProviderCatalogChange, "additions" | "updates" | "removals"> {
+  const previousById = new Map(previous.entries.map((entry) => [capabilityIdentity(entry), entry]));
+  const nextById = new Map(next.entries.map((entry) => [capabilityIdentity(entry), entry]));
+  return {
+    additions: next.entries.filter((entry) => !previousById.has(capabilityIdentity(entry))),
+    updates: next.entries.filter((entry) => {
+      const oldEntry = previousById.get(capabilityIdentity(entry));
+      return oldEntry !== undefined && !equal(oldEntry, entry);
+    }),
+    removals: previous.entries
+      .filter((entry) => !nextById.has(capabilityIdentity(entry)))
+      .map((entry) => entry.identity),
+  };
+}
+
+function reconcileAgents(
+  previous: ProviderCatalogSnapshot,
+  next: ProviderCatalogSnapshot,
+): ProviderCatalogChange["selectableAgents"] {
+  const previousById = new Map(previous.selectableAgents.map((agent) => [agentIdentity(agent), agent]));
+  const nextById = new Map(next.selectableAgents.map((agent) => [agentIdentity(agent), agent]));
+  return {
+    additions: next.selectableAgents.filter((agent) => !previousById.has(agentIdentity(agent))),
+    updates: next.selectableAgents.filter((agent) => {
+      const oldAgent = previousById.get(agentIdentity(agent));
+      return oldAgent !== undefined && !equal(oldAgent, agent);
+    }),
+    removals: previous.selectableAgents
+      .filter((agent) => !nextById.has(agentIdentity(agent)))
+      .map((agent) => agent.nativeId),
+  };
+}
+
+function catalogChange(
+  request: ProviderCatalogRequest,
+  previous: ProviderCatalogSnapshot,
+  next: ProviderCatalogSnapshot,
+): ProviderCatalogChange {
+  return {
+    request,
+    ...reconcileEntries(previous, next),
+    selectableAgents: reconcileAgents(previous, next),
+    ...(!equal(previous.diagnostics, next.diagnostics) ? { diagnostics: next.diagnostics } : {}),
+    ...(!equal(previous.freshness, next.freshness) ? { freshness: next.freshness } : {}),
+  };
+}
+
+/** Coordinates persisted snapshots, background refresh, and incremental catalog changes. */
+@injectable()
+export class ProviderCatalogService {
+  private readonly inflight = new Map<string, Promise<void>>();
+  private readonly trackedContexts = new Map<string, ProviderCatalogLoadInput>();
+  private readonly changedHandlers = new Set<(change: ProviderCatalogChange) => void>();
+
+  constructor(
+    @inject(ProviderCatalogSnapshotRepo)
+    private readonly snapshotRepo: ProviderCatalogSnapshotRepo,
+  ) {}
+
+  /** Returns cached state immediately and starts one background refresh for the context. */
+  request(input: ProviderCatalogLoadInput): ProviderCatalogSnapshot {
+    const key = providerCatalogContextKey(input.request, input.cwd);
+    const fallbackRequest = { ...input.request, threadId: undefined };
+    const fallbackKey = input.fallbackCwd === undefined
+      ? undefined
+      : providerCatalogContextKey(fallbackRequest, input.fallbackCwd);
+    const persisted = this.snapshotRepo.get(key)
+      ?? (fallbackKey && fallbackKey !== key ? this.snapshotRepo.get(fallbackKey) : null);
+    const visible = staleSnapshot(persisted, input.request, input.context);
+    this.rememberContext(key, input);
+    this.scheduleRefresh(key, visible, input);
+    return visible;
+  }
+
+  /** Subscribes to completed refresh changes. */
+  onChanged(handler: (change: ProviderCatalogChange) => void): () => void {
+    this.changedHandlers.add(handler);
+    return () => this.changedHandlers.delete(handler);
+  }
+
+  /** Reconciles requested contexts after a provider-native background change signal. */
+  refreshKnownContexts(providerId: string, cwd?: string): void {
+    for (const [key, input] of this.trackedContexts) {
+      if (
+        input.request.providerId !== providerId
+        || input.cwd !== cwd
+        || !input.refreshFromCache
+      ) {
+        continue;
+      }
+      const persisted = this.snapshotRepo.get(key);
+      const visible = staleSnapshot(persisted, input.request, input.context);
+      this.scheduleRefresh(key, visible, { ...input, refresh: input.refreshFromCache });
+    }
+  }
+
+  private rememberContext(key: string, input: ProviderCatalogLoadInput): void {
+    this.trackedContexts.delete(key);
+    this.trackedContexts.set(key, input);
+    while (this.trackedContexts.size > MAX_TRACKED_CATALOG_CONTEXTS) {
+      const oldest = this.trackedContexts.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.trackedContexts.delete(oldest);
+    }
+  }
+
+  private scheduleRefresh(
+    key: string,
+    visible: ProviderCatalogSnapshot,
+    input: ProviderCatalogLoadInput,
+  ): void {
+    if (this.inflight.has(key)) return;
+    const refresh = new Promise<void>((resolve) => {
+      setImmediate(() => {
+        void this.refresh(key, visible, input).finally(resolve);
+      });
+    }).finally(() => {
+      this.inflight.delete(key);
+    });
+    this.inflight.set(key, refresh);
+  }
+
+  private async refresh(
+    key: string,
+    visible: ProviderCatalogSnapshot,
+    input: ProviderCatalogLoadInput,
+  ): Promise<void> {
+    let refreshed: ProviderCatalogSnapshot;
+    try {
+      refreshed = await input.refresh();
+    } catch (error) {
+      logger.warn("Provider catalog background refresh failed", {
+        providerId: input.request.providerId,
+        workspaceId: input.request.workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      refreshed = {
+        ...visible,
+        diagnostics: [{
+          severity: "warning",
+          code: "source-unavailable",
+          message: "The provider catalog is temporarily unavailable for this context.",
+        }],
+        freshness: {
+          status: "stale",
+          fetchedAt: visible.freshness.fetchedAt,
+          reason: "Provider catalog refresh failed.",
+        },
+      };
+    }
+
+    const next = refreshed.freshness.status === "fresh"
+      ? { ...refreshed, context: input.context }
+      : {
+          ...visible,
+          diagnostics: refreshed.diagnostics,
+          freshness: refreshed.freshness,
+        };
+    this.snapshotRepo.upsert(key, input.request.workspaceId, input.cwd, next);
+    const change = catalogChange(input.request, visible, next);
+    for (const handler of this.changedHandlers) {
+      try {
+        handler(change);
+      } catch (error) {
+        logger.debug("Provider catalog change subscriber failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+}

--- a/apps/server/src/services/provider-catalog-service.ts
+++ b/apps/server/src/services/provider-catalog-service.ts
@@ -346,14 +346,15 @@ export class ProviderCatalogService {
             ...visible,
             diagnostics: refreshed.diagnostics,
             freshness: refreshed.freshness,
-          };
+      };
       if (!persisted) {
-        this.snapshotRepo.upsert(
+        const workspaceExists = this.snapshotRepo.upsert(
           persistenceKey,
           input.request.workspaceId,
           input.cwd,
           next,
         );
+        if (!workspaceExists) return;
         persisted = true;
       }
       const change = catalogChange(input.request, visible, next);

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -322,6 +322,23 @@ export const providerModelCache = sqliteTable("provider_model_cache", {
   modelCount: integer("model_count").notNull().default(0),
 });
 
+/** Last known provider catalog snapshots, isolated by provider and realized context. */
+export const providerCatalogSnapshots = sqliteTable(
+  "provider_catalog_snapshots",
+  {
+    contextKey: text("context_key").primaryKey().notNull(),
+    providerId: text("provider_id").notNull(),
+    workspaceId: text("workspace_id"),
+    cwd: text("cwd"),
+    snapshotJson: text("snapshot_json").notNull(),
+    updatedAt: text("updated_at").notNull().default(timestampDefault),
+  },
+  (table) => [
+    index("idx_provider_catalog_snapshots_workspace").on(table.workspaceId),
+    index("idx_provider_catalog_snapshots_provider").on(table.providerId),
+  ],
+);
+
 export const planQuestionAnswers = sqliteTable(
   "plan_question_answers",
   {

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -328,7 +328,8 @@ export const providerCatalogSnapshots = sqliteTable(
   {
     contextKey: text("context_key").primaryKey().notNull(),
     providerId: text("provider_id").notNull(),
-    workspaceId: text("workspace_id"),
+    workspaceId: text("workspace_id")
+      .references(() => workspaces.id, { onDelete: "cascade" }),
     cwd: text("cwd"),
     snapshotJson: text("snapshot_json").notNull(),
     updatedAt: text("updated_at").notNull().default(timestampDefault),

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -34,7 +34,11 @@ import type { GithubService } from "../services/github-service";
 import type { FileService } from "../services/file-service";
 import type { ConfigService } from "../services/config-service";
 import type { SkillService } from "../services/skill-service";
-import type { CodexCatalogService } from "../services/codex-catalog-service";
+import type {
+  CodexCatalogRefreshResult,
+  CodexCatalogService,
+} from "../services/codex-catalog-service";
+import type { ProviderCatalogService } from "../services/provider-catalog-service";
 import type { TerminalService } from "../services/terminal-service";
 import type { MessageRepo } from "../repositories/message-repo";
 import type { ToolCallRecordRepo } from "../repositories/tool-call-record-repo";
@@ -223,6 +227,8 @@ export interface RouterDeps {
   skillService: SkillService;
   /** Owns the thread-independent Codex app-server catalog connection. */
   codexCatalogService: CodexCatalogService;
+  /** Serves persisted snapshots and coordinates background catalog reconciliation. */
+  providerCatalogService: ProviderCatalogService;
   terminalService: TerminalService;
   messageRepo: MessageRepo;
   toolCallRecordRepo: ToolCallRecordRepo;
@@ -997,31 +1003,45 @@ async function dispatch(
     }
     case "provider.catalog": {
       const { cwd, context: catalogContext } = resolveProviderCatalogContext(deps, params);
-      let nativeSkills;
-      let diagnostics;
-      let freshness;
-      if (params.providerId === "codex") {
-        const catalog = await deps.codexCatalogService.refresh(cwd);
-        nativeSkills = catalog.skills;
-        diagnostics = catalog.diagnostics;
-        freshness = catalog.freshness;
-      }
-      const skills = deps.skillService.list(cwd, params.providerId, nativeSkills);
-      const agentDiscovery = params.providerId === "codex"
-        ? await discoverBoundedCodexAgents(resolveCodexAgentDirectories(
-            deps,
-            params.workspaceId,
-            params.threadId,
-            params.cwd,
-          ))
+      const workspaceRoot = params.workspaceId
+        ? deps.workspaceService.findById(params.workspaceId)?.path
         : undefined;
-      return buildProviderCatalogSnapshot({
-        providerId: params.providerId,
+      const buildSnapshot = async (
+        catalog?: CodexCatalogRefreshResult,
+      ) => {
+        const skills = deps.skillService.list(cwd, params.providerId, catalog?.skills);
+        const agentDiscovery = params.providerId === "codex"
+          ? await discoverBoundedCodexAgents(resolveCodexAgentDirectories(
+              deps,
+              params.workspaceId,
+              params.threadId,
+              params.cwd,
+            ))
+          : undefined;
+        return buildProviderCatalogSnapshot({
+          providerId: params.providerId,
+          context: catalogContext,
+          skills,
+          ...(agentDiscovery ? { agentDiscovery } : {}),
+          ...(catalog?.diagnostics ? { diagnostics: catalog.diagnostics } : {}),
+          ...(catalog?.freshness ? { freshness: catalog.freshness } : {}),
+        });
+      };
+      return deps.providerCatalogService.request({
+        request: params,
         context: catalogContext,
-        skills,
-        ...(agentDiscovery ? { agentDiscovery } : {}),
-        ...(diagnostics ? { diagnostics } : {}),
-        ...(freshness ? { freshness } : {}),
+        cwd,
+        ...(params.threadId && workspaceRoot ? { fallbackCwd: workspaceRoot } : {}),
+        refresh: async () => buildSnapshot(
+          params.providerId === "codex"
+            ? await deps.codexCatalogService.refresh(cwd)
+            : undefined,
+        ),
+        ...(params.providerId === "codex" ? {
+          refreshFromCache: async () => buildSnapshot(
+            deps.codexCatalogService.currentSnapshot(cwd),
+          ),
+        } : {}),
       });
     }
     case "skill.diagnose":

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -104,6 +104,11 @@ describe("routeMessage provider.catalog", () => {
     );
     const refresh = vi.spyOn(codexCatalogService, "refresh");
     const db = openMemoryDatabase();
+    const insertWorkspace = db.prepare(
+      "INSERT INTO workspaces (id, name, path) VALUES (?, ?, ?)",
+    );
+    insertWorkspace.run("workspace-1", "Workspace 1", "C:/repo");
+    insertWorkspace.run("workspace-2", "Workspace 2", "C:/other");
     const snapshotRepo = new ProviderCatalogSnapshotRepo(db);
     const providerCatalogService = new ProviderCatalogService(snapshotRepo);
     const list = vi.fn().mockImplementation((_cwd, _providerId, discoveredSkills = []) => [

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -232,6 +232,29 @@ describe("routeMessage provider.catalog", () => {
       removals: [expect.objectContaining({ nativeId: "C:/repo/.codex/skills/review/SKILL.md" })],
     });
     expect(create).toHaveBeenCalledTimes(1);
+
+    refresh.mockRejectedValueOnce(new Error("provider unavailable"));
+    const failedRefresh = new Promise<import("@mcode/contracts").ProviderCatalogChange>((resolve) => {
+      restartedCatalogService.onChanged((change) => {
+        if (change.request.workspaceId === "workspace-1") resolve(change);
+      });
+    });
+    const failureResponse = await routeMessage(JSON.stringify({
+      id: "catalog-failure",
+      method: "provider.catalog",
+      params: { providerId: "codex", workspaceId: "workspace-1" },
+    }), deps);
+    expect(failureResponse.result).toMatchObject({
+      freshness: { status: "stale" },
+      entries: expect.arrayContaining([expect.objectContaining({ name: "ship" })]),
+    });
+    await expect(failedRefresh).resolves.toMatchObject({
+      additions: [],
+      updates: [],
+      removals: [],
+      diagnostics: [expect.objectContaining({ code: "source-unavailable" })],
+      freshness: { status: "stale" },
+    });
     await codexCatalogService.shutdown();
     db.close();
   });

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -4,6 +4,9 @@ import { EventEmitter } from "events";
 import type { WebSocket } from "ws";
 import { routeMessage, type RouterDeps } from "./ws-router.js";
 import { CodexCatalogService } from "../services/codex-catalog-service.js";
+import { ProviderCatalogService } from "../services/provider-catalog-service.js";
+import { ProviderCatalogSnapshotRepo } from "../repositories/provider-catalog-snapshot-repo.js";
+import { openMemoryDatabase } from "../store/database.js";
 import { _resetForTest, addClient } from "./push.js";
 import {
   RECAP_MAX_MESSAGE_CONTENT_CHARS,
@@ -59,7 +62,7 @@ describe("routeMessage result validation seam", () => {
 });
 
 describe("routeMessage provider.catalog", () => {
-  it("discovers path-scoped Codex Skills before a thread exists", async () => {
+  it("returns persisted Codex Skills immediately and reconciles refreshes in the background", async () => {
     let catalogVersion = 1;
     const client = Object.assign(new EventEmitter(), {
       isAlive: true,
@@ -100,6 +103,9 @@ describe("routeMessage provider.catalog", () => {
       { create } as never,
     );
     const refresh = vi.spyOn(codexCatalogService, "refresh");
+    const db = openMemoryDatabase();
+    const snapshotRepo = new ProviderCatalogSnapshotRepo(db);
+    const providerCatalogService = new ProviderCatalogService(snapshotRepo);
     const list = vi.fn().mockImplementation((_cwd, _providerId, discoveredSkills = []) => [
       ...discoveredSkills,
       {
@@ -122,8 +128,13 @@ describe("routeMessage provider.catalog", () => {
       },
       threadRepo: { findById: threadLookup },
       codexCatalogService,
+      providerCatalogService,
       skillService: { list },
     } as unknown as RouterDeps;
+
+    const firstChange = new Promise<import("@mcode/contracts").ProviderCatalogChange>((resolve) => {
+      providerCatalogService.onChanged(resolve);
+    });
 
     const response = await routeMessage(JSON.stringify({
       id: "catalog-1",
@@ -135,30 +146,17 @@ describe("routeMessage provider.catalog", () => {
     expect(response.result).toMatchObject({
       providerId: "codex",
       context: { scope: "workspace", workspaceId: "workspace-1" },
-      freshness: { status: "fresh" },
+      freshness: { status: "stale" },
       diagnostics: [],
-      entries: [
-        {
-          kind: "skill",
-          identity: {
-            providerId: "codex",
-            kind: "skill",
-            nativeId: "C:/users/test/.codex/skills/review/SKILL.md",
-          },
-        },
-        {
-          kind: "skill",
-          identity: {
-            providerId: "codex",
-            kind: "skill",
-            nativeId: "C:/repo/.codex/skills/review/SKILL.md",
-          },
-        },
-        {
-          kind: "customPrompt",
-          identity: { providerId: "codex", kind: "customPrompt", nativeId: "release" },
-        },
-      ],
+      entries: [],
+    });
+    await expect(firstChange).resolves.toMatchObject({
+      request: { providerId: "codex", workspaceId: "workspace-1" },
+      additions: expect.arrayContaining([
+        expect.objectContaining({ name: "review", kind: "skill" }),
+        expect.objectContaining({ name: "prompts:release", kind: "customPrompt" }),
+      ]),
+      freshness: { status: "fresh" },
     });
     expect(refresh).toHaveBeenCalledWith("C:/repo");
     expect(threadLookup).not.toHaveBeenCalled();
@@ -178,33 +176,64 @@ describe("routeMessage provider.catalog", () => {
     }).selectableAgents.every((agent) => agent.providerId === "codex" && agent.nativeId.length > 0))
       .toBe(true);
 
+    const restartedCatalogService = new ProviderCatalogService(snapshotRepo);
+    (deps as { providerCatalogService: ProviderCatalogService }).providerCatalogService = restartedCatalogService;
+    const restartedChange = new Promise<import("@mcode/contracts").ProviderCatalogChange>((resolve) => {
+      restartedCatalogService.onChanged((change) => {
+        if (change.request.workspaceId === "workspace-1") resolve(change);
+      });
+    });
+    const restartedResponse = await routeMessage(JSON.stringify({
+      id: "catalog-restarted",
+      method: "provider.catalog",
+      params: { providerId: "codex", workspaceId: "workspace-1" },
+    }), deps);
+    expect(restartedResponse.result).toMatchObject({
+      freshness: { status: "stale" },
+      entries: expect.arrayContaining([
+        expect.objectContaining({ name: "review" }),
+        expect.objectContaining({ name: "prompts:release" }),
+      ]),
+    });
+    await restartedChange;
+
+    const otherWorkspaceChange = new Promise<import("@mcode/contracts").ProviderCatalogChange>((resolve) => {
+      restartedCatalogService.onChanged((change) => {
+        if (change.request.workspaceId === "workspace-2") resolve(change);
+      });
+    });
     const otherWorkspaceResponse = await routeMessage(JSON.stringify({
       id: "catalog-2",
       method: "provider.catalog",
       params: { providerId: "codex", workspaceId: "workspace-2" },
     }), deps);
     expect(otherWorkspaceResponse.error).toBeUndefined();
+    expect((otherWorkspaceResponse.result as { entries: unknown[] }).entries).toEqual([]);
+    await otherWorkspaceChange;
     expect(client.listSkills).toHaveBeenLastCalledWith(["C:/other"], false);
-    expect((otherWorkspaceResponse.result as { entries: Array<{ identity: { nativeId: string } }> })
-      .entries.some((entry) => entry.identity.nativeId.startsWith("C:/other/"))).toBe(true);
 
     catalogVersion = 2;
     const refreshed = new Promise<string | undefined>((resolve) => {
       codexCatalogService.onSkillsChanged(resolve);
     });
+    codexCatalogService.onSkillsChanged((cwd) => {
+      restartedCatalogService.refreshKnownContexts("codex", cwd);
+    });
+    const reconciled = new Promise<import("@mcode/contracts").ProviderCatalogChange>((resolve) => {
+      restartedCatalogService.onChanged((change) => {
+        if (change.request.workspaceId === "workspace-1") resolve(change);
+      });
+    });
     client.emit("notification", { method: "skills/changed", params: { cwd: "C:/repo" } });
     await expect(refreshed).resolves.toBe("C:/repo");
     expect(client.listSkills).toHaveBeenCalledWith(["C:/repo"], true);
-
-    const refreshedResponse = await routeMessage(JSON.stringify({
-      id: "catalog-3",
-      method: "provider.catalog",
-      params: { providerId: "codex", workspaceId: "workspace-1" },
-    }), deps);
-    expect((refreshedResponse.result as { entries: Array<{ name: string }> }).entries)
-      .toEqual(expect.arrayContaining([expect.objectContaining({ name: "ship" })]));
+    await expect(reconciled).resolves.toMatchObject({
+      additions: [expect.objectContaining({ name: "ship" })],
+      removals: [expect.objectContaining({ nativeId: "C:/repo/.codex/skills/review/SKILL.md" })],
+    });
     expect(create).toHaveBeenCalledTimes(1);
     await codexCatalogService.shutdown();
+    db.close();
   });
 
   it("rejects unknown providers and oversized contexts before dispatch", async () => {

--- a/apps/web/src/stores/providerCatalogStore.test.ts
+++ b/apps/web/src/stores/providerCatalogStore.test.ts
@@ -214,4 +214,35 @@ describe("providerCatalogStore", () => {
     expect(snapshot?.entries).toEqual([updated]);
     expect(snapshot?.freshness.status).toBe("fresh");
   });
+
+  it("reloads the persisted snapshot when queued changes exceed the replay bound", async () => {
+    let resolveInitial!: (snapshot: ProviderCatalogSnapshot) => void;
+    const recoveredSnapshot = {
+      ...SNAPSHOT,
+      entries: [{ ...SNAPSHOT.entries[0], description: "Latest confirmed description" }],
+    };
+    getProviderCatalogMock
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveInitial = resolve; }))
+      .mockResolvedValueOnce(recoveredSnapshot);
+    const pending = useProviderCatalogStore.getState().load(REQUEST);
+
+    for (let index = 0; index < 65; index += 1) {
+      useProviderCatalogStore.getState().reconcile({
+        request: REQUEST,
+        additions: [],
+        updates: [{ ...SNAPSHOT.entries[0], description: `Queued description ${index}` }],
+        removals: [],
+        selectableAgents: { additions: [], updates: [], removals: [] },
+      });
+    }
+    resolveInitial(STALE_SNAPSHOT);
+    await pending;
+
+    await vi.waitFor(() => {
+      const snapshot = useProviderCatalogStore.getState()
+        .entries[providerCatalogCacheKey(REQUEST)]?.snapshot;
+      expect(snapshot).toEqual(recoveredSnapshot);
+    });
+    expect(getProviderCatalogMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/src/stores/providerCatalogStore.test.ts
+++ b/apps/web/src/stores/providerCatalogStore.test.ts
@@ -157,4 +157,61 @@ describe("providerCatalogStore", () => {
     expect(reconciled?.entries[0]).toBe(original);
     expect(reconciled?.freshness).toEqual(change.freshness);
   });
+
+  it("queues a catalog change until the initial RPC snapshot settles", async () => {
+    let resolveCatalog!: (snapshot: ProviderCatalogSnapshot) => void;
+    getProviderCatalogMock.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveCatalog = resolve; }),
+    );
+    const addition = {
+      kind: "skill" as const,
+      identity: { providerId: "codex" as const, kind: "skill" as const, nativeId: "ship" },
+      name: "ship",
+      description: "Ship changes",
+      source: "project" as const,
+    };
+    const pending = useProviderCatalogStore.getState().load(REQUEST);
+
+    useProviderCatalogStore.getState().reconcile({
+      request: REQUEST,
+      additions: [addition],
+      updates: [],
+      removals: [],
+      selectableAgents: { additions: [], updates: [], removals: [] },
+      freshness: { status: "fresh", fetchedAt: "2026-07-20T13:00:00.000Z" },
+    });
+    resolveCatalog(STALE_SNAPSHOT);
+    await pending;
+
+    const snapshot = useProviderCatalogStore.getState()
+      .entries[providerCatalogCacheKey(REQUEST)]?.snapshot;
+    expect(snapshot?.entries).toEqual([SNAPSHOT.entries[0], addition]);
+    expect(snapshot?.freshness.status).toBe("fresh");
+  });
+
+  it("does not let a stale force-load response overwrite a catalog push", async () => {
+    await useProviderCatalogStore.getState().load(REQUEST);
+    let resolveCatalog!: (snapshot: ProviderCatalogSnapshot) => void;
+    getProviderCatalogMock.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveCatalog = resolve; }),
+    );
+    const pending = useProviderCatalogStore.getState().load(REQUEST, true);
+    const updated = { ...SNAPSHOT.entries[0], description: "Review current changes" };
+
+    useProviderCatalogStore.getState().reconcile({
+      request: REQUEST,
+      additions: [],
+      updates: [updated],
+      removals: [],
+      selectableAgents: { additions: [], updates: [], removals: [] },
+      freshness: { status: "fresh", fetchedAt: "2026-07-20T13:00:00.000Z" },
+    });
+    resolveCatalog(STALE_SNAPSHOT);
+    await pending;
+
+    const snapshot = useProviderCatalogStore.getState()
+      .entries[providerCatalogCacheKey(REQUEST)]?.snapshot;
+    expect(snapshot?.entries).toEqual([updated]);
+    expect(snapshot?.freshness.status).toBe("fresh");
+  });
 });

--- a/apps/web/src/stores/providerCatalogStore.test.ts
+++ b/apps/web/src/stores/providerCatalogStore.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderCatalogRequest, ProviderCatalogSnapshot } from "@/transport";
+import type { ProviderCatalogChange } from "@mcode/contracts";
 import { providerCatalogCacheKey, useProviderCatalogStore } from "./providerCatalogStore";
 
 const REQUEST: ProviderCatalogRequest = {
@@ -127,5 +128,33 @@ describe("providerCatalogStore", () => {
 
     await expect(store.getState().load(REQUEST)).resolves.toEqual(SNAPSHOT);
     expect(calls).toHaveLength(2);
+  });
+
+  it("reconciles identity changes without replacing unaffected entries", async () => {
+    await useProviderCatalogStore.getState().load(REQUEST);
+    const key = providerCatalogCacheKey(REQUEST);
+    const original = useProviderCatalogStore.getState().entries[key]?.snapshot?.entries[0];
+    const addition = {
+      kind: "skill" as const,
+      identity: { providerId: "codex" as const, kind: "skill" as const, nativeId: "ship" },
+      name: "ship",
+      description: "Ship changes",
+      source: "project" as const,
+    };
+    const change: ProviderCatalogChange = {
+      request: REQUEST,
+      additions: [addition],
+      updates: [],
+      removals: [],
+      selectableAgents: { additions: [], updates: [], removals: [] },
+      freshness: { status: "fresh", fetchedAt: "2026-07-20T13:00:00.000Z" },
+    };
+
+    useProviderCatalogStore.getState().reconcile(change);
+
+    const reconciled = useProviderCatalogStore.getState().entries[key]?.snapshot;
+    expect(reconciled?.entries).toEqual([SNAPSHOT.entries[0], addition]);
+    expect(reconciled?.entries[0]).toBe(original);
+    expect(reconciled?.freshness).toEqual(change.freshness);
   });
 });

--- a/apps/web/src/stores/providerCatalogStore.ts
+++ b/apps/web/src/stores/providerCatalogStore.ts
@@ -19,6 +19,7 @@ export interface ProviderCatalogCacheEntry {
   readonly inflight: Promise<ProviderCatalogSnapshot> | null;
   readonly loadEpoch: number;
   readonly lastFetchedAt: number;
+  readonly pendingChanges: readonly ProviderCatalogChange[];
 }
 
 /** Stable empty entry used by selectors before a catalog context has loaded. */
@@ -30,6 +31,7 @@ export const EMPTY_PROVIDER_CATALOG_CACHE_ENTRY: ProviderCatalogCacheEntry = Obj
   inflight: null,
   loadEpoch: 0,
   lastFetchedAt: 0,
+  pendingChanges: [],
 });
 
 /** Builds a collision-safe cache key for one provider catalog request. */
@@ -77,6 +79,45 @@ function agentIdentity(agent: SelectableProviderAgent): string {
   return JSON.stringify([agent.providerId, agent.nativeId]);
 }
 
+function applyCatalogChange(
+  snapshot: ProviderCatalogSnapshot,
+  change: ProviderCatalogChange,
+): ProviderCatalogSnapshot {
+  const removedEntries = new Set(change.removals.map((identity) => JSON.stringify([
+    identity.providerId,
+    identity.kind,
+    identity.nativeId,
+  ])));
+  const updatedEntries = new Map(change.updates.map((item) => [capabilityIdentity(item), item]));
+  const existingEntryIds = new Set(snapshot.entries.map(capabilityIdentity));
+  const entries = snapshot.entries
+    .filter((item) => !removedEntries.has(capabilityIdentity(item)))
+    .map((item) => updatedEntries.get(capabilityIdentity(item)) ?? item);
+  for (const addition of change.additions) {
+    if (!existingEntryIds.has(capabilityIdentity(addition))) entries.push(addition);
+  }
+
+  const removedAgents = new Set(change.selectableAgents.removals);
+  const updatedAgents = new Map(
+    change.selectableAgents.updates.map((agent) => [agentIdentity(agent), agent]),
+  );
+  const existingAgentIds = new Set(snapshot.selectableAgents.map(agentIdentity));
+  const selectableAgents = snapshot.selectableAgents
+    .filter((agent) => !removedAgents.has(agent.nativeId))
+    .map((agent) => updatedAgents.get(agentIdentity(agent)) ?? agent);
+  for (const addition of change.selectableAgents.additions) {
+    if (!existingAgentIds.has(agentIdentity(addition))) selectableAgents.push(addition);
+  }
+
+  return {
+    ...snapshot,
+    entries,
+    selectableAgents,
+    diagnostics: change.diagnostics ?? snapshot.diagnostics,
+    freshness: change.freshness ?? snapshot.freshness,
+  };
+}
+
 /** Module-scoped store for provider capability catalog snapshots. */
 export const useProviderCatalogStore = create<ProviderCatalogState>((set, get) => ({
   entries: {},
@@ -96,7 +137,7 @@ export const useProviderCatalogStore = create<ProviderCatalogState>((set, get) =
     if (existing.inflight) return existing.inflight;
 
     const epoch = existing.loadEpoch + 1;
-    const promise = (async () => {
+    const fetchSnapshot = async () => {
       const transport = getTransport();
       const attempt = () => transport.getProviderCatalog(request);
       try {
@@ -116,7 +157,11 @@ export const useProviderCatalogStore = create<ProviderCatalogState>((set, get) =
       } catch (value) {
         throw value instanceof Error ? value : new Error(String(value));
       }
-    })();
+    };
+    let startRequest!: () => void;
+    const promise = new Promise<ProviderCatalogSnapshot>((resolve, reject) => {
+      startRequest = () => { void fetchSnapshot().then(resolve, reject); };
+    });
 
     set({
       entries: replaceEntry(state.entries, key, {
@@ -127,20 +172,26 @@ export const useProviderCatalogStore = create<ProviderCatalogState>((set, get) =
         loadEpoch: epoch,
       }),
     });
+    startRequest();
 
     void promise.then(
       (snapshot) => {
         const current = get();
         if (current.entries[key]?.loadEpoch !== epoch) return;
+        const reconciledSnapshot = current.entries[key].pendingChanges.reduce(
+          applyCatalogChange,
+          snapshot,
+        );
         set({
           entries: replaceEntry(current.entries, key, {
-            snapshot,
+            snapshot: reconciledSnapshot,
             isLoading: false,
             needsRefresh: false,
             error: null,
             inflight: null,
             loadEpoch: epoch,
             lastFetchedAt: Date.now(),
+            pendingChanges: [],
           }),
         });
       },
@@ -184,48 +235,25 @@ export const useProviderCatalogStore = create<ProviderCatalogState>((set, get) =
     const key = providerCatalogCacheKey(change.request);
     const current = get();
     const entry = current.entries[key];
-    if (!entry?.snapshot) return;
-
-    const removedEntries = new Set(change.removals.map((identity) => JSON.stringify([
-      identity.providerId,
-      identity.kind,
-      identity.nativeId,
-    ])));
-    const updatedEntries = new Map(change.updates.map((item) => [capabilityIdentity(item), item]));
-    const existingEntryIds = new Set(entry.snapshot.entries.map(capabilityIdentity));
-    const entries = entry.snapshot.entries
-      .filter((item) => !removedEntries.has(capabilityIdentity(item)))
-      .map((item) => updatedEntries.get(capabilityIdentity(item)) ?? item);
-    for (const addition of change.additions) {
-      if (!existingEntryIds.has(capabilityIdentity(addition))) entries.push(addition);
+    if (!entry) {
+      set({
+        entries: replaceEntry(current.entries, key, {
+          ...EMPTY_PROVIDER_CATALOG_CACHE_ENTRY,
+          pendingChanges: [change],
+        }),
+      });
+      return;
     }
-
-    const removedAgents = new Set(change.selectableAgents.removals);
-    const updatedAgents = new Map(
-      change.selectableAgents.updates.map((agent) => [agentIdentity(agent), agent]),
-    );
-    const existingAgentIds = new Set(entry.snapshot.selectableAgents.map(agentIdentity));
-    const selectableAgents = entry.snapshot.selectableAgents
-      .filter((agent) => !removedAgents.has(agent.nativeId))
-      .map((agent) => updatedAgents.get(agentIdentity(agent)) ?? agent);
-    for (const addition of change.selectableAgents.additions) {
-      if (!existingAgentIds.has(agentIdentity(addition))) selectableAgents.push(addition);
-    }
+    const queueChange = entry.inflight !== null || entry.pendingChanges.length > 0;
 
     set({
       entries: replaceEntry(current.entries, key, {
         ...entry,
-        snapshot: {
-          ...entry.snapshot,
-          entries,
-          selectableAgents,
-          diagnostics: change.diagnostics ?? entry.snapshot.diagnostics,
-          freshness: change.freshness ?? entry.snapshot.freshness,
-        },
-        isLoading: false,
+        snapshot: entry.snapshot ? applyCatalogChange(entry.snapshot, change) : null,
+        pendingChanges: queueChange ? [...entry.pendingChanges, change] : [],
+        isLoading: entry.inflight !== null,
         needsRefresh: false,
         error: null,
-        inflight: null,
         lastFetchedAt: Date.now(),
       }),
     });

--- a/apps/web/src/stores/providerCatalogStore.ts
+++ b/apps/web/src/stores/providerCatalogStore.ts
@@ -4,6 +4,11 @@ import {
   type ProviderCatalogRequest,
   type ProviderCatalogSnapshot,
 } from "@/transport";
+import type {
+  ProviderCapabilityEntry,
+  ProviderCatalogChange,
+  SelectableProviderAgent,
+} from "@mcode/contracts";
 
 /** Cached provider catalog state for one discovery context. */
 export interface ProviderCatalogCacheEntry {
@@ -44,6 +49,8 @@ interface ProviderCatalogState {
   load(request: ProviderCatalogRequest, force?: boolean): Promise<ProviderCatalogSnapshot>;
   /** Marks every catalog stale while retaining visible rows during refresh. */
   invalidate(): void;
+  /** Applies one server-produced identity reconciliation to a loaded context. */
+  reconcile(change: ProviderCatalogChange): void;
   /** Clears every cached catalog and fences in-flight loads. */
   reset(): void;
 }
@@ -56,6 +63,18 @@ function replaceEntry(
   entry: ProviderCatalogCacheEntry,
 ): Readonly<Record<string, ProviderCatalogCacheEntry>> {
   return { ...entries, [key]: entry };
+}
+
+function capabilityIdentity(entry: ProviderCapabilityEntry): string {
+  return JSON.stringify([
+    entry.identity.providerId,
+    entry.identity.kind,
+    entry.identity.nativeId,
+  ]);
+}
+
+function agentIdentity(agent: SelectableProviderAgent): string {
+  return JSON.stringify([agent.providerId, agent.nativeId]);
 }
 
 /** Module-scoped store for provider capability catalog snapshots. */
@@ -159,6 +178,57 @@ export const useProviderCatalogStore = create<ProviderCatalogState>((set, get) =
       ]),
     );
     set({ entries });
+  },
+
+  reconcile(change) {
+    const key = providerCatalogCacheKey(change.request);
+    const current = get();
+    const entry = current.entries[key];
+    if (!entry?.snapshot) return;
+
+    const removedEntries = new Set(change.removals.map((identity) => JSON.stringify([
+      identity.providerId,
+      identity.kind,
+      identity.nativeId,
+    ])));
+    const updatedEntries = new Map(change.updates.map((item) => [capabilityIdentity(item), item]));
+    const existingEntryIds = new Set(entry.snapshot.entries.map(capabilityIdentity));
+    const entries = entry.snapshot.entries
+      .filter((item) => !removedEntries.has(capabilityIdentity(item)))
+      .map((item) => updatedEntries.get(capabilityIdentity(item)) ?? item);
+    for (const addition of change.additions) {
+      if (!existingEntryIds.has(capabilityIdentity(addition))) entries.push(addition);
+    }
+
+    const removedAgents = new Set(change.selectableAgents.removals);
+    const updatedAgents = new Map(
+      change.selectableAgents.updates.map((agent) => [agentIdentity(agent), agent]),
+    );
+    const existingAgentIds = new Set(entry.snapshot.selectableAgents.map(agentIdentity));
+    const selectableAgents = entry.snapshot.selectableAgents
+      .filter((agent) => !removedAgents.has(agent.nativeId))
+      .map((agent) => updatedAgents.get(agentIdentity(agent)) ?? agent);
+    for (const addition of change.selectableAgents.additions) {
+      if (!existingAgentIds.has(agentIdentity(addition))) selectableAgents.push(addition);
+    }
+
+    set({
+      entries: replaceEntry(current.entries, key, {
+        ...entry,
+        snapshot: {
+          ...entry.snapshot,
+          entries,
+          selectableAgents,
+          diagnostics: change.diagnostics ?? entry.snapshot.diagnostics,
+          freshness: change.freshness ?? entry.snapshot.freshness,
+        },
+        isLoading: false,
+        needsRefresh: false,
+        error: null,
+        inflight: null,
+        lastFetchedAt: Date.now(),
+      }),
+    });
   },
 
   reset() {

--- a/apps/web/src/stores/providerCatalogStore.ts
+++ b/apps/web/src/stores/providerCatalogStore.ts
@@ -20,6 +20,7 @@ export interface ProviderCatalogCacheEntry {
   readonly loadEpoch: number;
   readonly lastFetchedAt: number;
   readonly pendingChanges: readonly ProviderCatalogChange[];
+  readonly pendingChangesOverflowed: boolean;
 }
 
 /** Stable empty entry used by selectors before a catalog context has loaded. */
@@ -32,6 +33,7 @@ export const EMPTY_PROVIDER_CATALOG_CACHE_ENTRY: ProviderCatalogCacheEntry = Obj
   loadEpoch: 0,
   lastFetchedAt: 0,
   pendingChanges: [],
+  pendingChangesOverflowed: false,
 });
 
 /** Builds a collision-safe cache key for one provider catalog request. */
@@ -58,6 +60,7 @@ interface ProviderCatalogState {
 }
 
 const CACHE_TTL_MS = 5 * 60 * 1_000;
+const MAX_PENDING_CATALOG_CHANGES = 64;
 
 function replaceEntry(
   entries: Readonly<Record<string, ProviderCatalogCacheEntry>>,
@@ -177,23 +180,31 @@ export const useProviderCatalogStore = create<ProviderCatalogState>((set, get) =
     void promise.then(
       (snapshot) => {
         const current = get();
-        if (current.entries[key]?.loadEpoch !== epoch) return;
-        const reconciledSnapshot = current.entries[key].pendingChanges.reduce(
+        const currentEntry = current.entries[key];
+        if (currentEntry?.loadEpoch !== epoch) return;
+        const reconciledSnapshot = currentEntry.pendingChanges.reduce(
           applyCatalogChange,
           snapshot,
         );
+        const recoverOverflow = currentEntry.pendingChangesOverflowed;
         set({
           entries: replaceEntry(current.entries, key, {
             snapshot: reconciledSnapshot,
             isLoading: false,
-            needsRefresh: false,
+            needsRefresh: recoverOverflow,
             error: null,
             inflight: null,
             loadEpoch: epoch,
             lastFetchedAt: Date.now(),
             pendingChanges: [],
+            pendingChangesOverflowed: false,
           }),
         });
+        if (recoverOverflow) {
+          queueMicrotask(() => {
+            void get().load(request, true).catch(() => undefined);
+          });
+        }
       },
       (error: Error) => {
         console.warn("[providerCatalogStore] load failed after retry", error);
@@ -245,12 +256,19 @@ export const useProviderCatalogStore = create<ProviderCatalogState>((set, get) =
       return;
     }
     const queueChange = entry.inflight !== null || entry.pendingChanges.length > 0;
+    const pendingChangesAtCapacity = queueChange
+      && entry.pendingChanges.length >= MAX_PENDING_CATALOG_CHANGES;
 
     set({
       entries: replaceEntry(current.entries, key, {
         ...entry,
         snapshot: entry.snapshot ? applyCatalogChange(entry.snapshot, change) : null,
-        pendingChanges: queueChange ? [...entry.pendingChanges, change] : [],
+        pendingChanges: queueChange && !pendingChangesAtCapacity
+          ? [...entry.pendingChanges, change]
+          : entry.pendingChanges,
+        pendingChangesOverflowed: queueChange
+          ? entry.pendingChangesOverflowed || pendingChangesAtCapacity
+          : false,
         isLoading: entry.inflight !== null,
         needsRefresh: false,
         error: null,

--- a/apps/web/src/transport/ws-events.test.ts
+++ b/apps/web/src/transport/ws-events.test.ts
@@ -111,3 +111,19 @@ describe("ws-events skills.changed", () => {
     expect(invalidate).toHaveBeenCalledOnce();
   });
 });
+
+describe("ws-events provider.catalogChanged", () => {
+  afterEach(() => {
+    stopPushListeners();
+    vi.restoreAllMocks();
+  });
+
+  it("drops malformed catalog changes before store reconciliation", () => {
+    const reconcile = vi.spyOn(useProviderCatalogStore.getState(), "reconcile");
+    startPushListeners();
+
+    pushEmitter.emit("provider.catalogChanged", { request: { providerId: "codex" } });
+
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -1,4 +1,9 @@
-import type { Settings, ProviderAvailability, TurnFileEffectSummary } from "@mcode/contracts";
+import type {
+  ProviderAvailability,
+  ProviderCatalogChange,
+  Settings,
+  TurnFileEffectSummary,
+} from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { pushEmitter } from "./ws-transport";
 import { getTransport } from "@/transport";
@@ -50,6 +55,7 @@ function approxBase64DecodedBytes(encoded: string): number {
  * - `thread.modelUpdated` -- thread model and provider synced after a message send (multi-client)
  * - `files.changed` -- invalidates the file autocomplete cache
  * - `skills.changed` -- invalidates provider catalogs; popup re-fetches on next open
+ * - `provider.catalogChanged` -- reconciles a refreshed catalog by stable identity
  * - `turn.persisted` -- tool call persistence confirmation forwarded to threadStore
  * - `settings.changed` -- server-pushed settings updates forwarded to settingsStore
  * - `branch.changed` -- refreshes branch list and updates current branch if not manually overridden
@@ -336,6 +342,12 @@ export function startPushListeners(): void {
         skillsInvalidationTimer = null;
         useProviderCatalogStore.getState().invalidate();
       }, SKILLS_INVALIDATION_DEBOUNCE_MS);
+    }),
+  );
+
+  unsubs.push(
+    pushEmitter.on("provider.catalogChanged", (change) => {
+      useProviderCatalogStore.getState().reconcile(change as ProviderCatalogChange);
     }),
   );
 

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -1,8 +1,8 @@
-import type {
-  ProviderAvailability,
-  ProviderCatalogChange,
-  Settings,
-  TurnFileEffectSummary,
+import {
+  ProviderCatalogChangeSchema,
+  type ProviderAvailability,
+  type Settings,
+  type TurnFileEffectSummary,
 } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import { pushEmitter } from "./ws-transport";
@@ -347,7 +347,9 @@ export function startPushListeners(): void {
 
   unsubs.push(
     pushEmitter.on("provider.catalogChanged", (change) => {
-      useProviderCatalogStore.getState().reconcile(change as ProviderCatalogChange);
+      const parsed = ProviderCatalogChangeSchema().safeParse(change);
+      if (!parsed.success) return;
+      useProviderCatalogStore.getState().reconcile(parsed.data);
     }),
   );
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -527,6 +527,9 @@ export {
   ProviderCatalogContextSchema,
   ProviderCatalogRequestSchema,
   ProviderCatalogSnapshotSchema,
+  ProviderCapabilityIdentitySchema,
+  SelectableProviderAgentChangesSchema,
+  ProviderCatalogChangeSchema,
 } from "./providers/capability-catalog.js";
 export type {
   ProviderCapabilityKind,
@@ -538,6 +541,9 @@ export type {
   ProviderCatalogContext,
   ProviderCatalogRequest,
   ProviderCatalogSnapshot,
+  ProviderCapabilityIdentity,
+  SelectableProviderAgentChanges,
+  ProviderCatalogChange,
 } from "./providers/capability-catalog.js";
 
 // WebSocket protocol

--- a/packages/contracts/src/providers/capability-catalog.ts
+++ b/packages/contracts/src/providers/capability-catalog.ts
@@ -216,3 +216,41 @@ export const ProviderCatalogSnapshotSchema = lazySchema(() =>
 );
 /** Provider capability catalog snapshot for one validated discovery context. */
 export type ProviderCatalogSnapshot = z.infer<ReturnType<typeof ProviderCatalogSnapshotSchema>>;
+
+/** Stable provider capability identity used by incremental removals. */
+export const ProviderCapabilityIdentitySchema = lazySchema(() =>
+  z.discriminatedUnion("kind", [
+    identitySchema("skill"),
+    identitySchema("plugin"),
+    identitySchema("customPrompt"),
+    identitySchema("providerCommand"),
+  ]),
+);
+/** Stable provider capability identity used by incremental removals. */
+export type ProviderCapabilityIdentity = z.infer<ReturnType<typeof ProviderCapabilityIdentitySchema>>;
+
+/** Incremental selectable-agent reconciliation payload. */
+export const SelectableProviderAgentChangesSchema = lazySchema(() =>
+  z.object({
+    additions: z.array(SelectableProviderAgentSchema()).max(PROVIDER_CATALOG_MAX_SELECTABLE_AGENTS),
+    updates: z.array(SelectableProviderAgentSchema()).max(PROVIDER_CATALOG_MAX_SELECTABLE_AGENTS),
+    removals: z.array(z.string().trim().min(1).max(512)).max(PROVIDER_CATALOG_MAX_SELECTABLE_AGENTS),
+  }).strict(),
+);
+/** Incremental selectable-agent reconciliation payload. */
+export type SelectableProviderAgentChanges = z.infer<ReturnType<typeof SelectableProviderAgentChangesSchema>>;
+
+/** Incremental provider catalog reconciliation emitted after a background refresh. */
+export const ProviderCatalogChangeSchema = lazySchema(() =>
+  z.object({
+    request: ProviderCatalogRequestSchema(),
+    additions: z.array(ProviderCapabilityEntrySchema()).max(PROVIDER_CATALOG_MAX_ENTRIES),
+    updates: z.array(ProviderCapabilityEntrySchema()).max(PROVIDER_CATALOG_MAX_ENTRIES),
+    removals: z.array(ProviderCapabilityIdentitySchema()).max(PROVIDER_CATALOG_MAX_ENTRIES),
+    selectableAgents: SelectableProviderAgentChangesSchema(),
+    diagnostics: z.array(ProviderCatalogDiagnosticSchema()).max(100).optional(),
+    freshness: ProviderCatalogFreshnessSchema().optional(),
+  }).strict(),
+);
+/** Incremental provider catalog reconciliation emitted after a background refresh. */
+export type ProviderCatalogChange = z.infer<ReturnType<typeof ProviderCatalogChangeSchema>>;

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -9,6 +9,7 @@ import { PermissionRequestSchema, PermissionDecisionSchema } from "../models/per
 import { ProviderAvailabilitySchema } from "../providers/availability.js";
 import { lazySchema } from "../utils/lazySchema.js";
 import { TurnFileEffectSummarySchema } from "../models/file-effect.js";
+import { ProviderCatalogChangeSchema } from "../providers/capability-catalog.js";
 
 /** All push channel definitions keyed by channel name. */
 export const WS_CHANNELS = {
@@ -65,6 +66,8 @@ export const WS_CHANNELS = {
   }),
   "settings.changed": SettingsSchema(),
   "skills.changed": z.object({}),
+  /** Identity-based catalog changes produced by a completed background refresh. */
+  "provider.catalogChanged": ProviderCatalogChangeSchema(),
   /** Full-list broadcast of provider availability. Replaces the client cache. */
   "providers.availability": z.array(ProviderAvailabilitySchema()),
   "branch.changed": lazySchema(() =>


### PR DESCRIPTION
## What
Persist provider catalog snapshots per workspace and worktree context, then reconcile background refreshes by stable identity.

## Why
Catalog pickers should render the last confirmed capabilities immediately across restarts and provider process eviction without blocking on Codex startup.

## Key Changes
- Store bounded, validated catalog snapshots in SQLite and serve them as stale while refresh runs.
- Broadcast identity-based entry, agent, diagnostic, and freshness changes while retaining cached state on failures.
- Preserve logical thread contexts across shared physical refreshes and serialize WebSocket reconciliation safely.
- Bound refresh work and report explicit overload diagnostics with inactive-context recovery.
- Add persistence, restart, failure, lifecycle, overflow, and frontend ordering coverage.

Closes #893

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787159898&installation_model_id=20477&pr_number=905&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F905&signature=739bc29ef56cbde993a23949a81ed15f88c8165217c1e74492fb366128b4a6c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider catalogs now load quickly from saved snapshots while refreshing in the background.
  * Catalog updates are delivered incrementally, including additions, changes, and removals.
  * Catalog data persists across server restarts and supports workspace and working-directory contexts.
  * The web app applies live catalog updates without overwriting newer information.
* **Bug Fixes**
  * Improved handling of unavailable providers, stale data, concurrent refreshes, and connection restarts.
  * Prevented outdated catalog responses from replacing newer updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->