### PR TITLE
fix(web): preserve cached thread history

### DIFF
--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -274,13 +274,15 @@ test("rapid reselection paints the tail before auxiliary thread data resolves", 
   await page.goto("/");
   await page.getByRole("group", { name: "Conversation Page Workspace project" }).click();
   await page.waitForSelector("[data-testid='thread-item']");
-  const threadItems = page.locator("[data-testid='thread-item']");
+  const threadAItem = page.locator("[data-testid='thread-item'][data-thread-id='thread-a']");
+  const threadBItem = page.locator("[data-testid='thread-item'][data-thread-id='thread-b']");
 
-  await threadItems.nth(0).click();
+  await threadAItem.click();
   await expect.poll(() => typeof resolveThreadA).toBe("function");
-  await threadItems.nth(1).click();
+  await threadBItem.click();
   await expect.poll(() => typeof resolveThreadB).toBe("function");
-  await threadItems.nth(0).click();
+  await page.waitForTimeout(275);
+  await threadAItem.click();
 
   await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread A");
   await expect(page.locator("[data-testid=conversation-loading]")).toBeVisible();
@@ -303,6 +305,74 @@ test("rapid reselection paints the tail before auxiliary thread data resolves", 
   await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread A");
   await expect(page.getByText("Alpha tail after reselection", { exact: true })).toBeVisible();
   await expect(page.getByText("Beta tail", { exact: true })).not.toBeVisible();
+});
+
+test("rapid reselection discards an inactive result and refetches real data", async ({ page }) => {
+  test.setTimeout(90_000);
+  const calls: string[] = [];
+  const releases = new Map<string, Array<() => void>>();
+  const threads = [
+    thread("thread-a", "Thread A"),
+    thread("thread-b", "Thread B"),
+  ];
+
+  await interceptZustandStores(page);
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": threads,
+    "conversation.page": (params) => {
+      const input = params as { threadId: string };
+      calls.push(input.threadId);
+      const result = {
+        messages: input.threadId === "thread-a"
+          ? [message("thread-a", "thread-a-tail", "assistant", "Alpha real data", 12)]
+          : [message("thread-b", "thread-b-tail", "assistant", "Beta real data", 12)],
+        hasMore: false,
+        answeredPlanMessageIds: [],
+        narrativeByMessage: {},
+      };
+      return new Promise((resolve) => {
+        const queued = releases.get(input.threadId) ?? [];
+        queued.push(() => resolve(result));
+        releases.set(input.threadId, queued);
+      });
+    },
+  });
+
+  await page.goto("/");
+  await page.getByRole("group", { name: "Conversation Page Workspace project" }).click();
+  await page.waitForSelector("[data-testid='thread-item']");
+  const threadAItem = page.locator("[data-testid='thread-item'][data-thread-id='thread-a']");
+  const threadBItem = page.locator("[data-testid='thread-item'][data-thread-id='thread-b']");
+
+  await threadAItem.click();
+  await expect.poll(() => releases.get("thread-a")?.length).toBe(1);
+  await threadBItem.click();
+  await expect.poll(() => releases.get("thread-b")?.length).toBe(1);
+  await page.waitForTimeout(275);
+  await threadAItem.click();
+  await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread A");
+  await expect(page.locator("[data-testid=conversation-loading]")).toBeVisible();
+  await page.waitForTimeout(275);
+  await threadBItem.click();
+  await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread B");
+  await expect(page.locator("[data-testid=conversation-loading]")).toBeVisible();
+
+  releases.get("thread-a")?.shift()?.();
+  releases.get("thread-b")?.shift()?.();
+  await expect(page.getByText("Beta real data", { exact: true })).toBeVisible();
+  await expect(page.getByText("Alpha real data", { exact: true })).not.toBeVisible();
+
+  await page.waitForTimeout(275);
+  await threadAItem.click();
+  await expect(page.locator("[data-testid=chat-header-title]")).toContainText("Thread A");
+  await expect(page.locator("[data-testid=conversation-loading]")).toBeVisible();
+  await expect.poll(() => calls.filter((threadId) => threadId === "thread-a").length).toBe(2);
+  releases.get("thread-a")?.shift()?.();
+
+  await expect(page.getByText("Alpha real data", { exact: true })).toBeVisible();
+  expect(calls.filter((threadId) => threadId === "thread-a")).toHaveLength(2);
+  expect(calls.filter((threadId) => threadId === "thread-b")).toHaveLength(1);
 });
 
 test("thread switch paints the latest turn before older history finishes", async ({ page }) => {

--- a/apps/web/src/__tests__/record-cache.test.ts
+++ b/apps/web/src/__tests__/record-cache.test.ts
@@ -3,14 +3,18 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   getCachedRecord,
   cacheRecord,
+  cachePrefetchedHistoryPage,
+  takePrefetchedHistoryPage,
   evictCachedRecord,
   clearRecordCache,
   resizeRecordCache,
   RECORD_CACHE_SIZE,
+  RECORD_MESSAGE_CACHE_SIZE,
 } from "@/lib/thread-hydrator/record-cache";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 import {
   rememberScrollTop,
+  recallScrollPosition,
   recallScrollTop,
   clearScrollMemory,
 } from "@/components/chat/scrollPositionMemory";
@@ -93,6 +97,114 @@ describe("recordCache", () => {
     cacheRecord("t1", makeRecord("t1"));
     clearRecordCache();
     expect(getCachedRecord("t1")).toBeUndefined();
+  });
+
+  it("caps cached messages and prunes message-keyed metadata", () => {
+    const messages = Array.from({ length: RECORD_MESSAGE_CACHE_SIZE + 20 }, (_, index) => ({
+      ...makeRecord("bounded").messages[0],
+      id: `message-${index + 1}`,
+      sequence: index + 1,
+    }));
+    const metadata = Object.fromEntries(messages.map((message) => [message.id, 1]));
+    const files = Object.fromEntries(messages.map((message) => [message.id, [`${message.id}.ts`]]));
+    const responses = Object.fromEntries(messages.map((message) => [message.id, `response-${message.id}`]));
+
+    cacheRecord("bounded", {
+      ...createEmptyThreadRecord(),
+      messages,
+      oldestLoadedSequence: 1,
+      hasMoreMessages: false,
+      persistedToolCallCounts: metadata,
+      persistedFilesChanged: files,
+      serverMessageIds: responses,
+      assistantResponseKeys: responses,
+      narrativeByMessage: Object.fromEntries(messages.map((message) => [message.id, {
+        tools: [], thoughts: [], hooks: [],
+      }])),
+      answeredPlanMessageIds: new Set(messages.map((message) => message.id)),
+      latestTurnWithChanges: "message-1",
+    });
+
+    const cached = getCachedRecord("bounded");
+    expect(cached?.messages).toHaveLength(RECORD_MESSAGE_CACHE_SIZE);
+    expect(cached?.messages[0].id).toBe("message-21");
+    expect(cached?.oldestLoadedSequence).toBe(21);
+    expect(cached?.hasMoreMessages).toBe(true);
+    expect(cached?.persistedToolCallCounts["message-1"]).toBeUndefined();
+    expect(cached?.persistedToolCallCounts["message-21"]).toBe(1);
+    expect(cached?.persistedFilesChanged["message-1"]).toBeUndefined();
+    expect(cached?.serverMessageIds["message-1"]).toBeUndefined();
+    expect(cached?.assistantResponseKeys["message-1"]).toBeUndefined();
+    expect(cached?.narrativeByMessage["message-1"]).toBeUndefined();
+    expect(cached?.answeredPlanMessageIds.has("message-1")).toBe(false);
+    expect(cached?.latestTurnWithChanges).toBeNull();
+  });
+
+  it("forgets a remembered anchor when the message cap evicts it", () => {
+    const messages = Array.from({ length: RECORD_MESSAGE_CACHE_SIZE + 1 }, (_, index) => ({
+      ...makeRecord("anchor").messages[0],
+      id: `anchor-${index + 1}`,
+      sequence: index + 1,
+    }));
+    rememberScrollTop("anchor", 200, false, { messageId: "anchor-1", top: 30 });
+
+    cacheRecord("anchor", {
+      ...createEmptyThreadRecord(),
+      messages,
+      oldestLoadedSequence: 1,
+    });
+
+    expect(recallScrollPosition("anchor")).toBeUndefined();
+  });
+
+  it("keeps a remembered anchor that remains inside the message cap", () => {
+    const messages = Array.from({ length: RECORD_MESSAGE_CACHE_SIZE + 1 }, (_, index) => ({
+      ...makeRecord("anchor").messages[0],
+      id: `anchor-${index + 1}`,
+      sequence: index + 1,
+    }));
+    rememberScrollTop("anchor", 200, false, { messageId: "anchor-2", top: 30 });
+
+    cacheRecord("anchor", {
+      ...createEmptyThreadRecord(),
+      messages,
+      oldestLoadedSequence: 1,
+    });
+
+    expect(recallScrollPosition("anchor")?.anchorMessageId).toBe("anchor-2");
+  });
+
+  it("bounds a record and its prefetched history to one message budget", () => {
+    const cachedMessages = Array.from({ length: 40 }, (_, index) => ({
+      ...makeRecord("warm").messages[0],
+      id: `cached-${index + 61}`,
+      sequence: index + 61,
+    }));
+    const historyMessages = Array.from({ length: 100 }, (_, index) => ({
+      ...makeRecord("warm").messages[0],
+      id: `history-${index + 1}`,
+      sequence: index + 1,
+    }));
+    cacheRecord("warm", {
+      ...createEmptyThreadRecord(),
+      messages: cachedMessages,
+      oldestLoadedSequence: 61,
+    });
+    cachePrefetchedHistoryPage("warm", 61, {
+      messages: historyMessages,
+      hasMore: false,
+      answeredPlanMessageIds: historyMessages.map((message) => message.id),
+      narrativeByMessage: Object.fromEntries(historyMessages.map((message) => [message.id, {
+        tools: [], thoughts: [], hooks: [],
+      }])),
+    });
+
+    const prefetched = takePrefetchedHistoryPage("warm", 61);
+    expect(prefetched?.messages).toHaveLength(RECORD_MESSAGE_CACHE_SIZE - cachedMessages.length);
+    expect(prefetched?.messages[0].id).toBe("history-41");
+    expect(prefetched?.hasMore).toBe(true);
+    expect(prefetched?.answeredPlanMessageIds?.[0]).toBe("history-41");
+    expect(prefetched?.narrativeByMessage["history-1"]).toBeUndefined();
   });
 
   it("cleans up scroll memory when evicting via LRU capacity", () => {

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -522,7 +522,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
     isScrolledUpRef.current = scrolledUp;
     setShowScrollBtn(scrolledUp);
-    if (activeThreadId && renderedThreadId === activeThreadId) {
+    if (
+      activeThreadId
+      && renderedThreadId === activeThreadId
+      && !suppressPassiveAutoBottomScrollRef.current
+    ) {
       const viewportTop = el.getBoundingClientRect().top;
       const anchor = [...el.querySelectorAll<HTMLElement>("[data-message-id]")]
         .find((node) => node.getBoundingClientRect().bottom > viewportTop + 2);

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useShallow } from "zustand/shallow";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { defaultRangeExtractor, useVirtualizer, type Range } from "@tanstack/react-virtual";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useActiveThreadRecord } from "@/stores/thread-selectors";
@@ -26,7 +26,11 @@ import {
 } from "./virtual-items";
 import type { ChatVirtualItem } from "./virtual-items";
 import type { ToolCall } from "@/transport/types";
-import { rememberScrollTop, recallScrollTop, forgetScrollTop } from "./scrollPositionMemory";
+import {
+  rememberScrollTop,
+  recallScrollPosition,
+  type ThreadScrollPosition,
+} from "./scrollPositionMemory";
 import { NarrativeFlow } from "./narrative";
 import { PersistedNarrative } from "./narrative/PersistedNarrative";
 import { PersistedTurnFooter } from "./narrative/PersistedTurnFooter";
@@ -71,6 +75,16 @@ const MESSAGE_LIST_TOP_PADDING_PX = 16;
  */
 const TAIL_SETTLE_STABLE_FRAMES = 4;
 const TAIL_SETTLE_MAX_FRAMES = 60;
+
+/** Keep the prior viewport mounted while prepended rows receive their new indexes. */
+export function preservePrependedVirtualRange(range: Range, prependedCount: number): number[] {
+  const currentIndexes = defaultRangeExtractor(range);
+  if (prependedCount <= 0) return currentIndexes;
+  const previousViewportIndexes = currentIndexes
+    .map((index) => index + prependedCount)
+    .filter((index) => index < range.count);
+  return [...new Set([...currentIndexes, ...previousViewportIndexes])].sort((left, right) => left - right);
+}
 
 /** Renders a single virtual item based on its type discriminant. */
 const VirtualItemRenderer = memo(function VirtualItemRenderer({
@@ -229,6 +243,18 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const prevScrollHeightRef = useRef(0);
   /** Tracks the first message ID to detect real prepends vs appends. */
   const firstMessageIdRef = useRef<string | null>(null);
+  /** Number of inserted rows whose previous viewport must remain mounted until layout compensation. */
+  const pendingPrependCountRef = useRef(0);
+  /** Previous virtual row count used to translate retained keys after a prepend. */
+  const previousVirtualItemCountRef = useRef(0);
+  /** Previous first virtual key distinguishes a prepend from an append. */
+  const firstVirtualItemKeyRef = useRef<string | null>(null);
+  /** Visible message and viewport offset held steady while older history settles. */
+  const pendingHistoryAnchorRef = useRef<{ messageId: string; top: number } | null>(null);
+  /** First history reveal keeps the latest messages at the tail when the prior window could not scroll. */
+  const pinTailAfterHistoryPrependRef = useRef(false);
+  /** Invalidates stale history-anchor settle loops after navigation or another prepend. */
+  const historyAnchorSettleGenerationRef = useRef(0);
   /** True until initial messages are positioned at the bottom after a thread switch. */
   const isInitialLoadRef = useRef(true);
   /**
@@ -254,7 +280,9 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   /** Tracks the previous activeThreadId so we can save its scrollTop before switching. */
   const prevActiveThreadIdRef = useRef<string | null>(null);
   /** Holds the scrollTop value to restore on the next layout effect. */
-  const pendingScrollRestoreRef = useRef<number | null>(null);
+  const pendingScrollRestoreRef = useRef<ThreadScrollPosition | null>(null);
+  /** Invalidates stale reading-position settle loops after another navigation. */
+  const scrollRestoreGenerationRef = useRef(0);
   const [showScrollBtn, setShowScrollBtn] = useState(false);
   /** True when new content arrived while the user was scrolled up. */
   const [hasNewContent, setHasNewContent] = useState(false);
@@ -318,6 +346,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const isLoadingMore = useActiveThreadRecord((r) => r.isLoadingMore);
   const loadOlderMessages = useThreadStore((s) => s.loadOlderMessages);
   const currentThreadId = activeThreadId;
+  const renderedThreadId = messages[0]?.thread_id ?? null;
   const permissions = useActiveThreadRecord((r) => r.permissions);
   const hooks = useActiveThreadRecord((r) => r.hooks);
   const thoughtSegments = useActiveThreadRecord((r) => r.thoughtSegments);
@@ -411,6 +440,20 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
 
     olderHistoryRequestedRef.current = false;
+    pinTailAfterHistoryPrependRef.current = el.scrollHeight <= el.clientHeight;
+    if (el.scrollHeight > el.clientHeight) {
+      const viewportTop = el.getBoundingClientRect().top;
+      const anchor = [...el.querySelectorAll<HTMLElement>("[data-message-id]")]
+        .find((node) => node.getBoundingClientRect().bottom > viewportTop + 2);
+      pendingHistoryAnchorRef.current = anchor
+        ? {
+            messageId: anchor.getAttribute("data-message-id") ?? "",
+            top: anchor.getBoundingClientRect().top,
+          }
+        : null;
+    } else {
+      pendingHistoryAnchorRef.current = null;
+    }
     void loadOlderMessages(activeThreadId);
   }, [activeThreadId, hasMore, isLoadingMore, loadOlderMessages]);
 
@@ -479,6 +522,22 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
     isScrolledUpRef.current = scrolledUp;
     setShowScrollBtn(scrolledUp);
+    if (activeThreadId && renderedThreadId === activeThreadId) {
+      const viewportTop = el.getBoundingClientRect().top;
+      const anchor = [...el.querySelectorAll<HTMLElement>("[data-message-id]")]
+        .find((node) => node.getBoundingClientRect().bottom > viewportTop + 2);
+      rememberScrollTop(
+        activeThreadId,
+        el.scrollTop,
+        !awayFromTail,
+        anchor
+          ? {
+              messageId: anchor.getAttribute("data-message-id") ?? "",
+              top: anchor.getBoundingClientRect().top,
+            }
+          : undefined,
+      );
+    }
     if (!awayFromTail) {
       streamingFollowPauseUntilRef.current = 0;
     }
@@ -490,7 +549,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     loadOlderHistoryWhenRequested();
 
     prevScrollTopRef.current = el.scrollTop;
-  }, [loadOlderHistoryWhenRequested, syncStickyUserMessageVisibility]);
+  }, [activeThreadId, loadOlderHistoryWhenRequested, renderedThreadId, syncStickyUserMessageVisibility]);
 
   useEffect(() => {
     for (const message of messages) {
@@ -639,6 +698,19 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const itemsRef = useRef(items);
   itemsRef.current = items;
 
+  const previousVirtualItemCount = previousVirtualItemCountRef.current;
+  pendingPrependCountRef.current =
+    previousVirtualItemCount > 0
+    && items.length > previousVirtualItemCount
+    && firstVirtualItemKeyRef.current !== null
+    && items[0]?.key !== firstVirtualItemKeyRef.current
+      ? items.length - previousVirtualItemCount
+      : 0;
+  const rangeExtractor = useCallback(
+    (range: Range) => preservePrependedVirtualRange(range, pendingPrependCountRef.current),
+    [],
+  );
+
   const virtualizer = useVirtualizer({
     count: items.length,
     getScrollElement: () => containerRef.current,
@@ -648,6 +720,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     },
     getItemKey: (index) => items[index]?.key ?? String(index),
     overscan: OVERSCAN,
+    rangeExtractor,
     // Opt out of react-virtual's flushSync(rerender) on sync measurement. It
     // fires inside the library's commit-phase layout effect and trips React's
     // "flushSync called from inside a lifecycle method" warning. Scroll-tail
@@ -682,6 +755,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     }
     return item.start < scrollOffset;
   };
+
+  useLayoutEffect(() => {
+    previousVirtualItemCountRef.current = items.length;
+    firstVirtualItemKeyRef.current = items[0]?.key ?? null;
+  }, [items]);
 
   /** Pins the visible transcript to the current measured tail before paint. */
   const snapToBottom = useCallback(() => {
@@ -912,10 +990,6 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   useLayoutEffect(() => {
     const prevId = prevActiveThreadIdRef.current;
     const isThreadSwitch = !!prevId && prevId !== activeThreadId;
-    if (isThreadSwitch && prevId) {
-      const el = containerRef.current;
-      if (el) rememberScrollTop(prevId, el.scrollTop);
-    }
     prevActiveThreadIdRef.current = activeThreadId ?? null;
 
     if (!activeThreadId) return;
@@ -932,6 +1006,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       turnExpandRef.current.clear();
       scrollToTailIntentRef.current = false;
       olderHistoryRequestedRef.current = false;
+      pendingHistoryAnchorRef.current = null;
+      pinTailAfterHistoryPrependRef.current = false;
+      historyAnchorSettleGenerationRef.current += 1;
+      scrollRestoreGenerationRef.current += 1;
       prevMessageCountRef.current = 0;
       firstMessageIdRef.current = null;
       prevScrollHeightRef.current = 0;
@@ -963,11 +1041,13 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     // effect does not run a visible smooth scroll from a stale offset. This block
     // still runs when `loading` flips true→false on the same thread; the
     // `isThreadSwitch` guard on the bottom branch avoids clobbering initial load.
-    const rememberedScrollTop = recallScrollTop(activeThreadId);
-    if (rememberedScrollTop != null) {
+    const rememberedPosition = isThreadSwitch || prevId === null
+      ? recallScrollPosition(activeThreadId)
+      : undefined;
+    if (rememberedPosition) {
       isInitialLoadRef.current = false;
       setIsPositioned(true);
-      pendingScrollRestoreRef.current = rememberedScrollTop;
+      pendingScrollRestoreRef.current = rememberedPosition;
     } else if (isThreadSwitch) {
       // Cache hit on switch with no saved offset: avoid leaving stale scroll and
       // throttled smooth scroll from the discrete-messages effect.
@@ -986,7 +1066,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   // Stabilize scroll position when older messages are prepended.
   // Detects real prepends by comparing the first message ID before and after
   // the render, avoiding false positives from appends while near the top.
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = containerRef.current;
     const prevCount = prevMessageCountRef.current;
     const prevFirstId = firstMessageIdRef.current;
@@ -994,6 +1074,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     firstMessageIdRef.current = messages.length > 0 ? messages[0].id : null;
 
     if (!el || messages.length <= prevCount || prevCount === 0) {
+      pendingPrependCountRef.current = 0;
+      if (!isLoadingMore) {
+        pendingHistoryAnchorRef.current = null;
+        pinTailAfterHistoryPrependRef.current = false;
+      }
       prevScrollHeightRef.current = el?.scrollHeight ?? 0;
       return;
     }
@@ -1001,19 +1086,68 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     // A prepend occurred if the first message ID changed (new items at the front)
     const wasPrepend = prevFirstId !== null && messages[0].id !== prevFirstId;
     if (wasPrepend) {
-      // After React renders the new items, restore scroll position
-      requestAnimationFrame(() => {
-        const newScrollHeight = el.scrollHeight;
+      const newScrollHeight = el.scrollHeight;
+      const anchorSnapshot = pendingHistoryAnchorRef.current;
+      const findAnchor = () => anchorSnapshot
+        ? [...el.querySelectorAll<HTMLElement>("[data-message-id]")]
+            .find((node) => node.getAttribute("data-message-id") === anchorSnapshot.messageId)
+        : undefined;
+      const correctAnchor = () => {
+        const anchor = findAnchor();
+        if (!anchor || !anchorSnapshot) return 0;
+        const delta = anchor.getBoundingClientRect().top - anchorSnapshot.top;
+        if (Math.abs(delta) > 0.5) {
+          el.scrollTop += delta;
+        }
+        return Math.abs(delta);
+      };
+
+      if (pinTailAfterHistoryPrependRef.current) {
+        const generation = ++historyAnchorSettleGenerationRef.current;
+        let lastHeight = -1;
+        let stableFrames = 0;
+        const settleTail = () => {
+          if (historyAnchorSettleGenerationRef.current !== generation) return;
+          el.scrollTop = el.scrollHeight;
+          stableFrames = el.scrollHeight === lastHeight ? stableFrames + 1 : 0;
+          lastHeight = el.scrollHeight;
+          if (stableFrames >= 3) return;
+          requestAnimationFrame(settleTail);
+        };
+        settleTail();
+        pinTailAfterHistoryPrependRef.current = false;
+        pendingHistoryAnchorRef.current = null;
+      } else if (anchorSnapshot && findAnchor()) {
+        correctAnchor();
+        const generation = ++historyAnchorSettleGenerationRef.current;
+        let stableFrames = 0;
+        let attempts = 0;
+        const settleAnchor = () => {
+          if (historyAnchorSettleGenerationRef.current !== generation) return;
+          attempts += 1;
+          stableFrames = correctAnchor() <= 0.5 ? stableFrames + 1 : 0;
+          if (stableFrames >= 3 || attempts >= 12) {
+            pendingHistoryAnchorRef.current = null;
+            return;
+          }
+          requestAnimationFrame(settleAnchor);
+        };
+        requestAnimationFrame(settleAnchor);
+      } else {
         const addedHeight = newScrollHeight - prevScrollHeightRef.current;
         if (addedHeight > 0) {
           el.scrollTop += addedHeight;
         }
-        prevScrollHeightRef.current = newScrollHeight;
-      });
+        pendingHistoryAnchorRef.current = null;
+      }
+      prevScrollHeightRef.current = newScrollHeight;
     } else {
+      pendingHistoryAnchorRef.current = null;
+      pinTailAfterHistoryPrependRef.current = false;
       prevScrollHeightRef.current = el.scrollHeight;
     }
-  }, [messages]);
+    pendingPrependCountRef.current = 0;
+  }, [isLoadingMore, messages]);
 
   // Empty thread: reveal without a tail jump. Non-empty initial tail positioning
   // runs in the active-thread useLayoutEffect so cache-miss completion (same
@@ -1045,42 +1179,73 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     // to be briefly visible. When items load, items.length will change and trigger
     // another effect pass where loading is false.
     if (loading) return;
+    if (renderedThreadId && activeThreadId && renderedThreadId !== activeThreadId) return;
     beginSuppressPassiveAutoBottomScroll();
     const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
     const withinTail =
-      target <= maxScroll && maxScroll - target <= AUTO_SCROLL_THRESHOLD;
-    const snapToTail = withinTail || target > maxScroll;
+      target.scrollTop <= maxScroll && maxScroll - target.scrollTop <= AUTO_SCROLL_THRESHOLD;
+    const hasHistoryAnchor =
+      !target.atTail
+      && !!target.anchorMessageId
+      && target.anchorTop != null;
+    const snapToTail = target.atTail || (!hasHistoryAnchor && (withinTail || target.scrollTop > maxScroll));
+    pendingScrollRestoreRef.current = null;
+    scrollToTailIntentRef.current = false;
+
     if (snapToTail) {
       pinListTailRef.current = true;
       el.scrollTop = el.scrollHeight;
       pinTailBaselineMaxScrollRef.current = Math.max(0, el.scrollHeight - el.clientHeight);
-    } else {
-      pinListTailRef.current = false;
-      el.scrollTop = target;
-    }
-    pendingScrollRestoreRef.current = null;
-    scrollToTailIntentRef.current = false;
-    // Recall is for one-shot restore when entering a thread. The layout effect
-    // also depends on items.length (initial hydrate); without forgetting, every
-    // new message re-queues the same offset and yanks the viewport off the tail.
-    if (activeThreadId) forgetScrollTop(activeThreadId);
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const scrolledUp = distanceFromBottom > USER_AWAY_FROM_BOTTOM_PX;
-    isScrolledUpRef.current = scrolledUp;
-    setShowScrollBtn(scrolledUp);
-    if (!scrolledUp) {
+      isScrolledUpRef.current = false;
+      setShowScrollBtn(false);
       streamingFollowPauseUntilRef.current = 0;
       setHasNewContent(false);
+      requestAnimationFrame(() => {
+        const el2 = containerRef.current;
+        if (el2) {
+          el2.scrollTop = el2.scrollHeight;
+          pinTailBaselineMaxScrollRef.current = Math.max(0, el2.scrollHeight - el2.clientHeight);
+        }
+        scheduleEndSuppressPassiveAutoBottomScroll();
+      });
+      return;
     }
-    requestAnimationFrame(() => {
-      const el2 = containerRef.current;
-      if (el2 && snapToTail) {
-        el2.scrollTop = el2.scrollHeight;
-        pinTailBaselineMaxScrollRef.current = Math.max(0, el2.scrollHeight - el2.clientHeight);
-      }
+
+    pinListTailRef.current = false;
+    el.scrollTop = target.scrollTop;
+    isScrolledUpRef.current = true;
+    setShowScrollBtn(true);
+    if (!hasHistoryAnchor) {
       scheduleEndSuppressPassiveAutoBottomScroll();
-    });
-  }, [activeThreadId, items.length, loading, beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
+      return;
+    }
+    const generation = ++scrollRestoreGenerationRef.current;
+    let stableFrames = 0;
+    let attempts = 0;
+    const settleReadingAnchor = () => {
+      if (scrollRestoreGenerationRef.current !== generation) return;
+      attempts += 1;
+      const anchor = hasHistoryAnchor
+        ? [...el.querySelectorAll<HTMLElement>("[data-message-id]")]
+            .find((node) => node.getAttribute("data-message-id") === target.anchorMessageId)
+        : undefined;
+      if (anchor && target.anchorTop != null) {
+        const delta = anchor.getBoundingClientRect().top - target.anchorTop;
+        if (Math.abs(delta) > 0.5) {
+          el.scrollTop += delta;
+          stableFrames = 0;
+        } else {
+          stableFrames += 1;
+        }
+      }
+      if (stableFrames >= 3 || attempts >= 20) {
+        scheduleEndSuppressPassiveAutoBottomScroll();
+        return;
+      }
+      requestAnimationFrame(settleReadingAnchor);
+    };
+    requestAnimationFrame(settleReadingAnchor);
+  }, [activeThreadId, items.length, loading, renderedThreadId, beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
 
   // Discrete events (new message, tool call) -> scroll if at bottom, else highlight button
   useLayoutEffect(() => {

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -112,6 +112,7 @@ vi.mock("../narrative", () => ({ NarrativeFlow: () => null }));
 import { MessageList, preservePrependedVirtualRange } from "../MessageList";
 import {
   rememberScrollTop,
+  recallScrollPosition,
   recallScrollTop,
   clearScrollMemory,
   hasRememberedHistoryPosition,
@@ -536,6 +537,38 @@ describe("MessageList thread switch", () => {
     // The scroll restoration effect should have called scrollTop setter with 1500
     expect(setScrollTopValue).toBe(1500);
     expect(recallScrollTop("thread-B")).toBe(1500);
+  });
+
+  it("does not overwrite remembered posture while a cache-hit restore settles", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "a1", sequence: 1, thread_id: "thread-A" }];
+    const { rerender, container } = render(<MessageList />);
+    rememberScrollTop("thread-B", 1500, false, { messageId: "b1", top: 29 });
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    let scrollTop = 0;
+    Object.defineProperty(scrollEl, "scrollHeight", { configurable: true, value: 5000 });
+    Object.defineProperty(scrollEl, "clientHeight", { configurable: true, value: 400 });
+    Object.defineProperty(scrollEl, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+
+    activeThreadIdValue = "thread-B";
+    messagesValue = [{ id: "b1", sequence: 1, thread_id: "thread-B" }];
+    act(() => rerender(<MessageList />));
+    scrollTop = 900;
+    fireEvent.scroll(scrollEl);
+
+    expect(recallScrollPosition("thread-B")).toEqual({
+      scrollTop: 1500,
+      atTail: false,
+      anchorMessageId: "b1",
+      anchorTop: 29,
+    });
   });
 
   it("waits for the selected thread transcript before applying its remembered position", () => {

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -37,12 +37,21 @@ const mockVirtualizer = {
 
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: vi.fn(() => mockVirtualizer),
+  defaultRangeExtractor: ({ startIndex, endIndex, overscan, count }: {
+    startIndex: number;
+    endIndex: number;
+    overscan: number;
+    count: number;
+  }) => Array.from(
+    { length: Math.min(count - 1, endIndex + overscan) - Math.max(0, startIndex - overscan) + 1 },
+    (_, index) => Math.max(0, startIndex - overscan) + index,
+  ),
 }));
 
 // Minimal store mocks; control `loading` and `activeThreadId` between renders.
 let loadingValue = false;
 let activeThreadIdValue = "thread-A";
-let messagesValue: { id: string; sequence: number }[] = [{ id: "m1", sequence: 1 }];
+let messagesValue: { id: string; sequence: number; thread_id?: string }[] = [{ id: "m1", sequence: 1 }];
 let hasMoreMessagesValue = false;
 
 function buildMockRecord() {
@@ -100,8 +109,13 @@ vi.mock("../PermissionRequestCard", () => ({ PermissionRequestCard: () => null }
 vi.mock("../HookActivitySection", () => ({ HookActivitySection: () => null }));
 vi.mock("../narrative", () => ({ NarrativeFlow: () => null }));
 
-import { MessageList } from "../MessageList";
-import { rememberScrollTop, recallScrollTop, clearScrollMemory } from "../scrollPositionMemory";
+import { MessageList, preservePrependedVirtualRange } from "../MessageList";
+import {
+  rememberScrollTop,
+  recallScrollTop,
+  clearScrollMemory,
+  hasRememberedHistoryPosition,
+} from "../scrollPositionMemory";
 
 beforeEach(() => {
   measureSpy.mockClear();
@@ -117,6 +131,35 @@ afterEach(() => {
 });
 
 describe("MessageList thread switch", () => {
+  it("records history posture before navigation can replace the active transcript", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [];
+    const { container, rerender } = render(<MessageList />);
+    messagesValue = [{ id: "m1", sequence: 1, thread_id: "thread-A" }];
+    act(() => rerender(<MessageList />));
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    Object.defineProperty(scrollEl, "scrollHeight", { configurable: true, value: 6000 });
+    Object.defineProperty(scrollEl, "clientHeight", { configurable: true, value: 400 });
+    Object.defineProperty(scrollEl, "scrollTop", { configurable: true, value: 3000, writable: true });
+
+    fireEvent.wheel(scrollEl, { deltaY: -100 });
+    scrollEl.scrollTop = 3000;
+    fireEvent.scroll(scrollEl);
+
+    expect(recallScrollTop("thread-A")).toBe(3000);
+    expect(hasRememberedHistoryPosition("thread-A")).toBe(true);
+  });
+
+  it("keeps the previous viewport range mounted while prepended rows are positioned", () => {
+    expect(preservePrependedVirtualRange({
+      startIndex: 0,
+      endIndex: 4,
+      overscan: 2,
+      count: 105,
+    }, 100)).toEqual([0, 1, 2, 3, 4, 5, 6, 100, 101, 102, 103, 104]);
+  });
+
   it("keeps the measured transcript tail pinned as virtualized content grows", () => {
     loadingValue = false;
     activeThreadIdValue = "thread-A";
@@ -182,6 +225,46 @@ describe("MessageList thread switch", () => {
     act(() => rerender(<MessageList />));
 
     expect(scrollTop).toBe(3000);
+  });
+
+  it("compensates a history prepend before the next paint", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m1", sequence: 1 }];
+    const { rerender, container } = render(<MessageList />);
+
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    let scrollHeight = 6000;
+    let scrollTop = 3000;
+    Object.defineProperty(scrollEl, "scrollHeight", {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(scrollEl, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(scrollEl, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+
+    fireEvent.wheel(scrollEl, { deltaY: -100 });
+    fireEvent.scroll(scrollEl);
+    messagesValue = [{ id: "m1", sequence: 1 }];
+    act(() => rerender(<MessageList />));
+
+    scrollHeight = 8000;
+    messagesValue = [
+      { id: "m0", sequence: 0 },
+      { id: "m1", sequence: 1 },
+    ];
+    act(() => rerender(<MessageList />));
+
+    expect(scrollTop).toBe(5000);
   });
 
   it("does not restore tail pin when wheel-up remains inside the bottom cushion", () => {
@@ -452,7 +535,35 @@ describe("MessageList thread switch", () => {
 
     // The scroll restoration effect should have called scrollTop setter with 1500
     expect(setScrollTopValue).toBe(1500);
-    expect(recallScrollTop("thread-B")).toBeUndefined();
+    expect(recallScrollTop("thread-B")).toBe(1500);
+  });
+
+  it("waits for the selected thread transcript before applying its remembered position", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "a1", sequence: 1, thread_id: "thread-A" }];
+    const { rerender, container } = render(<MessageList />);
+    rememberScrollTop("thread-B", 1500);
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    let scrollTop = 0;
+    Object.defineProperty(scrollEl, "scrollHeight", { configurable: true, value: 5000 });
+    Object.defineProperty(scrollEl, "clientHeight", { configurable: true, value: 400 });
+    Object.defineProperty(scrollEl, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+
+    activeThreadIdValue = "thread-B";
+    act(() => rerender(<MessageList />));
+    expect(recallScrollTop("thread-B")).toBe(1500);
+
+    messagesValue = [{ id: "b1", sequence: 1, thread_id: "thread-B" }];
+    act(() => rerender(<MessageList />));
+    expect(scrollTop).toBe(1500);
+    expect(recallScrollTop("thread-B")).toBe(1500);
   });
 
   it("does not re-apply remembered scroll when messages append on the same thread", () => {
@@ -491,7 +602,7 @@ describe("MessageList thread switch", () => {
     });
 
     expect(scrollTop).toBe(1500);
-    expect(recallScrollTop("thread-B")).toBeUndefined();
+    expect(recallScrollTop("thread-B")).toBe(1500);
 
     // Simulate user pinned at bottom, then a new message arrives.
     scrollTop = scrollHeight - 400;

--- a/apps/web/src/components/chat/__tests__/scrollPositionMemory.test.ts
+++ b/apps/web/src/components/chat/__tests__/scrollPositionMemory.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   rememberScrollTop,
   recallScrollTop,
+  hasRememberedHistoryPosition,
   forgetScrollTop,
   clearScrollMemory,
 } from "../scrollPositionMemory";
@@ -30,6 +31,14 @@ describe("scrollPositionMemory", () => {
     rememberScrollTop("thread-a", 100);
     rememberScrollTop("thread-a", 200);
     expect(recallScrollTop("thread-a")).toBe(200);
+  });
+
+  it("distinguishes a history position from the transcript tail", () => {
+    rememberScrollTop("thread-history", 1_500, false);
+    rememberScrollTop("thread-tail", 5_600, true);
+
+    expect(hasRememberedHistoryPosition("thread-history")).toBe(true);
+    expect(hasRememberedHistoryPosition("thread-tail")).toBe(false);
   });
 
   it("forgets a single thread", () => {

--- a/apps/web/src/components/chat/__tests__/virtual-items-goal.test.ts
+++ b/apps/web/src/components/chat/__tests__/virtual-items-goal.test.ts
@@ -4,6 +4,7 @@ import {
   buildStableItems,
   buildVirtualItems,
   buildVolatileItems,
+  createVirtualItemsBuilder,
 } from "../virtual-items";
 
 function message(
@@ -74,5 +75,27 @@ describe("goal notices in chat virtual items", () => {
     expect(receiptIndex).toBeGreaterThan(-1);
     expect(narrativeIndex).toBeLessThan(answerIndex);
     expect(answerIndex).toBeLessThan(receiptIndex);
+  });
+});
+
+describe("history prepends", () => {
+  it("retains existing row identity when older messages are inserted", () => {
+    const first = message("first", "user", "First", 1);
+    const second = message("second", "assistant", "Second", 2);
+    const builder = createVirtualItemsBuilder();
+    const initial = builder(buildStableItems([first, second]), [], false);
+
+    const prepended = builder(
+      buildStableItems([message("older", "user", "Older", 0), first, second]),
+      [],
+      false,
+    );
+
+    expect(prepended.find((item) => item.key === first.id)).toBe(
+      initial.find((item) => item.key === first.id),
+    );
+    expect(prepended.find((item) => item.key === second.id)).toBe(
+      initial.find((item) => item.key === second.id),
+    );
   });
 });

--- a/apps/web/src/components/chat/scrollPositionMemory.ts
+++ b/apps/web/src/components/chat/scrollPositionMemory.ts
@@ -7,17 +7,46 @@
  * cached threads, and {@link forgetScrollTop} is called when a thread is
  * deleted or evicted.
  */
-const positions = new Map<string, number>();
+/** Saved viewport posture for one thread transcript. */
+export interface ThreadScrollPosition {
+  scrollTop: number;
+  atTail: boolean;
+  anchorMessageId?: string;
+  anchorTop?: number;
+}
+
+const positions = new Map<string, ThreadScrollPosition>();
 
 /** Persist the latest scrollTop for a thread. Ignores non-finite/negative values. */
-export function rememberScrollTop(threadId: string, scrollTop: number): void {
+export function rememberScrollTop(
+  threadId: string,
+  scrollTop: number,
+  atTail = false,
+  anchor?: { messageId: string; top: number },
+): void {
   if (!Number.isFinite(scrollTop) || scrollTop < 0) return;
-  positions.set(threadId, scrollTop);
+  positions.set(threadId, {
+    scrollTop,
+    atTail,
+    anchorMessageId: anchor?.messageId,
+    anchorTop: anchor?.top,
+  });
 }
 
 /** Recall the most recently saved scrollTop for a thread, or undefined. */
 export function recallScrollTop(threadId: string): number | undefined {
+  return positions.get(threadId)?.scrollTop;
+}
+
+/** Recall the full saved viewport posture for a thread, or undefined. */
+export function recallScrollPosition(threadId: string): ThreadScrollPosition | undefined {
   return positions.get(threadId);
+}
+
+/** Return whether a thread was left while the user was reading older history. */
+export function hasRememberedHistoryPosition(threadId: string): boolean {
+  const position = positions.get(threadId);
+  return position != null && !position.atTail;
 }
 
 /** Drop the saved scroll position for a thread. */

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -150,7 +150,8 @@ function resetStores() {
 describe("ThreadHydrator", () => {
   let hydrator: ThreadHydrator;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
     resetStores();
     hydrator = createStoreHydrator();
   });
@@ -411,6 +412,21 @@ describe("ThreadHydrator", () => {
     expect(hasPrefetchedHistoryPage(THREAD_A, 119)).toBe(true);
   });
 
+  it("retires a completed empty transcript into the bounded cache", async () => {
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_A,
+      records: new Map([[THREAD_A, createEmptyThreadRecord()]]),
+    });
+    cacheRecord(THREAD_B, makeCachedRecord([msgB]));
+
+    await hydrator.hydrate(THREAD_B, "active");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(useThreadStore.getState().records.has(THREAD_A)).toBe(false);
+    expect(getCachedRecord(THREAD_A)?.messages).toEqual([]);
+    expect(getCachedRecord(THREAD_A)?.loading).toBe(false);
+  });
+
   it("reopens a running resident layer without replacing its live state", async () => {
     resetThreadStoreForTests({
       currentThreadId: THREAD_B,
@@ -650,6 +666,118 @@ describe("ThreadHydrator", () => {
     expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
     expect(getCachedRecord(THREAD_A)?.goal).toBeNull();
     expect(getCachedRecord(THREAD_A)?.persistedFilesChanged).toEqual({});
+  });
+
+  it("does not retire a loading record before rapid reselection joins its hydrate", async () => {
+    let resolveA!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      (threadId: string) => threadId === THREAD_A
+        ? new Promise((resolve) => {
+            resolveA = resolve;
+          })
+        : Promise.resolve({ messages: [msgB], hasMore: false, narrativeByMessage: {} }),
+    );
+
+    const loadA = hydrator.hydrate(THREAD_A, "active");
+    await hydrator.hydrate(THREAD_B, "active");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(getCachedRecord(THREAD_A)).toBeUndefined();
+    const reselectA = hydrator.hydrate(THREAD_A, "active");
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_A);
+    expect(readActiveThreadField((record) => record.loading)).toBe(true);
+
+    resolveA({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
+    await Promise.all([loadA, reselectA]);
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(2);
+    expect(getTestActiveMessages()).toEqual([msgA]);
+    expect(readActiveThreadField((record) => record.loading)).toBe(false);
+  });
+
+  it("never restores an empty snapshot after an inactive hydrate completes", async () => {
+    let resolveA!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      (threadId: string) => threadId === THREAD_A
+        ? new Promise((resolve) => {
+            resolveA = resolve;
+          })
+        : Promise.resolve({ messages: [msgB], hasMore: false, narrativeByMessage: {} }),
+    );
+
+    const loadA = hydrator.hydrate(THREAD_A, "active");
+    await hydrator.hydrate(THREAD_B, "active");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const reselectA = hydrator.hydrate(THREAD_A, "active");
+    await hydrator.hydrate(THREAD_B, "active");
+
+    resolveA({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
+    await Promise.all([loadA, reselectA]);
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
+    expect(getCachedRecord(THREAD_A)).toBeUndefined();
+
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: [msgA],
+      hasMore: false,
+      narrativeByMessage: {},
+    });
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(3);
+    expect(getTestActiveMessages()).toEqual([msgA]);
+    expect(readActiveThreadField((record) => record.loading)).toBe(false);
+  });
+
+  it("discards a running thread's empty shell after a stale rapid reselection", async () => {
+    let resolveA!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    resetThreadStoreForTests({
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map([[THREAD_A, createEmptyThreadRecord()]]),
+    });
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      (threadId: string) => threadId === THREAD_A
+        ? new Promise((resolve) => {
+            resolveA = resolve;
+          })
+        : Promise.resolve({ messages: [msgB], hasMore: false, narrativeByMessage: {} }),
+    );
+
+    const loadA = hydrator.hydrate(THREAD_A, "active");
+    await hydrator.hydrate(THREAD_B, "active");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const reselectA = hydrator.hydrate(THREAD_A, "active");
+    expect(readActiveThreadField((record) => record.loading)).toBe(true);
+    await hydrator.hydrate(THREAD_B, "active");
+
+    resolveA({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
+    await Promise.all([loadA, reselectA]);
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
+    expect(useThreadStore.getState().records.has(THREAD_A)).toBe(false);
+    expect(getCachedRecord(THREAD_A)).toBeUndefined();
+
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: [msgA],
+      hasMore: false,
+      narrativeByMessage: {},
+    });
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(3);
+    expect(getTestActiveMessages()).toEqual([msgA]);
   });
 
   it("keeps repeated cache-hit switches bounded without refetching loaded history", async () => {

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -37,6 +37,7 @@ import { coerceTaskStatus } from "@/stores/taskStore";
 import { getTransport } from "@/transport";
 import { PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
 import type { GoalLookupResult, GoalState, TurnSnapshot } from "@mcode/contracts";
+import { clearScrollMemory, rememberScrollTop } from "@/components/chat/scrollPositionMemory";
 
 vi.mock("@/transport", async () => ({
   ...(await vi.importActual("@/transport")),
@@ -100,6 +101,7 @@ function createStoreHydrator(): ThreadHydrator {
 }
 
 function resetStores() {
+  clearScrollMemory();
   clearRecordCache();
   vi.clearAllMocks();
 
@@ -242,6 +244,24 @@ describe("ThreadHydrator", () => {
     expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
   });
 
+  it("restores the loaded window when returning to a cached history position", async () => {
+    const history = Array.from({ length: 100 }, (_, index) => createMockMessage({
+      id: `cached-history-${index + 1}`,
+      thread_id: THREAD_A,
+      sequence: index + 1,
+    }));
+    cacheRecord(THREAD_A, {
+      ...makeCachedRecord(history),
+      hasMoreMessages: true,
+    });
+    rememberScrollTop(THREAD_A, 1_500, false);
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(getTestActiveMessages()).toEqual(history);
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
+  });
+
   it("preserves an existing open goal when lookup returns non-authoritative null", async () => {
     const goal = makeGoal();
     resetThreadStoreForTests({
@@ -352,12 +372,46 @@ describe("ThreadHydrator", () => {
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
   });
 
-  it("activates a running resident layer before its history refresh resolves", async () => {
-    let resolvePage!: (value: {
-      messages: typeof msgA[];
-      hasMore: boolean;
-      narrativeByMessage: Record<string, never>;
-    }) => void;
+  it("refreshes a resident thread when its cache was invalidated", async () => {
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_B,
+      records: new Map<string, ThreadRecord>([
+        [THREAD_A, { ...createEmptyThreadRecord(), messages: [msgA] }],
+        [THREAD_B, { ...createEmptyThreadRecord(), messages: [msgB] }],
+      ]),
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_A);
+    expect(getTestActiveMessages()).toEqual([msgA]);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, BACKGROUND_PREFETCH_LIMIT);
+  });
+
+  it("retires an inactive tail transcript into the bounded cache", async () => {
+    const history = Array.from({ length: 120 }, (_, index) => createMockMessage({
+      id: `retired-a-${index + 1}`,
+      thread_id: THREAD_A,
+      sequence: index + 1,
+    }));
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_A,
+      records: new Map<string, ThreadRecord>([
+        [THREAD_A, { ...createEmptyThreadRecord(), messages: history, hasMoreMessages: true }],
+      ]),
+    });
+    rememberScrollTop(THREAD_A, 9_600, true);
+    cacheRecord(THREAD_B, makeCachedRecord([msgB]));
+
+    await hydrator.hydrate(THREAD_B, "active");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(useThreadStore.getState().records.has(THREAD_A)).toBe(false);
+    expect(getCachedRecord(THREAD_A)?.messages).toEqual(history.slice(-MESSAGE_FETCH_SIZE));
+    expect(hasPrefetchedHistoryPage(THREAD_A, 119)).toBe(true);
+  });
+
+  it("reopens a running resident layer without replacing its live state", async () => {
     resetThreadStoreForTests({
       currentThreadId: THREAD_B,
       runningThreadIds: new Set([THREAD_A]),
@@ -373,13 +427,7 @@ describe("ThreadHydrator", () => {
         },
       ]]),
     });
-    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
-      () => new Promise((resolve) => {
-        resolvePage = resolve;
-      }),
-    );
-
-    const hydration = hydrator.hydrate(THREAD_A, "active");
+    await hydrator.hydrate(THREAD_A, "active");
 
     expect(useThreadStore.getState().currentThreadId).toBe(THREAD_A);
     expect(readActiveThreadField((record) => record.loading)).toBe(false);
@@ -387,10 +435,6 @@ describe("ThreadHydrator", () => {
     expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
     expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, BACKGROUND_PREFETCH_LIMIT);
-
-    resolvePage({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
-    await hydration;
-
     expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
   });
@@ -604,8 +648,8 @@ describe("ThreadHydrator", () => {
     await Promise.resolve();
 
     expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
-    expect(useThreadStore.getState().records.get(THREAD_A)?.goal).toBeNull();
-    expect(useThreadStore.getState().records.get(THREAD_A)?.persistedFilesChanged).toEqual({});
+    expect(getCachedRecord(THREAD_A)?.goal).toBeNull();
+    expect(getCachedRecord(THREAD_A)?.persistedFilesChanged).toEqual({});
   });
 
   it("keeps repeated cache-hit switches bounded without refetching loaded history", async () => {
@@ -633,7 +677,8 @@ describe("ThreadHydrator", () => {
     await useThreadStore.getState().loadOlderMessages(THREAD_B);
 
     expect(getTestActiveMessages()).toEqual(tailB);
-    expect(getCachedRecord(THREAD_A)?.messages).toEqual(tailA);
+    expect(getCachedRecord(THREAD_A)?.messages).toEqual(tailA.slice(-MESSAGE_FETCH_SIZE));
+    expect(hasPrefetchedHistoryPage(THREAD_A, 99)).toBe(true);
   });
 
   it("background mode populates cache without touching the live store", async () => {

--- a/apps/web/src/lib/thread-hydrator/index.ts
+++ b/apps/web/src/lib/thread-hydrator/index.ts
@@ -22,6 +22,7 @@ export {
   clearRecordCache,
   resizeRecordCache,
   RECORD_CACHE_SIZE,
+  RECORD_MESSAGE_CACHE_SIZE,
 } from "./record-cache";
 export { AuxiliaryHydrator } from "./auxiliary-hydrator";
 export type { AuxiliaryHydratorOptions, AuxiliaryHydratorDeps } from "./auxiliary-hydrator";

--- a/apps/web/src/lib/thread-hydrator/record-cache.ts
+++ b/apps/web/src/lib/thread-hydrator/record-cache.ts
@@ -1,5 +1,8 @@
 import { LruCache } from "@/lib/lru-cache";
-import { forgetScrollTop } from "@/components/chat/scrollPositionMemory";
+import {
+  forgetScrollTop,
+  recallScrollPosition,
+} from "@/components/chat/scrollPositionMemory";
 import type { ThreadRecord } from "@/stores/thread-record";
 import type { ConversationPage } from "@mcode/contracts";
 
@@ -8,6 +11,9 @@ import type { ConversationPage } from "@mcode/contracts";
  * Overridden by the `performance.threadCacheSize` user setting at runtime.
  */
 export const RECORD_CACHE_SIZE = 15;
+
+/** Maximum messages retained across one thread's record and warm history page. */
+export const RECORD_MESSAGE_CACHE_SIZE = 100;
 
 /**
  * Module-scoped LRU cache of evicted {@link ThreadRecord}s.
@@ -23,6 +29,86 @@ interface PrefetchedHistoryPage {
 
 const prefetchedHistoryCache = new LruCache<string, PrefetchedHistoryPage>(RECORD_CACHE_SIZE);
 
+function filterMessageMetadata<T>(
+  metadata: Record<string, T>,
+  retainedMessageIds: Set<string>,
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([messageId]) => retainedMessageIds.has(messageId)),
+  );
+}
+
+function boundRecord(threadId: string, record: ThreadRecord): ThreadRecord {
+  if (record.messages.length <= RECORD_MESSAGE_CACHE_SIZE) return record;
+
+  const messages = record.messages.slice(-RECORD_MESSAGE_CACHE_SIZE);
+  const retainedMessageIds = new Set(messages.map((message) => message.id));
+  const rememberedPosition = recallScrollPosition(threadId);
+  if (
+    rememberedPosition?.anchorMessageId
+    && !retainedMessageIds.has(rememberedPosition.anchorMessageId)
+  ) {
+    forgetScrollTop(threadId);
+  }
+
+  return {
+    ...record,
+    messages,
+    oldestLoadedSequence: messages[0]?.sequence ?? record.oldestLoadedSequence,
+    hasMoreMessages: true,
+    persistedToolCallCounts: filterMessageMetadata(
+      record.persistedToolCallCounts,
+      retainedMessageIds,
+    ),
+    persistedFilesChanged: filterMessageMetadata(
+      record.persistedFilesChanged,
+      retainedMessageIds,
+    ),
+    serverMessageIds: filterMessageMetadata(record.serverMessageIds, retainedMessageIds),
+    narrativeByMessage: filterMessageMetadata(record.narrativeByMessage, retainedMessageIds),
+    answeredPlanMessageIds: new Set(
+      [...record.answeredPlanMessageIds].filter((messageId) => retainedMessageIds.has(messageId)),
+    ),
+    assistantResponseKeys: filterMessageMetadata(
+      record.assistantResponseKeys,
+      retainedMessageIds,
+    ),
+    latestTurnWithChanges:
+      record.latestTurnWithChanges && retainedMessageIds.has(record.latestTurnWithChanges)
+        ? record.latestTurnWithChanges
+        : null,
+  };
+}
+
+function boundHistoryPage(page: ConversationPage, limit: number): ConversationPage | undefined {
+  if (limit <= 0) return undefined;
+  const droppedMessages = page.messages.length > limit;
+  const messages = droppedMessages ? page.messages.slice(-limit) : page.messages;
+  const retainedMessageIds = new Set(messages.map((message) => message.id));
+  return {
+    messages,
+    hasMore: page.hasMore || droppedMessages,
+    answeredPlanMessageIds: page.answeredPlanMessageIds?.filter((messageId) =>
+      retainedMessageIds.has(messageId),
+    ),
+    narrativeByMessage: filterMessageMetadata(page.narrativeByMessage, retainedMessageIds),
+  };
+}
+
+function trimPrefetchedHistory(threadId: string, recordMessageCount: number): void {
+  const prefetched = prefetchedHistoryCache.get(threadId);
+  if (!prefetched) return;
+  const page = boundHistoryPage(
+    prefetched.page,
+    RECORD_MESSAGE_CACHE_SIZE - recordMessageCount,
+  );
+  if (!page) {
+    prefetchedHistoryCache.delete(threadId);
+    return;
+  }
+  prefetchedHistoryCache.set(threadId, { ...prefetched, page });
+}
+
 /** Read the cached record for a thread, refreshing LRU recency on hit. */
 export function getCachedRecord(threadId: string): ThreadRecord | undefined {
   return cache.get(threadId);
@@ -35,7 +121,9 @@ export function hasCachedRecord(threadId: string): boolean {
 
 /** Store a record for the given thread, evicting the LRU entry if at capacity. */
 export function cacheRecord(threadId: string, record: ThreadRecord): void {
-  const evicted = cache.set(threadId, record);
+  const boundedRecord = boundRecord(threadId, record);
+  const evicted = cache.set(threadId, boundedRecord);
+  trimPrefetchedHistory(threadId, boundedRecord.messages.length);
   if (evicted) {
     forgetScrollTop(evicted);
     prefetchedHistoryCache.delete(evicted);
@@ -48,7 +136,13 @@ export function cachePrefetchedHistoryPage(
   before: number,
   page: ConversationPage,
 ): void {
-  prefetchedHistoryCache.set(threadId, { before, page });
+  const recordMessageCount = cache.get(threadId)?.messages.length ?? 0;
+  const boundedPage = boundHistoryPage(page, RECORD_MESSAGE_CACHE_SIZE - recordMessageCount);
+  if (!boundedPage) {
+    prefetchedHistoryCache.delete(threadId);
+    return;
+  }
+  prefetchedHistoryCache.set(threadId, { before, page: boundedPage });
 }
 
 /** Check whether the requested older-history cursor is already warm. */

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -8,6 +8,7 @@ import {
 } from "./record-cache";
 import {
   createEmptyThreadRecord,
+  deleteThreadRecord,
   getThreadRecord,
   patchThreadRecord,
 } from "@/stores/thread-record";
@@ -24,6 +25,7 @@ import type {
 import { SnapshotBuilder, snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
 import type { ConversationPage } from "@mcode/contracts";
+import { hasRememberedHistoryPosition } from "@/components/chat/scrollPositionMemory";
 
 interface PendingHistoryPrefetch {
   expectedEpoch: number;
@@ -178,9 +180,22 @@ export class ThreadHydrator {
 
   /** Active-thread load invoked from ChatView and workspaceStore. */
   private async hydrateActive(threadId: string, opts?: ThreadHydratorOptions): Promise<void> {
-    // Defer until after the cache-restore set() so outgoing-thread streaming
-    // previews do not trigger a mid-switch MessageList re-render.
-    queueMicrotask(this.deps.flushPendingTextDeltas);
+    const outgoingThreadId = this.deps.getState().currentThreadId;
+    queueMicrotask(() => {
+      this.deps.flushPendingTextDeltas();
+    });
+    // React records the outgoing viewport in a layout effect. Retiring on the
+    // next frame lets that posture choose full-history or compact-tail caching.
+    const retireOutgoingRecord = () => {
+      if (outgoingThreadId && outgoingThreadId !== threadId) {
+        this.retireInactiveRecord(outgoingThreadId);
+      }
+    };
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(retireOutgoingRecord);
+    } else {
+      setTimeout(retireOutgoingRecord, 0);
+    }
 
     const cached = getCachedRecord(threadId);
     if (cached) {
@@ -223,6 +238,45 @@ export class ThreadHydrator {
     await hydrate;
   }
 
+  /** Move an inactive transcript under the bounded LRU and compact tail readers. */
+  private retireInactiveRecord(threadId: string): void {
+    const state = this.deps.getState();
+    if (state.currentThreadId === threadId) return;
+    const resident = state.records.get(threadId);
+    if (!resident) return;
+
+    const cached = this.compactCachedRecordForRestore(threadId, resident);
+    cacheRecord(threadId, cached);
+    this.deps.setState((latest: ThreadHydratorWriteState) => {
+      if (latest.currentThreadId === threadId) return {};
+      if (latest.runningThreadIds.has(threadId)) {
+        return {
+          records: patchThreadRecord(latest.records, threadId, cached),
+        };
+      }
+      return {
+        records: deleteThreadRecord(latest.records, threadId),
+      };
+    });
+  }
+
+  /** Makes a retained thread record visible while an existing background fetch settles. */
+  private activateResidentLayer(threadId: string): void {
+    this.deps.setState((state: ThreadHydratorWriteState) => {
+      const current = getThreadRecord(state.records, threadId);
+      return {
+        records: patchThreadRecord(state.records, threadId, {
+          loading: false,
+          error: null,
+          isLoadingMore: false,
+          loadEpoch: current.loadEpoch + 1,
+          settings: this.deps.getWorkspaceThreadSettings(threadId),
+        }),
+        currentThreadId: threadId,
+      };
+    });
+  }
+
   /** Active-thread cache miss path, reusing hover prefetches when available. */
   private async fetchActiveReusingBackground(
     threadId: string,
@@ -255,23 +309,6 @@ export class ThreadHydrator {
           prefetchEarlierHistory: false,
         }
       : undefined);
-  }
-
-  /** Makes a retained thread record visible while its persisted history refreshes. */
-  private activateResidentLayer(threadId: string): void {
-    this.deps.setState((state: ThreadHydratorWriteState) => {
-      const current = getThreadRecord(state.records, threadId);
-      return {
-        records: patchThreadRecord(state.records, threadId, {
-          loading: false,
-          error: null,
-          isLoadingMore: false,
-          loadEpoch: current.loadEpoch + 1,
-          settings: this.deps.getWorkspaceThreadSettings(threadId),
-        }),
-        currentThreadId: threadId,
-      };
-    });
   }
 
   /** Makes an already-loading thread current without invalidating its request epoch. */
@@ -313,10 +350,16 @@ export class ThreadHydrator {
 
   /** Keep cache-hit reconciliation bounded while retaining loaded history for upward pagination. */
   private compactCachedRecordForRestore(threadId: string, cached: ThreadRecord): ThreadRecord {
-    if (cached.messages.length <= MESSAGE_FETCH_SIZE) return cached;
+    if (
+      cached.messages.length <= MESSAGE_FETCH_SIZE
+      || hasRememberedHistoryPosition(threadId)
+    ) {
+      return cached;
+    }
 
     const tailStart = cached.messages.length - MESSAGE_FETCH_SIZE;
     const earlierMessages = cached.messages.slice(0, tailStart);
+    const retainedEarlierMessages = earlierMessages.slice(-HISTORY_PREFETCH_SIZE);
     const tailMessages = cached.messages.slice(tailStart);
     const narrativeByMessage: ConversationPage["narrativeByMessage"] = {};
     for (const [messageId, narrative] of Object.entries(cached.narrativeByMessage)) {
@@ -332,10 +375,14 @@ export class ThreadHydrator {
     cachePrefetchedHistoryPage(
       threadId,
       tailMessages[0].sequence,
-      buildConversationPageSubset(page, earlierMessages, cached.hasMoreMessages),
+      buildConversationPageSubset(
+        page,
+        retainedEarlierMessages,
+        cached.hasMoreMessages || retainedEarlierMessages.length < earlierMessages.length,
+      ),
     );
 
-    return {
+    const compacted = {
       ...cached,
       messages: tailMessages,
       oldestLoadedSequence: tailMessages[0].sequence,
@@ -343,6 +390,8 @@ export class ThreadHydrator {
       narrativeByMessage: tailPage.narrativeByMessage,
       answeredPlanMessageIds: new Set(tailPage.answeredPlanMessageIds ?? []),
     };
+    cacheRecord(threadId, compacted);
+    return compacted;
   }
 
   /**

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -32,6 +32,14 @@ interface PendingHistoryPrefetch {
   promise: Promise<void>;
 }
 
+function hasResidentLayer(record: ThreadRecord): boolean {
+  return record.messages.length > 0
+    || record.streaming.length > 0
+    || record.toolCalls.length > 0
+    || record.thoughtSegments.length > 0
+    || record.hooks.length > 0;
+}
+
 /** Build a conversation page containing only the supplied messages and their metadata. */
 function buildConversationPageSubset(
   page: ConversationPage,
@@ -181,6 +189,9 @@ export class ThreadHydrator {
   /** Active-thread load invoked from ChatView and workspaceStore. */
   private async hydrateActive(threadId: string, opts?: ThreadHydratorOptions): Promise<void> {
     const outgoingThreadId = this.deps.getState().currentThreadId;
+    const outgoingHydrate = outgoingThreadId
+      ? this.activeHydrates.get(outgoingThreadId)
+      : undefined;
     queueMicrotask(() => {
       this.deps.flushPendingTextDeltas();
     });
@@ -188,7 +199,7 @@ export class ThreadHydrator {
     // next frame lets that posture choose full-history or compact-tail caching.
     const retireOutgoingRecord = () => {
       if (outgoingThreadId && outgoingThreadId !== threadId) {
-        this.retireInactiveRecord(outgoingThreadId);
+        this.retireInactiveRecord(outgoingThreadId, outgoingHydrate != null);
       }
     };
     if (typeof requestAnimationFrame === "function") {
@@ -197,25 +208,12 @@ export class ThreadHydrator {
       setTimeout(retireOutgoingRecord, 0);
     }
 
-    const cached = getCachedRecord(threadId);
-    if (cached) {
-      this.restoreCachedActive(threadId, cached, opts);
-      return;
-    }
-
     const resident = this.deps.getState().records.get(threadId);
-    const hasResidentLayer = resident != null && (
-      resident.messages.length > 0
-      || resident.streaming.length > 0
-      || resident.toolCalls.length > 0
-      || resident.thoughtSegments.length > 0
-      || resident.hooks.length > 0
-      || this.deps.getState().runningThreadIds.has(threadId)
-    );
+    const hasResidentContent = resident != null && hasResidentLayer(resident);
 
     const inFlight = this.activeHydrates.get(threadId);
     if (inFlight) {
-      this.selectInFlightLayer(threadId, hasResidentLayer);
+      this.selectInFlightLayer(threadId, hasResidentContent);
       await inFlight;
       const state = this.deps.getState();
       const current = getThreadRecord(state.records, threadId);
@@ -225,13 +223,20 @@ export class ThreadHydrator {
       return;
     }
 
-    if (hasResidentLayer) {
+    const cached = getCachedRecord(threadId);
+    if (cached) {
+      this.restoreCachedActive(threadId, cached, opts);
+      return;
+    }
+
+    if (hasResidentContent) {
       this.activateResidentLayer(threadId);
     }
 
-    const hydrate = this.fetchActiveReusingBackground(threadId, opts, hasResidentLayer).finally(() => {
+    const hydrate = this.fetchActiveReusingBackground(threadId, opts, hasResidentContent).finally(() => {
       if (this.activeHydrates.get(threadId) === hydrate) {
         this.activeHydrates.delete(threadId);
+        this.discardInactiveLoadingRecord(threadId);
       }
     });
     this.activeHydrates.set(threadId, hydrate);
@@ -239,11 +244,15 @@ export class ThreadHydrator {
   }
 
   /** Move an inactive transcript under the bounded LRU and compact tail readers. */
-  private retireInactiveRecord(threadId: string): void {
+  private retireInactiveRecord(threadId: string, hadActiveHydrate: boolean): void {
     const state = this.deps.getState();
     if (state.currentThreadId === threadId) return;
     const resident = state.records.get(threadId);
     if (!resident) return;
+    if (
+      !hasResidentLayer(resident)
+      && (hadActiveHydrate || this.activeHydrates.has(threadId))
+    ) return;
 
     const cached = this.compactCachedRecordForRestore(threadId, resident);
     cacheRecord(threadId, cached);
@@ -257,6 +266,16 @@ export class ThreadHydrator {
       return {
         records: deleteThreadRecord(latest.records, threadId),
       };
+    });
+  }
+
+  /** Remove an inactive empty loading shell after its hydrate result was discarded. */
+  private discardInactiveLoadingRecord(threadId: string): void {
+    this.deps.setState((state: ThreadHydratorWriteState) => {
+      if (state.currentThreadId === threadId) return {};
+      const resident = state.records.get(threadId);
+      if (!resident || hasResidentLayer(resident)) return {};
+      return { records: deleteThreadRecord(state.records, threadId) };
     });
   }
 
@@ -350,40 +369,32 @@ export class ThreadHydrator {
 
   /** Keep cache-hit reconciliation bounded while retaining loaded history for upward pagination. */
   private compactCachedRecordForRestore(threadId: string, cached: ThreadRecord): ThreadRecord {
+    cacheRecord(threadId, cached);
+    const bounded = getCachedRecord(threadId) ?? cached;
     if (
-      cached.messages.length <= MESSAGE_FETCH_SIZE
+      bounded.messages.length <= MESSAGE_FETCH_SIZE
       || hasRememberedHistoryPosition(threadId)
     ) {
-      return cached;
+      return bounded;
     }
 
-    const tailStart = cached.messages.length - MESSAGE_FETCH_SIZE;
-    const earlierMessages = cached.messages.slice(0, tailStart);
+    const tailStart = bounded.messages.length - MESSAGE_FETCH_SIZE;
+    const earlierMessages = bounded.messages.slice(0, tailStart);
     const retainedEarlierMessages = earlierMessages.slice(-HISTORY_PREFETCH_SIZE);
-    const tailMessages = cached.messages.slice(tailStart);
+    const tailMessages = bounded.messages.slice(tailStart);
     const narrativeByMessage: ConversationPage["narrativeByMessage"] = {};
-    for (const [messageId, narrative] of Object.entries(cached.narrativeByMessage)) {
+    for (const [messageId, narrative] of Object.entries(bounded.narrativeByMessage)) {
       if (narrative) narrativeByMessage[messageId] = narrative;
     }
     const page: ConversationPage = {
-      messages: cached.messages,
-      hasMore: cached.hasMoreMessages,
-      answeredPlanMessageIds: [...cached.answeredPlanMessageIds],
+      messages: bounded.messages,
+      hasMore: bounded.hasMoreMessages,
+      answeredPlanMessageIds: [...bounded.answeredPlanMessageIds],
       narrativeByMessage,
     };
     const tailPage = buildConversationPageSubset(page, tailMessages, true);
-    cachePrefetchedHistoryPage(
-      threadId,
-      tailMessages[0].sequence,
-      buildConversationPageSubset(
-        page,
-        retainedEarlierMessages,
-        cached.hasMoreMessages || retainedEarlierMessages.length < earlierMessages.length,
-      ),
-    );
-
     const compacted = {
-      ...cached,
+      ...bounded,
       messages: tailMessages,
       oldestLoadedSequence: tailMessages[0].sequence,
       hasMoreMessages: true,
@@ -391,6 +402,15 @@ export class ThreadHydrator {
       answeredPlanMessageIds: new Set(tailPage.answeredPlanMessageIds ?? []),
     };
     cacheRecord(threadId, compacted);
+    cachePrefetchedHistoryPage(
+      threadId,
+      tailMessages[0].sequence,
+      buildConversationPageSubset(
+        page,
+        retainedEarlierMessages,
+        bounded.hasMoreMessages || retainedEarlierMessages.length < earlierMessages.length,
+      ),
+    );
     return compacted;
   }
 


### PR DESCRIPTION
## What

Preserve cached long-thread history and reading position across thread switches without repeated message fetches or bubble remounts.

## Why

Revisiting a previously opened long thread could reload its latest messages, remount existing bubbles, or restore an empty transcript during rapid switching. Unbounded cached history also made memory use grow with scroll depth.

## Key Changes

- Restore cached transcripts and stable reading anchors without duplicate conversation page requests
- Keep existing bubble DOM nodes stable while older history is prepended
- Join pending hydrates during rapid thread switching and discard stale empty shells
- Bound each thread's warm message cache to 100 messages across the record and prefetched history
- Add unit and browser coverage for rapid switching, cache bounds, and scroll restoration

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787161010&installation_model_id=20477&pr_number=906&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F906&signature=b0076ba0ea0ac2a588a34553ce6b12ddae32641829caa4dc82f8047676454b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->