### PR TITLE
fix: track subagent file changes in parent turns

### DIFF
--- a/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-event-mapper.test.ts
@@ -1390,6 +1390,104 @@ describe("CodexEventMapper", () => {
     });
   });
 
+  it("replays an early child file mutation after its receiver thread is registered", () => {
+    mapper = new CodexEventMapper("test-thread", "parent-thread");
+    const earlyStart = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        threadId: "child-thread-early",
+        item: {
+          type: "fileChange",
+          id: "file-child",
+          changes: [{ path: "src/child.ts", kind: "edit" }],
+        },
+      },
+    });
+    const earlyCompletion = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "child-thread-early",
+        item: {
+          type: "fileChange",
+          id: "file-child",
+          changes: [{ path: "src/child.ts", kind: "edit" }],
+        },
+      },
+    });
+
+    const registered = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "parent-thread",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-early",
+          tool: "spawnAgent",
+          receiverThreadIds: ["child-thread-early"],
+          result: "spawned",
+        },
+      },
+    });
+
+    expect(earlyStart).toEqual([]);
+    expect(earlyCompletion).toEqual([]);
+    expect(registered).toEqual([
+      expect.objectContaining({
+        type: "toolUse",
+        toolCallId: "collab-early",
+      }),
+      expect.objectContaining({
+        type: "toolUse",
+        toolCallId: "file-child",
+        toolName: "file_change",
+        parentToolCallId: "collab-early",
+      }),
+      expect.objectContaining({
+        type: "toolResult",
+        toolCallId: "file-child",
+      }),
+    ]);
+  });
+
+  it("drops an unrelated unknown-thread notification instead of replaying it", () => {
+    mapper = new CodexEventMapper("test-thread", "parent-thread");
+    const unknown = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        threadId: "unrelated-thread",
+        item: {
+          type: "commandExecution",
+          id: "unrelated-command",
+          command: "git status",
+        },
+      },
+    });
+
+    const registered = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "parent-thread",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-unrelated",
+          tool: "spawnAgent",
+          receiverThreadIds: ["unrelated-thread"],
+          result: "spawned",
+        },
+      },
+    });
+
+    expect(unknown).toEqual([]);
+    expect(registered).toEqual([
+      expect.objectContaining({ type: "toolUse", toolCallId: "collab-unrelated" }),
+    ]);
+  });
+
   it("nests commandExecution under inner collab on a nested receiver thread (two-level sub-agents)", () => {
     mapper = new CodexEventMapper("test-thread", "parent-thread");
     mapper.mapNotification({

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -73,6 +73,7 @@ const EARLY_CHILD_FILE_TOOL_NAMES = new Set([
   "searchreplace", "strreplace", "write",
 ]);
 
+/** Maps Codex app-server notifications into Mcode agent events. */
 export class CodexEventMapper {
   /** Main-thread assistant text buffers keyed by Codex item id. */
   private readonly assistantTextByItemId = new Map<string, string>();

--- a/apps/server/src/providers/codex/codex-event-mapper.ts
+++ b/apps/server/src/providers/codex/codex-event-mapper.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import { logger } from "@mcode/shared";
 import { AgentEventType } from "@mcode/contracts";
-import type { AgentEvent, GoalState } from "@mcode/contracts";
+import type { AgentEvent, GoalState, ProviderFileMutationStart } from "@mcode/contracts";
 import {
   BoundedToolOutputBuffer,
   boundToolOutput,
@@ -66,6 +66,12 @@ const TOOL_LIKE_ITEM_TYPES = new Set([
 ]);
 
 const FALLBACK_ASSISTANT_ITEM_ID = "__codex_assistant_message__";
+const MAX_EARLY_CHILD_THREADS = 8;
+const MAX_EARLY_CHILD_NOTIFICATIONS = 64;
+const EARLY_CHILD_FILE_TOOL_NAMES = new Set([
+  "apply_patch", "create", "delete", "edit", "move", "remove", "rename",
+  "searchreplace", "strreplace", "write",
+]);
 
 export class CodexEventMapper {
   /** Main-thread assistant text buffers keyed by Codex item id. */
@@ -120,6 +126,11 @@ export class CodexEventMapper {
    * under the correct Agent row even when multiple sub-agents run in parallel.
    */
   private collabReceiverThreadToCollabId = new Map<string, string>();
+  /** Bounded mutation/collab notifications received before spawn receiver metadata. */
+  private earlyChildNotificationsByThread = new Map<string, CodexNotification[]>();
+  private earlyChildNotificationCount = 0;
+  /** Child events replayed while the current main-thread notification registers receivers. */
+  private replayedChildEvents: AgentEvent[] = [];
   /**
    * True once `turn/completed` fired but before the next turn's `turn/started`.
    * While this is set we suppress all event emission so trailing notifications
@@ -128,7 +139,11 @@ export class CodexEventMapper {
    */
   private turnEnded = false;
 
-  constructor(threadId: string, mainCodexThreadId?: string) {
+  constructor(
+    threadId: string,
+    mainCodexThreadId?: string,
+    private readonly onPendingMutationStart?: (event: ProviderFileMutationStart) => void,
+  ) {
     this.threadId = threadId;
     this.mainCodexThreadId = mainCodexThreadId;
   }
@@ -232,6 +247,54 @@ export class CodexEventMapper {
     return "main";
   }
 
+  /** Retains only bounded notifications that can establish or report explicit child mutations. */
+  private bufferEligibleEarlyChildNotification(notification: CodexNotification): boolean {
+    const childThreadId = this.notificationThreadId(notification);
+    if (!childThreadId || !this.isEligibleEarlyChildNotification(notification)) return false;
+    if (this.earlyChildNotificationCount >= MAX_EARLY_CHILD_NOTIFICATIONS) return false;
+    let pending = this.earlyChildNotificationsByThread.get(childThreadId);
+    if (!pending) {
+      if (this.earlyChildNotificationsByThread.size >= MAX_EARLY_CHILD_THREADS) return false;
+      pending = [];
+      this.earlyChildNotificationsByThread.set(childThreadId, pending);
+    }
+    pending.push(notification);
+    this.earlyChildNotificationCount += 1;
+    this.capturePendingMutationStart(notification);
+    logger.debug("CodexEventMapper: buffering eligible early child notification", {
+      method: notification.method,
+      notificationThreadId: childThreadId,
+    });
+    return true;
+  }
+
+  /** Captures file state at an eligible unknown child start without publishing an attributed tool row. */
+  private capturePendingMutationStart(notification: CodexNotification): void {
+    if (notification.method !== "item/started" || !this.onPendingMutationStart) return;
+    const item = notification.params.item as CompletedItem | undefined;
+    const itemId = typeof item?.id === "string" ? item.id : undefined;
+    if (!item || !itemId || item.type === "collabAgentToolCall") return;
+    const toolUse = this.buildToolUseEvent(item, itemId, notification);
+    if (!toolUse || toolUse.type !== AgentEventType.ToolUse) return;
+    this.onPendingMutationStart({
+      threadId: toolUse.threadId,
+      toolCallId: toolUse.toolCallId,
+      toolName: toolUse.toolName,
+      toolInput: toolUse.toolInput,
+    });
+  }
+
+  private isEligibleEarlyChildNotification(notification: CodexNotification): boolean {
+    if (notification.method !== "item/started" && notification.method !== "item/completed") {
+      return false;
+    }
+    const item = notification.params.item as CompletedItem | undefined;
+    if (item?.type === "fileChange" || item?.type === "collabAgentToolCall") return true;
+    return item?.type === "function_call"
+      && typeof item.name === "string"
+      && EARLY_CHILD_FILE_TOOL_NAMES.has(item.name.toLowerCase());
+  }
+
   /** Child receiver threads contribute tool rows only; text and lifecycle stay private to Codex. */
   private mapChildThreadNotification(notification: CodexNotification): AgentEvent[] {
     const { method } = notification;
@@ -262,6 +325,13 @@ export class CodexEventMapper {
           this.openSpawnAgentIds.add(itemId);
         }
         return [this.buildCollabToolUseEvent(item, itemId, notification)];
+      }
+      if (itemType && itemId && TOOL_LIKE_ITEM_TYPES.has(itemType) && itemType !== "webSearch") {
+        const toolUse = this.buildToolUseEvent(item as CompletedItem, itemId, notification);
+        if (toolUse) {
+          this.startedToolUseSignatures.set(itemId, this.toolUseSignature(toolUse));
+          return [toolUse];
+        }
       }
       logger.debug("Codex child thread notification consumed", { method, itemType });
       return [];
@@ -349,6 +419,13 @@ export class CodexEventMapper {
     }
     for (const id of receiverThreadIds) {
       this.collabReceiverThreadToCollabId.set(id, collabId);
+      const pending = this.earlyChildNotificationsByThread.get(id);
+      if (!pending) continue;
+      this.earlyChildNotificationsByThread.delete(id);
+      this.earlyChildNotificationCount -= pending.length;
+      for (const notification of pending) {
+        this.replayedChildEvents.push(...this.mapChildThreadNotification(notification));
+      }
     }
     return receiverThreadIds.size;
   }
@@ -778,6 +855,14 @@ export class CodexEventMapper {
    * Returns an empty array for silently consumed notification types.
    */
   mapNotification(notification: CodexNotification): AgentEvent[] {
+    this.replayedChildEvents = [];
+    const events = this.mapNotificationInternal(notification);
+    return this.replayedChildEvents.length > 0
+      ? [...events, ...this.replayedChildEvents]
+      : events;
+  }
+
+  private mapNotificationInternal(notification: CodexNotification): AgentEvent[] {
     const { method } = notification;
     if (method === "warning") {
       logger.warn("Codex warning notification", { method, params: notification.params });
@@ -787,6 +872,7 @@ export class CodexEventMapper {
     const route = this.classifyNotificationThread(notification);
 
     if (route === "unknown") {
+      if (this.bufferEligibleEarlyChildNotification(notification)) return [];
       logger.warn("CodexEventMapper: dropping unknown-thread notification", {
         method,
         notificationThreadId: this.notificationThreadId(notification),
@@ -1132,6 +1218,9 @@ export class CodexEventMapper {
     this.childAssistantTextByThreadId.clear();
     this.pendingLegacyCollabPops.clear();
     this.collabReceiverThreadToCollabId.clear();
+    this.earlyChildNotificationsByThread.clear();
+    this.earlyChildNotificationCount = 0;
+    this.replayedChildEvents = [];
     // Note: turnEnded is intentionally NOT cleared here. reset() is called
     // from inside turn/completed, and we want the latch to stay armed until
     // the next turn opens. Use prepareForTurn() before a new outbound turn.

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -945,7 +945,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       getSpawnEnv: () => args.env,
     });
 
-    const mapper = new CodexEventMapper(threadId);
+    const mapper = new CodexEventMapper(threadId, undefined, (event) => {
+      this.emit("file_mutation_start", event);
+    });
     mapper.setOutputTruncationMode(this.outputTruncationMode);
 
     server.on("notification", (notification) => {

--- a/apps/server/src/services/__tests__/turn-file-tracker.test.ts
+++ b/apps/server/src/services/__tests__/turn-file-tracker.test.ts
@@ -8,6 +8,7 @@ import {
   createCursorAcpTurnState,
   mapCursorAcpSessionNotification,
 } from "../../providers/cursor/cursor-acp-event-mapper.js";
+import { CodexEventMapper } from "../../providers/codex/codex-event-mapper.js";
 import { AgentEventType } from "@mcode/contracts";
 
 const dirs: string[] = [];
@@ -36,6 +37,89 @@ function trackerWithBaseline(
 }
 
 describe("TurnFileTracker", () => {
+  it("captures an unavailable-Git baseline before an early child mutation is attributed", async () => {
+    const root = await tempDir("mcode-early-child-effects-");
+    const trackedPath = join(root, "tracked.txt");
+    await writeFile(trackedPath, "before\n");
+    const updates: TurnFileEffectSummary[] = [];
+    const tracker = new TurnFileTracker(
+      async () => ({ kind: "unavailable" }),
+      (_threadId, _turnId, summary) => updates.push(summary),
+    );
+    tracker.beginTurn("t", root, "unavailable-ref");
+    const pendingStarts: Promise<void>[] = [];
+    const mapper = new CodexEventMapper("t", "parent-thread", (event) => {
+      pendingStarts.push(tracker.observeToolUse(
+        event.threadId,
+        event.toolCallId,
+        event.toolName,
+        event.toolInput,
+      ));
+    });
+
+    const earlyStart = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        threadId: "child-thread-early",
+        item: {
+          type: "fileChange",
+          id: "file-child",
+          changes: [{ path: "tracked.txt", kind: "edit" }],
+        },
+      },
+    });
+    await writeFile(trackedPath, "after\nextra\n");
+    const earlyCompletion = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "child-thread-early",
+        item: {
+          type: "fileChange",
+          id: "file-child",
+          changes: [{ path: "tracked.txt", kind: "edit" }],
+        },
+      },
+    });
+    const registered = mapper.mapNotification({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "parent-thread",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-early",
+          tool: "spawnAgent",
+          receiverThreadIds: ["child-thread-early"],
+          result: "spawned",
+        },
+      },
+    });
+
+    expect(earlyStart).toEqual([]);
+    expect(earlyCompletion).toEqual([]);
+    expect(pendingStarts).toHaveLength(1);
+    for (const event of registered) {
+      if (event.type === AgentEventType.ToolUse && event.toolName !== "Agent") {
+        await tracker.observeToolUse("t", event.toolCallId, event.toolName, event.toolInput);
+      }
+      if (event.type === AgentEventType.ToolResult) {
+        await tracker.observeToolResult("t", event.toolCallId, event.toolInput);
+      }
+    }
+    await Promise.all(pendingStarts);
+
+    const summary = await tracker.finalizeTurn("t");
+    expect(summary).toMatchObject({ fileCount: 1, additions: 2, deletions: 1 });
+    expect(summary.effects[0]).toMatchObject({
+      path: "tracked.txt",
+      kind: "edited",
+      toolCallIds: ["file-child"],
+    });
+    expect(updates.at(-1)).toEqual(summary);
+  });
+
   it("classifies added, edited, and removed files with net line totals", async () => {
     const root = await tempDir("mcode-file-effects-");
     await writeFile(join(root, "edited.txt"), "one\ntwo");
@@ -104,6 +188,30 @@ describe("TurnFileTracker", () => {
     await writeFile(join(root, "same.txt"), "base");
     await tracker.observeToolResult("t", "c");
     expect(await tracker.finalizeTurn("t")).toMatchObject({ fileCount: 0, additions: 0, deletions: 0 });
+  });
+
+  it("coalesces parallel sub-agent tools by path while retaining their provenance", async () => {
+    const root = await tempDir("mcode-file-effects-subagents-");
+    await writeFile(join(root, "shared.txt"), "base\n");
+    const tracker = trackerWithBaseline({ "shared.txt": "base\n" }, []);
+    tracker.beginTurn("parent-turn", root, "before");
+
+    await Promise.all([
+      tracker.observeToolUse("parent-turn", "subagent-a-edit", "Edit", { file_path: "shared.txt" }),
+      tracker.observeToolUse("parent-turn", "subagent-b-edit", "Edit", { file_path: "shared.txt" }),
+    ]);
+    await writeFile(join(root, "shared.txt"), "changed\n");
+    await Promise.all([
+      tracker.observeToolResult("parent-turn", "subagent-a-edit"),
+      tracker.observeToolResult("parent-turn", "subagent-b-edit"),
+    ]);
+
+    const summary = await tracker.finalizeTurn("parent-turn");
+    expect(summary.fileCount).toBe(1);
+    expect(summary.effects[0]).toMatchObject({
+      path: "shared.txt",
+      toolCallIds: ["subagent-a-edit", "subagent-b-edit"],
+    });
   });
 
   it("detects a partial write even when the tool result is an error", async () => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -38,6 +38,7 @@ import type {
   SendMessageInput,
   CreateAndSendInput,
   PermissionMode,
+  ProviderFileMutationStart,
 } from "@mcode/contracts";
 import { ThreadRepo } from "../repositories/thread-repo";
 import { WorkspaceRepo } from "../repositories/workspace-repo";
@@ -2151,6 +2152,17 @@ export class AgentService {
     });
 
     for (const provider of this.providerRegistry.resolveAll()) {
+      provider.on("file_mutation_start", (event: ProviderFileMutationStart) => {
+        void this.ensureTurnFileTracking(event.threadId);
+        this.queueTurnFileTracking(event.threadId, () => (
+          this.turnFileTracker.observeToolUse(
+            event.threadId,
+            event.toolCallId,
+            event.toolName,
+            event.toolInput,
+          )
+        ));
+      });
       const handleEvent = (event: AgentEvent): void => {
         const priorFinalization = this.fileTrackingFinalizationByThread.get(event.threadId);
         const existingBarrier = this.providerEventBarrierByThread.get(event.threadId);

--- a/apps/server/src/services/turn-file-tracker.ts
+++ b/apps/server/src/services/turn-file-tracker.ts
@@ -146,7 +146,7 @@ export class TurnFileTracker {
       for (const tracked of turn.tracked.values()) {
         if (!tracked.providerConfirmed || tracked.scope !== "workspace") continue;
         const baseline = await this.readGitBaseline(turn, tracked.displayPath);
-        if (baseline) tracked.baseline = baseline;
+        if (baseline && (baseline.known || !tracked.baseline.known)) tracked.baseline = baseline;
         if (tracked.oldPath && tracked.oldResolvedPath) {
           const oldBaseline = await this.readGitBaseline(turn, tracked.oldPath);
           if (oldBaseline) tracked.oldBaseline = oldBaseline;
@@ -179,8 +179,7 @@ export class TurnFileTracker {
     };
     const observations = boundedCandidates.map((candidate) => {
       const requiredPaths = candidate.operationHint === "rename" && candidate.oldPath ? 2 : 1;
-      return candidate.providerConfirmed === true
-        || candidate.beforeText !== undefined
+      return candidate.beforeText !== undefined
         || syncBudget.remainingPaths < requiredPaths
         ? undefined
         : observeCandidateSynchronously(turn.canonicalRoot, candidate, syncBudget);
@@ -296,7 +295,9 @@ export class TurnFileTracker {
         const oldBaseline = candidate.beforeText !== undefined
           ? stateFromEvidenceText(candidate.beforeText)
           : observation?.oldBaseline
-            ? observation.oldBaseline
+            ? candidate.providerConfirmed === true
+              ? await this.readProviderConfirmedBaseline(turn, validOldPath, "remove", observation.oldBaseline)
+              : observation.oldBaseline
             : candidate.providerConfirmed === true
               ? await this.readProviderConfirmedBaseline(turn, validOldPath, "remove")
               : await readBoundedState(validOldPath.path);
@@ -308,20 +309,26 @@ export class TurnFileTracker {
       return;
     }
 
-    let baseline = candidate.beforeText !== undefined && !validOldPath
+    const baseline = candidate.beforeText !== undefined && !validOldPath
       ? stateFromEvidenceText(candidate.beforeText)
-      : observation?.baseline ?? null;
-    baseline ??= candidate.providerConfirmed === true
-      ? await this.readProviderConfirmedBaseline(turn, resolvedPath, candidate.operationHint)
-      : await readBoundedState(resolvedPath.path);
+      : candidate.providerConfirmed === true
+        ? await this.readProviderConfirmedBaseline(
+            turn,
+            resolvedPath,
+            candidate.operationHint,
+            observation?.baseline ?? undefined,
+          )
+        : observation?.baseline ?? await readBoundedState(resolvedPath.path);
     const oldBaseline = validOldPath
       ? candidate.beforeText !== undefined
         ? stateFromEvidenceText(candidate.beforeText)
-        : observation?.oldBaseline
-          ? observation.oldBaseline
-        : candidate.providerConfirmed === true
-          ? await this.readProviderConfirmedBaseline(turn, validOldPath, "remove")
-          : await readBoundedState(validOldPath.path)
+          : observation?.oldBaseline
+            ? candidate.providerConfirmed === true
+              ? await this.readProviderConfirmedBaseline(turn, validOldPath, "remove", observation.oldBaseline)
+              : observation.oldBaseline
+            : candidate.providerConfirmed === true
+              ? await this.readProviderConfirmedBaseline(turn, validOldPath, "remove")
+              : await readBoundedState(validOldPath.path)
       : undefined;
     turn.tracked.set(resolvedPath.path, {
       ...resolvedPath,
@@ -343,12 +350,13 @@ export class TurnFileTracker {
     turn: TurnState,
     resolvedPath: Pick<TrackedPath, "path" | "displayPath" | "scope">,
     operationHint: OperationHint,
+    observedBaseline?: FileState,
   ): Promise<FileState> {
     if (resolvedPath.scope === "workspace" && turn.baselineRef) {
       const baseline = await this.readGitBaseline(turn, resolvedPath.displayPath);
-      if (baseline) return baseline;
+      if (baseline?.known) return baseline;
     }
-    return inferredProviderBaseline(operationHint);
+    return observedBaseline ?? inferredProviderBaseline(operationHint);
   }
 
   private async readGitBaseline(turn: TurnState, relativePath: string): Promise<FileState | null> {

--- a/apps/web/src/components/chat/TaskBubble.test.tsx
+++ b/apps/web/src/components/chat/TaskBubble.test.tsx
@@ -62,7 +62,7 @@ describe("getTaskAggregateStatus", () => {
     expect(screen.getByRole("button", { name: "1 of 3 tasks settled" })).toHaveTextContent("1/3 steps");
   });
 
-  it("expands upward from the centered bubble anchor", () => {
+  it("opens on pointer hover using the shared collision-aware popover", () => {
     render(
       <TaskBubble
         tasks={[
@@ -72,9 +72,12 @@ describe("getTaskAggregateStatus", () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId("task-bubble"));
+    fireEvent.pointerEnter(screen.getByTestId("task-bubble"));
 
-    expect(screen.getByTestId("task-bubble-expanded")).toHaveClass("bottom-full", "left-1/2", "-translate-x-1/2");
+    const panel = screen.getByTestId("task-bubble-expanded");
+    expect(panel).toHaveClass("w-[min(40rem,calc(100vw-2rem))]");
+    expect(panel).toHaveClass("max-h-(--available-height)");
+    expect(panel.parentElement).toHaveAttribute("data-side", "top");
   });
 
   it("bounds the expanded list with a scrollable padded viewport", () => {
@@ -93,6 +96,52 @@ describe("getTaskAggregateStatus", () => {
       .querySelector('[data-slot="scroll-area-viewport"]');
 
     expect(viewport).toHaveClass("overflow-x-hidden", "overflow-y-auto", "scroll-py-2");
+    expect(viewport).toHaveAttribute("aria-label", "Task list");
+    expect(viewport).toHaveAttribute("tabindex", "0");
+  });
+
+  it("opens on keyboard focus and Escape closes it", () => {
+    render(
+      <TaskBubble tasks={[item("one", "in_progress", "Finish one")]} />,
+    );
+
+    const bubble = screen.getByTestId("task-bubble");
+    fireEvent.focus(bubble);
+    expect(screen.getByTestId("task-bubble-expanded")).toBeInTheDocument();
+
+    fireEvent.keyDown(bubble, { key: "Escape" });
+    expect(screen.queryByTestId("task-bubble-expanded")).not.toBeInTheDocument();
+  });
+
+  it("keeps click as a touch-compatible open and close fallback", () => {
+    render(
+      <TaskBubble tasks={[item("one", "pending", "Finish one")]} />,
+    );
+
+    const bubble = screen.getByTestId("task-bubble");
+    fireEvent.pointerEnter(bubble, { pointerType: "touch" });
+    fireEvent.click(bubble);
+    expect(screen.getByTestId("task-bubble-expanded")).toBeInTheDocument();
+
+    fireEvent.pointerEnter(bubble, { pointerType: "touch" });
+    fireEvent.click(bubble);
+    expect(screen.queryByTestId("task-bubble-expanded")).not.toBeInTheDocument();
+  });
+
+  it("renders semantic task rows with accessible statuses", () => {
+    render(
+      <TaskBubble tasks={[
+        item("one", "completed", "Finish one"),
+        item("two", "pending", "Finish two"),
+      ]} />,
+    );
+
+    fireEvent.click(screen.getByTestId("task-bubble"));
+    const list = screen.getByRole("list", { name: "Tasks" });
+    expect(list).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getByText(/Completed:/)).toHaveClass("sr-only");
+    expect(screen.getByText(/Pending:/)).toHaveClass("sr-only");
   });
 
   it("renders live file, addition, and deletion facts beside step progress", () => {

--- a/apps/web/src/components/chat/TaskBubble.test.tsx
+++ b/apps/web/src/components/chat/TaskBubble.test.tsx
@@ -128,6 +128,44 @@ describe("getTaskAggregateStatus", () => {
     expect(screen.queryByTestId("task-bubble-expanded")).not.toBeInTheDocument();
   });
 
+  it("keeps the preview open when a mouse click follows pointer hover", () => {
+    render(
+      <TaskBubble tasks={[item("one", "pending", "Finish one")]} />,
+    );
+
+    const bubble = screen.getByTestId("task-bubble");
+    fireEvent.pointerEnter(bubble, { pointerType: "mouse" });
+    fireEvent.click(bubble);
+
+    expect(screen.getByTestId("task-bubble-expanded")).toBeInTheDocument();
+
+    fireEvent.click(bubble);
+    expect(screen.queryByTestId("task-bubble-expanded")).not.toBeInTheDocument();
+  });
+
+  it("closes a hover-open preview on Escape", () => {
+    render(
+      <TaskBubble tasks={[item("one", "pending", "Finish one")]} />,
+    );
+
+    fireEvent.pointerEnter(screen.getByTestId("task-bubble"), { pointerType: "mouse" });
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByTestId("task-bubble-expanded")).not.toBeInTheDocument();
+  });
+
+  it("closes a hover-open preview on outside press", () => {
+    render(
+      <TaskBubble tasks={[item("one", "pending", "Finish one")]} />,
+    );
+
+    fireEvent.pointerEnter(screen.getByTestId("task-bubble"), { pointerType: "mouse" });
+    fireEvent.pointerDown(document.body);
+    fireEvent.click(document.body);
+
+    expect(screen.queryByTestId("task-bubble-expanded")).not.toBeInTheDocument();
+  });
+
   it("renders semantic task rows with accessible statuses", () => {
     render(
       <TaskBubble tasks={[

--- a/apps/web/src/components/chat/TaskBubble.tsx
+++ b/apps/web/src/components/chat/TaskBubble.tsx
@@ -161,9 +161,16 @@ export function TaskBubble({
   return (
     <Popover
       open={expanded}
-      onOpenChange={(open) => {
-        if (open) setPinnedOpen(true);
-        else closePreview();
+      onOpenChange={(open, eventDetails) => {
+        if (open || (
+          eventDetails.reason === "trigger-press"
+          && hoverOpen
+          && !pinnedOpen
+        )) {
+          setPinnedOpen(true);
+        } else {
+          closePreview();
+        }
       }}
     >
       <div className="w-fit max-w-full">

--- a/apps/web/src/components/chat/TaskBubble.tsx
+++ b/apps/web/src/components/chat/TaskBubble.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { TaskItem } from "@/stores/taskStore";
 import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { TaskItem as TaskRow } from "@/components/tasks/TaskItem";
 import { TaskPanelHeader } from "@/components/tasks/TaskPanelHeader";
@@ -85,49 +86,159 @@ export function TaskBubble({
   tasks: readonly TaskItem[];
   fileEffects?: TurnFileEffectSummary;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [hoverOpen, setHoverOpen] = useState(false);
+  const [focusOpen, setFocusOpen] = useState(false);
+  const [pinnedOpen, setPinnedOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pointerDownRef = useRef(false);
+  const suppressFocusOpenRef = useRef(false);
+  const expanded = hoverOpen || focusOpen || pinnedOpen;
+  useEffect(() => () => {
+    if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current);
+  }, []);
+  useEffect(() => {
+    if (!expanded) return;
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (closeTimerRef.current !== null) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+      setHoverOpen(false);
+      setFocusOpen(false);
+      setPinnedOpen(false);
+      suppressFocusOpenRef.current = document.activeElement != null
+        && Boolean(triggerRef.current?.contains(document.activeElement)
+          || panelRef.current?.contains(document.activeElement));
+    };
+    document.addEventListener("keydown", handleEscape, true);
+    return () => document.removeEventListener("keydown", handleEscape, true);
+  }, [expanded]);
   const aggregate = getTaskAggregateStatus(tasks);
   if (!aggregate) return null;
 
   const settled = settledCount(tasks);
   const total = tasks.length;
+  const cancelScheduledClose = () => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+
+  const openFromPointer = () => {
+    cancelScheduledClose();
+    setHoverOpen(true);
+  };
+
+  const closeAfterPointerLeaves = () => {
+    cancelScheduledClose();
+    closeTimerRef.current = setTimeout(() => {
+      setHoverOpen(false);
+      closeTimerRef.current = null;
+    }, 100);
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLElement>) => {
+    const next = event.relatedTarget as Node | null;
+    if (next && (triggerRef.current?.contains(next) || panelRef.current?.contains(next))) return;
+    suppressFocusOpenRef.current = false;
+    setFocusOpen(false);
+  };
+
+  const closePreview = () => {
+    cancelScheduledClose();
+    setHoverOpen(false);
+    setFocusOpen(false);
+    setPinnedOpen(false);
+    suppressFocusOpenRef.current = document.activeElement != null
+      && Boolean(triggerRef.current?.contains(document.activeElement)
+        || panelRef.current?.contains(document.activeElement));
+  };
 
   return (
-    <div className="relative w-fit max-w-full">
-      {expanded && (
-        <div
+    <Popover
+      open={expanded}
+      onOpenChange={(open) => {
+        if (open) setPinnedOpen(true);
+        else closePreview();
+      }}
+    >
+      <div className="w-fit max-w-full">
+        <PopoverTrigger
+          render={
+            <Button
+              ref={triggerRef}
+              type="button"
+              variant="outline"
+              size="sm"
+              data-testid="task-bubble"
+              aria-label={`${settled} of ${total} tasks settled${fileEffects?.fileCount ? `, ${fileEffects.fileCount} ${fileEffects.fileCount === 1 ? "file" : "files"} changed, ${fileEffects.additions} lines added, ${fileEffects.deletions} lines removed` : ""}`}
+              onPointerDown={() => {
+                pointerDownRef.current = true;
+                suppressFocusOpenRef.current = false;
+                queueMicrotask(() => { pointerDownRef.current = false; });
+              }}
+              onPointerEnter={(event) => {
+                if (event.pointerType !== "touch") openFromPointer();
+              }}
+              onPointerLeave={(event) => {
+                if (event.pointerType !== "touch") closeAfterPointerLeaves();
+              }}
+              onFocus={() => {
+                if (!pointerDownRef.current && !suppressFocusOpenRef.current) setFocusOpen(true);
+              }}
+              onBlur={handleBlur}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") closePreview();
+              }}
+              className="h-8 gap-2 rounded-full bg-card/75 px-3 focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            >
+              <ProgressCircle settled={settled} total={total} status={aggregate} />
+              <span className="flex min-w-0 items-center gap-1.5 whitespace-nowrap font-mono text-xs tabular-nums text-muted-foreground">
+                {settled}/{total} steps
+                {fileEffects && <FileEffectFacts summary={fileEffects} />}
+              </span>
+            </Button>
+          }
+        />
+        <PopoverContent
+          ref={panelRef}
           data-testid="task-bubble-expanded"
-          className="absolute bottom-full left-1/2 z-30 mb-2 flex w-[min(30rem,calc(100vw-2rem))] -translate-x-1/2 flex-col overflow-hidden rounded-xl border border-border/70 bg-popover shadow-xl shadow-black/25"
+          align="center"
+          side="top"
+          sideOffset={8}
+          collisionPadding={16}
+          collisionAvoidance={{ side: "flip", align: "shift", fallbackAxisSide: "none" }}
+          onPointerEnter={(event) => {
+            if (event.pointerType !== "touch") openFromPointer();
+          }}
+          onPointerLeave={(event) => {
+            if (event.pointerType !== "touch") closeAfterPointerLeaves();
+          }}
+          onFocusCapture={() => setFocusOpen(true)}
+          onBlurCapture={handleBlur}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") closePreview();
+          }}
+          className="flex max-h-(--available-height) w-[min(40rem,calc(100vw-2rem))] flex-col overflow-hidden rounded-xl border-border/70 p-0 shadow-lg shadow-black/20"
         >
           <TaskPanelHeader tasks={tasks} />
           <ScrollArea
-            className="max-h-[min(18rem,calc(100vh-14rem))] min-h-0 overflow-hidden"
-            viewportClassName="max-h-[min(18rem,calc(100vh-14rem))] overflow-x-hidden overflow-y-auto scroll-py-2"
+            className="min-h-0 max-h-[calc(var(--available-height)-3.25rem)] flex-1 overflow-hidden"
+            viewportClassName="max-h-[calc(var(--available-height)-3.25rem)] overflow-x-hidden overflow-y-auto scroll-py-2"
+            viewportProps={{ tabIndex: 0, "aria-label": "Task list" }}
           >
-            <div className="py-2 pb-3 pr-2">
+            <ul className="m-0 list-none py-2 pb-3 pr-2" aria-label="Tasks">
               {tasks.map((task) => (
                 <TaskRow key={task.id} task={task} />
               ))}
-            </div>
+            </ul>
           </ScrollArea>
-        </div>
-      )}
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        data-testid="task-bubble"
-        aria-expanded={expanded}
-        aria-label={`${settled} of ${total} tasks settled${fileEffects?.fileCount ? `, ${fileEffects.fileCount} ${fileEffects.fileCount === 1 ? "file" : "files"} changed, ${fileEffects.additions} lines added, ${fileEffects.deletions} lines removed` : ""}`}
-        onClick={() => setExpanded((value) => !value)}
-        className="h-8 gap-2 rounded-full bg-card/75 px-3"
-      >
-        <ProgressCircle settled={settled} total={total} status={aggregate} />
-        <span className="flex min-w-0 items-center gap-1.5 whitespace-nowrap font-mono text-xs tabular-nums text-muted-foreground">
-          {settled}/{total} steps
-          {fileEffects && <FileEffectFacts summary={fileEffects} />}
-        </span>
-      </Button>
-    </div>
+        </PopoverContent>
+      </div>
+    </Popover>
   );
 }

--- a/apps/web/src/components/tasks/TaskGroup.test.tsx
+++ b/apps/web/src/components/tasks/TaskGroup.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { TaskItem } from "@/stores/taskStore";
+import { TaskGroup } from "./TaskGroup";
+
+const TASK: TaskItem = {
+  id: "task-1",
+  content: "Track child changes",
+  status: "in_progress",
+  group: "Tasks",
+};
+
+describe("TaskGroup", () => {
+  it.each([true, false])("contains task rows in a list when hideHeader is %s", (hideHeader) => {
+    render(<TaskGroup name="Tasks" tasks={[TASK]} hideHeader={hideHeader} />);
+
+    const taskRow = screen.getByRole("listitem");
+    expect(taskRow.parentElement).toHaveRole("list");
+  });
+});

--- a/apps/web/src/components/tasks/TaskGroup.tsx
+++ b/apps/web/src/components/tasks/TaskGroup.tsx
@@ -39,11 +39,11 @@ export function TaskGroup({ name, tasks, hideHeader }: TaskGroupProps) {
 
   if (hideHeader) {
     return (
-      <div className="py-0.5">
+      <ul className="m-0 list-none py-0.5">
         {tasks.map((task) => (
           <TaskItem key={task.id} task={task} />
         ))}
-      </div>
+      </ul>
     );
   }
 
@@ -102,11 +102,11 @@ export function TaskGroup({ name, tasks, hideHeader }: TaskGroupProps) {
           gridTemplateRows: expanded ? "1fr" : "0fr",
         }}
       >
-        <div className="overflow-hidden min-h-0">
+        <ul className="m-0 min-h-0 list-none overflow-hidden">
           {tasks.map((task) => (
             <TaskItem key={task.id} task={task} />
           ))}
-        </div>
+        </ul>
       </div>
     </div>
   );

--- a/apps/web/src/components/tasks/TaskItem.tsx
+++ b/apps/web/src/components/tasks/TaskItem.tsx
@@ -15,9 +15,16 @@ export const TaskItem = memo(function TaskItem({ task }: { task: TaskItemType })
   const isDone = task.status === "completed";
   const isPending = task.status === "pending";
   const isCancelled = task.status === "cancelled";
+  const statusLabel = isActive
+    ? "In progress"
+    : isDone
+      ? "Completed"
+      : isCancelled
+        ? "Cancelled"
+        : "Pending";
 
   return (
-    <div
+    <li
       className={`flex items-start gap-2.5 px-3 py-[7px] text-[11.5px] leading-[1.5] transition-colors duration-150 ${
         isActive
           ? "bg-primary/[0.06]"
@@ -41,13 +48,13 @@ export const TaskItem = memo(function TaskItem({ task }: { task: TaskItemType })
             size={11}
             strokeWidth={2.25}
             className="text-[var(--diff-add-strong)]"
-            aria-label="Completed"
+            aria-hidden
           />
         )}
 
         {isActive && (
           /* Active: a quietly pulsing concentric mark */
-          <span className="relative inline-flex h-[12px] w-[12px] items-center justify-center" aria-label="In progress">
+          <span className="relative inline-flex h-[12px] w-[12px] items-center justify-center" aria-hidden>
             <span
               className="absolute inset-0 rounded-full bg-primary/25 animate-ping"
               style={{ animationDuration: "1.8s" }}
@@ -60,7 +67,7 @@ export const TaskItem = memo(function TaskItem({ task }: { task: TaskItemType })
           /* Pending: a quiet open ring */
           <span
             className="h-[10px] w-[10px] rounded-full border border-muted-foreground/30"
-            aria-label="Pending"
+            aria-hidden
           />
         )}
 
@@ -69,7 +76,7 @@ export const TaskItem = memo(function TaskItem({ task }: { task: TaskItemType })
             size={11}
             strokeWidth={2.25}
             className="text-muted-foreground/40"
-            aria-label="Cancelled"
+            aria-hidden
           />
         )}
       </div>
@@ -80,8 +87,9 @@ export const TaskItem = memo(function TaskItem({ task }: { task: TaskItemType })
           isActive ? "font-medium" : "font-normal"
         } ${isCancelled ? "line-through" : ""}`}
       >
+        <span className="sr-only">{statusLabel}: </span>
         {isActive ? (task.activeForm ?? task.content) : task.content}
       </span>
-    </div>
+    </li>
   );
 });

--- a/apps/web/src/components/tasks/TaskPanelHeader.test.tsx
+++ b/apps/web/src/components/tasks/TaskPanelHeader.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { TaskItem } from "@/stores/taskStore";
+import { TaskPanelHeader } from "./TaskPanelHeader";
+
+const TASKS: readonly TaskItem[] = [
+  { id: "done", content: "Done", status: "completed", group: "Tasks" },
+  { id: "pending", content: "Pending", status: "pending", group: "Tasks" },
+];
+
+describe("TaskPanelHeader", () => {
+  it("exposes the progress label to assistive technology", () => {
+    render(<TaskPanelHeader tasks={TASKS} />);
+
+    const progressLabel = screen.getByText("1 of 2 tasks completed");
+    expect(progressLabel).toHaveClass("sr-only");
+    expect(progressLabel.nextElementSibling).toHaveAttribute("aria-hidden", "true");
+    expect(progressLabel.nextElementSibling).toHaveTextContent("1/2");
+  });
+});

--- a/apps/web/src/components/tasks/TaskPanelHeader.tsx
+++ b/apps/web/src/components/tasks/TaskPanelHeader.tsx
@@ -72,7 +72,6 @@ export function TaskPanelHeader({ tasks }: TaskPanelHeaderProps) {
 
         {/* Fraction counter — typographic ratio with a soft slash */}
         <span
-          aria-label={progressLabel}
           className={`shrink-0 font-mono tabular-nums text-[10.5px] leading-none transition-colors duration-300 ${
             hasActive
               ? "text-primary/85"
@@ -81,9 +80,12 @@ export function TaskPanelHeader({ tasks }: TaskPanelHeaderProps) {
                 : "text-muted-foreground/55"
           }`}
         >
-          <span className="font-medium">{settled}</span>
-          <span className="text-muted-foreground/30">/</span>
-          {total}
+          <span className="sr-only">{progressLabel}</span>
+          <span aria-hidden="true">
+            <span className="font-medium">{settled}</span>
+            <span className="text-muted-foreground/30">/</span>
+            {total}
+          </span>
         </span>
       </div>
     </div>

--- a/apps/web/src/components/tasks/TaskPanelHeader.tsx
+++ b/apps/web/src/components/tasks/TaskPanelHeader.tsx
@@ -1,4 +1,3 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { TaskItem } from "@/stores/taskStore";
 
 /** Props for TaskPanelHeader. */
@@ -28,12 +27,20 @@ export function TaskPanelHeader({ tasks }: TaskPanelHeaderProps) {
   if (total === 0) return null;
 
   const useDots = total <= 24;
+  const progressLabel = allDone
+    ? cancelled > 0
+      ? `All tasks settled: ${completed} completed, ${cancelled} cancelled`
+      : "All tasks completed"
+    : cancelled > 0
+      ? `${completed} completed, ${cancelled} cancelled, ${total - settled} remaining`
+      : `${completed} of ${total} tasks completed`;
 
   return (
     <div className="flex-none border-b border-border/20 px-3 py-2.5">
       <div className="flex items-center gap-3">
+        <span className="shrink-0 text-xs font-medium text-foreground/80">Tasks</span>
         {/* Task status visualization — slim ticks (vertical bars) read as a typographic ledger */}
-        <div className="flex flex-1 min-w-0 items-center">
+        <div className="flex min-w-0 flex-1 items-center" aria-hidden>
           {useDots ? (
             <div className="flex items-center gap-[3px]">
               {tasks.map((task, i) => (
@@ -64,34 +71,20 @@ export function TaskPanelHeader({ tasks }: TaskPanelHeaderProps) {
         </div>
 
         {/* Fraction counter — typographic ratio with a soft slash */}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <span
-                className={`shrink-0 font-mono tabular-nums text-[10.5px] leading-none transition-colors duration-300 cursor-help ${
-                  hasActive
-                    ? "text-primary/85"
-                    : allDone
-                      ? "text-[var(--diff-add-strong)]/75"
-                      : "text-muted-foreground/55"
-                }`}
-              >
-                <span className="font-medium">{settled}</span>
-                <span className="text-muted-foreground/30">/</span>
-                {total}
-              </span>
-            }
-          />
-          <TooltipContent side="top" className="text-xs">
-            {allDone
-              ? cancelled > 0
-                ? `All tasks settled (${completed} completed, ${cancelled} cancelled)`
-                : "All tasks completed"
-              : cancelled > 0
-                ? `${completed} completed, ${cancelled} cancelled, ${total - settled} remaining`
-                : `${completed} of ${total} tasks completed`}
-          </TooltipContent>
-        </Tooltip>
+        <span
+          aria-label={progressLabel}
+          className={`shrink-0 font-mono tabular-nums text-[10.5px] leading-none transition-colors duration-300 ${
+            hasActive
+              ? "text-primary/85"
+              : allDone
+                ? "text-[var(--diff-add-strong)]/75"
+                : "text-muted-foreground/55"
+          }`}
+        >
+          <span className="font-medium">{settled}</span>
+          <span className="text-muted-foreground/30">/</span>
+          {total}
+        </span>
       </div>
     </div>
   );

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -12,6 +12,7 @@ function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
+/** Renders collision-aware popover content in a portal. */
 function PopoverContent({
   className,
   align = "center",

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -18,12 +18,13 @@ function PopoverContent({
   sideOffset = 4,
   alignOffset,
   collisionPadding,
+  collisionAvoidance,
   side,
   ...props
 }: PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
-    "align" | "sideOffset" | "alignOffset" | "collisionPadding" | "side"
+    "align" | "sideOffset" | "alignOffset" | "collisionPadding" | "collisionAvoidance" | "side"
   >) {
   return (
     <PopoverPrimitive.Portal>
@@ -32,6 +33,7 @@ function PopoverContent({
         sideOffset={sideOffset}
         alignOffset={alignOffset}
         collisionPadding={collisionPadding}
+        collisionAvoidance={collisionAvoidance}
         side={side}
         className="pointer-events-none isolate z-50"
       >

--- a/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
@@ -368,6 +368,54 @@ describe("AuxiliaryHydrator", () => {
     });
   });
 
+  it("preserves live file facts while backfilling historical snapshots", async () => {
+    const liveSummary = {
+      revision: 3,
+      fileCount: 1,
+      additions: 2,
+      deletions: 0,
+      effects: [],
+    };
+    const liveRecord = {
+      ...makeThinRecord(),
+      fileEffectTurnId: "live-turn",
+      fileEffectSummary: liveSummary,
+    };
+    records = new Map([[THREAD_ID, liveRecord]]);
+    cacheRecord(THREAD_ID, liveRecord);
+    (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        message_id: "persisted-turn",
+        files_changed: ["src/old.ts"],
+        file_effects: {
+          revision: 8,
+          fileCount: 8,
+          additions: 8,
+          deletions: 8,
+          effects: [],
+        },
+      },
+    ]);
+
+    const aux = createAux({
+      getWorkspaceThread: () => createMockThread({ id: THREAD_ID, has_file_changes: true }),
+      runningThreadIds: new Set([THREAD_ID]),
+    });
+    aux.hydrate(THREAD_ID, {
+      freshnessTtlMs: HYDRATION_TTL_MS,
+      force: true,
+      commitFileChangesToStore: true,
+    });
+
+    await vi.waitFor(() => {
+      expect(getThreadRecord(records, THREAD_ID).persistedFilesChanged).toEqual({
+        "persisted-turn": ["src/old.ts"],
+      });
+    });
+    expect(getThreadRecord(records, THREAD_ID).fileEffectSummary).toEqual(liveSummary);
+    expect(getCachedRecord(THREAD_ID)?.fileEffectSummary).toEqual(liveSummary);
+  });
+
   it("discarded file-change snapshots after the expected load epoch changed", async () => {
     let resolveSnapshots!: (value: Array<{
       message_id: string;

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -177,6 +177,57 @@ describe("ThreadHydrator", () => {
     expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
   });
 
+  it("does not let delayed snapshot hydration replace a running turn file summary", async () => {
+    const liveSummary = {
+      revision: 2,
+      fileCount: 1,
+      additions: 3,
+      deletions: 1,
+      effects: [],
+    };
+    useWorkspaceStore.setState({
+      threads: [
+        createMockThread({ id: THREAD_A, has_file_changes: true }),
+        createMockThread({ id: THREAD_B, has_file_changes: false }),
+      ],
+    });
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_A,
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map([
+        [THREAD_A, {
+          ...createEmptyThreadRecord(),
+          messages: [msgA],
+          fileEffectTurnId: "live-turn",
+          fileEffectSummary: liveSummary,
+        }],
+      ]),
+    });
+    (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        message_id: "persisted-turn",
+        files_changed: ["old.ts"],
+        file_effects: {
+          revision: 9,
+          fileCount: 9,
+          additions: 9,
+          deletions: 9,
+          effects: [],
+        },
+      } as unknown as TurnSnapshot,
+    ]);
+
+    await hydrator.hydrate(THREAD_A, "active");
+    await vi.waitFor(() => {
+      expect(readActiveThreadField((record) => record.persistedFilesChanged)).toEqual({
+        "persisted-turn": ["old.ts"],
+      });
+    });
+
+    expect(readActiveThreadField((record) => record.fileEffectTurnId)).toBe("live-turn");
+    expect(readActiveThreadField((record) => record.fileEffectSummary)).toEqual(liveSummary);
+  });
+
   it("keeps prefetched earlier history out of live state until pagination", async () => {
     const history = Array.from({ length: 100 }, (_, index) => createMockMessage({
       id: `a-${index + 1}`,

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -193,6 +193,10 @@ export class AuxiliaryHydrator {
 
         const latestCached = getCachedRecord(threadId);
         if (!latestCached) return;
+        const liveState = this.deps.getState();
+        const liveRecord = getThreadRecord(liveState.records, threadId);
+        const ownsLiveFileEffects = liveRecord.fileEffectTurnId.length > 0
+          || liveState.runningThreadIds.has(threadId);
 
         const fileChanges = SnapshotBuilder.deriveFileChanges(snapshots);
         if (
@@ -207,7 +211,7 @@ export class AuxiliaryHydrator {
             ...fileChanges.persistedFilesChanged,
           },
           latestTurnWithChanges: fileChanges.latestTurnWithChanges,
-          fileEffectSummary: fileChanges.fileEffectSummary,
+          ...(!ownsLiveFileEffects ? { fileEffectSummary: fileChanges.fileEffectSummary } : {}),
         });
 
         if (!commitToStore) return;
@@ -225,7 +229,9 @@ export class AuxiliaryHydrator {
                 ...fileChanges.persistedFilesChanged,
               },
               latestTurnWithChanges: fileChanges.latestTurnWithChanges,
-              fileEffectSummary: fileChanges.fileEffectSummary,
+              ...(rec.fileEffectTurnId.length === 0 && !state.runningThreadIds.has(threadId)
+                ? { fileEffectSummary: fileChanges.fileEffectSummary }
+                : {}),
             }),
           };
         });

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -364,6 +364,7 @@ export class ThreadHydrator {
       // The cache snapshot predates in-flight narration, so for a running
       // thread the live record wins (mirrors fetchAndCommit's isRunning guard).
       const isRunning = state.runningThreadIds.has(threadId);
+      const ownsLiveFileEffects = isRunning || current.fileEffectTurnId.length > 0;
       const liveVolatile: Partial<ThreadRecord> = isRunning
         ? {
             toolCalls: current.toolCalls,
@@ -376,6 +377,10 @@ export class ThreadHydrator {
             isCompacting: current.isCompacting,
           }
         : {};
+      if (ownsLiveFileEffects) {
+        liveVolatile.fileEffectSummary = current.fileEffectSummary;
+        liveVolatile.fileEffectTurnId = current.fileEffectTurnId;
+      }
       return {
         records: patchThreadRecord(state.records, threadId, {
           ...cached,
@@ -435,14 +440,28 @@ export class ThreadHydrator {
         return {};
       }
       applied = true;
+      const ownsLiveFileEffects = current.fileEffectTurnId.length > 0
+        || state.runningThreadIds.has(threadId);
       return {
-        records: patchThreadRecord(state.records, threadId, fileChanges),
+        records: patchThreadRecord(state.records, threadId, {
+          persistedFilesChanged: fileChanges.persistedFilesChanged,
+          latestTurnWithChanges: fileChanges.latestTurnWithChanges,
+          ...(!ownsLiveFileEffects ? { fileEffectSummary: fileChanges.fileEffectSummary } : {}),
+        }),
       };
     });
 
     const cached = getCachedRecord(threadId);
     if (!cached || !applied) return;
-    cacheRecord(threadId, { ...cached, ...fileChanges });
+    const liveRecord = getThreadRecord(this.deps.getState().records, threadId);
+    const ownsLiveFileEffects = liveRecord.fileEffectTurnId.length > 0
+      || this.deps.getState().runningThreadIds.has(threadId);
+    cacheRecord(threadId, {
+      ...cached,
+      persistedFilesChanged: fileChanges.persistedFilesChanged,
+      latestTurnWithChanges: fileChanges.latestTurnWithChanges,
+      ...(!ownsLiveFileEffects ? { fileEffectSummary: fileChanges.fileEffectSummary } : {}),
+    });
   }
 
   /** Refresh one thread's active goal without blocking main hydration. */
@@ -551,15 +570,21 @@ export class ThreadHydrator {
         answeredPlanMessageIds: pageResult.answeredPlanMessageIds,
       });
 
-      setState((state: ThreadHydratorWriteState) => ({
-        records: patchThreadRecord(state.records, threadId, {
-          ...patch,
-          narrativeByMessage: pageResult.narrativeByMessage,
-          loading: false,
-          isLoadingMore: false,
-          settings: this.deps.getWorkspaceThreadSettings(threadId),
-        }),
-      }));
+      setState((state: ThreadHydratorWriteState) => {
+        const current = getThreadRecord(state.records, threadId);
+        const ownsLiveFileEffects = current.fileEffectTurnId.length > 0
+          || state.runningThreadIds.has(threadId);
+        return {
+          records: patchThreadRecord(state.records, threadId, {
+            ...patch,
+            ...(ownsLiveFileEffects ? { fileEffectSummary: current.fileEffectSummary } : {}),
+            narrativeByMessage: pageResult.narrativeByMessage,
+            loading: false,
+            isLoadingMore: false,
+            settings: this.deps.getWorkspaceThreadSettings(threadId),
+          }),
+        };
+      });
 
       this.auxiliaryHydrator.hydrate(threadId, {
         freshnessTtlMs: HYDRATION_TTL_MS,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -601,6 +601,7 @@ export type {
   TurnRequest,
   ProviderOptionsByProvider,
   CompletionOptions,
+  ProviderFileMutationStart,
 } from "./providers/interfaces.js";
 
 export * from "./providers/catalog.js";

--- a/packages/contracts/src/providers/interfaces.ts
+++ b/packages/contracts/src/providers/interfaces.ts
@@ -25,6 +25,14 @@ export interface CompletionOptions {
   reasoningLevel?: ReasoningLevel;
 }
 
+/** Explicit provider file-tool start used to capture a mutation baseline without publishing narrative UI. */
+export interface ProviderFileMutationStart {
+  threadId: string;
+  toolCallId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+}
+
 /**
  * Per-Provider knobs that ride on a {@link TurnRequest}, keyed by {@link ProviderId}.
  * Generic call sites cannot reach into the wrong Provider's knobs because the
@@ -155,6 +163,8 @@ export interface IAgentProvider {
 
   /** Subscribe to agent events. */
   on(event: "event", handler: (event: AgentEvent) => void): void;
+  /** Subscribe to private file-tool starts that must be observed before public attribution is known. */
+  on(event: "file_mutation_start", handler: (event: ProviderFileMutationStart) => void): void;
   /** Subscribe to provider-level errors. */
   on(event: "error", handler: (error: Error) => void): void;
   /** Subscribe to permission request events (emitted when canUseTool fires). */


### PR DESCRIPTION
## What
Track explicit file mutations from nested agents in the parent Mcode turn and improve the TaskBubble task preview.

## Why
Nested Codex events can arrive before parent receiver registration. The previous flow dropped those mutations or observed their file baseline after the mutation completed. TaskBubble file facts could also be overwritten by stale hydration, and its task preview needed better pointer, keyboard, touch, and constrained-viewport behavior.

## Key Changes
- Buffer bounded early child events and replay them under the parent turn with child tool-call provenance.
- Capture eligible child mutation baselines privately at tool start without publishing narrative events before registration.
- Preserve current-turn file facts during hydration and keep TaskBubble counts turn-scoped.
- Open the task preview on hover or focus with touch click fallback, Escape dismissal, accessible task semantics, and collision-aware sizing.
- Add focused mapper, tracker, hydration, and TaskBubble regression coverage.

## Verification
- `bun run verify`: typecheck, lint, and all five test workspaces passed.
- Real Electron run on exact HEAD with GPT-5.6 Luna: a nested agent created one file, the child mutation persisted under its parent Agent tool call, and TaskBubble showed `1/1 steps · 1 file changed +1`.
- Electron hover, focus, Escape, constrained sizing, renderer errors, page errors, and Codex provider failures all passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787161447&installation_model_id=20477&pr_number=907&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F907&signature=da0b9acb00bc8d245434bd59b9155b060bbc7059b3d665eeaffb854fa4ff3082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task details now open through hover, keyboard focus, touch, or click, with improved positioning and Escape/outside-click support.
  * Task lists are more accessible, including screen-reader status labels, keyboard navigation, and clearer progress descriptions.

* **Bug Fixes**
  * File changes from parallel or early-starting sub-agents are now tracked and attributed more reliably.
  * Live file-change summaries are preserved during background synchronization and historical data loading.
  * Duplicate edits to the same file are consolidated while retaining contributing tool details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->