### PR TITLE
fix: preserve LF line endings for git hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.githooks/* text eol=lf


### PR DESCRIPTION
## What

Force tracked Git hooks to LF on checkout.

## Why

Windows `core.autocrlf=true` checkouts converted `post-checkout` to CRLF. Git Bash could not complete the hook.

## Key Changes

- Add a root attributes rule for `.githooks`.
- Keep the hook behavior unchanged.

## Verification

- Git reports `text: set` and `eol: lf` for `post-checkout`.
- The hook exits with code 0.
- A missing-`.env` fixture copies `.env.example` byte for byte.
- `bun run verify` exits with code 0 and skips code checks for this config-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787178832&installation_model_id=20477&pr_number=909&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F909&signature=a510dcd71ac30c6a970376552b22d834c98891b303dc7f13d90db2a3b85e4b7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->