### PR TITLE
feat(catalog): add Codex plugins to composer

### DIFF
--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -321,6 +321,38 @@ describe("CodexProvider first turn on new session", () => {
     ]);
   });
 
+  it("sends selected plugin mentions as native Codex mention input", async () => {
+    const provider = makeProvider();
+
+    await provider.sendTurn({
+      sessionId: "mcode-mentioned-plugin",
+      threadId: "mentioned-plugin",
+      message: "@Browser inspect the page",
+      mentions: [{
+        id: "mention-plugin-1",
+        kind: "plugin",
+        label: "Browser",
+        name: "Browser",
+        path: "plugin://browser@openai-bundled",
+        range: { start: 0, end: 8 },
+      }],
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build",
+      permissionMode: "auto",
+      providerOptions: {},
+    });
+
+    for (let i = 0; i < 20 && sendTurnMock.mock.calls.length === 0; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(sendTurnMock.mock.calls[0][0]).toEqual([
+      { type: "mention", name: "Browser", path: "plugin://browser@openai-bundled" },
+      { type: "text", text: "@Browser inspect the page" },
+    ]);
+  });
+
   it("sends selected agent mentions as Codex subagent URI input", async () => {
     const provider = makeProvider();
 

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -1014,7 +1014,7 @@ export class CodexAppServer extends EventEmitter {
     if (!this._isAlive || !this.rpc) {
       throw new Error("readPlugin called before codex app-server was ready");
     }
-    return this.rpc.sendRequest<PluginReadParams, PluginReadResult>("plugin/read", params, 10000);
+    return this.rpc.sendRequest<PluginReadParams, PluginReadResult>("plugin/read", params, 2_000);
   }
 
   /**

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -36,6 +36,10 @@ import type {
   AccountRateLimitsReadResult,
   SkillsListParams,
   SkillsListResult,
+  PluginListParams,
+  PluginListResult,
+  PluginReadParams,
+  PluginReadResult,
   SandboxMode,
   AskForApproval,
 } from "./codex-types.js";
@@ -992,6 +996,25 @@ export class CodexAppServer extends EventEmitter {
       ...(forceReload ? { forceReload } : {}),
     };
     return this.rpc.sendRequest<SkillsListParams, SkillsListResult>("skills/list", params, 10000);
+  }
+
+  /** Reads installed plugin summaries for the effective working-directory context. */
+  async listPlugins(cwds?: string[]): Promise<PluginListResult> {
+    if (!this._isAlive || !this.rpc) {
+      throw new Error("listPlugins called before codex app-server was ready");
+    }
+    const params: PluginListParams = {
+      ...(cwds && cwds.length > 0 ? { cwds } : {}),
+    };
+    return this.rpc.sendRequest<PluginListParams, PluginListResult>("plugin/list", params, 10000);
+  }
+
+  /** Reads plugin detail only when its list summary omits composer metadata. */
+  async readPlugin(params: PluginReadParams): Promise<PluginReadResult> {
+    if (!this._isAlive || !this.rpc) {
+      throw new Error("readPlugin called before codex app-server was ready");
+    }
+    return this.rpc.sendRequest<PluginReadParams, PluginReadResult>("plugin/read", params, 10000);
   }
 
   /**

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -287,7 +287,7 @@ async function buildCodexInput(
   }
 
   for (const mention of mentions) {
-    if (mention.kind !== "file") continue;
+    if (mention.kind !== "file" && mention.kind !== "plugin") continue;
     inputs.push({
       type: "mention",
       name: mention.label,

--- a/apps/server/src/providers/codex/codex-types.ts
+++ b/apps/server/src/providers/codex/codex-types.ts
@@ -206,6 +206,66 @@ export interface SkillsListResult {
   }>;
 }
 
+// Plugin RPCs
+
+/** Parameters for the `plugin/list` RPC method. */
+export interface PluginListParams {
+  cwds?: string[];
+}
+
+/** Composer metadata included in a Codex plugin summary. */
+export interface CodexPluginInterface {
+  displayName?: string | null;
+  shortDescription?: string | null;
+  longDescription?: string | null;
+  developerName?: string | null;
+  capabilities?: string[];
+  [key: string]: unknown;
+}
+
+/** Installed-state metadata returned for a Codex plugin. */
+export interface CodexPluginSummary {
+  id: string;
+  name: string;
+  installed: boolean;
+  enabled: boolean;
+  version?: string | null;
+  localVersion?: string | null;
+  interface?: CodexPluginInterface | null;
+  [key: string]: unknown;
+}
+
+/** One plugin marketplace and its summarized plugins. */
+export interface CodexPluginMarketplace {
+  name: string;
+  path: string | null;
+  plugins: CodexPluginSummary[];
+  [key: string]: unknown;
+}
+
+/** Result returned by the `plugin/list` RPC method. */
+export interface PluginListResult {
+  marketplaces: CodexPluginMarketplace[];
+  marketplaceLoadErrors: Array<{ marketplacePath: string; message: string }>;
+  featuredPluginIds: string[];
+}
+
+/** Parameters for the `plugin/read` RPC method. */
+export interface PluginReadParams {
+  marketplacePath?: string;
+  remoteMarketplaceName?: string;
+  pluginName: string;
+}
+
+/** Result returned by the `plugin/read` RPC method. */
+export interface PluginReadResult {
+  plugin: {
+    description?: string | null;
+    summary?: CodexPluginSummary;
+    [key: string]: unknown;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Notification payloads
 // Source: codex-rs/app-server-protocol/schema/typescript/ServerNotification.ts

--- a/apps/server/src/services/__tests__/codex-catalog-service.test.ts
+++ b/apps/server/src/services/__tests__/codex-catalog-service.test.ts
@@ -2,7 +2,11 @@ import "reflect-metadata";
 import { EventEmitter } from "events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CodexCatalogService } from "../codex-catalog-service.js";
-import type { SkillsListResult } from "../../providers/codex/codex-types.js";
+import type {
+  PluginListResult,
+  PluginReadResult,
+  SkillsListResult,
+} from "../../providers/codex/codex-types.js";
 
 class ControlledCatalogClient extends EventEmitter {
   isAlive = true;
@@ -35,6 +39,48 @@ class ControlledCatalogClient extends EventEmitter {
       }],
     };
   });
+  readonly listPlugins = vi.fn(async (cwds?: string[]): Promise<PluginListResult> => ({
+    marketplaces: [{
+      name: "openai-bundled",
+      path: "C:/marketplaces/openai-bundled",
+      interface: null,
+      plugins: [
+        {
+          id: "review@openai-bundled",
+          name: "review",
+          installed: true,
+          enabled: true,
+          version: "1.2.3",
+          localVersion: "1.2.3",
+          interface: {
+            displayName: "Review",
+            shortDescription: `Review plugin for ${cwds?.[0] ?? "user"}`,
+            developerName: "OpenAI",
+            capabilities: ["mcp"],
+          },
+        },
+        {
+          id: "disabled@openai-bundled",
+          name: "disabled",
+          installed: true,
+          enabled: false,
+          interface: { shortDescription: "Disabled plugin" },
+        },
+        {
+          id: "available@openai-bundled",
+          name: "available",
+          installed: false,
+          enabled: true,
+          interface: { shortDescription: "Available plugin" },
+        },
+      ],
+    }],
+    marketplaceLoadErrors: [],
+    featuredPluginIds: [],
+  }));
+  readonly readPlugin = vi.fn(async (): Promise<PluginReadResult> => ({
+    plugin: { description: "Detailed plugin description" },
+  }));
 }
 
 describe("CodexCatalogService", () => {
@@ -75,6 +121,10 @@ describe("CodexCatalogService", () => {
       [["C:/workspaces/one"], false],
       [["C:/workspaces/two"], false],
     ]);
+    expect(client.listPlugins.mock.calls).toEqual([
+      [["C:/workspaces/one"]],
+      [["C:/workspaces/two"]],
+    ]);
     expect(first.skills.map((skill) => skill.path)).toEqual([
       "C:/users/test/.codex/skills/review/SKILL.md",
       "C:/workspaces/one/.codex/skills/review/SKILL.md",
@@ -83,6 +133,70 @@ describe("CodexCatalogService", () => {
       "C:/users/test/.codex/skills/review/SKILL.md",
       "C:/workspaces/two/.codex/skills/review/SKILL.md",
     ]);
+    expect(first.plugins).toEqual([expect.objectContaining({
+      kind: "plugin",
+      identity: { providerId: "codex", kind: "plugin", nativeId: "review@openai-bundled" },
+      name: "Review",
+      description: "Review plugin for C:/workspaces/one",
+      mentionPath: "plugin://review@openai-bundled",
+      marketplaceName: "openai-bundled",
+      version: "1.2.3",
+      developerName: "OpenAI",
+      capabilities: ["mcp"],
+    })]);
+    expect(client.readPlugin).not.toHaveBeenCalled();
+  });
+
+  it("reads only plugin summaries that omit composer details", async () => {
+    const client = new ControlledCatalogClient();
+    client.listPlugins.mockResolvedValueOnce({
+      marketplaces: [{
+        name: "personal",
+        path: "C:/marketplaces/personal",
+        interface: null,
+        plugins: [{
+          id: "minimal@personal",
+          name: "minimal",
+          installed: true,
+          enabled: true,
+          version: null,
+          localVersion: null,
+          interface: null,
+        }],
+      }],
+      marketplaceLoadErrors: [],
+      featuredPluginIds: [],
+    });
+    const service = createService(client);
+
+    const result = await service.refresh("C:/workspaces/one");
+
+    expect(client.readPlugin).toHaveBeenCalledWith({
+      marketplacePath: "C:/marketplaces/personal",
+      pluginName: "minimal",
+    });
+    expect(result.plugins[0]?.description).toBe("Detailed plugin description");
+  });
+
+  it("keeps valid plugins when a marketplace reports a scoped load error", async () => {
+    const client = new ControlledCatalogClient();
+    client.listPlugins.mockResolvedValueOnce({
+      ...(await client.listPlugins()),
+      marketplaceLoadErrors: [{
+        marketplacePath: "C:/marketplaces/broken.json",
+        message: "invalid marketplace metadata",
+      }],
+    });
+    const service = createService(client);
+
+    const result = await service.refresh("C:/workspaces/one");
+
+    expect(result.plugins).toHaveLength(1);
+    expect(result.diagnostics).toContainEqual({
+      severity: "warning",
+      code: "discovery-error",
+      message: "Codex plugin marketplace C:/marketplaces/broken.json: invalid marketplace metadata",
+    });
   });
 
   it("reconciles the affected context after skills/changed", async () => {
@@ -175,7 +289,7 @@ describe("CodexCatalogService", () => {
     expect(failed.diagnostics).toEqual([{
       severity: "warning",
       code: "source-unavailable",
-      message: "Codex Skills are temporarily unavailable for this catalog context.",
+      message: "Codex capabilities are temporarily unavailable for this catalog context.",
     }]);
   });
 

--- a/apps/server/src/services/__tests__/codex-catalog-service.test.ts
+++ b/apps/server/src/services/__tests__/codex-catalog-service.test.ts
@@ -178,6 +178,49 @@ describe("CodexCatalogService", () => {
     expect(result.plugins[0]?.description).toBe("Detailed plugin description");
   });
 
+  it("bounds concurrent detail reads while retaining plugins beyond the enrichment cap", async () => {
+    const client = new ControlledCatalogClient();
+    let activeReads = 0;
+    let maxActiveReads = 0;
+    client.readPlugin.mockImplementation(async () => {
+      activeReads += 1;
+      maxActiveReads = Math.max(maxActiveReads, activeReads);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      activeReads -= 1;
+      return { plugin: { description: "Detailed plugin description" } };
+    });
+    client.listPlugins.mockResolvedValueOnce({
+      marketplaces: [{
+        name: "personal",
+        path: "C:/marketplaces/personal",
+        interface: null,
+        plugins: Array.from({ length: 65 }, (_, index) => ({
+          id: `minimal-${index}@personal`,
+          name: `minimal-${index}`,
+          installed: true,
+          enabled: true,
+          version: null,
+          localVersion: null,
+          interface: null,
+        })),
+      }],
+      marketplaceLoadErrors: [],
+      featuredPluginIds: [],
+    });
+    const service = createService(client);
+
+    const result = await service.refresh("C:/workspaces/one");
+
+    expect(client.readPlugin).toHaveBeenCalledTimes(64);
+    expect(maxActiveReads).toBeLessThanOrEqual(8);
+    expect(result.plugins).toHaveLength(65);
+    expect(result.diagnostics).toContainEqual({
+      severity: "warning",
+      code: "partial-result",
+      message: "Codex plugin detail reads were capped at 64 entries.",
+    });
+  });
+
   it("keeps valid plugins when a marketplace reports a scoped load error", async () => {
     const client = new ControlledCatalogClient();
     client.listPlugins.mockResolvedValueOnce({

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1021,7 +1021,7 @@ export class AgentService {
       if (mention.kind === "command") continue;
 
       if (input.provider !== "codex") {
-        throw new Error("Agent mentions are only supported by Codex");
+        throw new Error("Provider mentions are only supported by Codex");
       }
     }
 

--- a/apps/server/src/services/codex-catalog-service.ts
+++ b/apps/server/src/services/codex-catalog-service.ts
@@ -3,15 +3,20 @@ import { inject, injectable } from "tsyringe";
 import type {
   ProviderCatalogDiagnostic,
   ProviderCatalogFreshness,
+  ProviderPluginCapability,
   SkillInfo,
 } from "@mcode/contracts";
 import {
   PROVIDER_CATALOG_MAX_ENTRIES,
+  ProviderPluginCapabilitySchema,
   SkillInfoSchema,
 } from "@mcode/contracts";
 import { logger } from "@mcode/shared";
 import { CodexAppServer, type CodexAppServerOptions } from "../providers/codex/codex-app-server.js";
 import type {
+  PluginListResult,
+  PluginReadParams,
+  PluginReadResult,
   SkillsListResult,
 } from "../providers/codex/codex-types.js";
 import { codexPluginNameFromSkillPath } from "./skill-service.js";
@@ -26,6 +31,7 @@ const CODEX_CATALOG_MAX_CWD_LENGTH = 4_096;
 /** Result of refreshing native Codex Skills for one working-directory context. */
 export interface CodexCatalogRefreshResult {
   readonly skills: SkillInfo[];
+  readonly plugins: ProviderPluginCapability[];
   readonly diagnostics: ProviderCatalogDiagnostic[];
   readonly freshness: ProviderCatalogFreshness;
 }
@@ -35,6 +41,8 @@ export interface CodexCatalogClient extends EventEmitter {
   readonly isAlive: boolean;
   start(): Promise<void>;
   listSkills(cwds?: string[], forceReload?: boolean): Promise<SkillsListResult>;
+  listPlugins(cwds?: string[]): Promise<PluginListResult>;
+  readPlugin(params: PluginReadParams): Promise<PluginReadResult>;
   kill(): Promise<void>;
 }
 
@@ -135,7 +143,156 @@ function upstreamDiagnostics(rawErrors: unknown): ProviderCatalogDiagnostic[] {
   });
 }
 
-/** Owns one lazy, thread-independent Codex app-server connection for Skill catalogs. */
+function pluginDetailDescription(result: PluginReadResult): string {
+  const plugin = result.plugin;
+  const summaryInterface = plugin.summary?.interface;
+  return [
+    plugin.description,
+    summaryInterface?.shortDescription,
+    summaryInterface?.longDescription,
+  ].find((candidate): candidate is string => (
+    typeof candidate === "string" && candidate.trim().length > 0
+  ))?.trim() ?? "";
+}
+
+function pluginReadParams(
+  marketplaceName: string,
+  marketplacePath: string | null,
+  pluginName: string,
+): PluginReadParams {
+  return marketplacePath
+    ? { marketplacePath, pluginName }
+    : { remoteMarketplaceName: marketplaceName, pluginName };
+}
+
+async function reconcilePlugins(
+  client: CodexCatalogClient,
+  result: PluginListResult,
+): Promise<{
+  plugins: ProviderPluginCapability[];
+  diagnostics: ProviderCatalogDiagnostic[];
+}> {
+  const diagnostics: ProviderCatalogDiagnostic[] = (Array.isArray(result.marketplaceLoadErrors)
+    ? result.marketplaceLoadErrors
+    : []).slice(0, 90).flatMap((error) => {
+      if (
+        !error ||
+        typeof error.marketplacePath !== "string" ||
+        typeof error.message !== "string"
+      ) {
+        return [];
+      }
+      return [{
+        severity: "warning" as const,
+        code: "discovery-error" as const,
+        message: boundedDiagnosticMessage(
+          `Codex plugin marketplace ${error.marketplacePath}: ${error.message}`,
+        ),
+      }];
+    });
+  const candidates: Array<{
+    marketplaceName: string;
+    marketplacePath: string | null;
+    summary: Record<string, unknown>;
+  }> = [];
+
+  for (const rawMarketplace of Array.isArray(result.marketplaces) ? result.marketplaces : []) {
+    if (!rawMarketplace || typeof rawMarketplace !== "object") continue;
+    const marketplace = rawMarketplace as unknown as Record<string, unknown>;
+    if (typeof marketplace.name !== "string" || !Array.isArray(marketplace.plugins)) continue;
+    const marketplacePath = typeof marketplace.path === "string" ? marketplace.path : null;
+    for (const rawPlugin of marketplace.plugins) {
+      if (!rawPlugin || typeof rawPlugin !== "object") continue;
+      const summary = rawPlugin as Record<string, unknown>;
+      if (summary.installed !== true || summary.enabled !== true) continue;
+      candidates.push({
+        marketplaceName: marketplace.name,
+        marketplacePath,
+        summary,
+      });
+    }
+  }
+
+  const pluginsById = new Map<string, ProviderPluginCapability>();
+  let invalidMetadata = false;
+  for (const candidate of candidates.slice(0, PROVIDER_CATALOG_MAX_ENTRIES)) {
+    const { marketplaceName, marketplacePath, summary } = candidate;
+    if (typeof summary.id !== "string" || typeof summary.name !== "string") {
+      invalidMetadata = true;
+      continue;
+    }
+    const interfaceValue = summary.interface && typeof summary.interface === "object"
+      ? summary.interface as Record<string, unknown>
+      : undefined;
+    let description = [interfaceValue?.shortDescription, interfaceValue?.longDescription]
+      .find((value): value is string => typeof value === "string" && value.trim().length > 0)
+      ?.trim() ?? "";
+    if (!description) {
+      try {
+        description = pluginDetailDescription(await client.readPlugin(pluginReadParams(
+          marketplaceName,
+          marketplacePath,
+          summary.name,
+        )));
+      } catch {
+        diagnostics.push({
+          severity: "warning",
+          code: "partial-result",
+          message: boundedDiagnosticMessage(
+            `Codex plugin details are unavailable for ${summary.id}.`,
+          ),
+        });
+      }
+    }
+    const name = typeof interfaceValue?.displayName === "string" && interfaceValue.displayName.trim()
+      ? interfaceValue.displayName.trim()
+      : summary.name;
+    const version = [summary.localVersion, summary.version]
+      .find((value): value is string => typeof value === "string" && value.trim().length > 0)
+      ?.trim();
+    const developerName = typeof interfaceValue?.developerName === "string" && interfaceValue.developerName.trim()
+      ? interfaceValue.developerName.trim()
+      : undefined;
+    const capabilities = Array.isArray(interfaceValue?.capabilities)
+      ? interfaceValue.capabilities
+          .filter((value): value is string => typeof value === "string")
+          .slice(0, 100)
+      : [];
+    const parsed = ProviderPluginCapabilitySchema().safeParse({
+      kind: "plugin",
+      identity: { providerId: "codex", kind: "plugin", nativeId: summary.id },
+      name,
+      description,
+      mentionPath: `plugin://${summary.id}`,
+      marketplaceName,
+      ...(version ? { version } : {}),
+      ...(developerName ? { developerName } : {}),
+      capabilities,
+    });
+    if (parsed.success) pluginsById.set(parsed.data.identity.nativeId, parsed.data);
+    else invalidMetadata = true;
+  }
+  if (candidates.length > PROVIDER_CATALOG_MAX_ENTRIES) {
+    diagnostics.push({
+      severity: "warning",
+      code: "partial-result",
+      message: `Codex plugins were capped at ${PROVIDER_CATALOG_MAX_ENTRIES} entries.`,
+    });
+  }
+  if (invalidMetadata) {
+    diagnostics.push({
+      severity: "warning",
+      code: "partial-result",
+      message: "Some Codex plugins were omitted because their metadata was invalid.",
+    });
+  }
+  return {
+    plugins: [...pluginsById.values()],
+    diagnostics: diagnostics.slice(0, 100),
+  };
+}
+
+/** Owns one lazy, thread-independent Codex app-server connection for capability catalogs. */
 @injectable()
 export class CodexCatalogService {
   private client: CodexCatalogClient | null = null;
@@ -152,7 +309,7 @@ export class CodexCatalogService {
     @inject(CodexCatalogClientFactory) private readonly clientFactory: CodexCatalogClientFactory,
   ) {}
 
-  /** Refreshes the complete native Skill list for one working-directory context. */
+  /** Refreshes the complete native capability list for one working-directory context. */
   async refresh(cwd?: string): Promise<CodexCatalogRefreshResult> {
     this.rememberContext(cwd);
     this.armIdleTimer();
@@ -193,9 +350,12 @@ export class CodexCatalogService {
   ): Promise<CodexCatalogRefreshResult> {
     try {
       const client = await this.acquireClient(cwd);
-      const result = await client.listSkills(cwd ? [cwd] : undefined, forceReload);
-      const rawData = Array.isArray((result as { data?: unknown }).data)
-        ? (result as { data: unknown[] }).data
+      const [skillsResult, pluginsResult] = await Promise.all([
+        client.listSkills(cwd ? [cwd] : undefined, forceReload),
+        client.listPlugins(cwd ? [cwd] : undefined),
+      ]);
+      const rawData = Array.isArray((skillsResult as { data?: unknown }).data)
+        ? (skillsResult as { data: unknown[] }).data
         : [];
       const data = (cwd
         ? rawData.find((item) => (
@@ -207,6 +367,8 @@ export class CodexCatalogService {
       }
       const reconciled = reconcileSkills(data?.skills);
       const diagnostics = upstreamDiagnostics(data?.errors);
+      const reconciledPlugins = await reconcilePlugins(client, pluginsResult);
+      diagnostics.push(...reconciledPlugins.diagnostics);
       if (reconciled.invalidMetadata) {
         diagnostics.push({
           severity: "warning",
@@ -224,7 +386,8 @@ export class CodexCatalogService {
       const fetchedAt = new Date().toISOString();
       const snapshot: CodexCatalogRefreshResult = {
         skills: reconciled.skills,
-        diagnostics,
+        plugins: reconciledPlugins.plugins,
+        diagnostics: diagnostics.slice(0, 100),
         freshness: { status: "fresh", fetchedAt },
       };
       this.snapshots.set(catalogKey(cwd), snapshot);
@@ -238,15 +401,16 @@ export class CodexCatalogService {
       });
       const snapshot: CodexCatalogRefreshResult = {
         skills: previous?.skills ?? [],
+        plugins: previous?.plugins ?? [],
         diagnostics: [{
           severity: "warning",
           code: "source-unavailable",
-          message: "Codex Skills are temporarily unavailable for this catalog context.",
+          message: "Codex capabilities are temporarily unavailable for this catalog context.",
         }],
         freshness: {
           status: "stale",
           fetchedAt,
-          reason: "Codex Skill discovery failed.",
+          reason: "Codex capability discovery failed.",
         },
       };
       this.snapshots.set(catalogKey(cwd), snapshot);

--- a/apps/server/src/services/codex-catalog-service.ts
+++ b/apps/server/src/services/codex-catalog-service.ts
@@ -27,6 +27,14 @@ import type { JobObject } from "./job-object.js";
 const CODEX_CATALOG_IDLE_TTL_MS = 60_000;
 const CODEX_CATALOG_MAX_CONTEXTS = 64;
 const CODEX_CATALOG_MAX_CWD_LENGTH = 4_096;
+const CODEX_CATALOG_MAX_PLUGIN_DETAIL_READS = 64;
+const CODEX_CATALOG_PLUGIN_DETAIL_CONCURRENCY = 8;
+
+interface PluginCandidate {
+  readonly marketplaceName: string;
+  readonly marketplacePath: string | null;
+  readonly summary: Record<string, unknown>;
+}
 
 /** Result of refreshing native Codex Skills for one working-directory context. */
 export interface CodexCatalogRefreshResult {
@@ -155,6 +163,15 @@ function pluginDetailDescription(result: PluginReadResult): string {
   ))?.trim() ?? "";
 }
 
+function pluginSummaryDescription(summary: Record<string, unknown>): string {
+  const interfaceValue = summary.interface && typeof summary.interface === "object"
+    ? summary.interface as Record<string, unknown>
+    : undefined;
+  return [interfaceValue?.shortDescription, interfaceValue?.longDescription]
+    .find((value): value is string => typeof value === "string" && value.trim().length > 0)
+    ?.trim() ?? "";
+}
+
 function pluginReadParams(
   marketplaceName: string,
   marketplacePath: string | null,
@@ -163,6 +180,59 @@ function pluginReadParams(
   return marketplacePath
     ? { marketplacePath, pluginName }
     : { remoteMarketplaceName: marketplaceName, pluginName };
+}
+
+async function readMissingPluginDescriptions(
+  client: CodexCatalogClient,
+  candidates: PluginCandidate[],
+  diagnostics: ProviderCatalogDiagnostic[],
+): Promise<Map<string, string>> {
+  const missing = candidates.filter(({ summary }) => (
+    typeof summary.id === "string" &&
+    typeof summary.name === "string" &&
+    !pluginSummaryDescription(summary)
+  ));
+  const selected = missing.slice(0, CODEX_CATALOG_MAX_PLUGIN_DETAIL_READS);
+  const descriptions = new Map<string, string>();
+  let nextIndex = 0;
+
+  const worker = async (): Promise<void> => {
+    while (nextIndex < selected.length) {
+      const candidate = selected[nextIndex++];
+      if (!candidate) return;
+      const { marketplaceName, marketplacePath, summary } = candidate;
+      const pluginId = summary.id as string;
+      try {
+        const detail = await client.readPlugin(pluginReadParams(
+          marketplaceName,
+          marketplacePath,
+          summary.name as string,
+        ));
+        descriptions.set(pluginId, pluginDetailDescription(detail));
+      } catch {
+        diagnostics.push({
+          severity: "warning",
+          code: "partial-result",
+          message: boundedDiagnosticMessage(
+            `Codex plugin details are unavailable for ${pluginId}.`,
+          ),
+        });
+      }
+    }
+  };
+
+  await Promise.all(Array.from(
+    { length: Math.min(CODEX_CATALOG_PLUGIN_DETAIL_CONCURRENCY, selected.length) },
+    worker,
+  ));
+  if (missing.length > CODEX_CATALOG_MAX_PLUGIN_DETAIL_READS) {
+    diagnostics.push({
+      severity: "warning",
+      code: "partial-result",
+      message: `Codex plugin detail reads were capped at ${CODEX_CATALOG_MAX_PLUGIN_DETAIL_READS} entries.`,
+    });
+  }
+  return descriptions;
 }
 
 async function reconcilePlugins(
@@ -190,11 +260,7 @@ async function reconcilePlugins(
         ),
       }];
     });
-  const candidates: Array<{
-    marketplaceName: string;
-    marketplacePath: string | null;
-    summary: Record<string, unknown>;
-  }> = [];
+  const candidates: PluginCandidate[] = [];
 
   for (const rawMarketplace of Array.isArray(result.marketplaces) ? result.marketplaces : []) {
     if (!rawMarketplace || typeof rawMarketplace !== "object") continue;
@@ -213,10 +279,16 @@ async function reconcilePlugins(
     }
   }
 
+  const selectedCandidates = candidates.slice(0, PROVIDER_CATALOG_MAX_ENTRIES);
+  const detailDescriptions = await readMissingPluginDescriptions(
+    client,
+    selectedCandidates,
+    diagnostics,
+  );
   const pluginsById = new Map<string, ProviderPluginCapability>();
   let invalidMetadata = false;
-  for (const candidate of candidates.slice(0, PROVIDER_CATALOG_MAX_ENTRIES)) {
-    const { marketplaceName, marketplacePath, summary } = candidate;
+  for (const candidate of selectedCandidates) {
+    const { marketplaceName, summary } = candidate;
     if (typeof summary.id !== "string" || typeof summary.name !== "string") {
       invalidMetadata = true;
       continue;
@@ -224,26 +296,7 @@ async function reconcilePlugins(
     const interfaceValue = summary.interface && typeof summary.interface === "object"
       ? summary.interface as Record<string, unknown>
       : undefined;
-    let description = [interfaceValue?.shortDescription, interfaceValue?.longDescription]
-      .find((value): value is string => typeof value === "string" && value.trim().length > 0)
-      ?.trim() ?? "";
-    if (!description) {
-      try {
-        description = pluginDetailDescription(await client.readPlugin(pluginReadParams(
-          marketplaceName,
-          marketplacePath,
-          summary.name,
-        )));
-      } catch {
-        diagnostics.push({
-          severity: "warning",
-          code: "partial-result",
-          message: boundedDiagnosticMessage(
-            `Codex plugin details are unavailable for ${summary.id}.`,
-          ),
-        });
-      }
-    }
+    const description = pluginSummaryDescription(summary) || detailDescriptions.get(summary.id) || "";
     const name = typeof interfaceValue?.displayName === "string" && interfaceValue.displayName.trim()
       ? interfaceValue.displayName.trim()
       : summary.name;

--- a/apps/server/src/transport/provider-catalog.ts
+++ b/apps/server/src/transport/provider-catalog.ts
@@ -43,6 +43,7 @@ export interface BuildProviderCatalogSnapshotInput {
   readonly providerId: SettingsProviderId;
   readonly context: ProviderCatalogContext;
   readonly skills: readonly SkillInfo[];
+  readonly entries?: readonly ProviderCapabilityEntry[];
   readonly agentDiscovery?: BoundedCodexAgentDiscovery;
   readonly diagnostics?: readonly ProviderCatalogDiagnostic[];
   readonly freshness?: ProviderCatalogFreshness;
@@ -211,12 +212,22 @@ export function buildProviderCatalogSnapshot(
   const diagnostics: ProviderCatalogDiagnostic[] = [...(input.diagnostics ?? [])];
   let invalidItemOmitted = false;
   const entries: ProviderCapabilityEntry[] = [];
-  for (const item of input.skills.slice(0, PROVIDER_CATALOG_MAX_ENTRIES)) {
+  for (const item of input.skills) {
+    if (entries.length >= PROVIDER_CATALOG_MAX_ENTRIES) break;
     const entry = parseProviderCapabilityEntry(input.providerId, item);
     if (entry) entries.push(entry);
     else invalidItemOmitted = true;
   }
-  if (input.skills.length > PROVIDER_CATALOG_MAX_ENTRIES) {
+  for (const item of input.entries ?? []) {
+    if (entries.length >= PROVIDER_CATALOG_MAX_ENTRIES) break;
+    const entry = ProviderCapabilityEntrySchema().safeParse(item);
+    if (entry.success && entry.data.identity.providerId === input.providerId) {
+      entries.push(entry.data);
+    } else {
+      invalidItemOmitted = true;
+    }
+  }
+  if (input.skills.length + (input.entries?.length ?? 0) > PROVIDER_CATALOG_MAX_ENTRIES) {
     diagnostics.push(partialResultDiagnostic(
       `Catalog entries were capped at ${PROVIDER_CATALOG_MAX_ENTRIES}.`,
     ));
@@ -255,7 +266,7 @@ export function buildProviderCatalogSnapshot(
       status: "fresh",
       fetchedAt: input.fetchedAt ?? new Date().toISOString(),
     },
-    diagnostics,
+    diagnostics: diagnostics.slice(0, 100),
     entries,
     selectableAgents,
   });

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -1022,6 +1022,7 @@ async function dispatch(
           providerId: params.providerId,
           context: catalogContext,
           skills,
+          ...(catalog?.plugins ? { entries: catalog.plugins } : {}),
           ...(agentDiscovery ? { agentDiscovery } : {}),
           ...(catalog?.diagnostics ? { diagnostics: catalog.diagnostics } : {}),
           ...(catalog?.freshness ? { freshness: catalog.freshness } : {}),

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -94,6 +94,49 @@ describe("routeMessage provider.catalog", () => {
         }],
         };
       }),
+      listPlugins: vi.fn(async (cwds?: string[]) => ({
+        marketplaces: [{
+          name: "personal",
+          path: "C:/marketplaces/personal",
+          interface: null,
+          plugins: catalogVersion === 1
+            ? [
+                {
+                  id: "review@personal",
+                  name: "review",
+                  installed: true,
+                  enabled: true,
+                  interface: {
+                    displayName: "review",
+                    shortDescription: `Review plugin for ${cwds?.[0] ?? "user"}`,
+                    capabilities: ["mcp"],
+                  },
+                },
+                {
+                  id: "disabled@personal",
+                  name: "disabled",
+                  installed: true,
+                  enabled: false,
+                  interface: { shortDescription: "Disabled" },
+                },
+              ]
+            : [{
+                id: "browser@personal",
+                name: "browser",
+                installed: true,
+                enabled: true,
+                interface: { shortDescription: "Browse pages", capabilities: ["mcp"] },
+              }],
+        }],
+        marketplaceLoadErrors: catalogVersion === 1
+          ? [{
+              marketplacePath: "C:/marketplaces/broken.json",
+              message: "invalid metadata",
+            }]
+          : [],
+        featuredPluginIds: [],
+      })),
+      readPlugin: vi.fn(async () => ({ plugin: { description: "Plugin details" } })),
     });
     const create = vi.fn(() => client);
     const codexCatalogService = new CodexCatalogService(
@@ -159,8 +202,17 @@ describe("routeMessage provider.catalog", () => {
       request: { providerId: "codex", workspaceId: "workspace-1" },
       additions: expect.arrayContaining([
         expect.objectContaining({ name: "review", kind: "skill" }),
+        expect.objectContaining({
+          name: "review",
+          kind: "plugin",
+          mentionPath: "plugin://review@personal",
+        }),
         expect.objectContaining({ name: "prompts:release", kind: "customPrompt" }),
       ]),
+      diagnostics: [expect.objectContaining({
+        code: "discovery-error",
+        message: expect.stringContaining("C:/marketplaces/broken.json"),
+      })],
       freshness: { status: "fresh" },
     });
     expect(refresh).toHaveBeenCalledWith("C:/repo");
@@ -168,6 +220,8 @@ describe("routeMessage provider.catalog", () => {
     expect(create).toHaveBeenCalledTimes(1);
     expect(client.start).toHaveBeenCalledTimes(1);
     expect(client.listSkills).toHaveBeenCalledWith(["C:/repo"], false);
+    expect(client.listPlugins).toHaveBeenCalledWith(["C:/repo"]);
+    expect(client.readPlugin).not.toHaveBeenCalled();
     expect(list).toHaveBeenCalledWith(
       "C:/repo",
       "codex",
@@ -233,8 +287,14 @@ describe("routeMessage provider.catalog", () => {
     await expect(refreshed).resolves.toBe("C:/repo");
     expect(client.listSkills).toHaveBeenCalledWith(["C:/repo"], true);
     await expect(reconciled).resolves.toMatchObject({
-      additions: [expect.objectContaining({ name: "ship" })],
-      removals: [expect.objectContaining({ nativeId: "C:/repo/.codex/skills/review/SKILL.md" })],
+      additions: expect.arrayContaining([
+        expect.objectContaining({ kind: "skill", name: "ship" }),
+        expect.objectContaining({ kind: "plugin", name: "browser" }),
+      ]),
+      removals: expect.arrayContaining([
+        expect.objectContaining({ nativeId: "C:/repo/.codex/skills/review/SKILL.md" }),
+        expect.objectContaining({ nativeId: "review@personal", kind: "plugin" }),
+      ]),
     });
     expect(create).toHaveBeenCalledTimes(1);
 

--- a/apps/web/src/__tests__/mention-node.test.ts
+++ b/apps/web/src/__tests__/mention-node.test.ts
@@ -3,6 +3,7 @@ import { $createParagraphNode, $createTextNode, $getRoot, createEditor } from "l
 import {
   MentionNode,
   $createMentionNode,
+  $createTypedMentionNode,
   $isMentionNode,
 } from "@/components/chat/lexical/MentionNode";
 import { extractComposerMessage } from "@/components/chat/lexical/cursor-utils";
@@ -106,6 +107,36 @@ describe("MentionNode", () => {
         label: "src/app.ts",
         path: "src/app.ts",
         range: { start: 7, end: 18 },
+      }],
+    });
+  });
+
+  it("extracts a selected plugin as a native Codex mention", () => {
+    const editor = createTestEditor();
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTypedMentionNode({
+          id: "plugin-1",
+          kind: "plugin",
+          label: "Browser",
+          name: "Browser",
+          path: "plugin://browser@openai-bundled",
+        }));
+        $getRoot().append(paragraph);
+      },
+      { discrete: true },
+    );
+
+    expect(extractComposerMessage(editor)).toEqual({
+      text: "@Browser",
+      mentions: [{
+        id: "plugin-1",
+        kind: "plugin",
+        label: "Browser",
+        name: "Browser",
+        path: "plugin://browser@openai-bundled",
+        range: { start: 0, end: 8 },
       }],
     });
   });

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -310,7 +310,14 @@ describe("selection + text replacement", () => {
     let emittedValue = "";
     await act(async () => {
       result.current.onSelect(
-        { name: "commit", description: "Commit changes", namespace: "skill" },
+        {
+          id: "skill:commit",
+          name: "commit",
+          description: "Commit changes",
+          namespace: "skill",
+          capabilityKind: "skill",
+          nativeId: "commit",
+        },
         (v: string) => { emittedValue = v; }
       );
     });
@@ -643,7 +650,7 @@ describe("popup state machine", () => {
 });
 
 describe("includeBuiltins: false", () => {
-  it("adapts invocable catalog entries while keeping plugin records out of the picker", async () => {
+  it("keeps same-named plugin and Skill entries distinct in the picker", async () => {
     const getProviderCatalog = vi.fn().mockResolvedValue({
       providerId: "codex",
       context: { scope: "user" },
@@ -652,7 +659,7 @@ describe("includeBuiltins: false", () => {
       entries: [
         { kind: "providerCommand", identity: { providerId: "codex", kind: "providerCommand", nativeId: "deploy" }, name: "deploy", description: "Deploy" },
         { kind: "customPrompt", identity: { providerId: "codex", kind: "customPrompt", nativeId: "release" }, name: "prompts:release", description: "Release" },
-        { kind: "plugin", identity: { providerId: "codex", kind: "plugin", nativeId: "tools" }, name: "tools", description: "Tools" },
+        { kind: "plugin", identity: { providerId: "codex", kind: "plugin", nativeId: "review@personal" }, name: "review", description: "Review plugin", mentionPath: "plugin://review@personal", marketplaceName: "personal", capabilities: [] },
         { kind: "skill", identity: { providerId: "codex", kind: "skill", nativeId: "review" }, name: "review", description: "Review", source: "user" },
       ],
       selectableAgents: [{ providerId: "codex", nativeId: "reviewer", name: "reviewer", path: "C:/agents/reviewer.toml" }],
@@ -668,11 +675,27 @@ describe("includeBuiltins: false", () => {
     await act(async () => { result.current.onInputChange("/"); });
     await act(async () => {});
 
-    expect(result.current.allCommands.map((command) => [command.name, command.namespace])).toEqual([
-      ["deploy", "command"],
-      ["prompts:release", "command"],
-      ["review", "skill"],
+    expect(result.current.allCommands.map((command) => [
+      command.name,
+      command.namespace,
+      command.capabilityKind,
+      command.nativeId,
+    ])).toEqual([
+      ["deploy", "command", "providerCommand", "deploy"],
+      ["prompts:release", "command", "customPrompt", "release"],
+      ["review", "skill", "skill", "review"],
+      ["review", "plugin", "plugin", "review@personal"],
     ]);
+
+    const replaceText = vi.fn();
+    await act(async () => {
+      result.current.onInputChange("/rev");
+      result.current.onSelect(
+        result.current.allCommands.find((command) => command.capabilityKind === "plugin")!,
+        replaceText,
+      );
+    });
+    expect(replaceText).toHaveBeenCalledWith("@review ");
   });
 
   it("excludes all BUILTIN_COMMANDS when includeBuiltins is false", async () => {

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -65,6 +65,7 @@ import {
   ComposerEditor,
   $createSlashCommandNode,
   $createTypedMentionNode,
+  createMentionId,
   extractComposerMessage,
   insertMentionNode,
   insertSelectedPluginMention,
@@ -1345,14 +1346,10 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     fileAutocomplete.selectSuggestion(item);
     if (!editorRef.current) return;
 
-    const id =
-      typeof crypto !== "undefined" && "randomUUID" in crypto
-        ? crypto.randomUUID()
-        : `mention-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const mention: MentionNodeData =
       item.kind === "agent"
         ? {
-            id,
+            id: createMentionId(),
             kind: "agent",
             label: item.label,
             name: item.name,
@@ -1360,7 +1357,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
             provider: item.provider,
           }
         : {
-            id,
+            id: createMentionId(),
             kind: "file",
             label: item.label,
             path: item.path,

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -67,7 +67,7 @@ import {
   $createTypedMentionNode,
   extractComposerMessage,
   insertMentionNode,
-  insertPluginMentionNode,
+  insertSelectedPluginMention,
   insertSlashCommandNode,
   removeSlashCommandTrigger,
   type MentionNodeData,
@@ -2714,19 +2714,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     if (editorRef.current) {
       if (cmd.action) {
         removeSlashCommandTrigger(editorRef.current);
-      } else if (cmd.capabilityKind === "plugin" && cmd.mentionPath) {
-        const id =
-          typeof crypto !== "undefined" && "randomUUID" in crypto
-            ? crypto.randomUUID()
-            : `mention-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-        insertPluginMentionNode(editorRef.current, {
-          id,
-          kind: "plugin",
-          label: cmd.name,
-          name: cmd.name,
-          path: cmd.mentionPath,
-        });
-      } else {
+      } else if (!insertSelectedPluginMention(editorRef.current, cmd)) {
         insertSlashCommandNode(editorRef.current, cmd.name, cmd.namespace);
       }
     }

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -67,6 +67,7 @@ import {
   $createTypedMentionNode,
   extractComposerMessage,
   insertMentionNode,
+  insertPluginMentionNode,
   insertSlashCommandNode,
   removeSlashCommandTrigger,
   type MentionNodeData,
@@ -224,7 +225,7 @@ function writeComposerContent(
               label: mention.label,
               name: mention.name,
               path: mention.path,
-              provider: mention.provider,
+              ...(mention.kind === "agent" ? { provider: mention.provider } : {}),
             };
       paragraph.append($createTypedMentionNode(nodeMention));
       cursor = mention.range.end;
@@ -2713,6 +2714,18 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
     if (editorRef.current) {
       if (cmd.action) {
         removeSlashCommandTrigger(editorRef.current);
+      } else if (cmd.capabilityKind === "plugin" && cmd.mentionPath) {
+        const id =
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : `mention-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        insertPluginMentionNode(editorRef.current, {
+          id,
+          kind: "plugin",
+          label: cmd.name,
+          name: cmd.name,
+          path: cmd.mentionPath,
+        });
       } else {
         insertSlashCommandNode(editorRef.current, cmd.name, cmd.namespace);
       }

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -257,6 +257,9 @@ function CommandRow({
       id={`slash-cmd-${index}`}
       role="option"
       aria-selected={selected}
+      aria-label={cmd.capabilityKind === "plugin"
+        ? `${commandDisplayLabel(cmd)} Plugin ${cmd.description}`
+        : `${commandDisplayLabel(cmd)} ${cmd.description}`}
       onMouseDown={(e) => {
         e.preventDefault(); // prevent textarea blur
         onSelect(cmd);

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -294,7 +294,7 @@ function CommandRow({
         )}>
           <span>{commandDisplayLabel(cmd)}</span>
           <span className={cn(
-            "ml-2 text-[10px] font-medium uppercase tracking-wide",
+            "ml-2 text-xs font-medium uppercase tracking-wide",
             tone === "dark" ? "text-neutral-500" : "text-muted-foreground",
           )}>
             {commandKindLabel(cmd)}

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -20,9 +20,20 @@ const NAMESPACE_LABELS: Record<Command["namespace"], string> = {
 };
 
 function commandDisplayLabel(command: Command): string {
+  if (command.capabilityKind === "plugin") return `@${command.name}`;
   if (command.namespace === "skill") return command.name;
   if (command.namespace === "plugin") return command.name.split(":").at(-1) ?? command.name;
   return `/${command.name}`;
+}
+
+function commandKindLabel(command: Command): string {
+  switch (command.capabilityKind) {
+    case "customPrompt": return "Prompt";
+    case "providerCommand": return "Command";
+    case "plugin": return "Plugin";
+    case "skill": return "Skill";
+    case "mcode": return "Mcode";
+  }
 }
 
 /** Preserve command ordering while exposing the source context of each command. */
@@ -165,7 +176,7 @@ export function SlashCommandPopup({
                     ref={scrollRef}
                     role="listbox"
                     aria-label="Slash commands"
-                    aria-activedescendant={items[selectedIndex] ? `slash-cmd-${items[selectedIndex].name}` : undefined}
+                    aria-activedescendant={items[selectedIndex] ? `slash-cmd-${selectedIndex}` : undefined}
                     className="overflow-y-auto"
                     style={{ maxHeight: listMaxHeight, scrollbarGutter: "stable" }}
                   >
@@ -189,9 +200,10 @@ export function SlashCommandPopup({
                           </div>
                           {groupItems.map(({ command: cmd, index }) => {
                             return (
-                              <div key={cmd.name} role="presentation" data-index={index}>
+                              <div key={cmd.id} role="presentation" data-index={index}>
                                 <CommandRow
                                   cmd={cmd}
+                                  index={index}
                                   selected={index === selectedIndex}
                                   onSelect={onSelect}
                                   tone={tone}
@@ -226,11 +238,13 @@ export function SlashCommandPopup({
 
 function CommandRow({
   cmd,
+  index,
   selected,
   onSelect,
   tone = "default",
 }: {
   cmd: Command;
+  index: number;
   selected: boolean;
   onSelect: (cmd: Command) => void;
   tone?: "default" | "dark";
@@ -240,7 +254,7 @@ function CommandRow({
       type="button"
       variant="ghost"
       size="sm"
-      id={`slash-cmd-${cmd.name}`}
+      id={`slash-cmd-${index}`}
       role="option"
       aria-selected={selected}
       onMouseDown={(e) => {
@@ -265,7 +279,11 @@ function CommandRow({
           ? "bg-white/[0.06] text-neutral-400 ring-white/10"
           : "bg-muted/65 text-muted-foreground ring-border/60",
       )}>
-        <EntityIcon kind={cmd.namespace} size={14} className="flex items-center justify-center" />
+        <EntityIcon
+          kind={cmd.capabilityKind === "mcode" ? "mcode" : cmd.capabilityKind === "customPrompt" || cmd.capabilityKind === "providerCommand" ? "command" : cmd.capabilityKind}
+          size={14}
+          className="flex items-center justify-center"
+        />
       </span>
 
       {/* Name + description */}
@@ -274,7 +292,13 @@ function CommandRow({
           "truncate text-sm font-medium leading-4",
           tone === "dark" ? "text-neutral-50" : "text-foreground",
         )}>
-          {commandDisplayLabel(cmd)}
+          <span>{commandDisplayLabel(cmd)}</span>
+          <span className={cn(
+            "ml-2 text-[10px] font-medium uppercase tracking-wide",
+            tone === "dark" ? "text-neutral-500" : "text-muted-foreground",
+          )}>
+            {commandKindLabel(cmd)}
+          </span>
         </span>
         <span className={cn(
           "overflow-hidden whitespace-nowrap text-xs font-normal leading-4",

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
@@ -33,9 +33,10 @@ function makeAnchorRect(): DOMRect {
 }
 
 const COMMANDS: Command[] = [
-  { name: "deploy", description: "Deploy command", namespace: "command" },
-  { name: "my-skill", description: "A skill", namespace: "skill" },
-  { name: "figma:use", description: "A plugin skill", namespace: "plugin" },
+  { id: "command:deploy", name: "deploy", description: "Deploy command", namespace: "command", capabilityKind: "providerCommand", nativeId: "deploy" },
+  { id: "skill:my-skill", name: "my-skill", description: "A skill", namespace: "skill", capabilityKind: "skill", nativeId: "my-skill" },
+  { id: "skill:figma:use", name: "figma:use", description: "A plugin skill", namespace: "plugin", capabilityKind: "skill", nativeId: "figma:use" },
+  { id: "plugin:browser", name: "Browser", description: "A native plugin", namespace: "plugin", capabilityKind: "plugin", nativeId: "browser@openai-bundled", mentionPath: "plugin://browser@openai-bundled" },
 ];
 
 function renderPopup() {
@@ -84,8 +85,8 @@ describe("SlashCommandPopup source groups", () => {
     const pluginRow = screen.getByRole("option", { name: /A plugin skill/ });
     const title = within(pluginRow).getByText("use");
     const description = within(pluginRow).getByText("A plugin skill");
-    expect(title.parentElement).toBe(description.parentElement);
-    expect(title.parentElement).toHaveClass("flex-col");
+    const content = title.closest(".flex-col");
+    expect(content).toBe(description.parentElement);
   });
 
   it("fades overflowing descriptions instead of showing an ellipsis", () => {
@@ -122,10 +123,17 @@ describe("SlashCommandPopup namespace icons", () => {
     expect(terminalIcon).not.toBeNull();
   });
 
-  it("plugin namespace renders a blocks SVG", () => {
+  it("native plugin entries render a blocks SVG", () => {
     renderPopup();
-    const pluginRow = screen.getByRole("option", { name: /A plugin skill/ });
+    const pluginRow = screen.getByRole("option", { name: /A native plugin/ });
     expect(pluginRow.querySelector(".lucide-blocks")).not.toBeNull();
+  });
+
+  it("plugin-provided skills remain skill entries", () => {
+    renderPopup();
+    const pluginSkillRow = screen.getByRole("option", { name: /A plugin skill/ });
+    expect(pluginSkillRow.querySelector(".lucide-sparkles")).not.toBeNull();
+    expect(pluginSkillRow.querySelector(".lucide-blocks")).toBeNull();
   });
 
   it("command namespace does NOT render a lucide-sparkles SVG", () => {

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
@@ -68,15 +68,18 @@ function makeAnchorRect(): DOMRect {
 }
 
 const COMMANDS: Command[] = [
-  { name: "foo", description: "First command", namespace: "command" },
-  { name: "bar", description: "Second command", namespace: "skill" },
-  { name: "baz", description: "Third command", namespace: "mcode" },
+  { id: "command:foo", name: "foo", description: "First command", namespace: "command", capabilityKind: "providerCommand", nativeId: "foo" },
+  { id: "skill:bar", name: "bar", description: "Second command", namespace: "skill", capabilityKind: "skill", nativeId: "bar" },
+  { id: "mcode:baz", name: "baz", description: "Third command", namespace: "mcode", capabilityKind: "mcode", nativeId: "baz" },
 ];
 
 const LONG_COMMANDS: Command[] = Array.from({ length: 25 }, (_, i) => ({
+  id: `skill:${i}`,
   name: `skill-${i.toString().padStart(2, "0")}`,
   description: `Skill ${i}`,
   namespace: "skill",
+  capabilityKind: "skill",
+  nativeId: `skill-${i}`,
 }));
 
 function renderPopup(selectedIndex: number) {

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-selection.test.tsx
@@ -4,10 +4,21 @@
  * The selected row should use bg-accent as its only selection indicator.
  * The previous border-l-2 left-stripe must not appear on any row.
  */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getNodeByKey,
+  $getRoot,
+  $isTextNode,
+  createEditor,
+} from "lexical";
 import { SlashCommandPopup } from "../SlashCommandPopup";
 import type { Command } from "../useSlashCommand";
+import { MentionNode } from "../lexical/MentionNode";
+import { insertSelectedPluginMention } from "../lexical/SlashCommandPlugin";
+import { extractComposerMessage } from "../lexical/cursor-utils";
 
 // jsdom doesn't implement ResizeObserver or scrollIntoView. Capture originals
 // so the polyfills are reverted after the suite to avoid leaking into other
@@ -160,6 +171,57 @@ describe("SlashCommandPopup selection indicator", () => {
     renderLongPopup();
     expect(screen.getByRole("option", { name: /skill-00/ })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: /skill-24/ })).toBeInTheDocument();
+  });
+
+  it("inserts a selected plugin as a rich mention", async () => {
+    const editor = createEditor({ nodes: [MentionNode], onError: (error) => { throw error; } });
+    let triggerKey = "";
+    editor.update(() => {
+      const paragraph = $createParagraphNode();
+      const trigger = $createTextNode("/browser");
+      triggerKey = trigger.getKey();
+      paragraph.append(trigger);
+      $getRoot().append(paragraph);
+    }, { discrete: true });
+    const plugin: Command = {
+      id: "plugin:browser@openai-bundled",
+      name: "Browser",
+      description: "Control the in-app browser",
+      namespace: "skill",
+      capabilityKind: "plugin",
+      nativeId: "browser@openai-bundled",
+      mentionPath: "plugin://browser@openai-bundled",
+    };
+    render(
+      <SlashCommandPopup
+        state={{ kind: "ready", items: [plugin] }}
+        selectedIndex={0}
+        anchorRect={makeAnchorRect()}
+        onSelect={(command) => {
+          editor.update(() => {
+            const trigger = $getNodeByKey(triggerKey);
+            if ($isTextNode(trigger)) trigger.selectEnd();
+          }, { discrete: true });
+          insertSelectedPluginMention(editor, command);
+        }}
+        onDismiss={() => {}}
+        onRetry={() => {}}
+      />,
+    );
+
+    fireEvent.mouseDown(screen.getByRole("option", { name: /@Browser/ }));
+
+    await waitFor(() => expect(extractComposerMessage(editor)).toEqual({
+      text: "@Browser ",
+      mentions: [{
+        id: expect.any(String),
+        kind: "plugin",
+        label: "Browser",
+        name: "Browser",
+        path: "plugin://browser@openai-bundled",
+        range: { start: 0, end: 8 },
+      }],
+    }));
   });
 
   it.each([

--- a/apps/web/src/components/chat/lexical/MentionNode.tsx
+++ b/apps/web/src/components/chat/lexical/MentionNode.tsx
@@ -176,7 +176,8 @@ export function $isMentionNode(
   return node instanceof MentionNode;
 }
 
-function createMentionId(): string {
+/** Creates a stable identifier for one composer mention. */
+export function createMentionId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
   }

--- a/apps/web/src/components/chat/lexical/MentionNode.tsx
+++ b/apps/web/src/components/chat/lexical/MentionNode.tsx
@@ -119,7 +119,9 @@ export class MentionNode extends DecoratorNode<JSX.Element> {
       label: this.__mention.label,
       filePath: this.__mention.kind === "file" ? this.__mention.path : undefined,
       path: this.__mention.path,
-      name: this.__mention.kind === "agent" ? this.__mention.name : undefined,
+      name: this.__mention.kind === "agent" || this.__mention.kind === "plugin"
+        ? this.__mention.name
+        : undefined,
       provider: this.__mention.kind === "agent" ? this.__mention.provider : undefined,
       version: 1,
     };
@@ -132,8 +134,11 @@ export class MentionNode extends DecoratorNode<JSX.Element> {
       kind: serializedNode.kind ?? "file",
       label: serializedNode.label ?? path,
       path,
-      ...(serializedNode.kind === "agent" && serializedNode.name
-        ? { name: serializedNode.name, provider: serializedNode.provider }
+      ...((serializedNode.kind === "agent" || serializedNode.kind === "plugin") && serializedNode.name
+        ? {
+            name: serializedNode.name,
+            ...(serializedNode.kind === "agent" ? { provider: serializedNode.provider } : {}),
+          }
         : {}),
     } as MentionNodeData);
   }

--- a/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
+++ b/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
@@ -11,6 +11,7 @@ import {
   $createSlashCommandNode,
   type SlashCommandNamespace,
 } from "./SlashCommandNode";
+import { $createTypedMentionNode, type MentionNodeData } from "./MentionNode";
 import { SLASH_TRIGGER_RE } from "../useSlashCommand";
 
 /** Props for the SlashCommandPlugin that detects /-triggers in the editor. */
@@ -124,6 +125,48 @@ export function insertSlashCommandNode(
     } else {
       node.replace(commandNode);
       commandNode.insertAfter(afterNode);
+    }
+
+    const offset = trailingText.startsWith(" ") ? 1 : 0;
+    afterNode.select(offset, offset);
+  });
+}
+
+/** Replaces the active slash trigger with a native Codex plugin mention. */
+export function insertPluginMentionNode(
+  editor: LexicalEditor,
+  mention: Extract<MentionNodeData, { kind: "plugin" }>,
+): void {
+  editor.update(() => {
+    const selection = $getSelection();
+    if (!$isRangeSelection(selection)) return;
+
+    const anchor = selection.anchor;
+    if (anchor.type !== "text") return;
+
+    const node = anchor.getNode();
+    if (!(node instanceof TextNode)) return;
+
+    const textContent = node.getTextContent();
+    const cursorOffset = anchor.offset;
+    const match = SLASH_TRIGGER_RE.exec(textContent.slice(0, cursorOffset));
+    if (!match) return;
+
+    const triggerStart = match.index + match[1].length;
+    const beforeText = textContent.slice(0, triggerStart);
+    const afterCursor = textContent.slice(cursorOffset);
+    const mentionNode = $createTypedMentionNode(mention);
+    const trailingText = afterCursor.length > 0 ? afterCursor : " ";
+    const afterNode = $createTextNode(trailingText);
+
+    if (beforeText) {
+      const beforeNode = $createTextNode(beforeText);
+      node.replace(beforeNode);
+      beforeNode.insertAfter(mentionNode);
+      mentionNode.insertAfter(afterNode);
+    } else {
+      node.replace(mentionNode);
+      mentionNode.insertAfter(afterNode);
     }
 
     const offset = trailingText.startsWith(" ") ? 1 : 0;

--- a/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
+++ b/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
@@ -6,13 +6,18 @@ import {
   $createTextNode,
   TextNode,
   type LexicalEditor,
+  type LexicalNode,
 } from "lexical";
 import {
   $createSlashCommandNode,
   type SlashCommandNamespace,
 } from "./SlashCommandNode";
-import { $createTypedMentionNode, type MentionNodeData } from "./MentionNode";
-import { SLASH_TRIGGER_RE } from "../useSlashCommand";
+import {
+  $createTypedMentionNode,
+  createMentionId,
+  type MentionNodeData,
+} from "./MentionNode";
+import { SLASH_TRIGGER_RE, type Command } from "../useSlashCommand";
 
 /** Props for the SlashCommandPlugin that detects /-triggers in the editor. */
 interface SlashCommandPluginProps {
@@ -84,58 +89,9 @@ export function SlashCommandPlugin({
   return null;
 }
 
-/**
- * Insert a slash command node at the current / trigger position.
- */
-export function insertSlashCommandNode(
+function replaceActiveSlashTrigger(
   editor: LexicalEditor,
-  commandName: string,
-  namespace: SlashCommandNamespace,
-): void {
-  editor.update(() => {
-    const selection = $getSelection();
-    if (!$isRangeSelection(selection)) return;
-
-    const anchor = selection.anchor;
-    if (anchor.type !== "text") return;
-
-    const node = anchor.getNode();
-    if (!(node instanceof TextNode)) return;
-
-    const textContent = node.getTextContent();
-    const cursorOffset = anchor.offset;
-    const textBeforeCursor = textContent.slice(0, cursorOffset);
-
-    const match = SLASH_TRIGGER_RE.exec(textBeforeCursor);
-    if (!match) return;
-
-    const triggerStart = match.index + match[1].length;
-    const afterCursor = textContent.slice(cursorOffset);
-
-    const commandNode = $createSlashCommandNode(commandName, namespace);
-    const trailingText = afterCursor.length > 0 ? afterCursor : " ";
-    const afterNode = $createTextNode(trailingText);
-
-    const beforeText = textContent.slice(0, triggerStart);
-    if (beforeText) {
-      const beforeNode = $createTextNode(beforeText);
-      node.replace(beforeNode);
-      beforeNode.insertAfter(commandNode);
-      commandNode.insertAfter(afterNode);
-    } else {
-      node.replace(commandNode);
-      commandNode.insertAfter(afterNode);
-    }
-
-    const offset = trailingText.startsWith(" ") ? 1 : 0;
-    afterNode.select(offset, offset);
-  });
-}
-
-/** Replaces the active slash trigger with a native Codex plugin mention. */
-export function insertPluginMentionNode(
-  editor: LexicalEditor,
-  mention: Extract<MentionNodeData, { kind: "plugin" }>,
+  createNode: () => LexicalNode,
 ): void {
   editor.update(() => {
     const selection = $getSelection();
@@ -155,18 +111,18 @@ export function insertPluginMentionNode(
     const triggerStart = match.index + match[1].length;
     const beforeText = textContent.slice(0, triggerStart);
     const afterCursor = textContent.slice(cursorOffset);
-    const mentionNode = $createTypedMentionNode(mention);
+    const insertedNode = createNode();
     const trailingText = afterCursor.length > 0 ? afterCursor : " ";
     const afterNode = $createTextNode(trailingText);
 
     if (beforeText) {
       const beforeNode = $createTextNode(beforeText);
       node.replace(beforeNode);
-      beforeNode.insertAfter(mentionNode);
-      mentionNode.insertAfter(afterNode);
+      beforeNode.insertAfter(insertedNode);
+      insertedNode.insertAfter(afterNode);
     } else {
-      node.replace(mentionNode);
-      mentionNode.insertAfter(afterNode);
+      node.replace(insertedNode);
+      insertedNode.insertAfter(afterNode);
     }
 
     const offset = trailingText.startsWith(" ") ? 1 : 0;
@@ -174,22 +130,33 @@ export function insertPluginMentionNode(
   });
 }
 
+/** Replaces the active slash trigger with a native Codex plugin mention. */
+export function insertPluginMentionNode(
+  editor: LexicalEditor,
+  mention: Extract<MentionNodeData, { kind: "plugin" }>,
+): void {
+  replaceActiveSlashTrigger(editor, () => $createTypedMentionNode(mention));
+}
+
+/**
+ * Insert a slash command node at the current / trigger position.
+ */
+export function insertSlashCommandNode(
+  editor: LexicalEditor,
+  commandName: string,
+  namespace: SlashCommandNamespace,
+): void {
+  replaceActiveSlashTrigger(editor, () => $createSlashCommandNode(commandName, namespace));
+}
+
 /** Inserts a selected plugin command as a native Codex mention. */
 export function insertSelectedPluginMention(
   editor: LexicalEditor,
-  command: {
-    readonly capabilityKind: string;
-    readonly mentionPath?: string;
-    readonly name: string;
-  },
+  command: Pick<Command, "capabilityKind" | "mentionPath" | "name">,
 ): boolean {
   if (command.capabilityKind !== "plugin" || !command.mentionPath) return false;
-  const id =
-    typeof crypto !== "undefined" && "randomUUID" in crypto
-      ? crypto.randomUUID()
-      : `mention-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   insertPluginMentionNode(editor, {
-    id,
+    id: createMentionId(),
     kind: "plugin",
     label: command.name,
     name: command.name,

--- a/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
+++ b/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
@@ -174,6 +174,30 @@ export function insertPluginMentionNode(
   });
 }
 
+/** Inserts a selected plugin command as a native Codex mention. */
+export function insertSelectedPluginMention(
+  editor: LexicalEditor,
+  command: {
+    readonly capabilityKind: string;
+    readonly mentionPath?: string;
+    readonly name: string;
+  },
+): boolean {
+  if (command.capabilityKind !== "plugin" || !command.mentionPath) return false;
+  const id =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `mention-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  insertPluginMentionNode(editor, {
+    id,
+    kind: "plugin",
+    label: command.name,
+    name: command.name,
+    path: command.mentionPath,
+  });
+  return true;
+}
+
 /** Removes the slash trigger at the current selection without inserting a command node. */
 export function removeSlashCommandTrigger(editor: LexicalEditor): void {
   editor.update(() => {

--- a/apps/web/src/components/chat/lexical/index.ts
+++ b/apps/web/src/components/chat/lexical/index.ts
@@ -9,6 +9,7 @@ export {
 export { insertMentionNode } from "./MentionPlugin";
 export {
   insertPluginMentionNode,
+  insertSelectedPluginMention,
   insertSlashCommandNode,
   removeSlashCommandTrigger,
 } from "./SlashCommandPlugin";

--- a/apps/web/src/components/chat/lexical/index.ts
+++ b/apps/web/src/components/chat/lexical/index.ts
@@ -1,5 +1,11 @@
 export { ComposerEditor } from "./ComposerEditor";
-export { MentionNode, $createMentionNode, $createTypedMentionNode, $isMentionNode } from "./MentionNode";
+export {
+  MentionNode,
+  $createMentionNode,
+  $createTypedMentionNode,
+  $isMentionNode,
+  createMentionId,
+} from "./MentionNode";
 export type { MentionNodeData } from "./MentionNode";
 export {
   SlashCommandNode,

--- a/apps/web/src/components/chat/lexical/index.ts
+++ b/apps/web/src/components/chat/lexical/index.ts
@@ -7,6 +7,10 @@ export {
   $isSlashCommandNode,
 } from "./SlashCommandNode";
 export { insertMentionNode } from "./MentionPlugin";
-export { insertSlashCommandNode, removeSlashCommandTrigger } from "./SlashCommandPlugin";
+export {
+  insertPluginMentionNode,
+  insertSlashCommandNode,
+  removeSlashCommandTrigger,
+} from "./SlashCommandPlugin";
 export { getPlainTextFromEditor, extractMentionPaths, extractComposerMessage } from "./cursor-utils";
 export type { ExtractedComposerMessage } from "./cursor-utils";

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -4,7 +4,11 @@ import {
   providerCatalogCacheKey,
   useProviderCatalogStore,
 } from "@/stores/providerCatalogStore";
-import { ProviderIdSchema, type ProviderCapabilityEntry } from "@mcode/contracts";
+import {
+  ProviderIdSchema,
+  type ProviderCapabilityEntry,
+  type ProviderCapabilityKind,
+} from "@mcode/contracts";
 import type { ProviderCatalogRequest } from "@/transport";
 import type { SlashCommandNamespace } from "./lexical/SlashCommandNode";
 import {
@@ -17,9 +21,13 @@ export type ComposerCommandAction = ComposerCapabilityAction;
 
 /** A slash command entry shown in the popup. */
 export interface Command {
+  id: string;
   name: string;
   description: string;
   namespace: SlashCommandNamespace;
+  capabilityKind: ProviderCapabilityKind | "mcode";
+  nativeId: string;
+  mentionPath?: string;
   /** For mcode-namespace commands, the action string dispatched on selection. */
   action?: ComposerCommandAction;
 }
@@ -43,9 +51,12 @@ const MAX_SLASH_COMMAND_ITEMS = 100;
 
 const BUILTIN_COMMANDS: Command[] = [
   {
+    id: "builtin:command:compact",
     name: "compact",
     description: "Summarise conversation history to free up context window",
     namespace: "command",
+    capabilityKind: "providerCommand",
+    nativeId: "compact",
   },
 ];
 
@@ -54,17 +65,29 @@ export const SLASH_TRIGGER_RE = /(^|\s)(\/\S*)$/;
 
 /** Map an invocable provider capability into the existing command presentation. */
 function toCommand(entry: ProviderCapabilityEntry): Command | null {
-  if (entry.kind === "plugin") return null;
+  const base = {
+    id: `${entry.identity.providerId}:${entry.identity.kind}:${entry.identity.nativeId}`,
+    name: entry.name,
+    description: entry.description || `Run /${entry.name}`,
+    capabilityKind: entry.kind,
+    nativeId: entry.identity.nativeId,
+  };
+  if (entry.kind === "plugin") {
+    return {
+      ...base,
+      description: entry.description || `Use @${entry.name}`,
+      namespace: "plugin",
+      mentionPath: entry.mentionPath,
+    };
+  }
   if (entry.kind === "customPrompt" || entry.kind === "providerCommand") {
     return {
-      name: entry.name,
-      description: entry.description || `Run /${entry.name}`,
+      ...base,
       namespace: "command",
     };
   }
   return {
-    name: entry.name,
-    description: entry.description || `Run /${entry.name}`,
+    ...base,
     namespace: entry.source === "plugin" || entry.name.includes(":") ? "plugin" : "skill",
   };
 }
@@ -80,7 +103,9 @@ const NAMESPACE_ORDER: Record<SlashCommandNamespace, number> = {
 function sortCommands(cmds: Command[]): Command[] {
   return [...cmds].sort((a, b) => {
     const order = NAMESPACE_ORDER[a.namespace] - NAMESPACE_ORDER[b.namespace];
-    return order !== 0 ? order : a.name.localeCompare(b.name);
+    if (order !== 0) return order;
+    const nameOrder = a.name.localeCompare(b.name);
+    return nameOrder !== 0 ? nameOrder : a.id.localeCompare(b.id);
   });
 }
 
@@ -103,6 +128,8 @@ interface UseSlashCommandOptions {
    * bubble where mcode actions are meaningless and must not be selectable.
    */
   includeBuiltins?: boolean;
+  /** Whether this surface can persist native plugin mentions. */
+  includePlugins?: boolean;
 }
 
 /** Return value of the useSlashCommand hook. */
@@ -141,6 +168,7 @@ export function useSlashCommand({
   providerId,
   modelId,
   includeBuiltins = true,
+  includePlugins = true,
 }: UseSlashCommandOptions): UseSlashCommandReturn {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -184,9 +212,12 @@ export function useSlashCommand({
       ? [
           ...resolveComposerCapabilities({ providerId, modelId }).map(
             (capability): Command => ({
+              id: `builtin:mcode:${capability.id}`,
               name: capability.slashCommand,
               description: `Attach ${capability.label} to the composer`,
               namespace: "mcode",
+              capabilityKind: "mcode",
+              nativeId: capability.id,
               action: capability.action,
             }),
           ),
@@ -194,6 +225,7 @@ export function useSlashCommand({
         ]
       : [];
     const providerCommands = (snapshot?.entries ?? [])
+      .filter((entry) => includePlugins || entry.kind !== "plugin")
       .map(toCommand)
       .filter((command): command is Command => command !== null);
     const commands: Command[] = [
@@ -201,7 +233,7 @@ export function useSlashCommand({
       ...providerCommands,
     ];
     return sortCommands(commands);
-  }, [snapshot, providerId, modelId, includeBuiltins]);
+  }, [snapshot, providerId, modelId, includeBuiltins, includePlugins]);
 
   const filtered = useMemo(() => {
     const f = filter.toLowerCase();
@@ -320,7 +352,9 @@ export function useSlashCommand({
         replaceText(
           cmd.action
             ? value.slice(0, triggerStart) + value.slice(cursor)
-            : value.slice(0, triggerStart) + `/${cmd.name} ` + value.slice(cursor),
+            : value.slice(0, triggerStart) + (
+                cmd.capabilityKind === "plugin" ? `@${cmd.name} ` : `/${cmd.name} `
+              ) + value.slice(cursor),
         );
       }
       if (cmd.action && onMcodeCommand) onMcodeCommand(cmd.action);

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1578,6 +1578,7 @@ export function PreviewPanel({ threadId, workspaceId }: PreviewPanelProps) {
     threadId,
     providerId,
     includeBuiltins: false,
+    includePlugins: false,
   });
   const {
     isOpen: bubbleSlashOpen,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -533,6 +533,7 @@ export {
 } from "./providers/capability-catalog.js";
 export type {
   ProviderCapabilityKind,
+  ProviderPluginCapability,
   ProviderCapabilityEntry,
   ProviderAgentMention,
   SelectableProviderAgent,

--- a/packages/contracts/src/models/__tests__/mention.test.ts
+++ b/packages/contracts/src/models/__tests__/mention.test.ts
@@ -25,4 +25,30 @@ describe("MessageMentionSchema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("preserves a Codex plugin mention target", () => {
+    const result = MessageMentionSchema.safeParse({
+      id: "mention-plugin-1",
+      kind: "plugin",
+      label: "Browser",
+      name: "Browser",
+      path: "plugin://browser@openai-bundled",
+      range: { start: 0, end: 8 },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects plugin mentions without Codex's plugin URI", () => {
+    const result = MessageMentionSchema.safeParse({
+      id: "mention-plugin-1",
+      kind: "plugin",
+      label: "Browser",
+      name: "Browser",
+      path: "C:/plugins/browser",
+      range: { start: 0, end: 8 },
+    });
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/contracts/src/models/mention.ts
+++ b/packages/contracts/src/models/mention.ts
@@ -48,6 +48,13 @@ export const MessageMentionSchema = z.discriminatedUnion("kind", [
     provider: z.string().min(1).max(64).optional(),
   }),
   MentionBaseSchema.extend({
+    kind: z.literal("plugin"),
+    name: MentionTextSchema,
+    path: MentionPathSchema.refine((value) => value.startsWith("plugin://"), {
+      message: "Plugin mention path must use the plugin:// scheme",
+    }),
+  }),
+  MentionBaseSchema.extend({
     kind: z.literal("command"),
     namespace: z.enum(["skill", "mcode", "plugin", "command"]),
   }),

--- a/packages/contracts/src/providers/__tests__/capability-catalog.test.ts
+++ b/packages/contracts/src/providers/__tests__/capability-catalog.test.ts
@@ -14,7 +14,16 @@ function entry(kind: "skill" | "plugin" | "customPrompt" | "providerCommand") {
     name: "same-name",
     description: `${kind} description`,
   } as const;
-  return kind === "skill" ? { ...base, source: "user" as const } : base;
+  if (kind === "skill") return { ...base, source: "user" as const };
+  if (kind === "plugin") {
+    return {
+      ...base,
+      mentionPath: "plugin://same-name@personal",
+      marketplaceName: "personal",
+      capabilities: [],
+    };
+  }
+  return base;
 }
 
 describe("ProviderCatalogSnapshotSchema", () => {

--- a/packages/contracts/src/providers/capability-catalog.ts
+++ b/packages/contracts/src/providers/capability-catalog.ts
@@ -27,6 +27,9 @@ const CatalogNameSchema = z.string().trim().min(1).max(256);
 const CatalogDescriptionSchema = z.string().max(2_000);
 const CatalogNativeIdSchema = z.string().trim().min(1).max(512);
 const CatalogPathSchema = z.string().min(1).max(PROVIDER_CATALOG_PATH_MAX_CHARS);
+const CatalogMarketplaceNameSchema = z.string().trim().min(1).max(256);
+const CatalogVersionSchema = z.string().trim().min(1).max(128);
+const CatalogCapabilitySchema = z.string().trim().min(1).max(256);
 
 function identitySchema<TKind extends ProviderCapabilityKind>(kind: TKind) {
   return z.object({
@@ -56,8 +59,15 @@ export const ProviderPluginCapabilitySchema = lazySchema(() =>
     identity: identitySchema("plugin"),
     name: CatalogNameSchema,
     description: CatalogDescriptionSchema,
+    mentionPath: z.string().startsWith("plugin://").max(PROVIDER_CATALOG_PATH_MAX_CHARS),
+    marketplaceName: CatalogMarketplaceNameSchema,
+    version: CatalogVersionSchema.optional(),
+    developerName: CatalogNameSchema.optional(),
+    capabilities: z.array(CatalogCapabilitySchema).max(100),
   }).strict(),
 );
+/** Installed and enabled provider plugin entry. */
+export type ProviderPluginCapability = z.infer<ReturnType<typeof ProviderPluginCapabilitySchema>>;
 
 /** Deprecated Codex custom prompt entry available through the slash gesture. */
 export const ProviderCustomPromptCapabilitySchema = lazySchema(() =>


### PR DESCRIPTION
## What

Adds installed Codex plugins to the capability catalog and composer.

## Why

Mcode's catalog only exposed Codex skills and prompts, so users could not select a plugin as a rich mention or send its native identity to Codex.

## Key Changes

- Reads installed, enabled plugins for the effective workspace and keeps plugin identity separate from skills and prompts.
- Preserves valid plugins when marketplace entries are malformed and reports scoped catalog diagnostics.
- Adds plugins to the slash-command picker and serializes selections as rich `plugin://` mentions.
- Sends plugin mentions to Codex through native mention inputs while keeping plugin-provided skills as skill entries.
- Covers filtering, identity collisions, diagnostics, refreshes, mention persistence, and provider dispatch.

Closes #894

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787183960&installation_model_id=20477&pr_number=910&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F910&signature=77f033f38198dbc4eeac83146d5ef4b006a6abde74b58d0d795570a49c6b3995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex plugin discovery alongside skills, including marketplace metadata, descriptions, and diagnostics.
  * Plugins now appear in provider catalogs and slash-command suggestions with distinct labels and icons.
  * Selecting a plugin inserts an `@PluginName` mention that is preserved and sent to Codex.
  * Added support for plugin mentions in messages with validated plugin paths.
* **Bug Fixes**
  * Improved handling of duplicate plugin and skill names.
  * Clarified provider-mention validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->