### PR TITLE
feat(codex): preserve bounded custom prompts

### DIFF
--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -46,6 +46,7 @@ import {
   CodexCatalogClientFactory,
   CodexCatalogService,
 } from "./services/codex-catalog-service";
+import { CodexCustomPromptService } from "./services/codex-custom-prompt-service";
 import { ProviderCatalogService } from "./services/provider-catalog-service";
 import { TerminalService } from "./services/terminal-service";
 import { AttachmentService } from "./services/attachment-service";
@@ -368,6 +369,11 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register(
     CodexCatalogClientFactory,
     { useClass: CodexCatalogClientFactory },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    CodexCustomPromptService,
+    { useClass: CodexCustomPromptService },
     { lifecycle: Lifecycle.Singleton },
   );
   container.register(

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -56,11 +56,15 @@ function makeProvider(
   skillList: (...args: unknown[]) => unknown[] = vi.fn(() => []),
   catalogService: {
     currentSkills: (cwd?: string) => unknown[];
+    currentPrompts: () => unknown[];
+    refreshCustomPrompts: () => Promise<{ prompts: unknown[] }>;
     refresh: (cwd?: string) => Promise<{ skills: unknown[] }>;
     onSkillsChanged: (handler: () => void) => () => void;
     shutdown: () => Promise<void>;
   } = {
     currentSkills: vi.fn(() => []),
+    currentPrompts: vi.fn(() => []),
+    refreshCustomPrompts: vi.fn(async () => ({ prompts: [] })),
     refresh: vi.fn(async () => ({ skills: [] })),
     onSkillsChanged: vi.fn(() => () => undefined),
     shutdown: vi.fn(async () => undefined),
@@ -145,6 +149,8 @@ describe("CodexProvider first turn on new session", () => {
     const list = vi.fn((_cwd, _providerId, skills) => skills as unknown[]);
     const provider = makeProvider(list, {
       currentSkills,
+      currentPrompts: vi.fn(() => []),
+      refreshCustomPrompts: vi.fn(async () => ({ prompts: [] })),
       refresh,
       onSkillsChanged: vi.fn(() => () => undefined),
       shutdown: vi.fn(async () => undefined),
@@ -393,7 +399,7 @@ describe("CodexProvider first turn on new session", () => {
         promptPath,
         "---\ndescription: Draft a PR\n---\nDraft a PR for $FILES titled $PR_TITLE. Args: $ARGUMENTS",
       );
-      const provider = makeProvider(vi.fn(() => [{
+      const prompt = {
         name: "prompts:draftpr",
         nativeName: "draftpr",
         description: "Draft a PR",
@@ -401,7 +407,19 @@ describe("CodexProvider first turn on new session", () => {
         source: "user",
         providers: ["codex"],
         path: promptPath,
-      }]));
+      };
+      const refreshCustomPrompts = vi.fn(async () => ({ prompts: [prompt] }));
+      const provider = makeProvider(
+        vi.fn((_cwd, _providerId, nativeItems) => nativeItems as unknown[]),
+        {
+          currentSkills: vi.fn(() => []),
+          currentPrompts: vi.fn(() => []),
+          refreshCustomPrompts,
+          refresh: vi.fn(async () => ({ skills: [] })),
+          onSkillsChanged: vi.fn(() => () => undefined),
+          shutdown: vi.fn(async () => undefined),
+        },
+      );
 
       await provider.sendTurn({
         sessionId: "mcode-prompt-turn",
@@ -422,6 +440,104 @@ describe("CodexProvider first turn on new session", () => {
         type: "text",
         text: 'Draft a PR for src/a.ts src/b.ts titled Add files. Args: FILES="src/a.ts src/b.ts" PR_TITLE="Add files"',
       }]);
+      expect(refreshCustomPrompts).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(promptDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses selected catalog identity when a Skill and custom prompt share a name", async () => {
+    const promptDir = mkdtempSync(join(tmpdir(), "codex-provider-collision-"));
+    try {
+      const promptPath = join(promptDir, "release.md");
+      const skillPath = join(promptDir, "release-skill", "SKILL.md");
+      writeFileSync(promptPath, "Prompt release $ARGUMENTS");
+      const prompt = {
+        name: "prompts:release",
+        nativeName: "release",
+        description: "Prompt release",
+        kind: "command",
+        source: "user",
+        providers: ["codex"],
+        path: promptPath,
+      };
+      const skill = {
+        name: "prompts:release",
+        nativeName: "prompts:release",
+        description: "Skill release",
+        kind: "skill",
+        source: "user",
+        providers: ["codex"],
+        path: skillPath,
+      };
+      const provider = makeProvider(
+        vi.fn((_cwd, _providerId, nativeItems) => [skill, ...(nativeItems as unknown[])]),
+        {
+          currentSkills: vi.fn(() => [skill]),
+          currentPrompts: vi.fn(() => [prompt]),
+          refreshCustomPrompts: vi.fn(async () => ({ prompts: [prompt] })),
+          refresh: vi.fn(async () => ({ skills: [skill] })),
+          onSkillsChanged: vi.fn(() => () => undefined),
+          shutdown: vi.fn(async () => undefined),
+        },
+      );
+
+      await provider.sendTurn({
+        sessionId: "mcode-prompt-collision",
+        threadId: "prompt-collision",
+        message: "/prompts:release alpha",
+        mentions: [{
+          id: "command:command:prompts:release",
+          kind: "command",
+          label: "prompts:release",
+          namespace: "command",
+          capabilityIdentity: {
+            providerId: "codex",
+            kind: "customPrompt",
+            nativeId: "release",
+          },
+          range: { start: 0, end: 16 },
+        }],
+        cwd: process.cwd(),
+        model: "gpt-5.4",
+        interactionMode: "build",
+        providerOptions: {},
+        permissionMode: "auto",
+      });
+      await provider.sendTurn({
+        sessionId: "mcode-skill-collision",
+        threadId: "skill-collision",
+        message: "/prompts:release beta",
+        mentions: [{
+          id: "command:skill:prompts:release",
+          kind: "command",
+          label: "prompts:release",
+          namespace: "skill",
+          capabilityIdentity: {
+            providerId: "codex",
+            kind: "skill",
+            nativeId: skillPath,
+          },
+          range: { start: 0, end: 16 },
+        }],
+        cwd: process.cwd(),
+        model: "gpt-5.4",
+        interactionMode: "build",
+        providerOptions: {},
+        permissionMode: "auto",
+      });
+
+      for (let i = 0; i < 20 && sendTurnMock.mock.calls.length < 2; i++) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+
+      expect(sendTurnMock.mock.calls[0][0]).toEqual([
+        { type: "text", text: "Prompt release alpha" },
+      ]);
+      expect(sendTurnMock.mock.calls[1][0]).toEqual([
+        { type: "skill", name: "prompts:release", path: skillPath },
+        { type: "text", text: "$prompts:release beta" },
+      ]);
     } finally {
       rmSync(promptDir, { recursive: true, force: true });
     }
@@ -430,7 +546,7 @@ describe("CodexProvider first turn on new session", () => {
   it("emits a controlled error when a listed Codex prompt cannot be read", async () => {
     const promptDir = mkdtempSync(join(tmpdir(), "missing-codex-prompt-"));
     try {
-      const provider = makeProvider(vi.fn(() => [{
+      const prompt = {
         name: "prompts:draftpr",
         nativeName: "draftpr",
         description: "Draft a PR",
@@ -438,7 +554,18 @@ describe("CodexProvider first turn on new session", () => {
         source: "user",
         providers: ["codex"],
         path: join(promptDir, "draftpr.md"),
-      }]));
+      };
+      const provider = makeProvider(
+        vi.fn((_cwd, _providerId, nativeItems) => nativeItems as unknown[]),
+        {
+          currentSkills: vi.fn(() => []),
+          currentPrompts: vi.fn(() => []),
+          refreshCustomPrompts: vi.fn(async () => ({ prompts: [prompt] })),
+          refresh: vi.fn(async () => ({ skills: [] })),
+          onSkillsChanged: vi.fn(() => () => undefined),
+          shutdown: vi.fn(async () => undefined),
+        },
+      );
       const events: AgentEvent[] = [];
       provider.on("event", (event: AgentEvent) => events.push(event));
 
@@ -502,6 +629,8 @@ describe("CodexProvider first turn on new session", () => {
     const refresh = vi.fn(async () => ({ skills: [nativeSkill] }));
     const provider = makeProvider(undefined, {
       currentSkills: vi.fn(() => []),
+      currentPrompts: vi.fn(() => []),
+      refreshCustomPrompts: vi.fn(async () => ({ prompts: [] })),
       refresh,
       onSkillsChanged: vi.fn(() => () => undefined),
       shutdown: vi.fn(async () => undefined),

--- a/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
@@ -62,6 +62,8 @@ describe("CodexProvider permission flow", () => {
       { persistGeneratedImageFromPath: vi.fn() } as never,
       {
         currentSkills: vi.fn(() => []),
+        currentPrompts: vi.fn(() => []),
+        refreshCustomPrompts: vi.fn(async () => ({ prompts: [] })),
         refresh: vi.fn(async () => ({ skills: [] })),
         onSkillsChanged: vi.fn(() => () => undefined),
         shutdown: vi.fn(async () => undefined),

--- a/apps/server/src/providers/codex/__tests__/codex-provider-subagent-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-subagent-turn.test.ts
@@ -81,6 +81,8 @@ function makeProvider(): CodexProvider {
     { persistGeneratedImageFromPath: vi.fn() } as never,
     {
       currentSkills: vi.fn(() => []),
+      currentPrompts: vi.fn(() => []),
+      refreshCustomPrompts: vi.fn(async () => ({ prompts: [] })),
       refresh: vi.fn(async () => ({ skills: [] })),
       onSkillsChanged: vi.fn(() => () => undefined),
       shutdown: vi.fn(async () => undefined),

--- a/apps/server/src/providers/codex/codex-prompt.ts
+++ b/apps/server/src/providers/codex/codex-prompt.ts
@@ -37,6 +37,20 @@ interface CachedPromptTemplate {
 
 const promptTemplateCache = new Map<string, CachedPromptTemplate>();
 
+/** Returns true only for catalog items produced by the Codex custom-prompt adapter. */
+export function isCodexCustomPromptCatalogItem(
+  item: SkillInfo,
+): item is SkillInfo & { path: string } {
+  return (
+    item.kind === "command"
+    && item.source === "user"
+    && item.providers.includes("codex")
+    && Boolean(item.path)
+    && Boolean(item.nativeName)
+    && item.name === `prompts:${item.nativeName}`
+  );
+}
+
 function stripFrontmatter(content: string): string {
   return content.replace(FRONTMATTER_RE, "");
 }
@@ -142,8 +156,7 @@ export function isCodexPromptCommand(
   requestedName: string,
 ): item is SkillInfo & { path: string } {
   return (
-    item.kind === "command" &&
-    Boolean(item.path) &&
+    isCodexCustomPromptCatalogItem(item) &&
     item.name === requestedName
   );
 }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -40,6 +40,7 @@ import type {
   PermissionRequest,
   ProviderModelInfo,
   ProviderUsageInfo,
+  ProviderCapabilityIdentity,
   QuotaCategory,
   SkillInfo,
 } from "@mcode/contracts";
@@ -296,7 +297,7 @@ async function buildCodexInput(
   }
 
   const wireMessage = rewriteAgentMentionsAsSubagentUris(message, mentions);
-  const invocation = await resolveCodexSlashInvocation(wireMessage, skills);
+  const invocation = await resolveCodexSlashInvocation(wireMessage, skills, mentions);
   if (invocation.skillItem) inputs.push(invocation.skillItem);
   inputs.push({ type: "text", text: invocation.text });
   return inputs;
@@ -333,34 +334,75 @@ function rewriteAgentMentionsAsSubagentUris(
 async function resolveCodexSlashInvocation(
   message: string,
   skills: readonly SkillInfo[],
+  mentions: readonly MessageMention[],
 ): Promise<{ text: string; skillItem?: TurnInputPart }> {
   const slash = parseCodexSlashInvocation(message);
   if (!slash) return { text: message };
 
-  let promptCommand: (SkillInfo & { path: string }) | undefined;
-  for (const item of skills) {
-    if (item.name !== slash.requestedName && item.nativeName !== slash.requestedName) continue;
-
-    if (item.kind === "skill") {
-      const nativeName = item.nativeName ?? item.name.split(":").pop() ?? item.name;
-      const args = slash.args.trimStart();
-      const text = `$${nativeName}${args ? ` ${args}` : ""}`;
-      return {
-        text,
-        ...(item.path ? { skillItem: { type: "skill" as const, name: nativeName, path: item.path } } : {}),
-      };
-    }
-
-    if (!promptCommand && isCodexPromptCommand(item, slash.requestedName)) {
-      promptCommand = item;
-    }
-  }
+  const leadingSpace = message.length - message.trimStart().length;
+  const commandEnd = leadingSpace + slash.requestedName.length + 1;
+  const selectedMention = mentions.find((mention): mention is Extract<
+    MessageMention,
+    { kind: "command" }
+  > => (
+    mention.kind === "command"
+    && mention.label === slash.requestedName
+    && mention.range.start === leadingSpace
+    && mention.range.end === commandEnd
+    && mention.capabilityIdentity?.providerId === "codex"
+  ));
+  const selectedIdentity = selectedMention?.capabilityIdentity;
+  const candidates = skills.filter((item) => (
+    item.name === slash.requestedName || item.nativeName === slash.requestedName
+  ));
+  const selected = selectedIdentity
+    ? candidates.find((item) => matchesCodexCapabilityIdentity(item, selectedIdentity))
+    : undefined;
+  const promptCommand = selectedIdentity?.kind === "customPrompt"
+    ? selected && isCodexPromptCommand(selected, slash.requestedName) ? selected : undefined
+    : selectedIdentity
+      ? undefined
+      : candidates.find((item) => isCodexPromptCommand(item, slash.requestedName));
 
   if (promptCommand) {
     return { text: await expandCodexPromptCommand(promptCommand, slash.args) };
   }
 
+  const skill = selectedIdentity?.kind === "skill"
+    ? selected?.kind === "skill" ? selected : undefined
+    : selectedIdentity
+      ? undefined
+      : candidates.find((item) => item.kind === "skill");
+  if (skill) {
+    const nativeName = skill.nativeName ?? skill.name.split(":").pop() ?? skill.name;
+    const args = slash.args.trimStart();
+    const text = `$${nativeName}${args ? ` ${args}` : ""}`;
+    return {
+      text,
+      ...(skill.path
+        ? { skillItem: { type: "skill" as const, name: nativeName, path: skill.path } }
+        : {}),
+    };
+  }
+
   return { text: message };
+}
+
+function matchesCodexCapabilityIdentity(
+  item: SkillInfo,
+  identity: ProviderCapabilityIdentity,
+): boolean {
+  if (identity.kind === "skill") {
+    return item.kind === "skill"
+      && (item.path ?? item.nativeName ?? item.name) === identity.nativeId;
+  }
+  if (identity.kind === "customPrompt") {
+    return isCodexPromptCommand(item, item.name)
+      && (item.nativeName ?? item.name) === identity.nativeId;
+  }
+  return item.kind === "command"
+    && !isCodexPromptCommand(item, item.name)
+    && (item.nativeName ?? item.name) === identity.nativeId;
 }
 
 /** Return the generated image path from an app-server imageGeneration item. */
@@ -775,7 +817,15 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     const codexFastMode = req.providerOptions.fastMode;
 
     const nativeSkills = this.codexCatalogService.currentSkills(cwd);
-    const skillCatalog = this.skillService.list(cwd, "codex", nativeSkills);
+    const slashInvocation = parseCodexSlashInvocation(message);
+    const customPrompts = slashInvocation?.requestedName.startsWith("prompts:")
+      ? (await this.codexCatalogService.refreshCustomPrompts()).prompts
+      : this.codexCatalogService.currentPrompts();
+    const skillCatalog = this.skillService.list(
+      cwd,
+      "codex",
+      [...nativeSkills, ...customPrompts],
+    );
     const threadId = sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
     let input: TurnInputPart[];
     try {

--- a/apps/server/src/services/__tests__/codex-catalog-service.test.ts
+++ b/apps/server/src/services/__tests__/codex-catalog-service.test.ts
@@ -1,7 +1,9 @@
 import "reflect-metadata";
 import { EventEmitter } from "events";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SkillInfo } from "@mcode/contracts";
 import { CodexCatalogService } from "../codex-catalog-service.js";
+import type { CodexCustomPromptDiscoveryResult } from "../codex-custom-prompt-service.js";
 import type {
   PluginListResult,
   PluginReadResult,
@@ -89,12 +91,20 @@ describe("CodexCatalogService", () => {
   function createService(
     client: ControlledCatalogClient,
     create: () => ControlledCatalogClient = () => client,
+    customPromptService: {
+      refresh: () => Promise<CodexCustomPromptDiscoveryResult>;
+      currentPrompts: () => SkillInfo[];
+    } = {
+      refresh: vi.fn(async () => ({ prompts: [], diagnostics: [], available: true })),
+      currentPrompts: vi.fn(() => []),
+    },
   ): CodexCatalogService {
     const service = new CodexCatalogService(
       { get: () => ({ provider: { cli: { codex: "codex" } } }) } as never,
       { isWindowsJob: false } as never,
       { getEnv: () => ({}) } as never,
       { create } as never,
+      customPromptService as never,
     );
     services.push(service);
     return service;
@@ -240,6 +250,29 @@ describe("CodexCatalogService", () => {
       code: "discovery-error",
       message: "Codex plugin marketplace C:/marketplaces/broken.json: invalid marketplace metadata",
     });
+  });
+
+  it("includes bounded custom prompts beside native Skills", async () => {
+    const client = new ControlledCatalogClient();
+    const prompt: SkillInfo = {
+      name: "prompts:release",
+      nativeName: "release",
+      description: "Prepare a release",
+      kind: "command" as const,
+      source: "user" as const,
+      providers: ["codex"],
+      path: "C:/codex-home/prompts/release.md",
+    };
+    const customPromptService = {
+      refresh: vi.fn(async () => ({ prompts: [prompt], diagnostics: [], available: true })),
+      currentPrompts: vi.fn(() => [prompt]),
+    };
+    const service = createService(client, () => client, customPromptService);
+
+    const result = await service.refresh("C:/workspaces/one");
+
+    expect(result.prompts).toEqual([prompt]);
+    expect(service.currentPrompts()).toEqual([prompt]);
   });
 
   it("reconciles the affected context after skills/changed", async () => {

--- a/apps/server/src/services/__tests__/codex-custom-prompt-service.test.ts
+++ b/apps/server/src/services/__tests__/codex-custom-prompt-service.test.ts
@@ -1,0 +1,232 @@
+import "reflect-metadata";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CODEX_CUSTOM_PROMPT_MAX_DIRECTORY_ENTRIES,
+  CODEX_CUSTOM_PROMPT_MAX_FILE_BYTES,
+  CODEX_CUSTOM_PROMPT_MAX_FILES,
+  CodexCustomPromptService,
+  discoverCodexCustomPrompts,
+  resolveEffectiveCodexHome,
+  type CodexCustomPromptFileSystem,
+} from "../codex-custom-prompt-service.js";
+
+const temporaryDirectories: string[] = [];
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "mcode-codex-prompts-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => (
+    rm(directory, { recursive: true, force: true })
+  )));
+});
+
+describe("CodexCustomPromptService", () => {
+  it("discovers only direct Markdown prompts under the effective CODEX_HOME", async () => {
+    const codexHome = await createTemporaryDirectory();
+    const promptDirectory = join(codexHome, "prompts");
+    await mkdir(join(promptDirectory, "nested"), { recursive: true });
+    await writeFile(
+      join(promptDirectory, "release.md"),
+      "---\ndescription: Prepare a release\n---\nRelease $ARGUMENTS.",
+    );
+    await writeFile(join(promptDirectory, "ignored.txt"), "Ignored");
+    await writeFile(join(promptDirectory, "nested", "project.md"), "Nested");
+
+    const service = new CodexCustomPromptService({
+      getEnv: () => ({ CODEX_HOME: codexHome, USERPROFILE: "C:\\wrong-home" }),
+    } as never);
+
+    const result = await service.refresh();
+
+    expect(resolveEffectiveCodexHome({ CODEX_HOME: codexHome })).toBe(codexHome);
+    expect(result.prompts).toEqual([{
+      name: "prompts:release",
+      nativeName: "release",
+      description: "Prepare a release",
+      kind: "command",
+      source: "user",
+      providers: ["codex"],
+      path: join(promptDirectory, "release.md"),
+    }]);
+    expect(result.diagnostics).toEqual([]);
+    expect(service.currentPrompts()).toEqual(result.prompts);
+  });
+
+  it("bounds direct prompt file count and reports the first excessive file", async () => {
+    const codexHome = await createTemporaryDirectory();
+    const promptDirectory = join(codexHome, "prompts");
+    await mkdir(promptDirectory, { recursive: true });
+    await Promise.all([
+      writeFile(join(promptDirectory, "one.md"), "One"),
+      writeFile(join(promptDirectory, "two.md"), "Two"),
+    ]);
+
+    const result = await discoverCodexCustomPrompts(codexHome, {
+      maxFiles: 1,
+      maxFileBytes: CODEX_CUSTOM_PROMPT_MAX_FILE_BYTES,
+    });
+
+    expect(result.prompts).toHaveLength(1);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "partial-result",
+        message: expect.stringContaining("at most 1 direct .md file"),
+      }),
+    ]);
+  });
+
+  it("bounds directory traversal even when entries are not supported prompt files", async () => {
+    let yieldedEntries = 0;
+    const fileSystem: CodexCustomPromptFileSystem = {
+      async *entries() {
+        for (const name of ["valid.md", "ignored.txt", "later.md", "never.md"]) {
+          yieldedEntries += 1;
+          yield { name, isFile: true };
+        }
+      },
+      async readFile(path) {
+        return Buffer.from(path.endsWith("valid.md") ? "Valid" : "Later");
+      },
+    };
+
+    const result = await discoverCodexCustomPrompts("C:\\codex-home", {
+      maxDirectoryEntries: 2,
+      maxFiles: CODEX_CUSTOM_PROMPT_MAX_FILES,
+      maxFileBytes: CODEX_CUSTOM_PROMPT_MAX_FILE_BYTES,
+      fileSystem,
+    });
+
+    expect(yieldedEntries).toBe(3);
+    expect(result.prompts.map((prompt) => prompt.nativeName)).toEqual(["valid"]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "partial-result",
+        message: expect.stringContaining("at most 2 direct directory entries"),
+      }),
+    ]);
+    expect(CODEX_CUSTOM_PROMPT_MAX_DIRECTORY_ENTRIES).toBeGreaterThan(
+      CODEX_CUSTOM_PROMPT_MAX_FILES,
+    );
+  });
+
+  it("retains the partial-result diagnostic after every supported file fails", async () => {
+    const fileSystem: CodexCustomPromptFileSystem = {
+      async *entries() {
+        for (let index = 0; index <= CODEX_CUSTOM_PROMPT_MAX_FILES; index += 1) {
+          yield { name: `prompt-${index}.md`, isFile: true };
+        }
+      },
+      async readFile() {
+        throw new Error("access denied");
+      },
+    };
+
+    const result = await discoverCodexCustomPrompts("C:\\codex-home", {
+      maxFiles: CODEX_CUSTOM_PROMPT_MAX_FILES,
+      maxFileBytes: CODEX_CUSTOM_PROMPT_MAX_FILE_BYTES,
+      fileSystem,
+    });
+
+    expect(result.diagnostics).toHaveLength(CODEX_CUSTOM_PROMPT_MAX_FILES + 1);
+    expect(result.diagnostics.at(-1)).toMatchObject({ code: "partial-result" });
+  });
+
+  it("rejects an oversized prompt while retaining a valid sibling", async () => {
+    const codexHome = await createTemporaryDirectory();
+    const promptDirectory = join(codexHome, "prompts");
+    await mkdir(promptDirectory, { recursive: true });
+    await writeFile(join(promptDirectory, "valid.md"), "Valid");
+    await writeFile(join(promptDirectory, "oversized.md"), "x".repeat(9));
+
+    const result = await discoverCodexCustomPrompts(codexHome, {
+      maxFiles: CODEX_CUSTOM_PROMPT_MAX_FILES,
+      maxFileBytes: 8,
+    });
+
+    expect(result.prompts.map((prompt) => prompt.nativeName)).toEqual(["valid"]);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({
+      code: "discovery-error",
+      message: expect.stringContaining("oversized.md"),
+    }));
+  });
+
+  it("isolates malformed and unreadable prompts while retaining valid siblings", async () => {
+    const codexHome = "C:\\codex-home";
+    const fileSystem: CodexCustomPromptFileSystem = {
+      async *entries() {
+        yield { name: "valid.md", isFile: true };
+        yield { name: "malformed.md", isFile: true };
+        yield { name: "unreadable.md", isFile: true };
+      },
+      async readFile(path) {
+        if (path.endsWith("unreadable.md")) throw new Error("access denied");
+        if (path.endsWith("malformed.md")) return Buffer.from("---\ndescription: missing close");
+        return Buffer.from("---\ndescription: Valid prompt\n---\nBody");
+      },
+    };
+
+    const result = await discoverCodexCustomPrompts(codexHome, {
+      maxFiles: CODEX_CUSTOM_PROMPT_MAX_FILES,
+      maxFileBytes: CODEX_CUSTOM_PROMPT_MAX_FILE_BYTES,
+      fileSystem,
+    });
+
+    expect(result.prompts.map((prompt) => prompt.nativeName)).toEqual(["valid"]);
+    expect(result.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ message: expect.stringContaining("malformed.md") }),
+      expect.objectContaining({ message: expect.stringContaining("unreadable.md") }),
+    ]));
+  });
+
+  it("rejects invalid UTF-8 without hiding valid prompts", async () => {
+    const codexHome = await createTemporaryDirectory();
+    const promptDirectory = join(codexHome, "prompts");
+    await mkdir(promptDirectory, { recursive: true });
+    await writeFile(join(promptDirectory, "valid.md"), "Valid");
+    await writeFile(join(promptDirectory, "invalid.md"), Buffer.from([0xc3, 0x28]));
+
+    const result = await discoverCodexCustomPrompts(codexHome);
+
+    expect(result.prompts.map((prompt) => prompt.nativeName)).toEqual(["valid"]);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({
+      code: "discovery-error",
+      message: expect.stringContaining("invalid.md"),
+    }));
+  });
+
+  it("refreshes changed prompt metadata and removes deleted prompts by stable name", async () => {
+    const codexHome = await createTemporaryDirectory();
+    const promptDirectory = join(codexHome, "prompts");
+    const promptPath = join(promptDirectory, "release.md");
+    await mkdir(promptDirectory, { recursive: true });
+    await writeFile(promptPath, "---\ndescription: First release prompt\n---\nFirst body");
+    const service = new CodexCustomPromptService({
+      getEnv: () => ({ CODEX_HOME: codexHome }),
+    } as never);
+
+    const first = await service.refresh();
+    await writeFile(promptPath, "---\ndescription: Updated release prompt\n---\nUpdated body");
+    const updated = await service.refresh();
+    await rm(promptPath);
+    const removed = await service.refresh();
+
+    expect(first.prompts[0]).toMatchObject({
+      name: "prompts:release",
+      nativeName: "release",
+      description: "First release prompt",
+    });
+    expect(updated.prompts[0]).toMatchObject({
+      name: "prompts:release",
+      nativeName: "release",
+      description: "Updated release prompt",
+    });
+    expect(removed.prompts).toEqual([]);
+  });
+});

--- a/apps/server/src/services/codex-catalog-service.ts
+++ b/apps/server/src/services/codex-catalog-service.ts
@@ -22,6 +22,10 @@ import type {
 import { codexPluginNameFromSkillPath } from "./skill-service.js";
 import { SettingsService } from "./settings-service.js";
 import { EnvService } from "./env-service.js";
+import {
+  CodexCustomPromptService,
+  type CodexCustomPromptDiscoveryResult,
+} from "./codex-custom-prompt-service.js";
 import type { JobObject } from "./job-object.js";
 
 const CODEX_CATALOG_IDLE_TTL_MS = 60_000;
@@ -36,12 +40,15 @@ interface PluginCandidate {
   readonly summary: Record<string, unknown>;
 }
 
-/** Result of refreshing native Codex Skills for one working-directory context. */
+/** Result of refreshing Codex capabilities for one working-directory context. */
 export interface CodexCatalogRefreshResult {
   readonly skills: SkillInfo[];
   readonly plugins: ProviderPluginCapability[];
+  readonly prompts: SkillInfo[];
   readonly diagnostics: ProviderCatalogDiagnostic[];
   readonly freshness: ProviderCatalogFreshness;
+  readonly skillsAvailable: boolean;
+  readonly promptsAvailable: boolean;
 }
 
 /** Minimal app-server surface used by the provider-wide catalog connection. */
@@ -360,9 +367,11 @@ export class CodexCatalogService {
     @inject("JobObject") private readonly jobObject: JobObject,
     @inject(EnvService) private readonly envService: EnvService,
     @inject(CodexCatalogClientFactory) private readonly clientFactory: CodexCatalogClientFactory,
+    @inject(CodexCustomPromptService)
+    private readonly customPromptService: CodexCustomPromptService,
   ) {}
 
-  /** Refreshes the complete native capability list for one working-directory context. */
+  /** Refreshes native Skills, plugins, and bounded custom prompts for one working-directory context. */
   async refresh(cwd?: string): Promise<CodexCatalogRefreshResult> {
     this.rememberContext(cwd);
     this.armIdleTimer();
@@ -378,6 +387,16 @@ export class CodexCatalogService {
   /** Returns the last complete Skill list without starting or waiting for catalog work. */
   currentSkills(cwd?: string): SkillInfo[] {
     return this.snapshots.get(catalogKey(cwd))?.skills ?? [];
+  }
+
+  /** Returns the latest bounded custom prompt list without starting filesystem work. */
+  currentPrompts(): SkillInfo[] {
+    return this.customPromptService.currentPrompts();
+  }
+
+  /** Refreshes only the bounded custom prompt adapter for an imminent invocation. */
+  refreshCustomPrompts(): Promise<CodexCustomPromptDiscoveryResult> {
+    return this.customPromptService.refresh();
   }
 
   /** Returns the last complete refresh result without touching the connection idle deadline. */
@@ -401,11 +420,13 @@ export class CodexCatalogService {
     cwd: string | undefined,
     forceReload: boolean,
   ): Promise<CodexCatalogRefreshResult> {
+    const promptRefresh = this.customPromptService.refresh();
     try {
       const client = await this.acquireClient(cwd);
-      const [skillsResult, pluginsResult] = await Promise.all([
+      const [skillsResult, pluginsResult, customPrompts] = await Promise.all([
         client.listSkills(cwd ? [cwd] : undefined, forceReload),
         client.listPlugins(cwd ? [cwd] : undefined),
+        promptRefresh,
       ]);
       const rawData = Array.isArray((skillsResult as { data?: unknown }).data)
         ? (skillsResult as { data: unknown[] }).data
@@ -440,12 +461,22 @@ export class CodexCatalogService {
       const snapshot: CodexCatalogRefreshResult = {
         skills: reconciled.skills,
         plugins: reconciledPlugins.plugins,
-        diagnostics: diagnostics.slice(0, 100),
-        freshness: { status: "fresh", fetchedAt },
+        prompts: customPrompts.prompts,
+        diagnostics: [...diagnostics, ...customPrompts.diagnostics].slice(0, 100),
+        freshness: customPrompts.available
+          ? { status: "fresh", fetchedAt }
+          : {
+              status: "stale",
+              fetchedAt,
+              reason: "Codex custom prompt discovery failed.",
+            },
+        skillsAvailable: true,
+        promptsAvailable: customPrompts.available,
       };
       this.snapshots.set(catalogKey(cwd), snapshot);
       return snapshot;
     } catch (error) {
+      const customPrompts = await promptRefresh;
       const previous = this.snapshots.get(catalogKey(cwd));
       const fetchedAt = previous?.freshness.fetchedAt ?? new Date().toISOString();
       logger.warn("Codex catalog refresh failed", {
@@ -455,16 +486,22 @@ export class CodexCatalogService {
       const snapshot: CodexCatalogRefreshResult = {
         skills: previous?.skills ?? [],
         plugins: previous?.plugins ?? [],
-        diagnostics: [{
-          severity: "warning",
-          code: "source-unavailable",
-          message: "Codex capabilities are temporarily unavailable for this catalog context.",
-        }],
+        prompts: customPrompts.prompts,
+        diagnostics: [
+          {
+            severity: "warning" as const,
+            code: "source-unavailable" as const,
+            message: "Codex capabilities are temporarily unavailable for this catalog context.",
+          },
+          ...customPrompts.diagnostics,
+        ].slice(0, 100),
         freshness: {
           status: "stale",
           fetchedAt,
           reason: "Codex capability discovery failed.",
         },
+        skillsAvailable: false,
+        promptsAvailable: customPrompts.available,
       };
       this.snapshots.set(catalogKey(cwd), snapshot);
       return snapshot;

--- a/apps/server/src/services/codex-custom-prompt-service.ts
+++ b/apps/server/src/services/codex-custom-prompt-service.ts
@@ -1,0 +1,317 @@
+/**
+ * Bounded compatibility adapter for deprecated Codex custom prompts.
+ *
+ * The adapter resolves its root from the `CODEX_HOME` value in the same
+ * {@link EnvService} environment used to spawn Codex. When that value is not
+ * set, it derives `<user home>/.codex` from that environment. Discovery reads
+ * only direct regular `*.md` files under the `prompts` directory. It never
+ * searches a workspace, recurses, or installs a filesystem watcher.
+ *
+ * Each file is bounded by {@link CODEX_CUSTOM_PROMPT_MAX_FILE_BYTES}, and each
+ * refresh inspects at most {@link CODEX_CUSTOM_PROMPT_MAX_DIRECTORY_ENTRIES}
+ * directory entries and {@link CODEX_CUSTOM_PROMPT_MAX_FILES} supported files.
+ * Prompt bodies may begin with YAML frontmatter; only a string `description` field is used.
+ * Invalid UTF-8, malformed frontmatter, unreadable files, and exceeded limits
+ * produce source-scoped diagnostics without hiding valid sibling prompts.
+ */
+
+import { open, opendir } from "fs/promises";
+import { homedir } from "os";
+import { join, resolve } from "path";
+import { inject, injectable } from "tsyringe";
+import { parseDocument } from "yaml";
+import type { ProviderCatalogDiagnostic, SkillInfo } from "@mcode/contracts";
+import { PROVIDER_CATALOG_PATH_MAX_CHARS } from "@mcode/contracts";
+import { EnvService } from "./env-service.js";
+
+/** Environment variable whose value is Codex's effective configuration root. */
+export const CODEX_HOME_ENVIRONMENT_VARIABLE = "CODEX_HOME";
+/** Direct child directory of the effective Codex home containing custom prompts. */
+export const CODEX_CUSTOM_PROMPT_DIRECTORY_NAME = "prompts";
+/** Exact supported suffix for direct Codex custom prompt files. */
+export const CODEX_CUSTOM_PROMPT_FILE_SUFFIX = ".md";
+/** Maximum direct custom prompt files inspected during one refresh. */
+export const CODEX_CUSTOM_PROMPT_MAX_FILES = 64;
+/** Maximum direct directory entries inspected during one refresh. */
+export const CODEX_CUSTOM_PROMPT_MAX_DIRECTORY_ENTRIES = 256;
+/** Maximum bytes read from one custom prompt file. */
+export const CODEX_CUSTOM_PROMPT_MAX_FILE_BYTES = 256 * 1_024;
+
+const CODEX_CUSTOM_PROMPT_MAX_DIAGNOSTICS = CODEX_CUSTOM_PROMPT_MAX_FILES + 1;
+const CODEX_CUSTOM_PROMPT_MAX_NAME_CHARS = 256;
+const CODEX_CUSTOM_PROMPT_MAX_DESCRIPTION_CHARS = 2_000;
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+/** File-count and per-file byte limits applied by custom prompt discovery. */
+export interface CodexCustomPromptDiscoveryLimits {
+  readonly maxFiles: number;
+  readonly maxFileBytes: number;
+}
+
+/** Minimal filesystem boundary used by the custom prompt adapter. */
+export interface CodexCustomPromptFileSystem {
+  entries(directory: string): AsyncIterable<{ readonly name: string; readonly isFile: boolean }>;
+  readFile(path: string, maxBytes: number): Promise<Buffer>;
+}
+
+/** Optional discovery limits and filesystem implementation. */
+export interface CodexCustomPromptDiscoveryOptions extends CodexCustomPromptDiscoveryLimits {
+  readonly maxDirectoryEntries?: number;
+  readonly fileSystem?: CodexCustomPromptFileSystem;
+}
+
+/** Complete result of one bounded custom prompt directory refresh. */
+export interface CodexCustomPromptDiscoveryResult {
+  readonly prompts: SkillInfo[];
+  readonly diagnostics: ProviderCatalogDiagnostic[];
+  readonly available: boolean;
+}
+
+const DEFAULT_DISCOVERY_OPTIONS: CodexCustomPromptDiscoveryLimits = {
+  maxFiles: CODEX_CUSTOM_PROMPT_MAX_FILES,
+  maxFileBytes: CODEX_CUSTOM_PROMPT_MAX_FILE_BYTES,
+};
+
+const NODE_FILE_SYSTEM: CodexCustomPromptFileSystem = {
+  async *entries(directory) {
+    const handle = await opendir(directory);
+    for await (const entry of handle) {
+      yield { name: entry.name, isFile: entry.isFile() };
+    }
+  },
+  async readFile(path, maxBytes) {
+    const handle = await open(path, "r");
+    try {
+      const buffer = Buffer.allocUnsafe(maxBytes + 1);
+      let offset = 0;
+      while (offset < buffer.length) {
+        const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+        if (bytesRead === 0) break;
+        offset += bytesRead;
+      }
+      return buffer.subarray(0, offset);
+    } finally {
+      await handle.close().catch(() => undefined);
+    }
+  },
+};
+
+function environmentValue(environment: Readonly<Record<string, string>>, key: string): string | undefined {
+  const value = environment[key]?.trim();
+  return value ? value : undefined;
+}
+
+/** Resolves the Codex configuration root from the spawn environment. */
+export function resolveEffectiveCodexHome(
+  environment: Readonly<Record<string, string>>,
+): string {
+  const configuredHome = environmentValue(environment, CODEX_HOME_ENVIRONMENT_VARIABLE);
+  if (configuredHome) return resolve(configuredHome);
+
+  const driveHome = environmentValue(environment, "HOMEDRIVE")
+    && environmentValue(environment, "HOMEPATH")
+    ? `${environmentValue(environment, "HOMEDRIVE")}${environmentValue(environment, "HOMEPATH")}`
+    : undefined;
+  const userHome = environmentValue(environment, "HOME")
+    ?? environmentValue(environment, "USERPROFILE")
+    ?? driveHome
+    ?? homedir();
+  return resolve(userHome, ".codex");
+}
+
+function safeSourceName(name: string): string {
+  return name.replace(/[\u0000-\u001f\u007f]/g, " ").trim().slice(0, 180) || "unnamed prompt";
+}
+
+function addDiagnostic(
+  diagnostics: ProviderCatalogDiagnostic[],
+  diagnostic: ProviderCatalogDiagnostic,
+): void {
+  if (diagnostics.length < CODEX_CUSTOM_PROMPT_MAX_DIAGNOSTICS) diagnostics.push(diagnostic);
+}
+
+function discoveryError(fileName: string, reason: string): ProviderCatalogDiagnostic {
+  return {
+    severity: "warning",
+    code: "discovery-error",
+    message: `Codex custom prompt "${safeSourceName(fileName)}" was omitted: ${reason}`,
+  };
+}
+
+function decodePrompt(buffer: Buffer): string {
+  return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+}
+
+function promptDescription(body: string): string {
+  if (!body.startsWith("---\n") && !body.startsWith("---\r\n")) return "";
+  const frontmatter = FRONTMATTER_RE.exec(body);
+  if (!frontmatter) throw new Error("its YAML frontmatter is not closed");
+
+  const document = parseDocument(frontmatter[1], { uniqueKeys: true });
+  if (document.errors.length > 0) throw new Error("its YAML frontmatter is malformed");
+  const metadata = document.toJS({ maxAliasCount: 10 }) as unknown;
+  if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new Error("its YAML frontmatter must be a mapping");
+  }
+  const description = (metadata as Record<string, unknown>).description;
+  if (description === undefined || description === null) return "";
+  if (typeof description !== "string") {
+    throw new Error("its YAML description must be a string");
+  }
+  if (description.length > CODEX_CUSTOM_PROMPT_MAX_DESCRIPTION_CHARS) {
+    throw new Error(`its description exceeds ${CODEX_CUSTOM_PROMPT_MAX_DESCRIPTION_CHARS} characters`);
+  }
+  return description.trim();
+}
+
+function promptFromFile(fileName: string, path: string, body: string): SkillInfo {
+  const nativeName = fileName.slice(0, -CODEX_CUSTOM_PROMPT_FILE_SUFFIX.length);
+  const name = `prompts:${nativeName}`;
+  if (
+    nativeName.length === 0
+    || nativeName.trim() !== nativeName
+    || /[\u0000-\u001f\u007f]/.test(nativeName)
+    || name.length > CODEX_CUSTOM_PROMPT_MAX_NAME_CHARS
+  ) {
+    throw new Error("its filename does not form a supported prompt name");
+  }
+  if (path.length > PROVIDER_CATALOG_PATH_MAX_CHARS) {
+    throw new Error(`its path exceeds ${PROVIDER_CATALOG_PATH_MAX_CHARS} characters`);
+  }
+  return {
+    name,
+    nativeName,
+    description: promptDescription(body),
+    kind: "command",
+    source: "user",
+    providers: ["codex"],
+    path,
+  };
+}
+
+/** Discovers direct custom prompt files within one effective Codex home. */
+export async function discoverCodexCustomPrompts(
+  codexHome: string,
+  options: CodexCustomPromptDiscoveryOptions = DEFAULT_DISCOVERY_OPTIONS,
+): Promise<CodexCustomPromptDiscoveryResult> {
+  const diagnostics: ProviderCatalogDiagnostic[] = [];
+  const prompts: SkillInfo[] = [];
+  const promptDirectory = join(codexHome, CODEX_CUSTOM_PROMPT_DIRECTORY_NAME);
+  if (promptDirectory.length > PROVIDER_CATALOG_PATH_MAX_CHARS) {
+    return {
+      prompts,
+      diagnostics: [{
+        severity: "warning",
+        code: "source-unavailable",
+        message: "The effective Codex custom prompt directory path is too long.",
+      }],
+      available: false,
+    };
+  }
+
+  const fileSystem = options.fileSystem ?? NODE_FILE_SYSTEM;
+  const maxDirectoryEntries = options.maxDirectoryEntries
+    ?? CODEX_CUSTOM_PROMPT_MAX_DIRECTORY_ENTRIES;
+  let inspectedEntries = 0;
+  let inspectedFiles = 0;
+  try {
+    for await (const entry of fileSystem.entries(promptDirectory)) {
+      if (inspectedEntries >= maxDirectoryEntries) {
+        addDiagnostic(diagnostics, {
+          severity: "warning",
+          code: "partial-result",
+          message: `Codex custom prompt discovery inspected at most ${maxDirectoryEntries} direct director${maxDirectoryEntries === 1 ? "y entry" : "y entries"}; "${safeSourceName(entry.name)}" and later entries were omitted.`,
+        });
+        break;
+      }
+      inspectedEntries += 1;
+      if (!entry.isFile || !entry.name.endsWith(CODEX_CUSTOM_PROMPT_FILE_SUFFIX)) continue;
+      if (inspectedFiles >= options.maxFiles) {
+        addDiagnostic(diagnostics, {
+          severity: "warning",
+          code: "partial-result",
+          message: `Codex custom prompt discovery inspected at most ${options.maxFiles} direct .md file${options.maxFiles === 1 ? "" : "s"}; "${safeSourceName(entry.name)}" and later files were omitted.`,
+        });
+        break;
+      }
+      inspectedFiles += 1;
+
+      const path = join(promptDirectory, entry.name);
+      try {
+        const buffer = await fileSystem.readFile(path, options.maxFileBytes);
+        if (buffer.length > options.maxFileBytes) {
+          addDiagnostic(diagnostics, discoveryError(
+            entry.name,
+            `it exceeds ${options.maxFileBytes} bytes`,
+          ));
+          continue;
+        }
+        const body = decodePrompt(buffer);
+        prompts.push(promptFromFile(entry.name, path, body));
+      } catch (error) {
+        const reason = error instanceof Error && error.message.startsWith("its ")
+          ? error.message
+          : "it could not be read or parsed";
+        addDiagnostic(diagnostics, discoveryError(entry.name, reason));
+      }
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { prompts: [], diagnostics: [], available: true };
+    }
+    return {
+      prompts,
+      diagnostics: [{
+        severity: "warning",
+        code: "source-unavailable",
+        message: "The effective Codex custom prompt directory could not be read.",
+      }],
+      available: false,
+    };
+  }
+
+  return { prompts, diagnostics, available: true };
+}
+
+/** Owns the cached result of bounded, picker-triggered custom prompt refreshes. */
+@injectable()
+export class CodexCustomPromptService {
+  private current: CodexCustomPromptDiscoveryResult = {
+    prompts: [],
+    diagnostics: [],
+    available: true,
+  };
+  private refreshInFlight: Promise<CodexCustomPromptDiscoveryResult> | null = null;
+
+  constructor(
+    @inject(EnvService) private readonly envService: EnvService,
+  ) {}
+
+  /** Refreshes custom prompts once, coalescing concurrent picker requests. */
+  refresh(): Promise<CodexCustomPromptDiscoveryResult> {
+    if (this.refreshInFlight) return this.refreshInFlight;
+    const codexHome = resolveEffectiveCodexHome(this.envService.getEnv());
+    const refresh = discoverCodexCustomPrompts(codexHome).then((result) => {
+      this.current = result.available
+        ? result
+        : { ...result, prompts: this.current.prompts };
+      return this.current;
+    });
+    this.refreshInFlight = refresh;
+    const clearRefresh = () => {
+      if (this.refreshInFlight === refresh) this.refreshInFlight = null;
+    };
+    void refresh.then(clearRefresh, clearRefresh);
+    return refresh;
+  }
+
+  /** Returns the latest bounded prompt list without starting filesystem work. */
+  currentPrompts(): SkillInfo[] {
+    return this.current.prompts;
+  }
+
+  /** Returns the latest complete adapter result without starting filesystem work. */
+  currentSnapshot(): CodexCustomPromptDiscoveryResult {
+    return this.current;
+  }
+}

--- a/apps/server/src/services/provider-catalog-service.test.ts
+++ b/apps/server/src/services/provider-catalog-service.test.ts
@@ -126,6 +126,65 @@ describe("ProviderCatalogService", () => {
     expect(repo.get(key)?.entries).toEqual(CACHED.entries);
   });
 
+  it("reconciles confirmed custom prompts while a Skill source remains stale", async () => {
+    const { repo, service } = createService();
+    const key = providerCatalogContextKey(REQUEST, "C:/repo");
+    const releasePrompt = {
+      kind: "customPrompt" as const,
+      identity: { providerId: "codex" as const, kind: "customPrompt" as const, nativeId: "release" },
+      name: "prompts:release",
+      description: "Release v1",
+    };
+    const removedPrompt = {
+      kind: "customPrompt" as const,
+      identity: { providerId: "codex" as const, kind: "customPrompt" as const, nativeId: "removed" },
+      name: "prompts:removed",
+      description: "Removed prompt",
+    };
+    repo.upsert(key, "workspace-1", "C:/repo", {
+      ...CACHED,
+      entries: [...CACHED.entries, releasePrompt, removedPrompt],
+    });
+    const changed = new Promise<ProviderCatalogChange>((resolve) => service.onChanged(resolve));
+
+    service.request({
+      request: REQUEST,
+      context: CACHED.context,
+      cwd: "C:/repo",
+      refresh: async () => ({
+        snapshot: {
+          ...CACHED,
+          entries: [
+            { ...releasePrompt, description: "Release v2" },
+            {
+              kind: "customPrompt",
+              identity: { providerId: "codex", kind: "customPrompt", nativeId: "added" },
+              name: "prompts:added",
+              description: "Added prompt",
+            },
+          ],
+          freshness: {
+            status: "stale",
+            fetchedAt: CACHED.freshness.fetchedAt,
+            reason: "Codex Skill discovery failed.",
+          },
+        },
+        confirmedEntryKinds: ["customPrompt"],
+      }),
+    });
+
+    await expect(changed).resolves.toMatchObject({
+      additions: [expect.objectContaining({ name: "prompts:added" })],
+      updates: [expect.objectContaining({ description: "Release v2" })],
+      removals: [expect.objectContaining({ nativeId: "removed" })],
+    });
+    expect(repo.get(key)?.entries).toEqual([
+      CACHED.entries[0],
+      { ...releasePrompt, description: "Release v2" },
+      expect.objectContaining({ name: "prompts:added" }),
+    ]);
+  });
+
   it("drops a delayed refresh after its workspace is deleted", async () => {
     const { repo, service } = createService();
     const key = providerCatalogContextKey(REQUEST, "C:/repo");

--- a/apps/server/src/services/provider-catalog-service.ts
+++ b/apps/server/src/services/provider-catalog-service.ts
@@ -5,6 +5,7 @@ import type {
   ProviderCatalogContext,
   ProviderCatalogRequest,
   ProviderCatalogSnapshot,
+  ProviderCapabilityKind,
   SelectableProviderAgent,
 } from "@mcode/contracts";
 import { logger } from "@mcode/shared";
@@ -16,8 +17,14 @@ export interface ProviderCatalogLoadInput {
   readonly context: ProviderCatalogContext;
   readonly cwd?: string;
   readonly fallbackCwd?: string;
-  readonly refresh: () => Promise<ProviderCatalogSnapshot>;
+  readonly refresh: () => Promise<ProviderCatalogSnapshot | ProviderCatalogPartialRefresh>;
   readonly refreshFromCache?: () => Promise<ProviderCatalogSnapshot>;
+}
+
+/** Stale snapshot plus the entry kinds that were authoritatively refreshed. */
+export interface ProviderCatalogPartialRefresh {
+  readonly snapshot: ProviderCatalogSnapshot;
+  readonly confirmedEntryKinds: readonly ProviderCapabilityKind[];
 }
 
 const MAX_TRACKED_CATALOG_CONTEXTS = 64;
@@ -29,9 +36,35 @@ interface CatalogRefreshSubscriber {
 }
 
 interface CatalogRefreshJob {
-  readonly refresh: () => Promise<ProviderCatalogSnapshot>;
+  readonly refresh: ProviderCatalogLoadInput["refresh"];
   readonly subscribers: Map<string, CatalogRefreshSubscriber>;
   readonly pendingSubscribers: Map<string, CatalogRefreshSubscriber>;
+}
+
+function applyConfirmedEntryKinds(
+  visible: ProviderCatalogSnapshot,
+  refreshed: ProviderCatalogSnapshot,
+  confirmedEntryKinds: readonly ProviderCapabilityKind[],
+): ProviderCatalogSnapshot {
+  const confirmed = new Set(confirmedEntryKinds);
+  const refreshedByIdentity = new Map(
+    refreshed.entries.map((entry) => [capabilityIdentity(entry), entry]),
+  );
+  const entries = visible.entries.flatMap((entry) => {
+    if (!confirmed.has(entry.kind)) return [entry];
+    const updated = refreshedByIdentity.get(capabilityIdentity(entry));
+    return updated ? [updated] : [];
+  });
+  const retainedIdentities = new Set(entries.map(capabilityIdentity));
+  entries.push(...refreshed.entries.filter((entry) => (
+    confirmed.has(entry.kind) && !retainedIdentities.has(capabilityIdentity(entry))
+  )));
+  return {
+    ...visible,
+    diagnostics: refreshed.diagnostics,
+    freshness: refreshed.freshness,
+    entries,
+  };
 }
 
 function capabilityIdentity(entry: ProviderCapabilityEntry): string {
@@ -311,8 +344,15 @@ export class ProviderCatalogService {
     job: CatalogRefreshJob,
   ): Promise<void> {
     let refreshed: ProviderCatalogSnapshot;
+    let confirmedEntryKinds: readonly ProviderCapabilityKind[] | undefined;
     try {
-      refreshed = await job.refresh();
+      const result = await job.refresh();
+      if ("snapshot" in result) {
+        refreshed = result.snapshot;
+        confirmedEntryKinds = result.confirmedEntryKinds;
+      } else {
+        refreshed = result;
+      }
     } catch (error) {
       const firstSubscriber = job.subscribers.values().next().value as
         | CatalogRefreshSubscriber
@@ -342,6 +382,11 @@ export class ProviderCatalogService {
     for (const { visible, input } of job.subscribers.values()) {
       const next = refreshed.freshness.status === "fresh"
         ? { ...refreshed, context: input.context }
+        : confirmedEntryKinds
+          ? {
+              ...applyConfirmedEntryKinds(visible, refreshed, confirmedEntryKinds),
+              context: input.context,
+            }
         : {
             ...visible,
             diagnostics: refreshed.diagnostics,

--- a/apps/server/src/services/skill-service.test.ts
+++ b/apps/server/src/services/skill-service.test.ts
@@ -408,7 +408,7 @@ describe("SkillService", () => {
       expect(codexDeploy!.description).toBe("Native Codex deploy");
     });
 
-    it("tags prompts from ~/.codex/prompts as Codex prompt commands", () => {
+    it("leaves Codex custom prompts to the bounded catalog adapter", () => {
       const cmdDir = join(fakeHome, ".codex", "prompts");
       mkdirSync(cmdDir, { recursive: true });
       const promptPath = join(cmdDir, "deploy.md");
@@ -416,13 +416,7 @@ describe("SkillService", () => {
 
       const items = new SkillService().list(undefined, "codex");
 
-      const cmd = items.find((i) => i.name === "prompts:deploy");
-      expect(cmd).toBeDefined();
-      expect(cmd!.kind).toBe("command");
-      expect(cmd!.description).toBe("Codex deploy prompt");
-      expect(cmd!.nativeName).toBe("deploy");
-      expect(cmd!.path).toBe(promptPath);
-      expect(cmd!.providers).toEqual(["codex"]);
+      expect(items.find((i) => i.name === "prompts:deploy")).toBeUndefined();
     });
 
     it("tags skills from ~/.cursor/skills with providers=['cursor']", () => {

--- a/apps/server/src/services/skill-service.ts
+++ b/apps/server/src/services/skill-service.ts
@@ -1,9 +1,9 @@
 /**
  * Skill and command scanning service.
  * Walks user, project, agent, and plugin directories looking for both
- * `skills/` (each subdirectory is a skill), provider command directories, and
- * Codex's deprecated `prompts/` directory. Native Codex Skills come only from
- * app-server `skills/list` and enter through the `nativeItems` boundary.
+ * `skills/` (each subdirectory is a skill) and provider command directories.
+ * Native Codex Skills and bounded custom prompts enter through the
+ * `nativeItems` boundary instead of this general filesystem scanner.
  */
 
 import { injectable } from "tsyringe";
@@ -305,7 +305,6 @@ interface ScanRoot {
 /** Build the ordered list of directories to scan for skills and commands. */
 function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
   const claudeDir = join(home, ".claude");
-  const codexDir = join(home, ".codex");
   const copilotDir = join(home, ".copilot");
   const agentsDir = join(home, ".agents");
   const cursorDir = join(home, ".cursor");
@@ -315,9 +314,6 @@ function buildScanRoots(home: string, cwd?: string): ScanRoot[] {
     { path: join(claudeDir, "skills"), source: "user", providers: ["claude"], kind: "skills" },
     { path: join(claudeDir, "commands"), source: "user", providers: ["claude"], kind: "commands" },
     { path: join(claudeDir, ".agents", "skills"), source: "agent", providers: ["claude"], kind: "skills" },
-
-    // Codex custom prompt compatibility
-    { path: join(codexDir, "prompts"), source: "user", providers: ["codex"], kind: "commands", prefix: "prompts" },
 
     // Copilot ecosystem
     { path: join(copilotDir, "skills"), source: "user", providers: ["copilot"], kind: "skills" },

--- a/apps/server/src/services/skill-watcher-service.test.ts
+++ b/apps/server/src/services/skill-watcher-service.test.ts
@@ -118,7 +118,7 @@ describe("SkillWatcherService", () => {
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("watches codex, agents, and cursor roots in addition to claude roots", () => {
+  it("watches Codex Skills and plugins without watching custom prompts", () => {
     const watchSpy = vi.spyOn(watcher, "watch");
 
     watcher.start();
@@ -126,7 +126,7 @@ describe("SkillWatcherService", () => {
 
     // Should watch all the new provider roots
     expect(watchedPaths.some((p) => p.includes(".codex"))).toBe(true);
-    expect(watchedPaths.some((p) => p.replace(/\\/g, "/").includes(".codex/prompts"))).toBe(true);
+    expect(watchedPaths.some((p) => p.replace(/\\/g, "/").includes(".codex/prompts"))).toBe(false);
     expect(watchedPaths.some((p) => p.includes(".agents"))).toBe(true);
     expect(watchedPaths.some((p) => p.replace(/\\/g, "/").includes(".cursor/skills"))).toBe(true);
   });

--- a/apps/server/src/services/skill-watcher-service.ts
+++ b/apps/server/src/services/skill-watcher-service.ts
@@ -85,7 +85,6 @@ export class SkillWatcherService {
       join(claudeDir, ".agents", "skills"),
       // Codex roots
       join(codexDir, "skills"),
-      join(codexDir, "prompts"),
       join(codexDir, "plugins"),
       join(codexRuntimeDir, "plugins"),
       // Cross-provider roots

--- a/apps/server/src/transport/provider-catalog.test.ts
+++ b/apps/server/src/transport/provider-catalog.test.ts
@@ -104,6 +104,27 @@ describe("provider catalog bounds", () => {
     });
   });
 
+  it("does not classify a project command as a Codex custom prompt by name", () => {
+    const snapshot = buildProviderCatalogSnapshot({
+      providerId: "codex",
+      context: { scope: "user" },
+      skills: [{
+        name: "prompts:release",
+        nativeName: "prompts:release",
+        description: "Project command",
+        kind: "command",
+        source: "project",
+        providers: ["codex"],
+        path: "C:/repo/.agents/commands/prompts:release.md",
+      }],
+      fetchedAt: "2026-07-20T12:00:00.000Z",
+    });
+
+    expect(snapshot.entries).toEqual([
+      expect.objectContaining({ kind: "providerCommand", name: "prompts:release" }),
+    ]);
+  });
+
   it("omits an invalid selectable agent while retaining valid siblings", () => {
     const snapshot = buildProviderCatalogSnapshot({
       providerId: "codex",

--- a/apps/server/src/transport/provider-catalog.ts
+++ b/apps/server/src/transport/provider-catalog.ts
@@ -19,6 +19,7 @@ import {
   type SettingsProviderId,
   type SkillInfo,
 } from "@mcode/contracts";
+import { isCodexCustomPromptCatalogItem } from "../providers/codex/codex-prompt.js";
 
 /** Limits used while reading Codex agent files for a catalog snapshot. */
 export interface CodexAgentDiscoveryLimits {
@@ -56,6 +57,14 @@ const DEFAULT_CODEX_AGENT_DISCOVERY_LIMITS: CodexAgentDiscoveryLimits = {
 };
 const INVALID_CATALOG_ITEM_DIAGNOSTIC =
   "Some provider catalog items were omitted because their metadata was invalid.";
+const PROVIDER_CATALOG_MAX_DIAGNOSTICS = 100;
+
+function appendDiagnostic(
+  diagnostics: ProviderCatalogDiagnostic[],
+  diagnostic: ProviderCatalogDiagnostic,
+): void {
+  if (diagnostics.length < PROVIDER_CATALOG_MAX_DIAGNOSTICS) diagnostics.push(diagnostic);
+}
 
 function tomlStringValue(body: string, key: string): string | undefined {
   const match = new RegExp(`^${key}\\s*=\\s*"([^"]*)"`, "m").exec(body);
@@ -133,7 +142,7 @@ function providerCommandCapabilityKind(
   providerId: SettingsProviderId,
   item: SkillInfo,
 ): "customPrompt" | "providerCommand" {
-  return providerId === "codex" && item.name.startsWith("prompts:")
+  return providerId === "codex" && isCodexCustomPromptCatalogItem(item)
     ? "customPrompt"
     : "providerCommand";
 }
@@ -228,7 +237,7 @@ export function buildProviderCatalogSnapshot(
     }
   }
   if (input.skills.length + (input.entries?.length ?? 0) > PROVIDER_CATALOG_MAX_ENTRIES) {
-    diagnostics.push(partialResultDiagnostic(
+    appendDiagnostic(diagnostics, partialResultDiagnostic(
       `Catalog entries were capped at ${PROVIDER_CATALOG_MAX_ENTRIES}.`,
     ));
   }
@@ -241,22 +250,22 @@ export function buildProviderCatalogSnapshot(
     else invalidItemOmitted = true;
   }
   if (discoveredAgents.length > PROVIDER_CATALOG_MAX_SELECTABLE_AGENTS) {
-    diagnostics.push(partialResultDiagnostic(
+    appendDiagnostic(diagnostics, partialResultDiagnostic(
       `Selectable agents were capped at ${PROVIDER_CATALOG_MAX_SELECTABLE_AGENTS}.`,
     ));
   }
   if (input.agentDiscovery?.limits.fileCount) {
-    diagnostics.push(partialResultDiagnostic(
+    appendDiagnostic(diagnostics, partialResultDiagnostic(
       `Codex agent discovery inspected at most ${PROVIDER_CATALOG_MAX_CODEX_AGENT_FILES} files.`,
     ));
   }
   if (input.agentDiscovery?.limits.fileSize) {
-    diagnostics.push(partialResultDiagnostic(
+    appendDiagnostic(diagnostics, partialResultDiagnostic(
       `Codex agent files larger than ${PROVIDER_CATALOG_MAX_CODEX_AGENT_FILE_BYTES} bytes were omitted.`,
     ));
   }
   if (invalidItemOmitted) {
-    diagnostics.push(partialResultDiagnostic(INVALID_CATALOG_ITEM_DIAGNOSTIC));
+    appendDiagnostic(diagnostics, partialResultDiagnostic(INVALID_CATALOG_ITEM_DIAGNOSTIC));
   }
 
   return ProviderCatalogSnapshotSchema().parse({
@@ -266,7 +275,7 @@ export function buildProviderCatalogSnapshot(
       status: "fresh",
       fetchedAt: input.fetchedAt ?? new Date().toISOString(),
     },
-    diagnostics: diagnostics.slice(0, 100),
+    diagnostics: diagnostics.slice(0, PROVIDER_CATALOG_MAX_DIAGNOSTICS),
     entries,
     selectableAgents,
   });

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -19,6 +19,7 @@ import {
   type IProviderRegistry,
   type ProviderUsageInfo,
   type ProviderCatalogContext,
+  type ProviderCapabilityKind,
   type ProviderAgentMention,
   type PreviewAnnotationBundle,
   getExtension,
@@ -1019,7 +1020,10 @@ async function dispatch(
       const buildSnapshot = async (
         catalog?: CodexCatalogRefreshResult,
       ) => {
-        const skills = deps.skillService.list(cwd, params.providerId, catalog?.skills);
+        const nativeItems = catalog
+          ? [...catalog.skills, ...catalog.prompts]
+          : undefined;
+        const skills = deps.skillService.list(cwd, params.providerId, nativeItems);
         const agentDiscovery = params.providerId === "codex"
           ? await discoverBoundedCodexAgents(resolveCodexAgentDirectories(
               deps,
@@ -1038,16 +1042,27 @@ async function dispatch(
           ...(catalog?.freshness ? { freshness: catalog.freshness } : {}),
         });
       };
+      const confirmedCodexEntryKinds = (
+        catalog: CodexCatalogRefreshResult,
+      ): ProviderCapabilityKind[] => [
+        ...(catalog.skillsAvailable
+          ? ["skill", "plugin", "providerCommand"] as const
+          : []),
+        ...(catalog.promptsAvailable ? ["customPrompt"] as const : []),
+      ];
       return deps.providerCatalogService.request({
         request: params,
         context: catalogContext,
         cwd,
         ...(params.threadId && workspaceRoot ? { fallbackCwd: workspaceRoot } : {}),
-        refresh: async () => buildSnapshot(
-          params.providerId === "codex"
-            ? await deps.codexCatalogService.refresh(cwd)
-            : undefined,
-        ),
+        refresh: async () => {
+          if (params.providerId !== "codex") return buildSnapshot();
+          const catalog = await deps.codexCatalogService.refresh(cwd);
+          return {
+            snapshot: await buildSnapshot(catalog),
+            confirmedEntryKinds: confirmedCodexEntryKinds(catalog),
+          };
+        },
         ...(params.providerId === "codex" ? {
           refreshFromCache: async () => buildSnapshot(
             deps.codexCatalogService.currentSnapshot(cwd),

--- a/apps/server/src/transport/ws-router.validation.test.ts
+++ b/apps/server/src/transport/ws-router.validation.test.ts
@@ -122,6 +122,13 @@ describe("routeMessage provider.catalog", () => {
               path: "C:/users/test/.codex/skills/review/SKILL.md",
             },
             {
+              name: "prompts:release",
+              description: "A Skill with the same name as a custom prompt",
+              enabled: true,
+              scope: "user",
+              path: "C:/users/test/.codex/skills/prompts-release/SKILL.md",
+            },
+            {
               name: projectSkill,
               description: `${projectSkill} project changes`,
               enabled: true,
@@ -177,11 +184,29 @@ describe("routeMessage provider.catalog", () => {
       readPlugin: vi.fn(async () => ({ plugin: { description: "Plugin details" } })),
     });
     const create = vi.fn(() => client);
+    const customPrompt = {
+      name: "prompts:release",
+      description: "Prepare a release",
+      kind: "command" as const,
+      source: "user" as const,
+      providers: ["codex"],
+      nativeName: "release",
+      path: "C:/users/test/.codex/prompts/release.md",
+    };
+    const customPromptService = {
+      refresh: vi.fn(async () => ({
+        prompts: [customPrompt],
+        diagnostics: [],
+        available: true,
+      })),
+      currentPrompts: vi.fn(() => [customPrompt]),
+    };
     const codexCatalogService = new CodexCatalogService(
       { get: () => ({ provider: { cli: { codex: "codex" } } }) } as never,
       { isWindowsJob: false } as never,
       { getEnv: () => ({}) } as never,
       { create } as never,
+      customPromptService as never,
     );
     const refresh = vi.spyOn(codexCatalogService, "refresh");
     const db = openMemoryDatabase();
@@ -192,18 +217,9 @@ describe("routeMessage provider.catalog", () => {
     insertWorkspace.run("workspace-2", "Workspace 2", "C:/other");
     const snapshotRepo = new ProviderCatalogSnapshotRepo(db);
     const providerCatalogService = new ProviderCatalogService(snapshotRepo);
-    const list = vi.fn().mockImplementation((_cwd, _providerId, discoveredSkills = []) => [
-      ...discoveredSkills,
-      {
-        name: "prompts:release",
-        description: "Prepare a release",
-        kind: "command" as const,
-        source: "user" as const,
-        providers: ["codex"],
-        nativeName: "release",
-        path: "C:/users/test/.codex/prompts/release.md",
-      },
-    ]);
+    const list = vi.fn().mockImplementation((_cwd, _providerId, discoveredSkills = []) => (
+      discoveredSkills
+    ));
     const threadLookup = vi.fn();
     const deps = {
       workspaceService: {
@@ -245,6 +261,7 @@ describe("routeMessage provider.catalog", () => {
           kind: "plugin",
           mentionPath: "plugin://review@personal",
         }),
+        expect.objectContaining({ name: "prompts:release", kind: "skill" }),
         expect.objectContaining({ name: "prompts:release", kind: "customPrompt" }),
       ]),
       diagnostics: [expect.objectContaining({

--- a/apps/web/src/__tests__/slash-command-node.test.ts
+++ b/apps/web/src/__tests__/slash-command-node.test.ts
@@ -95,7 +95,11 @@ describe("SlashCommandNode", () => {
       () => {
         const paragraph = $createParagraphNode();
         paragraph.append($createTextNode("Use "));
-        paragraph.append($createSlashCommandNode("impeccable", "skill"));
+        paragraph.append($createSlashCommandNode("impeccable", "skill", {
+          providerId: "codex",
+          kind: "skill",
+          nativeId: "C:/skills/impeccable/SKILL.md",
+        }));
         $getRoot().append(paragraph);
       },
       { discrete: true },
@@ -108,6 +112,11 @@ describe("SlashCommandNode", () => {
         kind: "command",
         label: "impeccable",
         namespace: "skill",
+        capabilityIdentity: {
+          providerId: "codex",
+          kind: "skill",
+          nativeId: "C:/skills/impeccable/SKILL.md",
+        },
         range: { start: 4, end: 15 },
       }],
     });

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -647,6 +647,126 @@ describe("popup state machine", () => {
 
     expect(getProviderCatalog).toHaveBeenCalledTimes(2);
   });
+
+  it("refreshes a warm Codex catalog when the slash picker opens", async () => {
+    const getProviderCatalog = catalogMock([
+      { name: "prompts:release", description: "Prepare a release", kind: "command" },
+    ]);
+    vi.mocked(getTransport).mockReturnValue({ getProviderCatalog } as never);
+
+    const ref = makeAnchor();
+    const { result } = renderHook(() => useSlashCommand({
+      anchorRef: ref,
+      providerId: "codex",
+    }));
+
+    await act(async () => {});
+    expect(getProviderCatalog).toHaveBeenCalledTimes(1);
+
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    expect(getProviderCatalog).toHaveBeenCalledTimes(2);
+    expect(result.current.items.map((item) => item.name)).toContain("prompts:release");
+  });
+
+  it("reconciles changed rows while the Codex picker remains open", async () => {
+    const request = { providerId: "codex" as const };
+    const getProviderCatalog = vi.fn()
+      .mockResolvedValueOnce(snapshotFromSkills([
+        { name: "prompts:release", description: "Release v1", kind: "command" },
+        { name: "review", description: "Review", kind: "skill" },
+      ], request))
+      .mockResolvedValueOnce(snapshotFromSkills([
+        { name: "prompts:release", description: "Release v2", kind: "command" },
+        { name: "review", description: "Review", kind: "skill" },
+      ], request));
+    vi.mocked(getTransport).mockReturnValue({ getProviderCatalog } as never);
+    const ref = makeAnchor();
+    const { result } = renderHook(() => useSlashCommand({
+      anchorRef: ref,
+      providerId: "codex",
+    }));
+
+    await act(async () => {});
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.items.find((item) => item.name === "prompts:release")?.description)
+      .toBe("Release v2");
+    expect(result.current.items.map((item) => item.name)).toContain("review");
+  });
+
+  it("groups prompt additions and removals while the Codex picker remains open", async () => {
+    const request = { providerId: "codex" as const };
+    const getProviderCatalog = vi.fn()
+      .mockResolvedValueOnce(snapshotFromSkills([
+        { name: "prompts:old", description: "Old prompt", kind: "command" },
+        { name: "review", description: "Review", kind: "skill" },
+      ], request))
+      .mockResolvedValueOnce(snapshotFromSkills([
+        { name: "prompts:added", description: "Added prompt", kind: "command" },
+        { name: "review", description: "Review", kind: "skill" },
+      ], request));
+    vi.mocked(getTransport).mockReturnValue({ getProviderCatalog } as never);
+    const ref = makeAnchor();
+    const { result } = renderHook(() => useSlashCommand({
+      anchorRef: ref,
+      providerId: "codex",
+      includeBuiltins: false,
+    }));
+
+    await act(async () => {});
+    await act(async () => { result.current.onInputChange("/"); });
+    await act(async () => {});
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.items.map((item) => [item.name, item.namespace])).toEqual([
+      ["prompts:added", "command"],
+      ["review", "skill"],
+    ]);
+  });
+
+  it("keeps same-name Skills and custom prompts distinct by catalog identity", async () => {
+    const getProviderCatalog = vi.fn().mockResolvedValue({
+      providerId: "codex",
+      context: { scope: "user" },
+      freshness: { status: "fresh", fetchedAt: "2026-07-20T12:00:00.000Z" },
+      diagnostics: [],
+      entries: [
+        {
+          kind: "skill",
+          identity: { providerId: "codex", kind: "skill", nativeId: "C:/skills/release/SKILL.md" },
+          name: "prompts:release",
+          description: "Release Skill",
+          source: "user",
+        },
+        {
+          kind: "customPrompt",
+          identity: { providerId: "codex", kind: "customPrompt", nativeId: "release" },
+          name: "prompts:release",
+          description: "Release prompt",
+        },
+      ],
+      selectableAgents: [],
+    });
+    vi.mocked(getTransport).mockReturnValue({ getProviderCatalog } as never);
+    const ref = makeAnchor();
+    const { result } = renderHook(() => useSlashCommand({
+      anchorRef: ref,
+      providerId: "codex",
+    }));
+
+    await act(async () => { result.current.onInputChange("/prompts:release"); });
+    await act(async () => {});
+
+    const collisions = result.current.items.filter((item) => item.name === "prompts:release");
+    expect(collisions.map((item) => item.identity?.kind)).toEqual([
+      "customPrompt",
+      "skill",
+    ]);
+  });
 });
 
 describe("includeBuiltins: false", () => {

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -208,7 +208,11 @@ function writeComposerContent(
       }
       appendText(text.slice(cursor, mention.range.start));
       if (mention.kind === "command") {
-        paragraph.append($createSlashCommandNode(mention.label, mention.namespace));
+        paragraph.append($createSlashCommandNode(
+          mention.label,
+          mention.namespace,
+          mention.capabilityIdentity,
+        ));
         cursor = mention.range.end;
         continue;
       }
@@ -2712,7 +2716,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       if (cmd.action) {
         removeSlashCommandTrigger(editorRef.current);
       } else if (!insertSelectedPluginMention(editorRef.current, cmd)) {
-        insertSlashCommandNode(editorRef.current, cmd.name, cmd.namespace);
+        insertSlashCommandNode(editorRef.current, cmd.name, cmd.namespace, cmd.identity);
       }
     }
   }, [slashCommand]);

--- a/apps/web/src/components/chat/lexical/SlashCommandNode.tsx
+++ b/apps/web/src/components/chat/lexical/SlashCommandNode.tsx
@@ -13,6 +13,10 @@ import {
   type NodeKey,
   type SerializedLexicalNode,
 } from "lexical";
+import {
+  ProviderCapabilityIdentitySchema,
+  type ProviderCapabilityIdentity,
+} from "@mcode/contracts";
 import { EntityToken } from "../EntityToken";
 
 // ---------------------------------------------------------------------------
@@ -27,6 +31,7 @@ export interface SerializedSlashCommandNode extends SerializedLexicalNode {
   readonly type: "slash-command";
   readonly commandName: string;
   readonly namespace: SlashCommandNamespace;
+  readonly capabilityIdentity?: ProviderCapabilityIdentity;
 }
 
 /** Valid namespace values for deserialisation fallback. */
@@ -55,6 +60,7 @@ function SlashCommandChip({
 export class SlashCommandNode extends DecoratorNode<JSX.Element> {
   __commandName: string;
   __namespace: SlashCommandNamespace;
+  __capabilityIdentity?: ProviderCapabilityIdentity;
 
   static getType(): string {
     return "slash-command";
@@ -64,6 +70,7 @@ export class SlashCommandNode extends DecoratorNode<JSX.Element> {
     return new SlashCommandNode(
       node.__commandName,
       node.__namespace,
+      node.__capabilityIdentity,
       node.__key,
     );
   }
@@ -71,11 +78,13 @@ export class SlashCommandNode extends DecoratorNode<JSX.Element> {
   constructor(
     commandName: string,
     namespace: SlashCommandNamespace,
+    capabilityIdentity?: ProviderCapabilityIdentity,
     key?: NodeKey,
   ) {
     super(key);
     this.__commandName = commandName;
     this.__namespace = namespace;
+    this.__capabilityIdentity = capabilityIdentity;
   }
 
   // -- Accessors ------------------------------------------------------------
@@ -86,6 +95,10 @@ export class SlashCommandNode extends DecoratorNode<JSX.Element> {
 
   getNamespace(): SlashCommandNamespace {
     return this.getLatest().__namespace;
+  }
+
+  getCapabilityIdentity(): ProviderCapabilityIdentity | undefined {
+    return this.getLatest().__capabilityIdentity;
   }
 
   // -- Behavior -------------------------------------------------------------
@@ -117,6 +130,7 @@ export class SlashCommandNode extends DecoratorNode<JSX.Element> {
       type: "slash-command",
       commandName: this.__commandName,
       namespace: this.__namespace,
+      ...(this.__capabilityIdentity ? { capabilityIdentity: this.__capabilityIdentity } : {}),
       version: 1,
     };
   }
@@ -127,7 +141,14 @@ export class SlashCommandNode extends DecoratorNode<JSX.Element> {
     const ns = VALID_NAMESPACES.has(serializedNode.namespace)
       ? serializedNode.namespace
       : "mcode";
-    return $createSlashCommandNode(serializedNode.commandName, ns);
+    const identity = ProviderCapabilityIdentitySchema().safeParse(
+      serializedNode.capabilityIdentity,
+    );
+    return $createSlashCommandNode(
+      serializedNode.commandName,
+      ns,
+      identity.success ? identity.data : undefined,
+    );
   }
 
   // -- Decoration -----------------------------------------------------------
@@ -150,8 +171,9 @@ export class SlashCommandNode extends DecoratorNode<JSX.Element> {
 export function $createSlashCommandNode(
   commandName: string,
   namespace: SlashCommandNamespace,
+  capabilityIdentity?: ProviderCapabilityIdentity,
 ): SlashCommandNode {
-  return new SlashCommandNode(commandName, namespace);
+  return new SlashCommandNode(commandName, namespace, capabilityIdentity);
 }
 
 /** Type guard: returns true when the node is a SlashCommandNode. */

--- a/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
+++ b/apps/web/src/components/chat/lexical/SlashCommandPlugin.tsx
@@ -17,6 +17,7 @@ import {
   createMentionId,
   type MentionNodeData,
 } from "./MentionNode";
+import type { ProviderCapabilityIdentity } from "@mcode/contracts";
 import { SLASH_TRIGGER_RE, type Command } from "../useSlashCommand";
 
 /** Props for the SlashCommandPlugin that detects /-triggers in the editor. */
@@ -145,8 +146,12 @@ export function insertSlashCommandNode(
   editor: LexicalEditor,
   commandName: string,
   namespace: SlashCommandNamespace,
+  capabilityIdentity?: ProviderCapabilityIdentity,
 ): void {
-  replaceActiveSlashTrigger(editor, () => $createSlashCommandNode(commandName, namespace));
+  replaceActiveSlashTrigger(
+    editor,
+    () => $createSlashCommandNode(commandName, namespace, capabilityIdentity),
+  );
 }
 
 /** Inserts a selected plugin command as a native Codex mention. */

--- a/apps/web/src/components/chat/lexical/cursor-utils.ts
+++ b/apps/web/src/components/chat/lexical/cursor-utils.ts
@@ -42,6 +42,9 @@ export function extractComposerMessage(editor: LexicalEditor): ExtractedComposer
             kind: "command",
             label,
             namespace: child.getNamespace(),
+            ...(child.getCapabilityIdentity()
+              ? { capabilityIdentity: child.getCapabilityIdentity() }
+              : {}),
             range: { start, end: text.length },
           });
         } else {

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -8,6 +8,7 @@ import {
   ProviderIdSchema,
   type ProviderCapabilityEntry,
   type ProviderCapabilityKind,
+  type ProviderCapabilityIdentity,
 } from "@mcode/contracts";
 import type { ProviderCatalogRequest } from "@/transport";
 import type { SlashCommandNamespace } from "./lexical/SlashCommandNode";
@@ -28,6 +29,7 @@ export interface Command {
   capabilityKind: ProviderCapabilityKind | "mcode";
   nativeId: string;
   mentionPath?: string;
+  identity?: ProviderCapabilityIdentity;
   /** For mcode-namespace commands, the action string dispatched on selection. */
   action?: ComposerCommandAction;
 }
@@ -71,6 +73,7 @@ function toCommand(entry: ProviderCapabilityEntry): Command | null {
     description: entry.description || `Run /${entry.name}`,
     capabilityKind: entry.kind,
     nativeId: entry.identity.nativeId,
+    identity: entry.identity,
   };
   if (entry.kind === "plugin") {
     return {
@@ -90,6 +93,31 @@ function toCommand(entry: ProviderCapabilityEntry): Command | null {
     ...base,
     namespace: entry.source === "plugin" || entry.name.includes(":") ? "plugin" : "skill",
   };
+}
+
+function commandIdentity(command: Command): string {
+  const identity = command.identity;
+  return identity
+    ? JSON.stringify([identity.providerId, identity.kind, identity.nativeId])
+    : JSON.stringify(["mcode", command.namespace, command.name, command.action ?? null]);
+}
+
+function reconcileOpenCommands(current: Command[], refreshed: Command[]): Command[] {
+  const refreshedByIdentity = new Map(
+    refreshed.map((command) => [commandIdentity(command), command]),
+  );
+  const retained = current.flatMap((command) => {
+    const updated = refreshedByIdentity.get(commandIdentity(command));
+    return updated ? [updated] : [];
+  });
+  const retainedIdentities = new Set(retained.map(commandIdentity));
+  const additions = refreshed.filter(
+    (command) => !retainedIdentities.has(commandIdentity(command)),
+  );
+  return (["mcode", "command", "skill", "plugin"] as const).flatMap((namespace) => [
+    ...retained.filter((command) => command.namespace === namespace),
+    ...additions.filter((command) => command.namespace === namespace),
+  ]);
 }
 
 /** Sort commands: source group order, then alphabetical within group. */
@@ -177,6 +205,7 @@ export function useSlashCommand({
   // The visible list is an interaction snapshot. Cache invalidations must not
   // reorder a picker while the user is navigating it with the keyboard.
   const [openCommands, setOpenCommands] = useState<Command[] | null>(null);
+  const selectedCommandIdentityRef = useRef<string | null>(null);
   const lastInputRef = useRef("");
   // Tracks the cursor position supplied by the most recent onInputChange call
   // so onSelect can splice the replacement at the correct offset rather than
@@ -243,6 +272,31 @@ export function useSlashCommand({
     return matches.slice(0, MAX_SLASH_COMMAND_ITEMS);
   }, [allCommands, filter, openCommands]);
 
+  useEffect(() => {
+    if (!isOpen || openCommands === null) return;
+    setOpenCommands((current) => (
+      current === null ? null : reconcileOpenCommands(current, allCommands)
+    ));
+  }, [allCommands, isOpen, openCommands === null]);
+
+  useEffect(() => {
+    setSelectedIndex((current) => {
+      const selectedIdentity = selectedCommandIdentityRef.current;
+      const retainedIndex = selectedIdentity
+        ? filtered.findIndex((command) => commandIdentity(command) === selectedIdentity)
+        : -1;
+      const next = retainedIndex >= 0
+        ? retainedIndex
+        : filtered.length === 0
+          ? 0
+          : Math.min(current, filtered.length - 1);
+      selectedCommandIdentityRef.current = filtered[next]
+        ? commandIdentity(filtered[next])
+        : null;
+      return next;
+    });
+  }, [filtered]);
+
   // Derive the typed popup state. Order encodes the stale-while-revalidate
   // priority that previously lived in a comment in SlashCommandPopup:
   //   error → list (ready / staleRevalidating) → loading → empty.
@@ -291,18 +345,25 @@ export function useSlashCommand({
       if (!match) {
         setIsOpen(false);
         setOpenCommands(null);
+        selectedCommandIdentityRef.current = null;
         return;
       }
 
       const anchor = anchorRef.current;
       if (anchor) setAnchorRect(anchor.getBoundingClientRect());
 
-      if (!isOpen && snapshot !== null) setOpenCommands(allCommands);
+      if (!isOpen) {
+        if (snapshot !== null) setOpenCommands(allCommands);
+        if (providerId === "codex" && catalogRequest) {
+          load(catalogRequest, true).catch(() => { /* surfaced via `error` */ });
+        }
+      }
       setFilter(match[2].slice(1));
       setIsOpen(true);
       setSelectedIndex(0);
+      selectedCommandIdentityRef.current = null;
     },
-    [anchorRef, allCommands, isOpen, snapshot],
+    [anchorRef, allCommands, catalogRequest, isOpen, load, providerId, snapshot],
   );
 
   const onKeyDown = useCallback(
@@ -314,20 +375,31 @@ export function useSlashCommand({
           e.stopPropagation();
           // Clamp to 0 when filtered is empty; otherwise `length - 1` would
           // be `-1`, leaking an invalid index into ARIA / keyboard handling.
-          setSelectedIndex((i) =>
-            filtered.length === 0 ? 0 : Math.min(i + 1, filtered.length - 1),
-          );
+          setSelectedIndex((i) => {
+            const next = filtered.length === 0 ? 0 : Math.min(i + 1, filtered.length - 1);
+            selectedCommandIdentityRef.current = filtered[next]
+              ? commandIdentity(filtered[next])
+              : null;
+            return next;
+          });
           break;
         case "ArrowUp":
           e.preventDefault();
           e.stopPropagation();
-          setSelectedIndex((i) => Math.max(i - 1, 0));
+          setSelectedIndex((i) => {
+            const next = Math.max(i - 1, 0);
+            selectedCommandIdentityRef.current = filtered[next]
+              ? commandIdentity(filtered[next])
+              : null;
+            return next;
+          });
           break;
         case "Escape":
           e.preventDefault();
           e.stopPropagation();
           setIsOpen(false);
           setOpenCommands(null);
+          selectedCommandIdentityRef.current = null;
           break;
       }
     },
@@ -360,6 +432,7 @@ export function useSlashCommand({
       if (cmd.action && onMcodeCommand) onMcodeCommand(cmd.action);
       setIsOpen(false);
       setOpenCommands(null);
+      selectedCommandIdentityRef.current = null;
     },
     [onMcodeCommand],
   );
@@ -367,6 +440,7 @@ export function useSlashCommand({
   const onDismiss = useCallback(() => {
     setIsOpen(false);
     setOpenCommands(null);
+    selectedCommandIdentityRef.current = null;
   }, []);
   const onRetry = useCallback(() => {
     if (!catalogRequest) return;

--- a/packages/contracts/src/models/__tests__/mention.test.ts
+++ b/packages/contracts/src/models/__tests__/mention.test.ts
@@ -8,10 +8,18 @@ describe("MessageMentionSchema", () => {
       kind: "command",
       label: "figma:use",
       namespace: "plugin",
+      capabilityIdentity: {
+        providerId: "codex",
+        kind: "skill",
+        nativeId: "C:/skills/figma-use/SKILL.md",
+      },
       range: { start: 4, end: 14 },
     });
 
     expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      capabilityIdentity: { kind: "skill", nativeId: "C:/skills/figma-use/SKILL.md" },
+    });
   });
 
   it("rejects unknown command namespaces", () => {

--- a/packages/contracts/src/models/mention.ts
+++ b/packages/contracts/src/models/mention.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ProviderCapabilityIdentitySchema } from "../providers/capability-catalog.js";
 
 export const MAX_MESSAGE_MENTIONS = 50;
 export const MENTION_ID_MAX_LENGTH = 128;
@@ -57,6 +58,7 @@ export const MessageMentionSchema = z.discriminatedUnion("kind", [
   MentionBaseSchema.extend({
     kind: z.literal("command"),
     namespace: z.enum(["skill", "mcode", "plugin", "command"]),
+    capabilityIdentity: ProviderCapabilityIdentitySchema().optional(),
   }),
 ]);
 


### PR DESCRIPTION
## What

Add first-class support for Codex custom prompts from `CODEX_HOME/prompts`, with bounded loading and source-aware invocation.

## Why

Mcode previously mixed Codex custom prompts into its general skill scan. That lost prompt identity, delayed picker updates, and could invoke a same-named skill or project command through the wrong path.

## Key Changes

- Load direct `.md` prompt files from the same Codex home used to launch the provider, with entry, file-count, file-size, and diagnostic limits.
- Parse prompt descriptions, retain the last good catalog snapshot, and isolate invalid files through per-file diagnostics.
- Refresh the picker when it opens and reconcile added, changed, and removed entries without closing it.
- Preserve capability identity through the composer and provider so same-named skills, custom prompts, and project commands remain distinct.
- Refresh `/prompts:*` before manual invocation and apply the existing prompt argument expansion.
- Remove `~/.codex/prompts` from the general skill scanner and watcher.

## Verification

- Monorepo typecheck passed in all five packages, and lint passed.
- Focused conflict coverage passed: 83 server tests, 54 web tests, and 4 contract tests.
- The Electron app refreshed an open prompt picker from the cached v3 prompt to the edited v4 prompt without closing the picker.
- The full server suite passed 197 of 198 files and 1,885 of 1,886 tests. One unrelated `TurnFileTracker` test reached its five-second timeout under full-suite load, then passed in a 45-test focused rerun.

Closes #896
