### PR TITLE
fix(web): preserve messages after inactive thread completion

### DIFF
--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -561,3 +561,89 @@ test("thread switch shows a running agent before persisted history refreshes", a
   });
   await expect(page.getByRole("button", { name: "Running command echo live-switch" })).toBeVisible();
 });
+
+test("thread revisit keeps messages added after an empty snapshot was cached", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (entry) => {
+    if (entry.type() === "error") consoleErrors.push(entry.text());
+  });
+  const threads = [
+    { ...thread("thread-a", "Thread A"), status: "active" as const },
+    thread("thread-b", "Thread B"),
+  ];
+  const completedMessage = message(
+    "thread-a",
+    "thread-a-completed",
+    "assistant",
+    "Alpha completed while inactive",
+    1,
+  );
+
+  await interceptZustandStores(page);
+  await mockWebSocketServer(page, {
+    "workspace.list": [workspace],
+    "thread.list": threads,
+    "agent.listRunning": ["thread-a"],
+    "conversation.page": (params) => {
+      const input = params as { threadId: string };
+      return {
+        messages: input.threadId === "thread-b"
+          ? [message("thread-b", "thread-b-message", "assistant", "Beta response", 1)]
+          : [],
+        hasMore: false,
+        answeredPlanMessageIds: [],
+        narrativeByMessage: {},
+      };
+    },
+  });
+
+  await page.goto("/");
+  await page.getByRole("group", { name: "Conversation Page Workspace project" }).click();
+  await page.waitForSelector("[data-testid='thread-item']");
+  const threadAItem = page.locator("[data-testid='thread-item'][data-thread-id='thread-a']");
+  const threadBItem = page.locator("[data-testid='thread-item'][data-thread-id='thread-b']");
+
+  await threadAItem.click();
+  await expect.poll(() => readThreadRecord(page, "thread-a")).toEqual({
+    currentThreadId: "thread-a",
+    loading: false,
+    messageIds: [],
+    messageSequences: [],
+    toolCallIds: [],
+    goalObjective: null,
+  });
+  await threadBItem.click();
+  await expect(page.getByText("Beta response", { exact: true })).toBeVisible();
+  await page.waitForTimeout(20);
+
+  await page.evaluate(({ targetThreadId, residentMessage }) => {
+    type StoreState = {
+      records: Map<string, { messages: unknown[] }>;
+      runningThreadIds: Set<string>;
+    };
+    type StoreHandle = {
+      getState: () => Record<string, unknown>;
+      setState: (partial: Partial<StoreState>) => void;
+    };
+    const stores = (window as unknown as { __mcodeStores?: StoreHandle[] }).__mcodeStores ?? [];
+    const store = stores.find((candidate) => {
+      const state = candidate.getState();
+      return "handleAgentEvent" in state && "records" in state;
+    });
+    if (!store) throw new Error("Thread store not found");
+    const state = store.getState() as unknown as StoreState;
+    const resident = state.records.get(targetThreadId);
+    if (!resident) throw new Error("Resident thread record not found");
+    const records = new Map(state.records);
+    records.set(targetThreadId, { ...resident, messages: [residentMessage] });
+    const runningThreadIds = new Set(state.runningThreadIds);
+    runningThreadIds.delete(targetThreadId);
+    store.setState({ records, runningThreadIds });
+  }, { targetThreadId: "thread-a", residentMessage: completedMessage });
+
+  await threadAItem.click();
+
+  await expect(page.getByText("Alpha completed while inactive", { exact: true })).toBeVisible();
+  await expect(page.getByText("no messages yet", { exact: true })).not.toBeVisible();
+  expect(consoleErrors).toEqual([]);
+});

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -478,6 +478,33 @@ describe("ThreadHydrator", () => {
     expect(getCachedRecord(THREAD_A)?.loading).toBe(false);
   });
 
+  it("restores messages added to a resident thread after its empty snapshot was cached", async () => {
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_A,
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map([[THREAD_A, createEmptyThreadRecord()]]),
+    });
+    cacheRecord(THREAD_B, makeCachedRecord([msgB]));
+
+    await hydrator.hydrate(THREAD_B, "active");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(getCachedRecord(THREAD_A)?.messages).toEqual([]);
+    useThreadStore.setState((state) => {
+      const runningThreadIds = new Set(state.runningThreadIds);
+      runningThreadIds.delete(THREAD_A);
+      return {
+        runningThreadIds,
+        records: patchThreadRecord(state.records, THREAD_A, { messages: [msgA] }),
+      };
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(getTestActiveMessages()).toEqual([msgA]);
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
+  });
+
   it("reopens a running resident layer without replacing its live state", async () => {
     resetThreadStoreForTests({
       currentThreadId: THREAD_B,

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -40,6 +40,12 @@ function hasResidentLayer(record: ThreadRecord): boolean {
     || record.hooks.length > 0;
 }
 
+function hasNewerResidentMessages(resident: ThreadRecord, cached: ThreadRecord): boolean {
+  const residentSequence = resident.messages.at(-1)?.sequence;
+  const cachedSequence = cached.messages.at(-1)?.sequence;
+  return residentSequence != null && (cachedSequence == null || residentSequence > cachedSequence);
+}
+
 /** Build a conversation page containing only the supplied messages and their metadata. */
 function buildConversationPageSubset(
   page: ConversationPage,
@@ -225,7 +231,11 @@ export class ThreadHydrator {
 
     const cached = getCachedRecord(threadId);
     if (cached) {
-      this.restoreCachedActive(threadId, cached, opts);
+      this.restoreCachedActive(
+        threadId,
+        resident && hasNewerResidentMessages(resident, cached) ? resident : cached,
+        opts,
+      );
       return;
     }
 


### PR DESCRIPTION
## What
Preserve newer resident thread messages when an older cached snapshot exists.

## Why
A thread that completed while inactive could retain new messages in memory while its cache still held an empty snapshot. Revisiting the thread restored the stale cache and showed the new-thread empty state even though persisted messages existed.

## Key Changes
- Prefer resident messages when their latest sequence is newer than the cached transcript.
- Add focused coverage for the A to B to inactive completion to A sequence.
- Add Chromium coverage that verifies the completed message is visible, the empty state is absent, and the browser console stays clean.

## Verification
- `cd apps/web && bun run test -- src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts`: 33 passed.
- Isolated Chromium regression: 1 passed.
- Independent static review: no findings.
- Local full-suite runs encountered unrelated pull-request UI timing flakes; each failing file passed in isolation. Authoritative PR CI will provide the merge gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787261028&installation_model_id=20477&pr_number=915&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F915&signature=b7277b36de79b0a300e7f48519986af26cb52ab50357b25d749a622d918bc33d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved newly added messages when revisiting conversations after an empty snapshot had been cached.
  * Prevented conversations from incorrectly displaying the “no messages yet” state.
  * Improved restoration of the latest available conversation data without unnecessary reloads.

* **Tests**
  * Added coverage for switching between conversations and restoring messages from resident thread data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->