### PR TITLE
feat: show active subagents in the right panel

### DIFF
--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -573,6 +573,35 @@ describe("handleAgentEvent branches", () => {
     expect(childCall?.isComplete).toBe(true);
     expect(childCall?.output).toBe("file contents");
   });
+
+  it("records provider activity time for tool progress and results", () => {
+    vi.setSystemTime(1_000);
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolUse",
+      params: { toolCallId: "read-1", toolName: "Read", toolInput: { file_path: "README.md" } },
+    });
+
+    vi.setSystemTime(2_000);
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolProgress",
+      params: { toolCallId: "read-1", elapsedSeconds: 1 },
+    });
+    expect(getTestThreadToolCalls("thread-1").find((call) => call.id === "read-1")?.lastActivityAt).toBe(2_000);
+
+    vi.setSystemTime(3_000);
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolProgress",
+      params: { toolCallId: "read-1", elapsedSeconds: 1 },
+    });
+    expect(getTestThreadToolCalls("thread-1").find((call) => call.id === "read-1")?.lastActivityAt).toBe(3_000);
+
+    vi.setSystemTime(4_000);
+    useThreadStore.getState().handleAgentEvent("thread-1", {
+      method: "session.toolResult",
+      params: { toolCallId: "read-1", output: "done", isError: false },
+    });
+    expect(getTestThreadToolCalls("thread-1").find((call) => call.id === "read-1")?.lastActivityAt).toBe(4_000);
+  });
 });
 
 describe("session.modelFallback", () => {

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -27,6 +27,7 @@ import { ensureTerminalForScope } from "@/lib/ensure-terminal";
 import { toggleRightPanelAdaptive } from "@/lib/right-panel-layout";
 import { cn } from "@/lib/utils";
 import { ResizableRightPanel } from "./ResizableRightPanel";
+import { SubagentsPanel } from "./SubagentsPanel";
 
 /**
  * Tracks whether the Changes tab has unreviewed new files for the active
@@ -146,6 +147,8 @@ export function RightPanel() {
   const previewActive = activeTab === "preview" && openTabs.includes("preview");
   const terminalActive =
     activeTab === "terminal" && openTabs.includes("terminal");
+  const subagentsActive =
+    activeTab === "subagents" && openTabs.includes("subagents");
 
   const isChangesActive = panelVisible && changesActive;
   const changesFresh = useChangesFreshness(
@@ -308,6 +311,9 @@ export function RightPanel() {
           {activeTab === "tasks" &&
             openTabs.includes("tasks") &&
             activeThreadId && <PlanPanel threadId={activeThreadId} />}
+          {subagentsActive && activeThreadId && (
+            <SubagentsPanel key={activeThreadId} threadId={activeThreadId} />
+          )}
           <div
             className={
               changesActive ? "flex flex-1 flex-col min-h-0" : "hidden"

--- a/apps/web/src/components/panels/SubagentsPanel.tsx
+++ b/apps/web/src/components/panels/SubagentsPanel.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { EntityIcon } from "@/components/chat/EntityToken";
+import { useThreadRecord } from "@/stores/thread-selectors";
+import { cn } from "@/lib/utils";
+import { formatDuration } from "@/lib/time";
+import { projectLiveSubagents, type LiveSubagentRow } from "@/components/subagents/subagent-projection";
+
+type RosterTab = "active" | "finished";
+
+const ROSTER_TABS: readonly RosterTab[] = ["active", "finished"];
+
+function rosterTabId(tab: RosterTab): string {
+  return `subagents-${tab}-tab`;
+}
+
+function rosterPanelId(tab: RosterTab): string {
+  return `subagents-${tab}-panel`;
+}
+
+/** A compact live row for one running provider subagent. */
+function LiveSubagentRowView({ row }: { readonly row: LiveSubagentRow }) {
+  return (
+    <article
+      data-testid="subagent-roster-row"
+      className="flex min-w-0 gap-3 border-b border-border/50 px-4 py-3 last:border-b-0"
+    >
+      <span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+        <EntityIcon kind="agent" animated size={15} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <h3 className="min-w-0 truncate text-sm font-medium text-foreground">{row.identity}</h3>
+          <Badge
+            variant="outline"
+            size="sm"
+            className="border-primary/35 bg-primary/10 text-primary"
+          >
+            Running
+          </Badge>
+          <span className="sr-only">Running subagent</span>
+          <time className="ml-auto shrink-0 font-mono text-xs tabular-nums text-muted-foreground" aria-label={`Elapsed ${formatDuration(row.elapsedSeconds)}`}>
+            {formatDuration(row.elapsedSeconds)}
+          </time>
+        </div>
+        <p className="mt-0.5 line-clamp-2 text-xs leading-5 text-foreground/80">{row.task}</p>
+        <p className="mt-1 truncate text-xs text-muted-foreground">{row.activity}</p>
+      </div>
+    </article>
+  );
+}
+
+/** Thread-only right-panel roster for live normalized Agent tool calls. */
+export function SubagentsPanel({ threadId }: { readonly threadId: string }) {
+  const toolCalls = useThreadRecord(threadId, (record) => record.toolCalls);
+  const [now, setNow] = useState(() => Date.now());
+  const roster = projectLiveSubagents(toolCalls, now);
+  const [selectedTab, setSelectedTab] = useState<RosterTab>(() => (
+    roster.active.length > 0 ? "active" : "finished"
+  ));
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    if (roster.active.length === 0) return;
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+  }, [roster.active.length]);
+
+  const counts: Record<RosterTab, number> = {
+    active: roster.active.length,
+    finished: roster.finishedCount,
+  };
+
+  const selectTab = (tab: RosterTab) => setSelectedTab(tab);
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex: number | null = null;
+    if (event.key === "ArrowRight") nextIndex = (index + 1) % ROSTER_TABS.length;
+    if (event.key === "ArrowLeft") nextIndex = (index - 1 + ROSTER_TABS.length) % ROSTER_TABS.length;
+    if (event.key === "Home") nextIndex = 0;
+    if (event.key === "End") nextIndex = ROSTER_TABS.length - 1;
+    if (nextIndex === null) return;
+    event.preventDefault();
+    const tab = ROSTER_TABS[nextIndex];
+    if (!tab) return;
+    selectTab(tab);
+    tabRefs.current[nextIndex]?.focus();
+  };
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col" aria-label="Subagents">
+      <header className="shrink-0 border-b border-border/50 px-4 pt-3">
+        <h2 className="text-sm font-semibold text-foreground">Subagents</h2>
+        <div role="tablist" aria-label="Subagent roster" className="mt-2 flex items-stretch gap-4">
+          {ROSTER_TABS.map((tab, index) => (
+            <Button
+              key={tab}
+              ref={(node) => { tabRefs.current[index] = node; }}
+              id={rosterTabId(tab)}
+              type="button"
+              role="tab"
+              aria-label={`${tab} ${counts[tab]}`}
+              aria-selected={selectedTab === tab}
+              aria-controls={rosterPanelId(tab)}
+              tabIndex={selectedTab === tab ? 0 : -1}
+              variant="ghost"
+              size="sm"
+              onClick={() => selectTab(tab)}
+              onKeyDown={(event) => handleTabKeyDown(event, index)}
+              className={cn(
+                "relative h-8 rounded-none px-0 text-xs font-medium capitalize after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:origin-center after:bg-primary after:transition-transform after:duration-150 motion-reduce:after:transition-none",
+                selectedTab === tab
+                  ? "text-foreground after:scale-x-100"
+                  : "text-muted-foreground after:scale-x-0 hover:bg-transparent hover:text-foreground",
+              )}
+            >
+              {tab}
+              <Badge variant="secondary" size="sm" className="font-mono tabular-nums">
+                {counts[tab]}
+              </Badge>
+            </Button>
+          ))}
+        </div>
+      </header>
+      <ScrollArea className="min-h-0 flex-1">
+        <div
+          id={rosterPanelId(selectedTab)}
+          role="tabpanel"
+          aria-labelledby={rosterTabId(selectedTab)}
+          className="min-h-full"
+        >
+          {selectedTab === "active" ? (
+            roster.active.length > 0 ? (
+              roster.active.map((row) => <LiveSubagentRowView key={row.id} row={row} />)
+            ) : (
+              <p data-testid="subagents-active-empty" className="px-4 py-6 text-sm text-muted-foreground">
+                No sub-agents are running.
+              </p>
+            )
+          ) : (
+            <p data-testid="subagents-finished-placeholder" className="px-4 py-6 text-sm text-muted-foreground">
+              {roster.finishedCount === 0
+                ? "No finished sub-agents in this turn."
+                : `${roster.finishedCount} finished sub-agent${roster.finishedCount === 1 ? "" : "s"} in this turn.`}
+            </p>
+          )}
+        </div>
+      </ScrollArea>
+    </section>
+  );
+}

--- a/apps/web/src/components/panels/__tests__/SubagentsPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/SubagentsPanel.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ToolCall } from "@/transport/types";
+
+const state = vi.hoisted(() => ({ toolCalls: [] as ToolCall[] }));
+
+vi.mock("@/stores/thread-selectors", () => ({
+  useThreadRecord: () => state.toolCalls,
+}));
+
+import { SubagentsPanel } from "../SubagentsPanel";
+
+function agent(overrides: Partial<ToolCall> = {}): ToolCall {
+  return {
+    id: "agent-1",
+    toolName: "Agent",
+    toolInput: { agentName: "Implementation worker", description: "Build the roster" },
+    output: null,
+    isError: false,
+    isComplete: false,
+    startedAt: Date.now() - 5_000,
+    lastActivityAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("SubagentsPanel", () => {
+  it("selects Active first while work runs and exposes rows, counts, and semantic running text", () => {
+    state.toolCalls = [agent()];
+    render(<SubagentsPanel threadId="thread-1" />);
+
+    expect(screen.getByRole("tab", { name: /active 1/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: /finished 0/i })).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByTestId("subagent-roster-row")).toHaveTextContent("Implementation worker");
+    expect(screen.getByTestId("subagent-roster-row")).toHaveTextContent("Build the roster");
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.getByText("Running subagent")).toHaveClass("sr-only");
+  });
+
+  it("selects Finished first without active work and keeps a manual Finished choice as counts change", () => {
+    state.toolCalls = [agent({ isComplete: true })];
+    const { rerender } = render(<SubagentsPanel threadId="thread-1" />);
+
+    const active = screen.getByRole("tab", { name: /active 0/i });
+    const finished = screen.getByRole("tab", { name: /finished 1/i });
+    expect(finished).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.click(active);
+    fireEvent.click(finished);
+    state.toolCalls = [agent(), agent({ id: "agent-2", toolInput: { description: "Review accessibility" } })];
+    rerender(<SubagentsPanel threadId="thread-1" />);
+
+    expect(screen.getByRole("tab", { name: /finished 0/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("subagents-finished-placeholder")).toBeInTheDocument();
+  });
+
+  it("supports arrow-key tab selection and shows the active empty state", () => {
+    state.toolCalls = [];
+    render(<SubagentsPanel threadId="thread-1" />);
+
+    const finished = screen.getByRole("tab", { name: /finished 0/i });
+    fireEvent.keyDown(finished, { key: "ArrowLeft" });
+
+    const active = screen.getByRole("tab", { name: /active 0/i });
+    expect(active).toHaveFocus();
+    expect(active).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("subagents-active-empty")).toHaveTextContent("No sub-agents are running.");
+    expect(screen.getByRole("tabpanel")).toHaveAttribute("aria-labelledby", active.id);
+  });
+});

--- a/apps/web/src/components/subagents/__tests__/subagent-projection.test.ts
+++ b/apps/web/src/components/subagents/__tests__/subagent-projection.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type { ToolCall } from "@/transport/types";
+import { projectLiveSubagents } from "../subagent-projection";
+
+function call(overrides: Partial<ToolCall> & Pick<ToolCall, "id" | "toolName">): ToolCall {
+  return {
+    toolInput: {},
+    output: null,
+    isError: false,
+    isComplete: false,
+    ...overrides,
+  };
+}
+
+describe("projectLiveSubagents", () => {
+  it("projects top-level running Agents with provider identity, task, descendant activity, and elapsed time", () => {
+    const roster = projectLiveSubagents([
+      call({
+        id: "agent-a",
+        toolName: "Agent",
+        toolInput: { agentName: "Security reviewer", description: "Review auth changes" },
+        startedAt: 1_000,
+        lastActivityAt: 1_000,
+      }),
+      call({
+        id: "child-a",
+        toolName: "Read",
+        toolInput: { file_path: "apps/server/src/auth.ts" },
+        parentToolCallId: "agent-a",
+        startedAt: 2_000,
+        lastActivityAt: 8_000,
+      }),
+    ], 11_000);
+
+    expect(roster).toEqual({
+      active: [
+        {
+          id: "agent-a",
+          identity: "Security reviewer",
+          task: "Review auth changes",
+          activity: "Read file: auth.ts",
+          activityAt: 8_000,
+          elapsedSeconds: 10,
+        },
+      ],
+      finishedCount: 0,
+    });
+  });
+
+  it("sorts by latest descendant activity and preserves source order for ties", () => {
+    const roster = projectLiveSubagents([
+      call({ id: "agent-first", toolName: "Agent", toolInput: { description: "First" }, lastActivityAt: 10 }),
+      call({ id: "agent-second", toolName: "Agent", toolInput: { description: "Second" }, lastActivityAt: 10 }),
+      call({ id: "child-second", toolName: "Grep", toolInput: { pattern: "Subagent" }, parentToolCallId: "agent-second", lastActivityAt: 20 }),
+      call({ id: "nested-agent", toolName: "Agent", toolInput: { description: "Nested" }, parentToolCallId: "agent-first", lastActivityAt: 30 }),
+    ], 30_000);
+
+    expect(roster.active.map((row) => row.id)).toEqual(["agent-first", "agent-second"]);
+    expect(roster.active[0]?.activity).toBe("Delegated task: Nested");
+    expect(roster.active[1]?.activity).toBe('Searched files: "Subagent"');
+  });
+
+  it("counts completed top-level Agents without treating child Agents as roster rows", () => {
+    const roster = projectLiveSubagents([
+      call({ id: "finished", toolName: "Agent", isComplete: true }),
+      call({ id: "active", toolName: "Agent", toolInput: { description: "Keep running" } }),
+      call({ id: "nested-finished", toolName: "Agent", parentToolCallId: "active", isComplete: true }),
+    ]);
+
+    expect(roster.finishedCount).toBe(1);
+    expect(roster.active.map((row) => row.id)).toEqual(["active"]);
+  });
+
+  it("uses provider names before task descriptions and never uses provider models as identities", () => {
+    const roster = projectLiveSubagents([
+      call({
+        id: "named-agent",
+        toolName: "Agent",
+        toolInput: {
+          agentName: "Repository reviewer",
+          description: "Review identity precedence",
+          model: "gpt-5.6",
+        },
+      }),
+      call({
+        id: "cursor-agent",
+        toolName: "Agent",
+        toolInput: {
+          description: "Cursor delegated task",
+          prompt: "Inspect the Cursor task result",
+          model: "cursor-large",
+          agentId: "cursor-internal-id",
+          subagentType: "general",
+        },
+      }),
+      call({
+        id: "codex-agent",
+        toolName: "Agent",
+        toolInput: {
+          codexCollabKind: "spawnAgent",
+          prompt: "Review Codex collaboration events",
+          model: "gpt-5.6-codex",
+        },
+      }),
+      call({ id: "unnamed-agent", toolName: "Agent", toolInput: { model: "not-a-name" } }),
+    ]);
+
+    expect(roster.active.map((row) => row.identity)).toEqual([
+      "Repository reviewer",
+      "Cursor delegated task",
+      "Review Codex collaboration events",
+      "Subagent",
+    ]);
+  });
+
+  it("bounds provider-supplied identity, task, and activity text", () => {
+    const roster = projectLiveSubagents([
+      call({
+        id: "agent",
+        toolName: "Agent",
+        toolInput: {
+          agentName: "i".repeat(160),
+          description: "t".repeat(400),
+        },
+        lastActivityAt: 1,
+      }),
+      call({
+        id: "activity",
+        toolName: "Bash",
+        toolInput: { command: "a".repeat(400) },
+        parentToolCallId: "agent",
+        lastActivityAt: 2,
+      }),
+    ]);
+
+    const row = roster.active[0];
+    expect(row?.identity).toHaveLength(96);
+    expect(row?.identity?.endsWith("…")).toBe(true);
+    expect(row?.task).toHaveLength(280);
+    expect(row?.task?.endsWith("…")).toBe(true);
+    expect(row?.activity).toHaveLength(160);
+    expect(row?.activity?.endsWith("…")).toBe(true);
+  });
+
+  it("bounds malformed descendant traversal", () => {
+    const calls: ToolCall[] = [call({ id: "agent", toolName: "Agent", lastActivityAt: 1 })];
+    for (let index = 0; index < 140; index += 1) {
+      calls.push(call({
+        id: `child-${index}`,
+        toolName: "Read",
+        parentToolCallId: index === 0 ? "agent" : `child-${index - 1}`,
+        lastActivityAt: index + 2,
+      }));
+    }
+
+    expect(projectLiveSubagents(calls).active[0]?.activityAt).toBe(129);
+  });
+});

--- a/apps/web/src/components/subagents/subagent-projection.ts
+++ b/apps/web/src/components/subagents/subagent-projection.ts
@@ -1,0 +1,150 @@
+import { extractSubagentDescription } from "@/components/chat/narrative/extract-subagent-description";
+import { extractToolInputDetail } from "@/components/chat/narrative/tool-detail";
+import { TOOL_LABELS, resolveToolName } from "@/components/chat/tool-renderers/constants";
+import type { ToolCall } from "@/transport/types";
+
+/** Maximum live graph nodes inspected beneath a single top-level subagent. */
+const MAX_SUBAGENT_GRAPH_NODES = 128;
+const MAX_IDENTITY_LENGTH = 96;
+const MAX_TASK_LENGTH = 280;
+const MAX_ACTIVITY_LENGTH = 160;
+
+/** A live top-level subagent row shown by the right-panel roster. */
+export interface LiveSubagentRow {
+  /** Stable Agent tool-call id. */
+  readonly id: string;
+  /** Best provider-supplied display identity available for the delegated agent. */
+  readonly identity: string;
+  /** Stable delegated-task description. */
+  readonly task: string;
+  /** Most recent provider-supplied tool activity in the Agent graph. */
+  readonly activity: string;
+  /** Epoch milliseconds for stable latest-activity ordering. */
+  readonly activityAt: number;
+  /** Elapsed seconds for the running delegation. */
+  readonly elapsedSeconds: number;
+}
+
+/** Live-only roster state derived from one thread's normalized tool-call graph. */
+export interface LiveSubagentRoster {
+  /** Running top-level Agent rows, newest meaningful activity first. */
+  readonly active: readonly LiveSubagentRow[];
+  /** Completed top-level Agent boundaries still present in the live turn. */
+  readonly finishedCount: number;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function boundedDisplayText(value: string, maxLength: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength - 1)}…`;
+}
+
+function subagentIdentity(agent: ToolCall): string {
+  const input = agent.toolInput;
+  const providerName = nonEmptyString(input.agentName)
+    ?? nonEmptyString(input.subagentName)
+    ?? nonEmptyString(input.name);
+  if (providerName) return boundedDisplayText(providerName, MAX_IDENTITY_LENGTH);
+
+  const task = extractSubagentDescription(agent);
+  return task === "Running subagent" || task === "Subagent task"
+    ? "Subagent"
+    : boundedDisplayText(task, MAX_IDENTITY_LENGTH);
+}
+
+function activityTimestamp(call: ToolCall): number {
+  return call.lastActivityAt ?? call.startedAt ?? 0;
+}
+
+function activityLabel(call: ToolCall): string {
+  const toolName = resolveToolName(call.toolName);
+  const label = TOOL_LABELS[toolName] ?? toolName;
+  const detail = extractToolInputDetail(call);
+  return boundedDisplayText(
+    detail === call.toolName ? label : `${label}: ${detail}`,
+    MAX_ACTIVITY_LENGTH,
+  );
+}
+
+/**
+ * Projects the current thread's normalized tool-call graph into live roster rows.
+ *
+ * Only top-level Agent calls form rows. Descendant traversal is bounded and
+ * cycle-safe so malformed provider parent links cannot expand render work.
+ */
+export function projectLiveSubagents(
+  calls: readonly ToolCall[] | undefined,
+  now: number = Date.now(),
+): LiveSubagentRoster {
+  if (!calls?.length) return { active: [], finishedCount: 0 };
+
+  const childrenByParent = new Map<string, Array<{ call: ToolCall; index: number }>>();
+  const topLevelAgents: Array<{ call: ToolCall; index: number }> = [];
+
+  calls.forEach((call, index) => {
+    const parentId = call.parentToolCallId;
+    if (typeof parentId === "string" && parentId.length > 0) {
+      const children = childrenByParent.get(parentId) ?? [];
+      children.push({ call, index });
+      childrenByParent.set(parentId, children);
+      return;
+    }
+    if (call.toolName === "Agent") topLevelAgents.push({ call, index });
+  });
+
+  const active: Array<LiveSubagentRow & { index: number }> = [];
+  let finishedCount = 0;
+
+  for (const { call: agent, index } of topLevelAgents) {
+    if (agent.isComplete) {
+      finishedCount += 1;
+      continue;
+    }
+
+    let latestCall = agent;
+    let latestIndex = index;
+    const queue = [...(childrenByParent.get(agent.id) ?? [])];
+    const visited = new Set<string>([agent.id]);
+    let inspected = 0;
+
+    while (queue.length > 0 && inspected < MAX_SUBAGENT_GRAPH_NODES) {
+      const next = queue.shift();
+      if (!next || visited.has(next.call.id)) continue;
+      visited.add(next.call.id);
+      inspected += 1;
+
+      const nextTimestamp = activityTimestamp(next.call);
+      const latestTimestamp = activityTimestamp(latestCall);
+      if (nextTimestamp > latestTimestamp || (nextTimestamp === latestTimestamp && next.index > latestIndex)) {
+        latestCall = next.call;
+        latestIndex = next.index;
+      }
+
+      const children = childrenByParent.get(next.call.id);
+      if (children) queue.push(...children);
+    }
+
+    const startedAt = agent.startedAt ?? now;
+    active.push({
+      id: agent.id,
+      identity: subagentIdentity(agent),
+      task: boundedDisplayText(extractSubagentDescription(agent), MAX_TASK_LENGTH),
+      activity: activityLabel(latestCall),
+      activityAt: activityTimestamp(latestCall),
+      elapsedSeconds: Math.max(0, Math.floor(agent.elapsedSeconds ?? (now - startedAt) / 1000)),
+      index,
+    });
+  }
+
+  active.sort((left, right) => right.activityAt - left.activityAt || left.index - right.index);
+  return {
+    active: active.map(({ index: _index, ...row }) => row),
+    finishedCount,
+  };
+}

--- a/apps/web/src/lib/__tests__/panel-tabs.test.ts
+++ b/apps/web/src/lib/__tests__/panel-tabs.test.ts
@@ -13,13 +13,14 @@ function ids(types: readonly { id: PanelTabTypeId }[]): PanelTabTypeId[] {
 }
 
 describe("PANEL_TAB_TYPES catalog", () => {
-  it("declares the five revamp tab types in prototype order", () => {
+  it("declares the six revamp tab types in prototype order", () => {
     expect(ids(PANEL_TAB_TYPES)).toEqual([
       "preview",
       "terminal",
       "files",
       "changes",
       "tasks",
+      "subagents",
     ]);
   });
 
@@ -28,16 +29,16 @@ describe("PANEL_TAB_TYPES catalog", () => {
     expect(comingSoon).toEqual(["files"]);
   });
 
-  it("marks only Plan as thread-only (Review is dual-scope)", () => {
+  it("marks Plan and Subagents as thread-only (Review is dual-scope)", () => {
     const threadOnly = PANEL_TAB_TYPES.filter((t) => t.needsThread).map((t) => t.id);
-    expect(threadOnly).toEqual(["tasks"]);
+    expect(threadOnly).toEqual(["tasks", "subagents"]);
   });
 
-  it("gives every openable type a commandId for keycap resolution", () => {
+  it("gives every shortcut-enabled type a commandId", () => {
     for (const type of PANEL_TAB_TYPES) {
       if (type.comingSoon) {
         expect(type.commandId).toBeUndefined();
-      } else {
+      } else if (type.id !== "subagents") {
         expect(type.commandId).toBeTruthy();
       }
     }
@@ -75,6 +76,7 @@ describe("shownTabTypes — scope filter", () => {
       "files",
       "changes",
       "tasks",
+      "subagents",
     ]);
   });
 });
@@ -90,7 +92,7 @@ describe("shownTabTypes — cardinality filter", () => {
 
   it("keeps the coming-soon teaser even when every openable type is open", () => {
     expect(
-      ids(shownTabTypes("thread", ["preview", "terminal", "changes", "tasks"])),
+      ids(shownTabTypes("thread", ["preview", "terminal", "changes", "tasks", "subagents"])),
     ).toEqual(["files"]);
   });
 
@@ -121,6 +123,7 @@ describe("creatableTypes — coming-soon exclusion", () => {
       "terminal",
       "changes",
       "tasks",
+      "subagents",
     ]);
   });
 
@@ -143,7 +146,7 @@ describe("creatableTypes — combined scope + cardinality", () => {
 
   it("returns an empty set when every openable type is open", () => {
     expect(
-      ids(creatableTypes("thread", ["preview", "terminal", "changes", "tasks"])),
+      ids(creatableTypes("thread", ["preview", "terminal", "changes", "tasks", "subagents"])),
     ).toEqual([]);
   });
 
@@ -168,6 +171,7 @@ describe("creatableTypes / shownTabTypes — purity", () => {
     expect(ids(creatableTypes("thread", ["tasks", "preview"]))).toEqual([
       "terminal",
       "changes",
+      "subagents",
     ]);
   });
 });

--- a/apps/web/src/lib/panel-tabs.ts
+++ b/apps/web/src/lib/panel-tabs.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { Globe, Terminal, Files, Diff, ListChecks } from "lucide-react";
+import { Bot, Globe, Terminal, Files, Diff, ListChecks } from "lucide-react";
 import type { RightPanelTab } from "@/stores/diffStore";
 
 /**
@@ -90,6 +90,13 @@ export const PANEL_TAB_TYPES: readonly PanelTabType[] = [
     blurb: "Read saved plans",
     needsThread: true,
     commandId: "tasks.toggle",
+  },
+  {
+    id: "subagents",
+    label: "Subagents",
+    icon: Bot,
+    blurb: "Follow delegated work",
+    needsThread: true,
   },
 ];
 

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -5,7 +5,7 @@ import { defaultReviewView, type ReviewChangeState } from "@/lib/review-views";
 export type { GitCommit, BranchComparison };
 
 /** Active tab in the right panel. */
-export type RightPanelTab = "tasks" | "changes" | "preview" | "terminal";
+export type RightPanelTab = "tasks" | "changes" | "preview" | "terminal" | "subagents";
 
 /**
  * View mode within the Review (Changes) tab. The tab is dual-scope: the first

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -2245,6 +2245,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         isComplete: false,
         parentToolCallId: parentToolCallId || undefined,
         startedAt: Date.now(),
+        lastActivityAt: Date.now(),
       };
       set((state) => {
         const rec = getThreadRecord(state.records, threadId);
@@ -2334,6 +2335,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             output,
             isError,
             isComplete: true,
+            lastActivityAt: Date.now(),
             ...(outputTruncated ? { outputTruncated: true } : {}),
             ...(outputTotalBytes != null ? { outputTotalBytes } : {}),
             ...(outputArtifactPath ? { outputArtifactPath } : {}),
@@ -2419,13 +2421,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const toolCallId = (params.toolCallId as string) || "";
       const elapsedSeconds = (params.elapsedSeconds as number) ?? 0;
       if (!toolCallId) return;
+      const lastActivityAt = Date.now();
       set((state) => {
         const current = getThreadRecord(state.records, threadId).toolCalls;
         let changed = false;
         const updated = current.map((tc) => {
-          if (tc.id === toolCallId && !tc.isComplete && tc.elapsedSeconds !== elapsedSeconds) {
+          if (tc.id === toolCallId && !tc.isComplete) {
             changed = true;
-            return { ...tc, elapsedSeconds };
+            return { ...tc, elapsedSeconds, lastActivityAt };
           }
           return tc;
         });

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -147,6 +147,8 @@ export interface ToolCall {
   elapsedSeconds?: number;
   /** Epoch ms when the toolUse event was received, used for duration display. */
   startedAt?: number;
+  /** Epoch ms when the provider last reported meaningful activity for this call. */
+  lastActivityAt?: number;
   /** Wall-clock duration when the tool call completed (ms). */
   durationMs?: number;
   /** Process exit code reported for a completed shell command. */


### PR DESCRIPTION
## What

Add a thread-scoped Subagents tab to the right panel that shows the active delegated-agent roster.

## Why

This is the first tracer-bullet slice of #916. It makes active delegated work visible without expanding into the durable finished-history scope assigned to #918.

## Key Changes

- Add accessible horizontal Active and Finished tabs with live counts and preserved manual selection.
- Show each running top-level agent's identity, task, latest descendant activity, elapsed time, and semantic running state.
- Bound provider-controlled display text and graph traversal while preserving stable activity ordering.
- Match the existing right-panel tokens, Filament Amber treatment, responsive widths, and reduced-motion behavior.
- Add focused coverage for panel scope, event activity timestamps, accessibility, provider fallbacks, oversized input, ordering, and malformed graphs.

## Verification

- Focused Vitest gate: 7 files, 148 tests passed.
- Live app: 2 parallel active agents rendered at exact 440 px and 384 px panel widths in dark and light themes.
- Live lifecycle: Finished changed from 0 to 1 while a manual Finished selection remained selected.
- Reduced motion: verified with the reduced-motion media query active.
- Visual captures: `subagents-dark-440.png`, `subagents-light-440.png`, `subagents-dark-384.png`, `subagents-light-384.png`, and `subagents-dark-440-reduced-motion.png` under the task's `.dev/verification/issue-917/` evidence directory.
- `bun run verify`: typecheck and lint passed. The local Windows run reached 1,897 of 1,898 server tests; an unrelated 5-second bulk-rename timing test failed, and the agent-script port test cannot bind OS-reserved port 53210. Hosted checks provide the clean full-gate environment.

Closes #917

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787284917&installation_model_id=20477&pr_number=921&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F921&signature=c78b1137f877615f178da87414b72f2888703bae71a14b919ca94bd211515a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a thread-scoped **Subagents** panel to monitor delegated work.
  - View active and completed subagents, including names, tasks, current activity, status, and elapsed time.
  - Added keyboard navigation for Active and Finished tabs.
  - Added the Subagents tab to the right-panel navigation.

- **Improvements**
  - Tool activity timestamps now update during progress and completion events, keeping elapsed-time displays current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->