### PR TITLE
feat(web): retain finished subagents across hydration

### DIFF
--- a/apps/server/src/__tests__/tool-call-record-repo.test.ts
+++ b/apps/server/src/__tests__/tool-call-record-repo.test.ts
@@ -165,6 +165,50 @@ describe("ToolCallRecordRepo", () => {
     expect(records.map((r) => r.tool_name)).toEqual(["Read", "Edit", "Bash"]);
   });
 
+  it("preserves explicit lifecycle timestamps for each bulk-created record", () => {
+    repo.bulkCreate([
+      {
+        toolCallId: "agent-first",
+        messageId,
+        toolName: "Agent",
+        inputSummary: "First delegated task",
+        outputSummary: "First result",
+        status: "completed",
+        startedAt: "2026-07-22T10:00:00.000Z",
+        completedAt: "2026-07-22T10:00:20.000Z",
+        sortOrder: 0,
+      },
+      {
+        toolCallId: "agent-second",
+        messageId,
+        toolName: "Agent",
+        inputSummary: "Second delegated task",
+        outputSummary: "Second result",
+        status: "completed",
+        startedAt: "2026-07-22T10:00:05.000Z",
+        completedAt: "2026-07-22T10:00:50.000Z",
+        sortOrder: 1,
+      },
+    ]);
+
+    expect(repo.listByMessage(messageId).map((record) => ({
+      id: record.id,
+      startedAt: record.started_at,
+      completedAt: record.completed_at,
+    }))).toEqual([
+      {
+        id: "agent-first",
+        startedAt: "2026-07-22T10:00:00.000Z",
+        completedAt: "2026-07-22T10:00:20.000Z",
+      },
+      {
+        id: "agent-second",
+        startedAt: "2026-07-22T10:00:05.000Z",
+        completedAt: "2026-07-22T10:00:50.000Z",
+      },
+    ]);
+  });
+
   it("supports parent nesting via listByParent", () => {
     const parent = repo.create({
       messageId,

--- a/apps/server/src/repositories/tool-call-record-repo.ts
+++ b/apps/server/src/repositories/tool-call-record-repo.ts
@@ -39,6 +39,10 @@ export interface CreateToolCallRecordInput {
   outputArtifactPath?: string;
   exitCode?: number;
   status: ToolCallStatus;
+  /** ISO timestamp captured when the provider started the tool call. */
+  startedAt?: string;
+  /** ISO timestamp captured when the tool call reached a terminal status. */
+  completedAt?: string;
   sortOrder: number;
   parentToolCallId?: string;
 }
@@ -92,7 +96,8 @@ export class ToolCallRecordRepo {
   create(input: CreateToolCallRecordInput): ToolCallRecord {
     const id = input.toolCallId ?? randomUUID();
     const now = new Date().toISOString();
-    const completedAt = input.status !== "running" ? now : null;
+    const startedAt = input.startedAt ?? now;
+    const completedAt = input.status !== "running" ? input.completedAt ?? now : null;
 
     this.stmtInsert.run(
       id,
@@ -106,7 +111,7 @@ export class ToolCallRecordRepo {
       input.outputArtifactPath ?? null,
       input.exitCode ?? null,
       input.status,
-      now,
+      startedAt,
       completedAt,
       input.sortOrder,
     );
@@ -123,7 +128,7 @@ export class ToolCallRecordRepo {
       output_artifact_path: input.outputArtifactPath ?? null,
       exit_code: input.exitCode ?? null,
       status: input.status,
-      started_at: now,
+      started_at: startedAt,
       completed_at: completedAt,
       sort_order: input.sortOrder,
     };
@@ -134,7 +139,8 @@ export class ToolCallRecordRepo {
     const tx = this.db.transaction((items: CreateToolCallRecordInput[]) => {
       const now = new Date().toISOString();
       for (const item of items) {
-        const completedAt = item.status !== "running" ? now : null;
+        const startedAt = item.startedAt ?? now;
+        const completedAt = item.status !== "running" ? item.completedAt ?? now : null;
         this.stmtInsert.run(
           item.toolCallId ?? randomUUID(),
           item.messageId,
@@ -147,7 +153,7 @@ export class ToolCallRecordRepo {
           item.outputArtifactPath ?? null,
           item.exitCode ?? null,
           item.status,
-          now,
+          startedAt,
           completedAt,
           item.sortOrder,
         );

--- a/apps/server/src/services/__tests__/narrative-store.test.ts
+++ b/apps/server/src/services/__tests__/narrative-store.test.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type Database from "better-sqlite3";
 import { openMemoryDatabase } from "../../store/database";
 import { MessageRepo } from "../../repositories/message-repo";
@@ -439,6 +439,56 @@ describe("NarrativeStore write seam (server-side traps)", () => {
   });
 
   describe("Trap 6: counting data preserved (semantics unchanged)", () => {
+    it("persists each Agent's captured lifecycle timestamps through the real repository", () => {
+      seedAssistantMessage("m1", "", 1);
+      vi.useFakeTimers();
+      try {
+        store.beginTurn(THREAD);
+        store.resetTurnCounters(THREAD);
+        vi.setSystemTime(new Date("2026-07-22T10:00:00.000Z"));
+        store.bufferToolCall(THREAD, toolUse("agent-first", "Agent"));
+        vi.setSystemTime(new Date("2026-07-22T10:00:05.000Z"));
+        store.bufferToolCall(THREAD, toolUse("agent-second", "Agent"));
+        vi.setSystemTime(new Date("2026-07-22T10:00:10.000Z"));
+        store.bufferToolCall(THREAD, toolUse("agent-settled", "Agent"));
+        vi.setSystemTime(new Date("2026-07-22T10:00:20.000Z"));
+        store.updateBufferedToolCallOutput(THREAD, "agent-first", "First result", false);
+        vi.setSystemTime(new Date("2026-07-22T10:00:50.000Z"));
+        store.updateBufferedToolCallOutput(THREAD, "agent-second", "Second result", false);
+        vi.setSystemTime(new Date("2026-07-22T10:01:00.000Z"));
+        store.persistNarrative(THREAD, "m1", "", "completed");
+      } finally {
+        vi.useRealTimers();
+      }
+
+      const records = new ToolCallRecordRepo(db).listByMessage("m1");
+      expect(records.map((record) => ({
+        id: record.id,
+        startedAt: record.started_at,
+        completedAt: record.completed_at,
+        durationMs: Date.parse(record.completed_at!) - Date.parse(record.started_at),
+      }))).toEqual([
+        {
+          id: "agent-first",
+          startedAt: "2026-07-22T10:00:00.000Z",
+          completedAt: "2026-07-22T10:00:20.000Z",
+          durationMs: 20_000,
+        },
+        {
+          id: "agent-second",
+          startedAt: "2026-07-22T10:00:05.000Z",
+          completedAt: "2026-07-22T10:00:50.000Z",
+          durationMs: 45_000,
+        },
+        {
+          id: "agent-settled",
+          startedAt: "2026-07-22T10:00:10.000Z",
+          completedAt: "2026-07-22T10:01:00.000Z",
+          durationMs: 50_000,
+        },
+      ]);
+    });
+
     it("persists every top-level tool call including Agent rows, so step counts are derivable", () => {
       seedAssistantMessage("m1", "", 1);
       store.beginTurn(THREAD);

--- a/apps/server/src/services/narrative-store.ts
+++ b/apps/server/src/services/narrative-store.ts
@@ -397,6 +397,7 @@ export class NarrativeStore {
       inputSummary: "", // Deferred to persistNarrative
       outputSummary: "",
       status: "running",
+      startedAt: new Date().toISOString(),
       sortOrder,
       parentToolCallId,
       _rawToolInput: event.toolInput,
@@ -453,6 +454,7 @@ export class NarrativeStore {
           buffer[i].exitCode = outputMeta.exitCode;
         }
         buffer[i].status = isError ? "failed" : "completed";
+        buffer[i].completedAt = new Date().toISOString();
         if (toolInput && Object.keys(toolInput).length > 0) {
           buffer[i]._rawToolInput = {
             ...(buffer[i]._rawToolInput ?? {}),
@@ -555,6 +557,7 @@ export class NarrativeStore {
     outcome: TurnOutcome,
   ): PersistNarrativeResult {
     const buffer = this.turnToolCalls.get(threadId) ?? [];
+    const settledAt = new Date().toISOString();
 
     for (const tc of buffer) {
       if (tc.status === "running") {
@@ -564,6 +567,7 @@ export class NarrativeStore {
         // updateBufferedToolCallOutput.
         tc.status =
           outcome === "errored" ? "failed" : outcome === "cancelled" ? "cancelled" : "completed";
+        tc.completedAt = settledAt;
       }
       tc.messageId = messageId;
 

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -17,6 +17,7 @@ describe("diffStore", () => {
       previewUrlByThread: {},
       rightPanelByThread: {},
       rightPanelFallbackByWorkspace: {},
+      subagentRosterTabByThread: {},
       reviewFilesVisibleByScope: {},
       snapshotsByThread: {},
       snapshotsLoadingByThread: {},
@@ -695,6 +696,17 @@ describe("diffStore", () => {
   });
 
   describe("clearThread", () => {
+    it("keeps roster tabs isolated by thread and drops the deleted thread's choice", () => {
+      const { setSubagentRosterTab, getSubagentRosterTab, clearThread } = useDiffStore.getState();
+      setSubagentRosterTab("thread-1", "active");
+      setSubagentRosterTab("thread-2", "finished");
+
+      clearThread("thread-1");
+
+      expect(getSubagentRosterTab("thread-1")).toBeUndefined();
+      expect(getSubagentRosterTab("thread-2")).toBe("finished");
+    });
+
     it("should remove all per-thread entries", () => {
       const {
         setSnapshots,

--- a/apps/web/src/components/panels/SubagentsPanel.tsx
+++ b/apps/web/src/components/panels/SubagentsPanel.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { Ban, CircleCheck, CircleX, type LucideIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { EntityIcon } from "@/components/chat/EntityToken";
-import { useThreadRecord } from "@/stores/thread-selectors";
+import { projectSubagents, type FinishedSubagentRow, type FinishedSubagentStatus, type LiveSubagentRow } from "@/components/subagents/subagent-projection";
 import { cn } from "@/lib/utils";
 import { formatDuration } from "@/lib/time";
-import { projectLiveSubagents, type LiveSubagentRow } from "@/components/subagents/subagent-projection";
+import { useDiffStore, type SubagentRosterTab } from "@/stores/diffStore";
+import { useThreadRecord } from "@/stores/thread-selectors";
 
-type RosterTab = "active" | "finished";
+type RosterTab = SubagentRosterTab;
 
 const ROSTER_TABS: readonly RosterTab[] = ["active", "finished"];
 
@@ -33,11 +35,7 @@ function LiveSubagentRowView({ row }: { readonly row: LiveSubagentRow }) {
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-2">
           <h3 className="min-w-0 truncate text-sm font-medium text-foreground">{row.identity}</h3>
-          <Badge
-            variant="outline"
-            size="sm"
-            className="border-primary/35 bg-primary/10 text-primary"
-          >
+          <Badge variant="outline" size="sm" className="border-primary/35 bg-primary/10 text-primary">
             Running
           </Badge>
           <span className="sr-only">Running subagent</span>
@@ -52,15 +50,62 @@ function LiveSubagentRowView({ row }: { readonly row: LiveSubagentRow }) {
   );
 }
 
-/** Thread-only right-panel roster for live normalized Agent tool calls. */
+const FINISHED_STATUS: Record<FinishedSubagentStatus, { label: string; Icon: LucideIcon; className: string }> = {
+  completed: { label: "Completed", Icon: CircleCheck, className: "border-[var(--diff-add-strong)]/35 bg-[var(--diff-add-strong)]/10 text-[var(--diff-add-strong)]" },
+  failed: { label: "Failed", Icon: CircleX, className: "border-destructive/35 bg-destructive/10 text-destructive" },
+  cancelled: { label: "Cancelled", Icon: Ban, className: "border-muted-foreground/35 bg-muted text-muted-foreground" },
+};
+
+/** A compact settled row for one completed, failed, or cancelled subagent. */
+function FinishedSubagentRowView({ row }: { readonly row: FinishedSubagentRow }) {
+  const status = FINISHED_STATUS[row.status];
+  return (
+    <article
+      data-testid="subagent-finished-row"
+      className="flex min-w-0 gap-3 border-b border-border/50 px-4 py-3 last:border-b-0"
+    >
+      <span className={cn("mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md", status.className)}>
+        <status.Icon size={15} aria-hidden />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <h3 className="min-w-0 truncate text-sm font-medium text-foreground">{row.identity}</h3>
+          <Badge variant="outline" size="sm" className={status.className}>
+            {status.label}
+          </Badge>
+          <time
+            className="ml-auto shrink-0 font-mono text-xs tabular-nums text-muted-foreground"
+            dateTime={new Date(row.completedAt).toISOString()}
+            aria-label={`Finished ${new Date(row.completedAt).toISOString()} after ${formatDuration(row.elapsedSeconds)}`}
+          >
+            {formatDuration(row.elapsedSeconds)}
+          </time>
+        </div>
+        <p className="mt-0.5 line-clamp-2 text-xs leading-5 text-foreground/80">{row.task}</p>
+        <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{row.activity}</p>
+      </div>
+    </article>
+  );
+}
+
+/** Thread-only right-panel roster for live and hydrated Agent tool calls. */
 export function SubagentsPanel({ threadId }: { readonly threadId: string }) {
-  const toolCalls = useThreadRecord(threadId, (record) => record.toolCalls);
+  const { toolCalls, narrativeByMessage } = useThreadRecord(threadId, (record) => ({
+    toolCalls: record.toolCalls,
+    narrativeByMessage: record.narrativeByMessage,
+  }));
+  const savedTab = useDiffStore((state) => state.subagentRosterTabByThread[threadId]);
+  const setSavedTab = useDiffStore((state) => state.setSubagentRosterTab);
   const [now, setNow] = useState(() => Date.now());
-  const roster = projectLiveSubagents(toolCalls, now);
+  const roster = projectSubagents(toolCalls, Object.values(narrativeByMessage).map((entry) => entry?.tools), now);
   const [selectedTab, setSelectedTab] = useState<RosterTab>(() => (
-    roster.active.length > 0 ? "active" : "finished"
+    savedTab ?? (roster.active.length > 0 ? "active" : "finished")
   ));
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    if (!savedTab) setSavedTab(threadId, selectedTab);
+  }, [savedTab, selectedTab, setSavedTab, threadId]);
 
   useEffect(() => {
     if (roster.active.length === 0) return;
@@ -70,10 +115,13 @@ export function SubagentsPanel({ threadId }: { readonly threadId: string }) {
 
   const counts: Record<RosterTab, number> = {
     active: roster.active.length,
-    finished: roster.finishedCount,
+    finished: roster.finished.length,
   };
 
-  const selectTab = (tab: RosterTab) => setSelectedTab(tab);
+  const selectTab = (tab: RosterTab) => {
+    setSelectedTab(tab);
+    setSavedTab(threadId, tab);
+  };
   const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
     let nextIndex: number | null = null;
     if (event.key === "ArrowRight") nextIndex = (index + 1) % ROSTER_TABS.length;
@@ -138,11 +186,11 @@ export function SubagentsPanel({ threadId }: { readonly threadId: string }) {
                 No sub-agents are running.
               </p>
             )
+          ) : roster.finished.length > 0 ? (
+            roster.finished.map((row) => <FinishedSubagentRowView key={row.id} row={row} />)
           ) : (
-            <p data-testid="subagents-finished-placeholder" className="px-4 py-6 text-sm text-muted-foreground">
-              {roster.finishedCount === 0
-                ? "No finished sub-agents in this turn."
-                : `${roster.finishedCount} finished sub-agent${roster.finishedCount === 1 ? "" : "s"} in this turn.`}
+            <p data-testid="subagents-finished-empty" className="px-4 py-6 text-sm text-muted-foreground">
+              No finished sub-agents in this loaded conversation.
             </p>
           )}
         </div>

--- a/apps/web/src/components/panels/__tests__/SubagentsPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/SubagentsPanel.test.tsx
@@ -1,11 +1,16 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import type { ToolCall } from "@/transport/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolCall, ToolCallRecord } from "@/transport/types";
+import { useDiffStore } from "@/stores/diffStore";
 
-const state = vi.hoisted(() => ({ toolCalls: [] as ToolCall[] }));
+const state = vi.hoisted(() => ({
+  records: {} as Record<string, { toolCalls: ToolCall[]; narrativeByMessage: Record<string, { tools: ToolCallRecord[] } | undefined> }>,
+}));
 
 vi.mock("@/stores/thread-selectors", () => ({
-  useThreadRecord: () => state.toolCalls,
+  useThreadRecord: (threadId: string, selector: (record: unknown) => unknown) => selector(
+    state.records[threadId] ?? { toolCalls: [], narrativeByMessage: {} },
+  ),
 }));
 
 import { SubagentsPanel } from "../SubagentsPanel";
@@ -24,9 +29,37 @@ function agent(overrides: Partial<ToolCall> = {}): ToolCall {
   };
 }
 
+function record(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
+  return {
+    id: "agent-1",
+    message_id: "message-1",
+    parent_tool_call_id: null,
+    tool_name: "Agent",
+    input_summary: "Build the roster",
+    output_summary: "Roster implementation complete",
+    status: "completed",
+    started_at: "2026-07-22T10:00:00.000Z",
+    completed_at: "2026-07-22T10:01:00.000Z",
+    sort_order: 0,
+    ...overrides,
+  };
+}
+
+function setThread(threadId: string, toolCalls: ToolCall[] = [], tools: ToolCallRecord[] = []): void {
+  state.records[threadId] = {
+    toolCalls,
+    narrativeByMessage: tools.length > 0 ? { "message-1": { tools } } : {},
+  };
+}
+
 describe("SubagentsPanel", () => {
+  beforeEach(() => {
+    state.records = {};
+    useDiffStore.setState({ subagentRosterTabByThread: {} });
+  });
+
   it("selects Active first while work runs and exposes rows, counts, and semantic running text", () => {
-    state.toolCalls = [agent()];
+    setThread("thread-1", [agent()]);
     render(<SubagentsPanel threadId="thread-1" />);
 
     expect(screen.getByRole("tab", { name: /active 1/i })).toHaveAttribute("aria-selected", "true");
@@ -37,25 +70,72 @@ describe("SubagentsPanel", () => {
     expect(screen.getByText("Running subagent")).toHaveClass("sr-only");
   });
 
-  it("selects Finished first without active work and keeps a manual Finished choice as counts change", () => {
-    state.toolCalls = [agent({ isComplete: true })];
-    const { rerender } = render(<SubagentsPanel threadId="thread-1" />);
+  it("renders completed, failed, and cancelled rows with explicit terminal status", () => {
+    setThread("thread-1", [], [
+      record({ id: "completed", status: "completed" }),
+      record({ id: "failed", status: "failed", output_summary: "Command failed" }),
+      record({ id: "cancelled", status: "cancelled" }),
+    ]);
+    render(<SubagentsPanel threadId="thread-1" />);
 
-    const active = screen.getByRole("tab", { name: /active 0/i });
-    const finished = screen.getByRole("tab", { name: /finished 1/i });
-    expect(finished).toHaveAttribute("aria-selected", "true");
-
-    fireEvent.click(active);
-    fireEvent.click(finished);
-    state.toolCalls = [agent(), agent({ id: "agent-2", toolInput: { description: "Review accessibility" } })];
-    rerender(<SubagentsPanel threadId="thread-1" />);
-
-    expect(screen.getByRole("tab", { name: /finished 0/i })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByTestId("subagents-finished-placeholder")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /finished 3/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getAllByTestId("subagent-finished-row")).toHaveLength(3);
+    expect(screen.getByText("Completed")).toHaveClass("text-[var(--diff-add-strong)]");
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+    expect(screen.getByText("Command failed")).toBeInTheDocument();
   });
 
-  it("supports arrow-key tab selection and shows the active empty state", () => {
-    state.toolCalls = [];
+  it("moves a settled Agent from Active to Finished once as the persisted narrative arrives", () => {
+    setThread("thread-1", [agent()]);
+    const { rerender } = render(<SubagentsPanel threadId="thread-1" />);
+
+    setThread("thread-1", [agent({ isComplete: true })], [record()]);
+    rerender(<SubagentsPanel threadId="thread-1" />);
+    expect(screen.getByRole("tab", { name: /active 0/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("subagents-active-empty")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: /finished 1/i }));
+    expect(screen.getAllByTestId("subagent-finished-row")).toHaveLength(1);
+  });
+
+  it("restores each thread's roster choice after unmount and keeps thread rows isolated", () => {
+    setThread("thread-1", [], [record({ id: "thread-1-finished" })]);
+    setThread("thread-2", [agent({ id: "thread-2-active", toolInput: { description: "Review thread two" } })]);
+    const first = render(<SubagentsPanel threadId="thread-1" />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /active 0/i }));
+    expect(screen.getByTestId("subagents-active-empty")).toBeInTheDocument();
+    first.unmount();
+
+    const second = render(<SubagentsPanel threadId="thread-2" />);
+    expect(screen.getByRole("tab", { name: /active 1/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("subagent-roster-row")).toHaveTextContent("Review thread two");
+    fireEvent.click(screen.getByRole("tab", { name: /finished 0/i }));
+    second.unmount();
+
+    render(<SubagentsPanel threadId="thread-1" />);
+    expect(screen.getByRole("tab", { name: /active 0/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("subagents-active-empty")).toBeInTheDocument();
+    expect(screen.queryByText("Review thread two")).not.toBeInTheDocument();
+  });
+
+  it("keeps a selected tab when counts change and gives each empty state distinct guidance", () => {
+    setThread("thread-1");
+    const { rerender } = render(<SubagentsPanel threadId="thread-1" />);
+
+    expect(screen.getByTestId("subagents-finished-empty")).toHaveTextContent("loaded conversation");
+    fireEvent.click(screen.getByRole("tab", { name: /active 0/i }));
+    expect(screen.getByTestId("subagents-active-empty")).toHaveTextContent("running");
+
+    setThread("thread-1", [], [record()]);
+    rerender(<SubagentsPanel threadId="thread-1" />);
+    expect(screen.getByRole("tab", { name: /active 0/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("subagents-active-empty")).toBeInTheDocument();
+  });
+
+  it("supports arrow-key tab selection", () => {
+    setThread("thread-1");
     render(<SubagentsPanel threadId="thread-1" />);
 
     const finished = screen.getByRole("tab", { name: /finished 0/i });
@@ -64,7 +144,6 @@ describe("SubagentsPanel", () => {
     const active = screen.getByRole("tab", { name: /active 0/i });
     expect(active).toHaveFocus();
     expect(active).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByTestId("subagents-active-empty")).toHaveTextContent("No sub-agents are running.");
     expect(screen.getByRole("tabpanel")).toHaveAttribute("aria-labelledby", active.id);
   });
 });

--- a/apps/web/src/components/subagents/__tests__/subagent-projection.test.ts
+++ b/apps/web/src/components/subagents/__tests__/subagent-projection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { ToolCall } from "@/transport/types";
-import { projectLiveSubagents } from "../subagent-projection";
+import type { ToolCall, ToolCallRecord } from "@/transport/types";
+import { projectSubagents } from "../subagent-projection";
 
 function call(overrides: Partial<ToolCall> & Pick<ToolCall, "id" | "toolName">): ToolCall {
   return {
@@ -12,9 +12,24 @@ function call(overrides: Partial<ToolCall> & Pick<ToolCall, "id" | "toolName">):
   };
 }
 
-describe("projectLiveSubagents", () => {
+function record(overrides: Partial<ToolCallRecord> & Pick<ToolCallRecord, "id">): ToolCallRecord {
+  return {
+    message_id: "message-1",
+    parent_tool_call_id: null,
+    tool_name: "Agent",
+    input_summary: "Review the roster",
+    output_summary: "Finished review",
+    status: "completed",
+    started_at: "2026-07-22T10:00:00.000Z",
+    completed_at: "2026-07-22T10:01:00.000Z",
+    sort_order: 0,
+    ...overrides,
+  };
+}
+
+describe("projectSubagents", () => {
   it("projects top-level running Agents with provider identity, task, descendant activity, and elapsed time", () => {
-    const roster = projectLiveSubagents([
+    const roster = projectSubagents([
       call({
         id: "agent-a",
         toolName: "Agent",
@@ -30,80 +45,108 @@ describe("projectLiveSubagents", () => {
         startedAt: 2_000,
         lastActivityAt: 8_000,
       }),
-    ], 11_000);
+    ], [], 11_000);
 
     expect(roster).toEqual({
-      active: [
-        {
-          id: "agent-a",
-          identity: "Security reviewer",
-          task: "Review auth changes",
-          activity: "Read file: auth.ts",
-          activityAt: 8_000,
-          elapsedSeconds: 10,
-        },
-      ],
-      finishedCount: 0,
+      active: [{
+        id: "agent-a",
+        identity: "Security reviewer",
+        task: "Review auth changes",
+        activity: "Read file: auth.ts",
+        activityAt: 8_000,
+        elapsedSeconds: 10,
+      }],
+      finished: [],
     });
   });
 
-  it("sorts by latest descendant activity and preserves source order for ties", () => {
-    const roster = projectLiveSubagents([
+  it("keeps nested Agents out of the top-level roster and orders active rows by descendant activity", () => {
+    const roster = projectSubagents([
       call({ id: "agent-first", toolName: "Agent", toolInput: { description: "First" }, lastActivityAt: 10 }),
       call({ id: "agent-second", toolName: "Agent", toolInput: { description: "Second" }, lastActivityAt: 10 }),
       call({ id: "child-second", toolName: "Grep", toolInput: { pattern: "Subagent" }, parentToolCallId: "agent-second", lastActivityAt: 20 }),
       call({ id: "nested-agent", toolName: "Agent", toolInput: { description: "Nested" }, parentToolCallId: "agent-first", lastActivityAt: 30 }),
-    ], 30_000);
+    ], [], 30_000);
 
     expect(roster.active.map((row) => row.id)).toEqual(["agent-first", "agent-second"]);
     expect(roster.active[0]?.activity).toBe("Delegated task: Nested");
     expect(roster.active[1]?.activity).toBe('Searched files: "Subagent"');
   });
 
-  it("counts completed top-level Agents without treating child Agents as roster rows", () => {
-    const roster = projectLiveSubagents([
-      call({ id: "finished", toolName: "Agent", isComplete: true }),
-      call({ id: "active", toolName: "Agent", toolInput: { description: "Keep running" } }),
-      call({ id: "nested-finished", toolName: "Agent", parentToolCallId: "active", isComplete: true }),
-    ]);
+  it("maps completed, failed, and cancelled terminal Agent rows with newest terminal time first", () => {
+    const roster = projectSubagents([], [[
+      record({ id: "completed", status: "completed", completed_at: "2026-07-22T10:01:00.000Z", sort_order: 4 }),
+      record({ id: "failed", status: "failed", started_at: "2026-07-22T10:00:05.000Z", completed_at: "2026-07-22T10:03:00.000Z", output_summary: "Command exited 1", sort_order: 3 }),
+      record({ id: "cancelled", status: "cancelled", started_at: "2026-07-22T10:00:10.000Z", completed_at: "2026-07-22T10:02:00.000Z", sort_order: 2 }),
+      record({ id: "nested", parent_tool_call_id: "completed", completed_at: "2026-07-22T10:04:00.000Z" }),
+    ]]);
 
-    expect(roster.finishedCount).toBe(1);
-    expect(roster.active.map((row) => row.id)).toEqual(["active"]);
+    expect(roster.finished.map((row) => [row.id, row.status])).toEqual([
+      ["failed", "failed"],
+      ["cancelled", "cancelled"],
+      ["completed", "completed"],
+    ]);
+    expect(roster.finished.find((row) => row.id === "failed")?.activity).toBe("Command exited 1");
+    expect(roster.finished.find((row) => row.id === "completed")?.elapsedSeconds).toBe(60);
+  });
+
+  it("uses deterministic source order for equal terminal times", () => {
+    const roster = projectSubagents([], [[
+      record({ id: "first", sort_order: 1 }),
+      record({ id: "second", sort_order: 2 }),
+    ]]);
+
+    expect(roster.finished.map((row) => row.id)).toEqual(["first", "second"]);
+  });
+
+  it("reconciles a settled live Agent with its hydrated record by id without a duplicate", () => {
+    const roster = projectSubagents([
+      call({
+        id: "agent-1",
+        toolName: "Agent",
+        toolInput: { agentName: "Live worker", description: "Live task" },
+        output: "Live result",
+        isComplete: true,
+        startedAt: 1_000,
+        lastActivityAt: 2_000,
+      }),
+    ], [[record({
+      id: "agent-1",
+      input_summary: "Persisted task",
+      output_summary: "Persisted result",
+      completed_at: "2026-07-22T10:01:00.000Z",
+    })]]);
+
+    expect(roster.active).toEqual([]);
+    expect(roster.finished).toHaveLength(1);
+    expect(roster.finished[0]).toMatchObject({
+      id: "agent-1",
+      identity: "Persisted task",
+      task: "Persisted task",
+      activity: "Persisted result",
+    });
+  });
+
+  it("recreates hydrated terminal rows from the loaded narrative without inventing provider identity", () => {
+    const roster = projectSubagents(undefined, [[
+      record({ id: "hydrated", input_summary: "Inspect the persisted call", status: "failed" }),
+    ]]);
+
+    expect(roster.finished).toEqual([expect.objectContaining({
+      id: "hydrated",
+      identity: "Inspect the persisted call",
+      task: "Inspect the persisted call",
+      status: "failed",
+    })]);
   });
 
   it("uses provider names before task descriptions and never uses provider models as identities", () => {
-    const roster = projectLiveSubagents([
-      call({
-        id: "named-agent",
-        toolName: "Agent",
-        toolInput: {
-          agentName: "Repository reviewer",
-          description: "Review identity precedence",
-          model: "gpt-5.6",
-        },
-      }),
-      call({
-        id: "cursor-agent",
-        toolName: "Agent",
-        toolInput: {
-          description: "Cursor delegated task",
-          prompt: "Inspect the Cursor task result",
-          model: "cursor-large",
-          agentId: "cursor-internal-id",
-          subagentType: "general",
-        },
-      }),
-      call({
-        id: "codex-agent",
-        toolName: "Agent",
-        toolInput: {
-          codexCollabKind: "spawnAgent",
-          prompt: "Review Codex collaboration events",
-          model: "gpt-5.6-codex",
-        },
-      }),
+    const roster = projectSubagents([
+      call({ id: "named-agent", toolName: "Agent", toolInput: { agentName: "Repository reviewer", description: "Review identity precedence", model: "gpt-5.6" } }),
+      call({ id: "cursor-agent", toolName: "Agent", toolInput: { description: "Cursor delegated task", prompt: "Inspect the Cursor task result", model: "cursor-large", agentId: "cursor-internal-id", subagentType: "general" } }),
+      call({ id: "codex-agent", toolName: "Agent", toolInput: { codexCollabKind: "spawnAgent", prompt: "Review Codex collaboration events", model: "gpt-5.6-codex" } }),
       call({ id: "unnamed-agent", toolName: "Agent", toolInput: { model: "not-a-name" } }),
-    ]);
+    ], []);
 
     expect(roster.active.map((row) => row.identity)).toEqual([
       "Repository reviewer",
@@ -114,24 +157,10 @@ describe("projectLiveSubagents", () => {
   });
 
   it("bounds provider-supplied identity, task, and activity text", () => {
-    const roster = projectLiveSubagents([
-      call({
-        id: "agent",
-        toolName: "Agent",
-        toolInput: {
-          agentName: "i".repeat(160),
-          description: "t".repeat(400),
-        },
-        lastActivityAt: 1,
-      }),
-      call({
-        id: "activity",
-        toolName: "Bash",
-        toolInput: { command: "a".repeat(400) },
-        parentToolCallId: "agent",
-        lastActivityAt: 2,
-      }),
-    ]);
+    const roster = projectSubagents([
+      call({ id: "agent", toolName: "Agent", toolInput: { agentName: "i".repeat(160), description: "t".repeat(400) }, lastActivityAt: 1 }),
+      call({ id: "activity", toolName: "Bash", toolInput: { command: "a".repeat(400) }, parentToolCallId: "agent", lastActivityAt: 2 }),
+    ], []);
 
     const row = roster.active[0];
     expect(row?.identity).toHaveLength(96);
@@ -145,14 +174,9 @@ describe("projectLiveSubagents", () => {
   it("bounds malformed descendant traversal", () => {
     const calls: ToolCall[] = [call({ id: "agent", toolName: "Agent", lastActivityAt: 1 })];
     for (let index = 0; index < 140; index += 1) {
-      calls.push(call({
-        id: `child-${index}`,
-        toolName: "Read",
-        parentToolCallId: index === 0 ? "agent" : `child-${index - 1}`,
-        lastActivityAt: index + 2,
-      }));
+      calls.push(call({ id: `child-${index}`, toolName: "Read", parentToolCallId: index === 0 ? "agent" : `child-${index - 1}`, lastActivityAt: index + 2 }));
     }
 
-    expect(projectLiveSubagents(calls).active[0]?.activityAt).toBe(129);
+    expect(projectSubagents(calls, []).active[0]?.activityAt).toBe(129);
   });
 });

--- a/apps/web/src/components/subagents/subagent-projection.ts
+++ b/apps/web/src/components/subagents/subagent-projection.ts
@@ -1,7 +1,7 @@
 import { extractSubagentDescription } from "@/components/chat/narrative/extract-subagent-description";
 import { extractToolInputDetail } from "@/components/chat/narrative/tool-detail";
 import { TOOL_LABELS, resolveToolName } from "@/components/chat/tool-renderers/constants";
-import type { ToolCall } from "@/transport/types";
+import type { ToolCall, ToolCallRecord } from "@/transport/types";
 
 /** Maximum live graph nodes inspected beneath a single top-level subagent. */
 const MAX_SUBAGENT_GRAPH_NODES = 128;
@@ -9,28 +9,42 @@ const MAX_IDENTITY_LENGTH = 96;
 const MAX_TASK_LENGTH = 280;
 const MAX_ACTIVITY_LENGTH = 160;
 
-/** A live top-level subagent row shown by the right-panel roster. */
-export interface LiveSubagentRow {
+/** Terminal state for a settled delegated Agent call. */
+export type FinishedSubagentStatus = "completed" | "failed" | "cancelled";
+
+/** A row shared by the Active and Finished subagent rosters. */
+interface SubagentRow {
   /** Stable Agent tool-call id. */
   readonly id: string;
-  /** Best provider-supplied display identity available for the delegated agent. */
+  /** Best surviving display identity for the delegated agent. */
   readonly identity: string;
   /** Stable delegated-task description. */
   readonly task: string;
-  /** Most recent provider-supplied tool activity in the Agent graph. */
+  /** Latest provider-supplied activity or terminal result summary. */
   readonly activity: string;
-  /** Epoch milliseconds for stable latest-activity ordering. */
+  /** Epoch milliseconds for stable row ordering. */
   readonly activityAt: number;
-  /** Elapsed seconds for the running delegation. */
+  /** Elapsed seconds for the delegation. */
   readonly elapsedSeconds: number;
 }
 
-/** Live-only roster state derived from one thread's normalized tool-call graph. */
-export interface LiveSubagentRoster {
+/** A running top-level subagent row shown by the right-panel roster. */
+export type LiveSubagentRow = SubagentRow;
+
+/** A settled top-level subagent row shown by the right-panel roster. */
+export interface FinishedSubagentRow extends SubagentRow {
+  /** Explicit terminal outcome retained through narrative hydration. */
+  readonly status: FinishedSubagentStatus;
+  /** Epoch milliseconds when the Agent reached its terminal outcome. */
+  readonly completedAt: number;
+}
+
+/** Reconciled roster state for the currently loaded thread narrative. */
+export interface SubagentRoster {
   /** Running top-level Agent rows, newest meaningful activity first. */
   readonly active: readonly LiveSubagentRow[];
-  /** Completed top-level Agent boundaries still present in the live turn. */
-  readonly finishedCount: number;
+  /** Settled top-level Agent rows, newest terminal event first. */
+  readonly finished: readonly FinishedSubagentRow[];
 }
 
 function nonEmptyString(value: unknown): string | undefined {
@@ -58,6 +72,15 @@ function subagentIdentity(agent: ToolCall): string {
     : boundedDisplayText(task, MAX_IDENTITY_LENGTH);
 }
 
+function hydratedTask(record: ToolCallRecord): string {
+  return boundedDisplayText(nonEmptyString(record.input_summary) ?? "Subagent task", MAX_TASK_LENGTH);
+}
+
+function hydratedIdentity(record: ToolCallRecord): string {
+  const task = hydratedTask(record);
+  return task === "Subagent task" ? "Subagent" : boundedDisplayText(task, MAX_IDENTITY_LENGTH);
+}
+
 function activityTimestamp(call: ToolCall): number {
   return call.lastActivityAt ?? call.startedAt ?? 0;
 }
@@ -72,22 +95,43 @@ function activityLabel(call: ToolCall): string {
   );
 }
 
-/**
- * Projects the current thread's normalized tool-call graph into live roster rows.
- *
- * Only top-level Agent calls form rows. Descendant traversal is bounded and
- * cycle-safe so malformed provider parent links cannot expand render work.
- */
-export function projectLiveSubagents(
-  calls: readonly ToolCall[] | undefined,
-  now: number = Date.now(),
-): LiveSubagentRoster {
-  if (!calls?.length) return { active: [], finishedCount: 0 };
+function liveStatus(call: ToolCall): "running" | FinishedSubagentStatus {
+  if (!call.isComplete) return "running";
+  if (call.isCancelled) return "cancelled";
+  return call.isError ? "failed" : "completed";
+}
 
+function parsedTimestamp(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function elapsedSeconds(startedAt: number, completedAt: number): number {
+  return Math.max(0, Math.floor((completedAt - startedAt) / 1_000));
+}
+
+function terminalLiveActivity(agent: ToolCall, fallback: string): string {
+  return nonEmptyString(agent.output)
+    ? boundedDisplayText(agent.output!, MAX_ACTIVITY_LENGTH)
+    : fallback;
+}
+
+/**
+ * Projects live calls and the current hydrated narrative into one bounded
+ * per-thread roster. Persisted records win a same-ID reconciliation because
+ * they carry the canonical settled status and terminal time.
+ */
+export function projectSubagents(
+  calls: readonly ToolCall[] | undefined,
+  narrativeBatches: readonly (readonly ToolCallRecord[] | undefined)[] | undefined,
+  now: number = Date.now(),
+): SubagentRoster {
+  const liveRows = new Map<string, { row: LiveSubagentRow | FinishedSubagentRow; index: number }>();
   const childrenByParent = new Map<string, Array<{ call: ToolCall; index: number }>>();
   const topLevelAgents: Array<{ call: ToolCall; index: number }> = [];
 
-  calls.forEach((call, index) => {
+  calls?.forEach((call, index) => {
     const parentId = call.parentToolCallId;
     if (typeof parentId === "string" && parentId.length > 0) {
       const children = childrenByParent.get(parentId) ?? [];
@@ -98,15 +142,7 @@ export function projectLiveSubagents(
     if (call.toolName === "Agent") topLevelAgents.push({ call, index });
   });
 
-  const active: Array<LiveSubagentRow & { index: number }> = [];
-  let finishedCount = 0;
-
   for (const { call: agent, index } of topLevelAgents) {
-    if (agent.isComplete) {
-      finishedCount += 1;
-      continue;
-    }
-
     let latestCall = agent;
     let latestIndex = index;
     const queue = [...(childrenByParent.get(agent.id) ?? [])];
@@ -131,20 +167,73 @@ export function projectLiveSubagents(
     }
 
     const startedAt = agent.startedAt ?? now;
-    active.push({
-      id: agent.id,
-      identity: subagentIdentity(agent),
-      task: boundedDisplayText(extractSubagentDescription(agent), MAX_TASK_LENGTH),
-      activity: activityLabel(latestCall),
-      activityAt: activityTimestamp(latestCall),
-      elapsedSeconds: Math.max(0, Math.floor(agent.elapsedSeconds ?? (now - startedAt) / 1000)),
+    const status = liveStatus(agent);
+    const latestActivity = activityLabel(latestCall);
+    if (status === "running") {
+      liveRows.set(agent.id, {
+        index,
+        row: {
+          id: agent.id,
+          identity: subagentIdentity(agent),
+          task: boundedDisplayText(extractSubagentDescription(agent), MAX_TASK_LENGTH),
+          activity: latestActivity,
+          activityAt: activityTimestamp(latestCall),
+          elapsedSeconds: Math.max(0, Math.floor(agent.elapsedSeconds ?? (now - startedAt) / 1_000)),
+        },
+      });
+      continue;
+    }
+
+    const completedAt = agent.lastActivityAt ?? (agent.durationMs === undefined ? startedAt : startedAt + agent.durationMs);
+    liveRows.set(agent.id, {
       index,
+      row: {
+        id: agent.id,
+        identity: subagentIdentity(agent),
+        task: boundedDisplayText(extractSubagentDescription(agent), MAX_TASK_LENGTH),
+        activity: terminalLiveActivity(agent, latestActivity),
+        activityAt: completedAt,
+        elapsedSeconds: Math.max(0, Math.floor(agent.elapsedSeconds ?? (agent.durationMs ?? completedAt - startedAt) / 1_000)),
+        status,
+        completedAt,
+      },
     });
   }
 
-  active.sort((left, right) => right.activityAt - left.activityAt || left.index - right.index);
+  let persistedIndex = calls?.length ?? 0;
+  for (const batch of narrativeBatches ?? []) {
+    for (const record of batch ?? []) {
+      if (record.tool_name !== "Agent" || record.parent_tool_call_id) continue;
+      const startedAt = parsedTimestamp(record.started_at) ?? 0;
+      const completedAt = parsedTimestamp(record.completed_at) ?? startedAt;
+      const task = hydratedTask(record);
+      const base = {
+        id: record.id,
+        identity: hydratedIdentity(record),
+        task,
+        activity: boundedDisplayText(nonEmptyString(record.output_summary) ?? task, MAX_ACTIVITY_LENGTH),
+        activityAt: record.status === "running" ? startedAt : completedAt,
+        elapsedSeconds: elapsedSeconds(startedAt, record.status === "running" ? now : completedAt),
+      };
+      const row: LiveSubagentRow | FinishedSubagentRow = record.status === "running"
+        ? base
+        : { ...base, status: record.status, completedAt };
+      liveRows.set(record.id, { row, index: persistedIndex + record.sort_order });
+    }
+    persistedIndex += batch?.length ?? 0;
+  }
+
+  const active: Array<LiveSubagentRow & { index: number }> = [];
+  const finished: Array<FinishedSubagentRow & { index: number }> = [];
+  for (const { row, index } of liveRows.values()) {
+    if ("status" in row) finished.push({ ...row, index });
+    else active.push({ ...row, index });
+  }
+
+  active.sort((left, right) => right.activityAt - left.activityAt || left.index - right.index || left.id.localeCompare(right.id));
+  finished.sort((left, right) => right.completedAt - left.completedAt || left.index - right.index || left.id.localeCompare(right.id));
   return {
     active: active.map(({ index: _index, ...row }) => row),
-    finishedCount,
+    finished: finished.map(({ index: _index, ...row }) => row),
   };
 }

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -7,6 +7,9 @@ export type { GitCommit, BranchComparison };
 /** Active tab in the right panel. */
 export type RightPanelTab = "tasks" | "changes" | "preview" | "terminal" | "subagents";
 
+/** Selected roster view within a thread's Subagents panel. */
+export type SubagentRosterTab = "active" | "finished";
+
 /**
  * View mode within the Review (Changes) tab. The tab is dual-scope: the first
  * four are threadless git working-tree views (read the workspace root); the last
@@ -279,6 +282,11 @@ interface DiffState {
    * {@link rightPanelByThread} entry. See ADR-0012.
    */
   readonly rightPanelFallbackByWorkspace: Record<string, RightPanelState>;
+  /**
+   * The remembered Subagents roster view for each thread. This inner-panel state
+   * survives right-panel unmounts but is intentionally dropped with its thread.
+   */
+  readonly subagentRosterTabByThread: Record<string, SubagentRosterTab>;
   /** Explicit Files visibility choices keyed by Review scope. Missing scopes start closed. */
   readonly reviewFilesVisibleByScope: Record<string, boolean>;
   /** View mode within the Changes tab (the single rendered view). */
@@ -418,6 +426,10 @@ interface DiffState {
    * is not open. See ADR-0004.
    */
   closeRightPanelTab: (workspaceId: string, threadId: string | null | undefined, tab: RightPanelTab) => void;
+  /** Read a thread's remembered Subagents roster view, if it has one. */
+  getSubagentRosterTab: (threadId: string) => SubagentRosterTab | undefined;
+  /** Remember the selected Subagents roster view for one thread. */
+  setSubagentRosterTab: (threadId: string, tab: SubagentRosterTab) => void;
   /** Read the persisted Files visibility choice for a Review scope. */
   getReviewFilesVisible: (scopeId: string) => boolean;
   /** Persist an explicit Files visibility choice for a Review scope. */
@@ -493,6 +505,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   previewUrlByThread: {},
   rightPanelByThread: {},
   rightPanelFallbackByWorkspace: {},
+  subagentRosterTabByThread: {},
   reviewFilesVisibleByScope: readReviewFilesVisibility(),
   viewMode: "last-turn",
   reviewViewByThread: {},
@@ -581,6 +594,14 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         activeTab,
       });
     }),
+
+  getSubagentRosterTab: (threadId) => get().subagentRosterTabByThread[threadId],
+  setSubagentRosterTab: (threadId, tab) =>
+    set((state) =>
+      state.subagentRosterTabByThread[threadId] === tab
+        ? {}
+        : { subagentRosterTabByThread: { ...state.subagentRosterTabByThread, [threadId]: tab } },
+    ),
 
   getReviewFilesVisible: (scopeId) => get().reviewFilesVisibleByScope[scopeId] ?? false,
   setReviewFilesVisible: (scopeId, visible) =>
@@ -759,6 +780,8 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       delete lineWrapByThread[threadId];
       const rightPanelByThread = { ...state.rightPanelByThread };
       delete rightPanelByThread[threadId];
+      const subagentRosterTabByThread = { ...state.subagentRosterTabByThread };
+      delete subagentRosterTabByThread[threadId];
       const reviewViewByThread = { ...state.reviewViewByThread };
       delete reviewViewByThread[threadId];
       const reviewViewManuallySelectedByThread = { ...state.reviewViewManuallySelectedByThread };
@@ -792,6 +815,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         previewUrlByThread: previewUrls,
         lineWrapByThread,
         rightPanelByThread,
+        subagentRosterTabByThread,
         reviewViewByThread,
         reviewViewManuallySelectedByThread,
         diffRevisionByScope,


### PR DESCRIPTION
## What

Keep settled delegated work inspectable in the Subagents panel after completion, thread switching, and hydration.

## Why

Finished subagents disappeared when volatile narrative state settled. This completes the second tracer-bullet slice of #916 and unblocks #919.

## Key Changes

- Reconcile live and hydrated subagent records by stable tool-call identity.
- Show completed, failed, and cancelled work in a dedicated Finished roster with status, result, elapsed duration, and terminal-time ordering.
- Persist lifecycle timestamps through narrative settlement and repository hydration.
- Keep Active or Finished selection per thread and clear it when a thread is deleted.
- Add focused server, projection, store, and component coverage.

## Verification

- Live Browser: observed one delegated row move from Active to Finished with a 20-second duration and its result.
- Live Browser: switched to another thread and observed an empty Finished roster, then returned to the original row.
- Live Browser: reloaded the app and observed the Finished tab, completed status, duration, task, and result restored from persistence.
- Focused tests: 122 passed across the affected server and web suites.
- `bun run verify`: passed all typecheck, lint, unit-test, and agent-script gates.

## Visual Evidence

Active roster before settlement:

![Active subagent roster](https://raw.githubusercontent.com/Mzeey-Empire/mcode/codex/issue-918-evidence/.github/pr-evidence/918/active.png)

Finished roster after settlement:

![Finished subagent roster](https://raw.githubusercontent.com/Mzeey-Empire/mcode/codex/issue-918-evidence/.github/pr-evidence/918/finished.png)

Thread isolation with an empty Finished roster:

![Thread-isolated subagent roster](https://raw.githubusercontent.com/Mzeey-Empire/mcode/codex/issue-918-evidence/.github/pr-evidence/918/thread-isolation.png)

Hydrated restoration after a full reload:

![Hydrated finished subagent roster](https://raw.githubusercontent.com/Mzeey-Empire/mcode/codex/issue-918-evidence/.github/pr-evidence/918/hydrated.png)

Closes #918
