### PR TITLE
fix(web): retain inactive thread responses

### DIFF
--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -571,16 +571,8 @@ test("thread revisit keeps messages added after an empty snapshot was cached", a
     { ...thread("thread-a", "Thread A"), status: "active" as const },
     thread("thread-b", "Thread B"),
   ];
-  const completedMessage = message(
-    "thread-a",
-    "thread-a-completed",
-    "assistant",
-    "Alpha completed while inactive",
-    1,
-  );
-
   await interceptZustandStores(page);
-  await mockWebSocketServer(page, {
+  const controller = await mockWebSocketServer(page, {
     "workspace.list": [workspace],
     "thread.list": threads,
     "agent.listRunning": ["thread-a"],
@@ -616,32 +608,37 @@ test("thread revisit keeps messages added after an empty snapshot was cached", a
   await expect(page.getByText("Beta response", { exact: true })).toBeVisible();
   await page.waitForTimeout(20);
 
-  await page.evaluate(({ targetThreadId, residentMessage }) => {
-    type StoreState = {
-      records: Map<string, { messages: unknown[] }>;
-      runningThreadIds: Set<string>;
-    };
-    type StoreHandle = {
-      getState: () => Record<string, unknown>;
-      setState: (partial: Partial<StoreState>) => void;
-    };
-    const stores = (window as unknown as { __mcodeStores?: StoreHandle[] }).__mcodeStores ?? [];
-    const store = stores.find((candidate) => {
-      const state = candidate.getState();
-      return "handleAgentEvent" in state && "records" in state;
-    });
-    if (!store) throw new Error("Thread store not found");
-    const state = store.getState() as unknown as StoreState;
-    const resident = state.records.get(targetThreadId);
-    if (!resident) throw new Error("Resident thread record not found");
-    const records = new Map(state.records);
-    records.set(targetThreadId, { ...resident, messages: [residentMessage] });
-    const runningThreadIds = new Set(state.runningThreadIds);
-    runningThreadIds.delete(targetThreadId);
-    store.setState({ records, runningThreadIds });
-  }, { targetThreadId: "thread-a", residentMessage: completedMessage });
+  await controller.sendPush("agent.event", {
+    type: "message",
+    threadId: "thread-a",
+    messageId: "thread-a-completed",
+    content: "Alpha completed while inactive",
+  });
+  await controller.sendPush("agent.event", {
+    type: "turnComplete",
+    threadId: "thread-a",
+    costUsd: 0.005,
+    tokensIn: 25,
+    tokensOut: 25,
+  });
+  await expect.poll(() => readThreadRecord(page, "thread-a")).toMatchObject({
+    currentThreadId: "thread-b",
+    messageIds: ["thread-a-completed"],
+  });
+  await expect(page.getByText("Beta response", { exact: true })).toBeVisible();
+  await expect(page.getByText("Alpha completed while inactive", { exact: true })).not.toBeVisible();
 
   await threadAItem.click();
+  await expect.poll(() => readThreadRecord(page, "thread-a")).toMatchObject({
+    currentThreadId: "thread-a",
+    messageIds: ["thread-a-completed"],
+  });
+  await controller.sendPush("turn.persisted", {
+    threadId: "thread-a",
+    messageId: "thread-a-completed",
+    toolCallCount: 0,
+    filesChanged: [],
+  });
 
   await expect(page.getByText("Alpha completed while inactive", { exact: true })).toBeVisible();
   await expect(page.getByText("no messages yet", { exact: true })).not.toBeVisible();

--- a/apps/web/src/__tests__/streaming.test.ts
+++ b/apps/web/src/__tests__/streaming.test.ts
@@ -80,7 +80,7 @@ describe("Agent Message Flow", () => {
     expect(liveKey).not.toBe(keys["msg-2"]);
   });
 
-  it("session.message only appends when threadId matches currentThreadId", () => {
+  it("session.message retains the target thread message without changing the active transcript", () => {
     useThreadStore.setState({ currentThreadId: "thread-a" });
     const { handleAgentEvent } = useThreadStore.getState();
 
@@ -92,7 +92,7 @@ describe("Agent Message Flow", () => {
     vi.runAllTimers();
     expect(getTestActiveMessages()).toHaveLength(1);
 
-    // Message for a different thread is NOT added to the visible list
+    // The background message belongs to its target record, not the visible transcript.
     handleAgentEvent("thread-b", {
       method: "session.message",
       params: { content: "Beta" },
@@ -100,6 +100,8 @@ describe("Agent Message Flow", () => {
     vi.runAllTimers();
     expect(getTestActiveMessages()).toHaveLength(1);
     expect(getTestActiveMessages()[0].content).toBe("Alpha");
+    expect(readThreadField("thread-b", (record) => record.messages.map((message) => message.content)))
+      .toEqual(["Beta"]);
   });
 
   it("when session.ended fires, running state and streaming are cleared", () => {
@@ -138,7 +140,7 @@ describe("Agent Message Flow", () => {
     expect(state.runningThreadIds.has(threadId)).toBe(false);
   });
 
-  it("when turnComplete fires for a non-current thread, message is not added to the list", () => {
+  it("turnComplete retains streaming fallback in the target record without changing the active transcript", () => {
     resetThreadStoreForTests({
       currentThreadId: "thread-other",
       records: new Map<string, ThreadRecord>([
@@ -154,10 +156,48 @@ describe("Agent Message Flow", () => {
     });
     vi.runAllTimers();
 
-    // Streaming content is cleared even for non-current thread
     expect(getTestThreadStreaming("thread-1")).toBeUndefined();
-    // But message is NOT added since it's not the current thread
     expect(getTestActiveMessages()).toHaveLength(0);
+    expect(readThreadField("thread-1", (record) => record.messages.map((message) => message.content)))
+      .toEqual(["background response"]);
+  });
+
+  it("keeps a background response through completion and persistence after reopening the thread", () => {
+    resetThreadStoreForTests({
+      currentThreadId: "thread-b",
+      records: new Map<string, ThreadRecord>([
+        ["thread-a", createEmptyThreadRecord()],
+        ["thread-b", createEmptyThreadRecord()],
+      ]),
+      runningThreadIds: new Set(["thread-a"]),
+    });
+
+    const { handleAgentEvent, handleTurnPersisted } = useThreadStore.getState();
+    handleAgentEvent("thread-a", {
+      method: "session.message",
+      params: {
+        content: "Alpha completed while inactive",
+        messageId: "thread-a-completed",
+      },
+    });
+    handleAgentEvent("thread-a", {
+      method: "session.turnComplete",
+      params: { costUsd: 0.005, tokensIn: 25, tokensOut: 25 },
+    });
+
+    useThreadStore.setState({ currentThreadId: "thread-a" });
+    handleTurnPersisted({
+      threadId: "thread-a",
+      messageId: "thread-a-completed",
+      toolCallCount: 0,
+      filesChanged: [],
+    });
+    vi.runAllTimers();
+
+    expect(getTestActiveMessages().map((message) => message.content)).toEqual([
+      "Alpha completed while inactive",
+    ]);
+    expect(readThreadField("thread-b", (record) => record.messages)).toEqual([]);
   });
 });
 

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -774,6 +774,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     set((s) => ({ records: patchThreadRecord(s.records, threadId, patch) }));
   };
 
+  const cacheInactiveRecord = (threadId: string): void => {
+    const state = get();
+    if (state.currentThreadId !== threadId) {
+      // The response can arrive before its database commit, so the resident
+      // transcript must replace any older snapshot used by thread switching.
+      cacheRecord(threadId, getThreadRecord(state.records, threadId));
+    }
+  };
+
   const applyGoalLookup = (threadId: string, lookup: GoalLookupResult): void => {
     const current = getRec(threadId);
     const goal = resolveGoalLookupGoal(lookup, current.goal);
@@ -1977,10 +1986,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             thoughtSegments: closedSegments,
           };
 
-          if (state.currentThreadId !== threadId) {
-            return { records: patchThreadRecord(state.records, threadId, turnPatch) };
-          }
-
           if (rec.messages.some((m) => m.id === message.id)) {
             return { records: patchThreadRecord(state.records, threadId, turnPatch) };
           }
@@ -2055,6 +2060,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             }),
           };
         });
+        cacheInactiveRecord(threadId);
       }
       return;
     }
@@ -2650,13 +2656,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             rateLimit: undefined,
           };
 
-          if (state.currentThreadId !== threadId) {
-            return {
-              runningThreadIds: nextRunning,
-              records: patchThreadRecord(state.records, threadId, basePatch),
-            };
-          }
-
           const { messages: capped, evicted } = capMessages([...rec.messages, ...pending]);
           const prunedAssistantResponseKeys = pruneAssistantResponseKeys(
             basePatch.assistantResponseKeys,
@@ -2722,6 +2721,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           };
         });
       }
+      cacheInactiveRecord(threadId);
 
       // Update context tracker. Prefer the SDK-reported contextWindow (authoritative)
       // over the local registry. The DB is updated server-side; contextByThread is


### PR DESCRIPTION
## What

Retain assistant responses that finish while their thread is inactive so revisiting the thread restores the completed conversation instead of the default empty view.

## Why

Thread event handling updated inactive resident records but skipped the response projection used by active threads. A cached empty snapshot could then replace the newer inactive response during an A → B → A switch.

## Key Changes

- Project message and completion events into their target Thread record even when another thread is selected.
- Refresh the bounded record cache for inactive responses until persistence completes.
- Cover the regression with focused store tests and a production-shaped WebSocket thread-switch scenario.

## Verification

- `bun run test -- src/__tests__/streaming.test.ts`: 15 passed.
- `bun run typecheck`: passed.
- `bun run lint -- src/stores/threadStore.ts src/__tests__/streaming.test.ts e2e/thread-switch-conversation-page.spec.ts`: passed.
- Exact Playwright A → B → A scenario: 1 passed using `PLAYWRIGHT_BASE_URL=http://127.0.0.1:5187`.
- `bun run verify:changed`: typecheck and lint passed; 1,285 of 1,286 tests passed. The unchanged pull-request performance test measured 2.092 ms against its 2 ms p95 budget.
- Isolated rerun of `pull-request-performance.test.ts`: 3 passed.

Fixes #924
Related to #923

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787312831&installation_model_id=20477&pr_number=931&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F931&signature=faca4b03f74eae14db991a1e848b77a6071cc8db45bf0214132584a1dc6f983b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where messages completed while viewing another conversation could be missing when returning to the original thread.
  * Background conversation updates are now retained more reliably during streaming and become visible after switching back.
  * Improved handling of completed responses so inactive threads preserve their latest messages without altering the active conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->