### PR TITLE
fix(web): correct right-panel rail layering

### DIFF
--- a/apps/web/e2e/right-panel-activity-rail.spec.ts
+++ b/apps/web/e2e/right-panel-activity-rail.spec.ts
@@ -49,6 +49,82 @@ function makeThread(id: string, title: string): Thread {
 
 const THREAD = makeThread("thread-activity-rail", "Rail Thread");
 
+/** Supplies the preview bridge methods used while Browser chrome is mounted. */
+async function injectPreviewBridge(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const noop = (): Promise<void> => Promise.resolve();
+    const captureFail = (): Promise<{ ok: false; error: string }> =>
+      Promise.resolve({ ok: false, error: "no-preview" });
+    const unsub = (): (() => void) => () => undefined;
+    const emptyTabSet = (threadId: string): unknown => ({
+      threadId,
+      activeTabId: null,
+      tabs: [],
+    });
+    const tabOk = (threadId: string): Promise<unknown> =>
+      Promise.resolve({ ok: true, data: emptyTabSet(threadId) });
+    const preview = {
+      sync: noop,
+      navigate: () => Promise.resolve({ ok: true } as const),
+      goBack: () => Promise.resolve(false),
+      goForward: () => Promise.resolve(false),
+      reload: noop,
+      forceReload: noop,
+      openExternal: noop,
+      openGuestDevTools: noop,
+      onShortcutFired: unsub,
+      getNavigationState: () =>
+        Promise.resolve({ canGoBack: false, canGoForward: false }),
+      capturePictureReference: captureFail,
+      capturePictureReferenceRegion: captureFail,
+      capturePictureReferenceElementPick: captureFail,
+      capturePageContext: captureFail,
+      releaseBrowserCaptureSpills: noop,
+      onPageStatus: (
+        callback: (status: {
+          url: string | null;
+          title: string | null;
+          favicon: string | null;
+          phase: "loaded";
+        }) => void,
+      ) => {
+        callback({ url: null, title: null, favicon: null, phase: "loaded" });
+        return () => undefined;
+      },
+      cancelCapture: noop,
+      tabs: {
+        list: (threadId: string) => tabOk(threadId),
+        create: (threadId: string) =>
+          Promise.resolve({
+            ok: true,
+            data: { tabSet: emptyTabSet(threadId), createdTabId: "mock-tab" },
+          }),
+        activate: (threadId: string) => tabOk(threadId),
+        close: (threadId: string) => tabOk(threadId),
+        onUpdated: unsub,
+      },
+      getPerfCounters: () =>
+        Promise.resolve({
+          ramKb: 0,
+          frameRateHz: 60,
+          gpuProcessActive: false,
+          allocationsPerSec: 0,
+        }),
+      adoptWebview: () => Promise.resolve({ ok: true } as const),
+      releaseWebview: () => Promise.resolve({ ok: true } as const),
+      design: {
+        setViewport: () =>
+          Promise.resolve({ ok: true, data: { width: 0, height: 0 } } as const),
+        resetViewport: noop,
+        setInspect: () => Promise.resolve({ ok: true } as const),
+        setAnnotationGuard: () => Promise.resolve({ ok: true } as const),
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).desktopBridge = { preview };
+  });
+}
+
 /**
  * Seeds the stores and opens the right panel, optionally with an active thread
  * and a list of tabs pre-opened (in order; the last becomes active). With no
@@ -199,6 +275,59 @@ test.describe("Right panel activity rail", () => {
     await expect
       .poll(() => panel.evaluate((element) => Math.round(element.getBoundingClientRect().width)))
       .toBe(Math.round(inlineWidth));
+  });
+
+  test("overlays Browser chrome without shifting content and aligns trailing controls", async ({
+    page,
+  }) => {
+    await injectPreviewBridge(page);
+    await seed(page, { tabs: ["preview", "terminal"] });
+
+    const rail = page.getByTestId("activity-rail");
+    const contentPane = rail.locator("xpath=following-sibling::*[1]");
+    const terminalClose = page.getByRole("button", { name: "Close Terminal" });
+    const maximizeToggle = page.getByTestId("rail-maximize-toggle");
+    const contentBefore = await contentPane.boundingBox();
+
+    await rail.hover({ position: { x: 24, y: 16 } });
+    await expect(rail).toHaveAttribute("data-expanded", "true");
+
+    const contentAfter = await contentPane.boundingBox();
+    expect(contentBefore).not.toBeNull();
+    expect(contentAfter).not.toBeNull();
+    expect(contentAfter!.x).toBeCloseTo(contentBefore!.x, 5);
+    expect(contentAfter!.width).toBeCloseTo(contentBefore!.width, 5);
+
+    const [closeBox, maximizeBox] = await Promise.all([
+      terminalClose.boundingBox(),
+      maximizeToggle.boundingBox(),
+    ]);
+    expect(closeBox).not.toBeNull();
+    expect(maximizeBox).not.toBeNull();
+    expect(Math.abs(closeBox!.x + closeBox!.width - (maximizeBox!.x + maximizeBox!.width))).toBeLessThanOrEqual(1);
+
+    await page.locator('[data-rail-tab="preview"]').click();
+    const browserHeader = page.getByTestId("browser-header");
+    await expect(browserHeader).toBeVisible();
+
+    const overlayCoverage = await page.evaluate(() => {
+      const railElement = document.querySelector<HTMLElement>('[data-testid="activity-rail"]');
+      const overlay = railElement?.firstElementChild as HTMLElement | null;
+      const header = document.querySelector<HTMLElement>('[data-testid="browser-header"]');
+      if (!railElement || !overlay || !header) return null;
+      const overlayRect = overlay.getBoundingClientRect();
+      const headerRect = header.getBoundingClientRect();
+      const overlapLeft = Math.max(overlayRect.left, headerRect.left);
+      const overlapRight = Math.min(overlayRect.right, headerRect.right);
+      const y = headerRect.top + headerRect.height / 2;
+      const sampleXs = [overlapLeft + 4, (overlapLeft + overlapRight) / 2, overlapRight - 4];
+      return {
+        overlayWidth: overlayRect.width,
+        covered: sampleXs.every((x) => railElement.contains(document.elementFromPoint(x, y))),
+      };
+    });
+
+    expect(overlayCoverage).toEqual({ overlayWidth: 160, covered: true });
   });
 
   test("add control: hidden when nothing is creatable", async ({ page }) => {

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -1,11 +1,28 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserTabSet } from "@mcode/contracts";
 import type { RightPanelTab } from "@/stores/diffStore";
 import { usePreviewSuppressionStore } from "@/stores/previewSuppressionStore";
 import { ActivityRail } from "./ActivityRail";
 
 const EXPECTED_EXPAND_DELAY_MS = 140;
 const EXPECTED_COLLAPSE_DELAY_MS = 250;
+
+const browserTabSet: BrowserTabSet = {
+  threadId: "thread-activity-rail",
+  activeTabId: "browser-page",
+  tabs: [
+    {
+      id: "browser-page",
+      url: "https://example.com",
+      title: "Example",
+      faviconUrl: null,
+      active: true,
+      threadId: "thread-activity-rail",
+      warm: true,
+    },
+  ],
+};
 
 const handlers = {
   onTogglePanel: vi.fn(),
@@ -70,6 +87,55 @@ describe("ActivityRail expansion", () => {
     act(() => vi.advanceTimersByTime(1));
     expect(rail).toHaveAttribute("data-expanded", "false");
     expect(usePreviewSuppressionStore.getState().count).toBe(0);
+  });
+
+  it("keeps a fixed collapsed footprint above right-panel content", () => {
+    renderRail();
+    const rail = screen.getByTestId("activity-rail");
+
+    expect(rail).toHaveClass("z-30", "w-12", "flex-none");
+    expect(rail.firstElementChild).toHaveClass("absolute", "w-12");
+
+    fireEvent.focus(screen.getByRole("button", { name: "Terminal" }));
+
+    expect(rail.firstElementChild).toHaveClass("w-40");
+    expect(rail).toHaveClass("w-12");
+  });
+
+  it("anchors tab, Browser-page, and maximize controls to the same trailing edge", () => {
+    const { rerender } = renderRail();
+    fireEvent.focus(screen.getByRole("button", { name: "Terminal" }));
+
+    expect(screen.getByRole("button", { name: "Close Terminal" })).toHaveClass(
+      "absolute",
+      "right-0",
+      "top-0",
+    );
+    expect(screen.getByTestId("rail-maximize-toggle")).toHaveClass(
+      "absolute",
+      "right-0",
+      "top-0",
+    );
+
+    rerender(
+      <ActivityRail
+        openTabs={["preview"]}
+        activeTab="preview"
+        scope="thread"
+        scopeProgress={{ done: 0, total: 0 }}
+        changesCount={0}
+        changesFresh={false}
+        browserTabSet={browserTabSet}
+        maximized={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Close page Example" })).toHaveClass(
+      "absolute",
+      "right-0",
+      "top-0",
+    );
   });
 
   it("cancels expansion when the pointer only crosses the rail", () => {

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -108,12 +108,12 @@ describe("ActivityRail expansion", () => {
 
     expect(screen.getByRole("button", { name: "Close Terminal" })).toHaveClass(
       "absolute",
-      "right-0",
+      "left-[7.75rem]",
       "top-0",
     );
     expect(screen.getByTestId("rail-maximize-toggle")).toHaveClass(
       "absolute",
-      "right-0",
+      "left-[7.75rem]",
       "top-0",
     );
 
@@ -133,7 +133,7 @@ describe("ActivityRail expansion", () => {
 
     expect(screen.getByRole("button", { name: "Close page Example" })).toHaveClass(
       "absolute",
-      "right-0",
+      "left-[7.75rem]",
       "top-0",
     );
   });

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -40,7 +40,7 @@ const RAIL_EXPAND_DELAY_MS = 140;
 const RAIL_COLLAPSE_DELAY_MS = 250;
 
 /** Shared trailing anchor for expanded-rail actions. */
-const RAIL_TRAILING_CONTROL_CLASS = "absolute right-0 top-0";
+const RAIL_TRAILING_CONTROL_CLASS = "absolute left-[7.75rem] top-0";
 
 /** Catalog metadata (product label + icon) for an openable tab, by store id. */
 function metaForTab(id: RightPanelTab): PanelTabType | undefined {

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -39,6 +39,9 @@ const RAIL_EXPAND_DELAY_MS = 140;
 /** Grace period that keeps the rail open while the pointer moves between rows. */
 const RAIL_COLLAPSE_DELAY_MS = 250;
 
+/** Shared trailing anchor for expanded-rail actions. */
+const RAIL_TRAILING_CONTROL_CLASS = "absolute right-0 top-0";
+
 /** Catalog metadata (product label + icon) for an openable tab, by store id. */
 function metaForTab(id: RightPanelTab): PanelTabType | undefined {
   return PANEL_TAB_TYPES.find((t) => t.id === id);
@@ -204,7 +207,8 @@ function RailTab({
         title={expanded ? undefined : `Close ${label}`}
         onClick={() => onClose(id)}
         className={cn(
-          "absolute left-[7.75rem] top-0 text-muted-foreground opacity-0 transition-opacity motion-reduce:duration-0 motion-reduce:transition-none hover:bg-card hover:text-foreground",
+          RAIL_TRAILING_CONTROL_CLASS,
+          "text-muted-foreground opacity-0 transition-opacity motion-reduce:duration-0 motion-reduce:transition-none hover:bg-card hover:text-foreground",
           expanded
             ? "focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
             : "pointer-events-none",
@@ -311,7 +315,8 @@ function BrowserPageRailTab({
           onClose(page.id);
         }}
         className={cn(
-          "absolute left-[7.75rem] top-0 text-muted-foreground opacity-0 transition-opacity motion-reduce:duration-0 motion-reduce:transition-none hover:bg-card hover:text-foreground",
+          RAIL_TRAILING_CONTROL_CLASS,
+          "text-muted-foreground opacity-0 transition-opacity motion-reduce:duration-0 motion-reduce:transition-none hover:bg-card hover:text-foreground",
           expanded
             ? "focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
             : "pointer-events-none",
@@ -593,7 +598,7 @@ export function ActivityRail({
       ref={railRef}
       data-testid="activity-rail"
       data-expanded={expanded ? "true" : "false"}
-      className="relative z-10 w-12 flex-none bg-background"
+      className="relative z-30 w-12 flex-none bg-background"
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}
       onFocusCapture={onFocusCapture}
@@ -634,7 +639,8 @@ export function ActivityRail({
           size="icon-xs"
           onClick={onToggleMaximized}
           className={cn(
-            "absolute left-[7.75rem] top-0 text-muted-foreground/70 transition-[color,opacity] motion-reduce:duration-0 motion-reduce:transition-none hover:bg-card hover:text-foreground",
+            RAIL_TRAILING_CONTROL_CLASS,
+            "text-muted-foreground/70 transition-[color,opacity] motion-reduce:duration-0 motion-reduce:transition-none hover:bg-card hover:text-foreground",
             expanded ? "opacity-100" : "pointer-events-none opacity-0",
           )}
           aria-label={maximized ? "Restore panel" : "Maximize panel"}

--- a/apps/web/src/components/panels/ResizableRightPanel.tsx
+++ b/apps/web/src/components/panels/ResizableRightPanel.tsx
@@ -152,7 +152,7 @@ export function ResizableRightPanel({
           aria-valuemax={getMaxWidth(panelRef.current)}
           aria-valuenow={width}
           tabIndex={0}
-          className="group absolute inset-y-0 left-0 z-20 flex w-2 cursor-col-resize items-stretch justify-start focus:outline-none"
+          className="group absolute inset-y-0 left-0 z-40 flex w-2 cursor-col-resize items-stretch justify-start focus:outline-none"
           onMouseDown={handleDragStart}
           onDoubleClick={toggleSnapWidth}
           onKeyDown={(event) => {


### PR DESCRIPTION
## What
Fix the expanded right-panel activity rail so it overlays panel content, aligns trailing controls, and preserves panel resizing.

## Why
The Browser header could paint above the expanded rail, and rem-based offsets misaligned tab close and maximize controls. Raising the rail exposed a second stacking conflict where the rail covered the resize separator's pointer target. A moving right-edge anchor also crossed collapsed rail click targets during the expansion animation.

## Key Changes
- Place the activity rail above Browser content without changing the content pane's geometry.
- Anchor tab close, Browser-page close, and maximize controls to one stable trailing coordinate.
- Place the resize separator above the rail while preserving its width and drag logic.
- Add component and Playwright geometry coverage for overlay, alignment, and resize behavior.

## Verification
- GitHub CI: all required build, test, lint, typecheck, and four E2E shard checks passed.
- Focused component tests: 8 passed.
- Live rail interactions: all five previously failing cases passed.
- Live expanded-rail overlay and control alignment: passed.
- Live terminal-panel drag resize: passed.