### PR TITLE
feat(web): consume typed AgentEvents in thread updates

### DIFF
--- a/apps/web/e2e/architecture.spec.ts
+++ b/apps/web/e2e/architecture.spec.ts
@@ -554,7 +554,7 @@ test.describe("Architecture: Push events via PushEmitter", () => {
 
     await waitForActiveThreadLoaded(page);
 
-    // Simulate an agent message event via the handleAgentEvent function
+    // Simulate a flat agent message event via the handleAgentEvent function.
     await page.evaluate(
       ({ threadId }) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -566,9 +566,8 @@ test.describe("Architecture: Push events via PushEmitter", () => {
         );
         if (!threadStore) throw new Error("Thread store not found");
 
-        // Simulate message event (as handleAgentEvent expects)
-        threadStore.getState().handleAgentEvent(threadId, {
-          method: "session.message",
+        threadStore.getState().handleAgentEvent({
+          type: "message",
           threadId,
           content: "Streaming from agent...",
           tokens: 50,
@@ -663,7 +662,7 @@ test.describe("Architecture: Push events via PushEmitter", () => {
 
 });
 
-test.describe("Architecture: session.turnStarted → sidebar running dot", () => {
+test.describe("Architecture: turnStarted → sidebar running dot", () => {
   test.beforeEach(async ({ page }) => {
     // Pre-seed localStorage so the workspace row is expanded on first render,
     // avoiding a manual click that would race with loadThreads().
@@ -686,7 +685,7 @@ test.describe("Architecture: session.turnStarted → sidebar running dot", () =>
     await page.waitForLoadState("networkidle");
 
     // Wait until the WS transport's initial hydration (agent.listRunning RPC)
-    // has resolved. Without this, a session.turnStarted injection below races
+    // has resolved. Without this, a turnStarted injection below races
     // hydrateRunningThreadsFromServer: the injected id gets captured in
     // `beforeRpc`, is not classified as a concurrent add, and the server's
     // empty [] response overwrites it.
@@ -696,7 +695,7 @@ test.describe("Architecture: session.turnStarted → sidebar running dot", () =>
     );
   });
 
-  test("session.turnStarted populates runningThreadIds for the sidebar spinner", async ({
+  test("turnStarted populates runningThreadIds for the sidebar spinner", async ({
     page,
   }) => {
     await setupWorkspaceState(page, {
@@ -718,7 +717,7 @@ test.describe("Architecture: session.turnStarted → sidebar running dot", () =>
       fullPage: true,
     });
 
-    // Inject session.turnStarted through the same channel the existing
+    // Inject turnStarted through the same channel the existing
     // `agent.event push updates streaming state` test uses: handleAgentEvent
     // on the thread store (which is what pushEmitter's `agent.event` listener
     // invokes in production).
@@ -734,8 +733,8 @@ test.describe("Architecture: session.turnStarted → sidebar running dot", () =>
         );
         if (!threadStore) throw new Error("[E2E] thread store not found");
 
-        threadStore.getState().handleAgentEvent(threadId, {
-          method: "session.turnStarted",
+        threadStore.getState().handleAgentEvent({
+          type: "turnStarted",
           threadId,
         });
       },

--- a/apps/web/e2e/final-response-continuity.spec.ts
+++ b/apps/web/e2e/final-response-continuity.spec.ts
@@ -154,7 +154,7 @@ async function setupThread(page: Page, messages: Array<Record<string, unknown>> 
 }
 
 async function dispatchThreadEvent(page: Page, threadId: string, event: unknown) {
-  await page.evaluate(({ targetThreadId, agentEvent }) => {
+  await page.evaluate(({ agentEvent }) => {
     const stores: Array<{ getState: () => Record<string, unknown> }> =
       (window as unknown as { __mcodeStores?: Array<{ getState: () => Record<string, unknown> }> })
         .__mcodeStores ?? [];
@@ -163,11 +163,11 @@ async function dispatchThreadEvent(page: Page, threadId: string, event: unknown)
       return "handleAgentEvent" in state && "records" in state;
     });
     const state = threadStore?.getState() as
-      | { handleAgentEvent: (threadId: string, event: unknown) => void }
+      | { handleAgentEvent: (event: unknown) => void }
       | undefined;
     if (!state) throw new Error("thread store not found");
-    state.handleAgentEvent(targetThreadId, agentEvent);
-  }, { targetThreadId: threadId, agentEvent: event });
+    state.handleAgentEvent(agentEvent);
+  }, { agentEvent: event });
 }
 
 async function commitAssistantMessage(page: Page, threadId: string, messageId: string, content: string) {
@@ -180,14 +180,15 @@ async function commitAssistantMessage(page: Page, threadId: string, messageId: s
       return "handleAgentEvent" in state && "records" in state;
     });
     const state = threadStore?.getState() as
-      | {
-          handleAgentEvent: (threadId: string, event: unknown) => void;
-        }
+      | { handleAgentEvent: (event: unknown) => void }
       | undefined;
     if (!state) throw new Error("thread store not found");
-    state.handleAgentEvent(targetThreadId, {
-      method: "session.message",
-      params: { content: text, messageId: targetMessageId, tokens: 12 },
+    state.handleAgentEvent({
+      type: "message",
+      threadId: targetThreadId,
+      content: text,
+      messageId: targetMessageId,
+      tokens: 12,
     });
   }, { targetThreadId: threadId, targetMessageId: messageId, text: content });
 }
@@ -259,18 +260,22 @@ test.describe("final response continuity", () => {
       "- Third visible item",
     ].join("\n");
 
-    await dispatchThreadEvent(page, THREAD.id, { method: "session.turnStarted", params: {} });
+    await dispatchThreadEvent(page, THREAD.id, { type: "turnStarted", threadId: THREAD.id });
     await dispatchThreadEvent(page, THREAD.id, {
-      method: "session.textDelta",
-      params: { delta: "Final answer", isFinalResponse: true },
+      type: "textDelta",
+      threadId: THREAD.id,
+      delta: "Final answer",
+      isFinalResponse: true,
     });
 
     const response = page.getByTestId("assistant-response-text").last();
     await expect(response).toContainText("Final answer");
 
     await dispatchThreadEvent(page, THREAD.id, {
-      method: "session.textDelta",
-      params: { delta: finalText.slice("Final answer".length), isFinalResponse: true },
+      type: "textDelta",
+      threadId: THREAD.id,
+      delta: finalText.slice("Final answer".length),
+      isFinalResponse: true,
     });
 
     await expect(page.getByTestId("assistant-message-actions").last()).toHaveAttribute("aria-hidden", "true");
@@ -327,10 +332,12 @@ test.describe("final response continuity", () => {
   test("keeps the response node when turnComplete promotes streaming text", async ({ page }) => {
     const finalText = "Codex-style final answer promoted at turn complete.";
 
-    await dispatchThreadEvent(page, THREAD.id, { method: "session.turnStarted", params: {} });
+    await dispatchThreadEvent(page, THREAD.id, { type: "turnStarted", threadId: THREAD.id });
     await dispatchThreadEvent(page, THREAD.id, {
-      method: "session.textDelta",
-      params: { delta: finalText, isFinalResponse: true },
+      type: "textDelta",
+      threadId: THREAD.id,
+      delta: finalText,
+      isFinalResponse: true,
     });
 
     const response = page.getByTestId("assistant-response-text").last();
@@ -342,8 +349,12 @@ test.describe("final response continuity", () => {
     });
 
     await dispatchThreadEvent(page, THREAD.id, {
-      method: "session.turnComplete",
-      params: { tokensIn: 0, tokensOut: 4, costUsd: 0 },
+      type: "turnComplete",
+      threadId: THREAD.id,
+      reason: "end_turn",
+      tokensIn: 0,
+      tokensOut: 4,
+      costUsd: 0,
     });
 
     const promotedMessageId = await getCurrentTurnMessageId(page, THREAD.id);

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -466,9 +466,9 @@ export async function dispatchAgentEvent(
       if (!threadStore) throw new Error("[E2E] thread store not found");
       (
         threadStore.getState() as {
-          handleAgentEvent: (id: string, e: unknown) => void;
+          handleAgentEvent: (event: unknown) => void;
         }
-      ).handleAgentEvent(tid, evt);
+      ).handleAgentEvent({ ...evt, threadId: tid });
     },
     { tid: threadId, evt: event, tsKeys: [...THREAD_STORE_KEYS] },
   );

--- a/apps/web/e2e/plan-wizard.spec.ts
+++ b/apps/web/e2e/plan-wizard.spec.ts
@@ -445,8 +445,11 @@ test.describe("Plan Question Wizard", () => {
     await expect(wizard).toBeVisible({ timeout: 3000 });
 
     await dispatchAgentEvent(page, THREAD.id, {
-      method: "session.turnComplete",
-      params: {},
+      type: "turnComplete",
+      reason: "end_turn",
+      tokensIn: 0,
+      tokensOut: 0,
+      costUsd: null,
     });
     await wizard.locator("button", { hasText: "cancel" }).first().click();
 
@@ -474,8 +477,11 @@ test.describe("Plan Question Wizard", () => {
     ).toHaveCount(0);
 
     await dispatchAgentEvent(page, THREAD.id, {
-      method: "session.turnComplete",
-      params: {},
+      type: "turnComplete",
+      reason: "end_turn",
+      tokensIn: 0,
+      tokensOut: 0,
+      costUsd: null,
     });
     await page.waitForTimeout(600);
     expect(
@@ -495,8 +501,11 @@ test.describe("Plan Question Wizard", () => {
     ).toHaveLength(0);
 
     await dispatchAgentEvent(page, THREAD.id, {
-      method: "session.turnComplete",
-      params: {},
+      type: "turnComplete",
+      reason: "end_turn",
+      tokensIn: 0,
+      tokensOut: 0,
+      costUsd: null,
     });
 
     await expect.poll(async () => {

--- a/apps/web/e2e/right-panel-tab-status.spec.ts
+++ b/apps/web/e2e/right-panel-tab-status.spec.ts
@@ -151,18 +151,17 @@ async function emitTaskCreate(page: Page): Promise<void> {
     (
       threadStore as {
         getState: () => {
-          handleAgentEvent: (threadId: string, event: unknown) => void;
+          handleAgentEvent: (event: unknown) => void;
         };
       }
-    ).getState().handleAgentEvent(tid, {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-create-live",
-        toolName: "TaskCreate",
-        toolInput: {
-          subject: "Buy groceries",
-          description: "Pick up milk, eggs, bread",
-        },
+    ).getState().handleAgentEvent({
+      type: "toolUse",
+      threadId: tid,
+      toolCallId: "task-create-live",
+      toolName: "TaskCreate",
+      toolInput: {
+        subject: "Buy groceries",
+        description: "Pick up milk, eggs, bread",
       },
     });
   }, THREAD.id);
@@ -178,21 +177,20 @@ async function emitUpdatePlan(page: Page): Promise<void> {
     (
       threadStore as {
         getState: () => {
-          handleAgentEvent: (threadId: string, event: unknown) => void;
+          handleAgentEvent: (event: unknown) => void;
         };
       }
-    ).getState().handleAgentEvent(tid, {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "update-plan-live",
-        toolName: "update_plan",
-        toolInput: {
-          plan: [
-            { status: "pending", step: "Test todo item one with CODE-A1 and CODE-B1" },
-            { status: "in_progress", step: "Test todo item two with CODE-A2 and CODE-B2" },
-            { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
-          ],
-        },
+    ).getState().handleAgentEvent({
+      type: "toolUse",
+      threadId: tid,
+      toolCallId: "update-plan-live",
+      toolName: "update_plan",
+      toolInput: {
+        plan: [
+          { status: "pending", step: "Test todo item one with CODE-A1 and CODE-B1" },
+          { status: "in_progress", step: "Test todo item two with CODE-A2 and CODE-B2" },
+          { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
+        ],
       },
     });
   }, THREAD.id);

--- a/apps/web/e2e/scope-task-hydration.spec.ts
+++ b/apps/web/e2e/scope-task-hydration.spec.ts
@@ -156,17 +156,16 @@ async function emitUpdatePlan(page: Page, task: string): Promise<void> {
       (
         threadStore as {
           getState: () => {
-            handleAgentEvent: (threadId: string, event: unknown) => void;
+            handleAgentEvent: (event: unknown) => void;
           };
         }
-      ).getState().handleAgentEvent(threadId, {
-        method: "session.toolUse",
-        params: {
-          toolCallId: `live-plan-${Date.now()}`,
-          toolName: "update_plan",
-          toolInput: {
-            plan: [{ status: "pending", step: task }],
-          },
+      ).getState().handleAgentEvent({
+        type: "toolUse",
+        threadId,
+        toolCallId: `live-plan-${Date.now()}`,
+        toolName: "update_plan",
+        toolInput: {
+          plan: [{ status: "pending", step: task }],
         },
       });
     },

--- a/apps/web/e2e/session-restart-divider.spec.ts
+++ b/apps/web/e2e/session-restart-divider.spec.ts
@@ -211,16 +211,16 @@ test.describe("Session Restart Divider", () => {
     });
   });
 
-  test("handleAgentEvent session_restarted creates exactly one divider", async ({
+  test("system session_restarted creates exactly one divider", async ({
     page,
   }) => {
     await activateThread(page, FAKE_WORKSPACE, FAKE_THREAD);
     await waitForActiveThreadLoaded(page);
 
-    // Trigger the event via the production handleAgentEvent code path
+    // Trigger the flat event via the production handleAgentEvent code path.
     await dispatchAgentEvent(page, THREAD_ID, {
-      method: "session.system",
-      params: { subtype: "session_restarted" },
+      type: "system",
+      subtype: "session_restarted",
     });
 
     await page.waitForFunction(
@@ -247,14 +247,14 @@ test.describe("Session Restart Divider", () => {
     await activateThread(page, FAKE_WORKSPACE, FAKE_THREAD);
     await waitForActiveThreadLoaded(page);
 
-    // Fire two session.system events through the production reducer
+    // Fire two system events through the production reducer.
     await dispatchAgentEvent(page, THREAD_ID, {
-      method: "session.system",
-      params: { subtype: "session_restarted" },
+      type: "system",
+      subtype: "session_restarted",
     });
     await dispatchAgentEvent(page, THREAD_ID, {
-      method: "session.system",
-      params: { subtype: "session_restarted" },
+      type: "system",
+      subtype: "session_restarted",
     });
 
     await page.waitForFunction(

--- a/apps/web/e2e/sidebar-interrupted-state.spec.ts
+++ b/apps/web/e2e/sidebar-interrupted-state.spec.ts
@@ -1,7 +1,7 @@
 /**
  * E2E tests verifying that threads with status "interrupted" render the correct
  * amber pulsing dot in the sidebar, and that the dot clears to running (primary)
- * when the thread resumes via session.turnStarted.
+ * when the thread resumes via turnStarted.
  *
  * This tests the fix for: "copilot not persisting working state" where threads
  * showed idle/normal state after a server restart instead of interrupted state.
@@ -124,7 +124,7 @@ test.describe("Sidebar: interrupted thread state", () => {
     });
   });
 
-  test("interrupted marker switches to primary spinner when session.turnStarted fires", async ({ page }) => {
+  test("interrupted marker switches to primary spinner when turnStarted fires", async ({ page }) => {
     await setupWorkspaceState(page, {
       workspaces: [WORKSPACE],
       threads: [THREAD_INTERRUPTED],
@@ -141,7 +141,7 @@ test.describe("Sidebar: interrupted thread state", () => {
     // Confirm amber state before resume.
     await expect(statusMarker).toHaveClass(/amber/);
 
-    // Inject session.turnStarted to simulate user resuming the thread.
+    // Inject turnStarted to simulate user resuming the thread.
     await page.evaluate(
       ({ threadId }) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -151,8 +151,7 @@ test.describe("Sidebar: interrupted thread state", () => {
           (s: any) => "handleAgentEvent" in s.getState() && "runningThreadIds" in s.getState(),
         );
         if (!threadStore) throw new Error("[E2E] thread store not found");
-        threadStore.getState().handleAgentEvent(threadId, {
-          method: "session.turnStarted",
+        threadStore.getState().handleAgentEvent({
           type: "turnStarted",
           threadId,
         });

--- a/apps/web/e2e/streaming-text-rendering.spec.ts
+++ b/apps/web/e2e/streaming-text-rendering.spec.ts
@@ -114,6 +114,7 @@ test("streaming assistant text uses plain text, then settled text uses markdown"
     type: "message",
     content: "Hello **stream**",
     messageId: "assistant-streaming-text",
+    tokens: null,
   });
 
   await expect(assistantText).toHaveCount(1);

--- a/apps/web/e2e/thread-switch-conversation-page.spec.ts
+++ b/apps/web/e2e/thread-switch-conversation-page.spec.ts
@@ -613,10 +613,12 @@ test("thread revisit keeps messages added after an empty snapshot was cached", a
     threadId: "thread-a",
     messageId: "thread-a-completed",
     content: "Alpha completed while inactive",
+    tokens: null,
   });
   await controller.sendPush("agent.event", {
     type: "turnComplete",
     threadId: "thread-a",
+    reason: "end_turn",
     costUsd: 0.005,
     tokensIn: 25,
     tokensOut: 25,

--- a/apps/web/e2e/tool-output-truncation.spec.ts
+++ b/apps/web/e2e/tool-output-truncation.spec.ts
@@ -144,7 +144,7 @@ async function setupApp(
 }
 
 async function dispatchAgentEvent(page: Page, event: unknown) {
-  await page.evaluate(({ threadId, agentEvent }) => {
+  await page.evaluate(({ agentEvent }) => {
     type Store = { getState: () => Record<string, unknown> };
     const stores = (window as unknown as { __mcodeStores?: Store[] }).__mcodeStores ?? [];
     const threadStore = stores.find((store) => {
@@ -152,11 +152,11 @@ async function dispatchAgentEvent(page: Page, event: unknown) {
       return "handleAgentEvent" in state && "records" in state;
     });
     const state = threadStore?.getState() as
-      | { handleAgentEvent: (targetThreadId: string, incoming: unknown) => void }
+      | { handleAgentEvent: (event: unknown) => void }
       | undefined;
     if (!state) throw new Error("thread store not found");
-    state.handleAgentEvent(threadId, agentEvent);
-  }, { threadId: THREAD_ID, agentEvent: event });
+    state.handleAgentEvent(agentEvent);
+  }, { agentEvent: event });
 }
 
 async function expectTruncationNotice(page: Page, total: string, duration?: string) {
@@ -184,25 +184,23 @@ test.describe("tool output truncation", () => {
   test("shows live truncation notice from streamed tool result metadata", async ({ page }) => {
     await setupApp(page, [userMessage()]);
 
-    await dispatchAgentEvent(page, { method: "session.turnStarted", params: {} });
+    await dispatchAgentEvent(page, { type: "turnStarted", threadId: THREAD_ID });
     await dispatchAgentEvent(page, {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "tool-large-output",
-        toolName: "Bash",
-        toolInput: { command: "node -e large output" },
-      },
+      type: "toolUse",
+      threadId: THREAD_ID,
+      toolCallId: "tool-large-output",
+      toolName: "Bash",
+      toolInput: { command: "node -e large output" },
     });
     await dispatchAgentEvent(page, {
-      method: "session.toolResult",
-      params: {
-        toolCallId: "tool-large-output",
-        output: "HEAD\nTAIL",
-        isError: false,
-        outputTruncated: true,
-        outputTotalBytes: 350 * 1024,
-        outputArtifactPath: ARTIFACT_PATH,
-      },
+      type: "toolResult",
+      threadId: THREAD_ID,
+      toolCallId: "tool-large-output",
+      output: "HEAD\nTAIL",
+      isError: false,
+      outputTruncated: true,
+      outputTotalBytes: 350 * 1024,
+      outputArtifactPath: ARTIFACT_PATH,
     });
 
     await expectTruncationNotice(page, "350 KB total");

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestActiveMessages,
@@ -49,10 +50,7 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.error clears thread running state and sets error", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.error",
-      params: { error: "Out of tokens" },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "error", threadId: "thread-1", error: "Out of tokens" } as AgentEvent);
 
     const state = useThreadStore.getState();
     expect(state.runningThreadIds.has("thread-1")).toBe(false);
@@ -60,10 +58,7 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.system sdk_session_invalidated appends a reset hairline message", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.system",
-      params: { subtype: "sdk_session_invalidated" },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "system", threadId: "thread-1", subtype: "sdk_session_invalidated" } as AgentEvent);
 
     const messages = getTestActiveMessages();
     expect(messages).toHaveLength(1);
@@ -74,19 +69,13 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.system with an unknown subtype appends no message", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.system",
-      params: { subtype: "some_other_subtype" },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "system", threadId: "thread-1", subtype: "some_other_subtype" } as AgentEvent);
 
     expect(getTestActiveMessages()).toHaveLength(0);
   });
 
   it("session.turnComplete without streaming content clears state only", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.turnComplete",
-      params: { sessionId: "mcode-thread-1", reason: "end_turn", costUsd: null, totalTokensIn: 0, totalTokensOut: 0 },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: "thread-1", reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 } as AgentEvent);
     vi.runAllTimers();
 
     const state = useThreadStore.getState();
@@ -95,10 +84,7 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse adds tool call to toolCallsByThread", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: { toolCallId: "tc1", toolName: "Read", toolInput: { path: "/foo" } },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "tc1", toolName: "Read", toolInput: { path: "/foo" } } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -110,14 +96,8 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse ignores duplicate toolCallId (defense in depth)", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: { toolCallId: "dup", toolName: "Read", toolInput: { path: "/a" } },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: { toolCallId: "dup", toolName: "Read", toolInput: { path: "/b" } },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "dup", toolName: "Read", toolInput: { path: "/a" } } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "dup", toolName: "Read", toolInput: { path: "/b" } } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -126,26 +106,16 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse merges enriched Agent toolInput for duplicate toolCallId", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "agent-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "agent-1",
         toolName: "Agent",
-        toolInput: { description: "Subagent task" },
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "agent-1",
+        toolInput: { description: "Subagent task" }, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "agent-1",
         toolName: "Agent",
         toolInput: {
           description: "Read detection file",
           prompt: "Read cursor-subagent-detection.ts",
           model: "composer-2.5-fast",
-        },
-      },
-    });
+        }, } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -159,26 +129,16 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse updates tasks when duplicate TodoWrite enriches sparse input", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "todo-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "todo-1",
         toolName: "TodoWrite",
-        toolInput: {},
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "todo-1",
+        toolInput: {}, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "todo-1",
         toolName: "TodoWrite",
         toolInput: {
           todos: [
             { id: "a", content: "Run mapper tests", status: "in_progress" },
           ],
-        },
-      },
-    });
+        }, } as AgentEvent);
 
     const calls = getTestThreadToolCalls("thread-1");
     expect(calls).toHaveLength(1);
@@ -198,35 +158,20 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse keeps sub-agent task grouping when duplicate TodoWrite omits parent", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "agent-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "agent-1",
         toolName: "Agent",
-        toolInput: { description: "Audit child scope" },
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "todo-child",
+        toolInput: { description: "Audit child scope" }, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "todo-child",
         toolName: "TodoWrite",
         toolInput: {},
-        parentToolCallId: "agent-1",
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "todo-child",
+        parentToolCallId: "agent-1", } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "todo-child",
         toolName: "TodoWrite",
         toolInput: {
           todos: [
             { id: "child-a", content: "Trace child scope", status: "in_progress" },
           ],
-        },
-      },
-    });
+        }, } as AgentEvent);
 
     const calls = getTestThreadToolCalls("thread-1");
     expect(calls.find((call) => call.id === "todo-child")?.parentToolCallId).toBe("agent-1");
@@ -241,28 +186,18 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse updates tasks from TaskCreate tool calls", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-create-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-create-1",
         toolName: "TaskCreate",
         toolInput: {
           subject: "Buy groceries",
           description: "Pick up milk, eggs, bread",
-        },
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-create-2",
+        }, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-create-2",
         toolName: "TaskCreate",
         toolInput: {
           subject: "Clean the kitchen",
           description: "Dishes, counters, floor",
-        },
-      },
-    });
+        }, } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
       {
@@ -281,23 +216,13 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse groups sub-agent TaskCreate calls by parent Agent", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "agent-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "agent-1",
         toolName: "Agent",
-        toolInput: { description: "Prepare child tasks" },
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-create-child",
+        toolInput: { description: "Prepare child tasks" }, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-create-child",
         toolName: "TaskCreate",
         toolInput: { subject: "Check child output" },
-        parentToolCallId: "agent-1",
-      },
-    });
+        parentToolCallId: "agent-1", } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
       {
@@ -310,22 +235,12 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("captures the harness task id from a TaskCreate result", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-create-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-create-1",
         toolName: "TaskCreate",
-        toolInput: { subject: "Buy groceries", description: "milk, eggs", activeForm: "Buying groceries" },
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: {
-        toolCallId: "task-create-1",
+        toolInput: { subject: "Buy groceries", description: "milk, eggs", activeForm: "Buying groceries" }, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "task-create-1",
         output: "Task #1 created successfully: Buy groceries",
-        isError: false,
-      },
-    });
+        isError: false, } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
       {
@@ -340,26 +255,13 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("applies a TaskUpdate status transition by harness task id", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-create-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-create-1",
         toolName: "TaskCreate",
-        toolInput: { subject: "Buy groceries", description: "milk, eggs" },
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "task-create-1", output: "Task #1 created successfully", isError: false },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-update-1",
+        toolInput: { subject: "Buy groceries", description: "milk, eggs" }, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "task-create-1", output: "Task #1 created successfully", isError: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-update-1",
         toolName: "TaskUpdate",
-        toolInput: { taskId: "1", status: "in_progress", activeForm: "Buying groceries" },
-      },
-    });
+        toolInput: { taskId: "1", status: "in_progress", activeForm: "Buying groceries" }, } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
       {
@@ -374,39 +276,21 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("removes a task when a TaskUpdate sets status deleted", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-create-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-create-1",
         toolName: "TaskCreate",
-        toolInput: { subject: "Buy groceries" },
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "task-create-1", output: "Task #1 created successfully", isError: false },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-update-1",
+        toolInput: { subject: "Buy groceries" }, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "task-create-1", output: "Task #1 created successfully", isError: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-update-1",
         toolName: "TaskUpdate",
-        toolInput: { taskId: "1", status: "deleted" },
-      },
-    });
+        toolInput: { taskId: "1", status: "deleted" }, } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([]);
   });
 
   it("ignores a TaskUpdate that matches no known task", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-update-orphan",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-update-orphan",
         toolName: "TaskUpdate",
-        toolInput: { taskId: "99", status: "completed" },
-      },
-    });
+        toolInput: { taskId: "99", status: "completed" }, } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toBeUndefined();
   });
@@ -423,14 +307,9 @@ describe("handleAgentEvent branches", () => {
       { id: "sb-1", harnessTaskId: "1", content: "child B", status: "pending", group: "Sub-agent B" },
     ]);
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "task-update-collide",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "task-update-collide",
         toolName: "TaskUpdate",
-        toolInput: { taskId: "1", status: "completed" },
-      },
-    });
+        toolInput: { taskId: "1", status: "completed" }, } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
       { id: "sa-1", harnessTaskId: "1", content: "child A", status: "pending", group: "Sub-agent A" },
@@ -439,10 +318,7 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse updates parent scope tasks from Codex update_plan calls", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "update-plan-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "update-plan-1",
         toolName: "update_plan",
         toolInput: {
           plan: [
@@ -450,9 +326,7 @@ describe("handleAgentEvent branches", () => {
             { status: "inProgress", step: "Test todo item two with CODE-A2 and CODE-B2" },
             { status: "completed", step: "Test todo item three with CODE-A3 and CODE-B3" },
           ],
-        },
-      },
-    });
+        }, } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
       {
@@ -477,24 +351,14 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse updates Codex update_plan tasks when duplicate enriches sparse input", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "update-plan-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "update-plan-1",
         toolName: "update_plan",
-        toolInput: {},
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "update-plan-1",
+        toolInput: {}, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "update-plan-1",
         toolName: "update_plan",
         toolInput: {
           plan: [{ status: "in_progress", step: "Fill plan after completion" }],
-        },
-      },
-    });
+        }, } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
       {
@@ -507,25 +371,15 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("session.toolUse keeps child Codex update_plan tasks out of the parent group", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "agent-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "agent-1",
         toolName: "Agent",
-        toolInput: { description: "Child work" },
-      },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: {
-        toolCallId: "update-plan-child",
+        toolInput: { description: "Child work" }, } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "update-plan-child",
         toolName: "update_plan",
         toolInput: {
           plan: [{ status: "pending", step: "Child-only plan item" }],
         },
-        parentToolCallId: "agent-1",
-      },
-    });
+        parentToolCallId: "agent-1", } as AgentEvent);
 
     expect(useTaskStore.getState().tasksByThread["thread-1"]).toEqual([
       {
@@ -555,10 +409,7 @@ describe("handleAgentEvent branches", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "no-match", output: "file contents", isError: false },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "no-match", output: "file contents", isError: false } as AgentEvent);
 
     const calls = getTestThreadToolCalls("thread-1");
     const agentCall = calls.find((c) => c.id === "agent-1");
@@ -576,30 +427,18 @@ describe("handleAgentEvent branches", () => {
 
   it("records provider activity time for tool progress and results", () => {
     vi.setSystemTime(1_000);
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: { toolCallId: "read-1", toolName: "Read", toolInput: { file_path: "README.md" } },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "read-1", toolName: "Read", toolInput: { file_path: "README.md" } } as AgentEvent);
 
     vi.setSystemTime(2_000);
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolProgress",
-      params: { toolCallId: "read-1", elapsedSeconds: 1 },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolProgress", threadId: "thread-1", toolCallId: "read-1", elapsedSeconds: 1 } as AgentEvent);
     expect(getTestThreadToolCalls("thread-1").find((call) => call.id === "read-1")?.lastActivityAt).toBe(2_000);
 
     vi.setSystemTime(3_000);
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolProgress",
-      params: { toolCallId: "read-1", elapsedSeconds: 1 },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolProgress", threadId: "thread-1", toolCallId: "read-1", elapsedSeconds: 1 } as AgentEvent);
     expect(getTestThreadToolCalls("thread-1").find((call) => call.id === "read-1")?.lastActivityAt).toBe(3_000);
 
     vi.setSystemTime(4_000);
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "read-1", output: "done", isError: false },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "read-1", output: "done", isError: false } as AgentEvent);
     expect(getTestThreadToolCalls("thread-1").find((call) => call.id === "read-1")?.lastActivityAt).toBe(4_000);
   });
 });
@@ -637,13 +476,8 @@ describe("session.modelFallback", () => {
   });
 
   it("stores transient fallback info without mutating thread.model", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.modelFallback",
-      params: {
-        requestedModel: "claude-opus-4-6",
-        actualModel: "claude-sonnet-4-6",
-      },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "modelFallback", threadId: "thread-1", requestedModel: "claude-opus-4-6",
+        actualModel: "claude-sonnet-4-6", } as AgentEvent);
 
     // thread.model must NOT be changed
     const thread = useWorkspaceStore.getState().threads.find((t) => t.id === "thread-1");
@@ -658,13 +492,8 @@ describe("session.modelFallback", () => {
   });
 
   it("shows an info toast on fallback", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.modelFallback",
-      params: {
-        requestedModel: "claude-opus-4-6",
-        actualModel: "claude-sonnet-4-6",
-      },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "modelFallback", threadId: "thread-1", requestedModel: "claude-opus-4-6",
+        actualModel: "claude-sonnet-4-6", } as AgentEvent);
 
     const toasts = useToastStore.getState().toasts;
     expect(toasts).toHaveLength(1);
@@ -673,13 +502,8 @@ describe("session.modelFallback", () => {
   });
 
   it("normalizes dated SDK variant in transient fallback info", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.modelFallback",
-      params: {
-        requestedModel: "claude-opus-4-6",
-        actualModel: "claude-haiku-4-5-20251001",
-      },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "modelFallback", threadId: "thread-1", requestedModel: "claude-opus-4-6",
+        actualModel: "claude-haiku-4-5-20251001", } as AgentEvent);
 
     // thread.model unchanged
     const thread = useWorkspaceStore.getState().threads.find((t) => t.id === "thread-1");
@@ -691,13 +515,8 @@ describe("session.modelFallback", () => {
   });
 
   it("shows human-readable label in toast for dated SDK variant", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.modelFallback",
-      params: {
-        requestedModel: "claude-opus-4-6",
-        actualModel: "claude-haiku-4-5-20251001",
-      },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "modelFallback", threadId: "thread-1", requestedModel: "claude-opus-4-6",
+        actualModel: "claude-haiku-4-5-20251001", } as AgentEvent);
 
     const toasts = useToastStore.getState().toasts;
     expect(toasts[0].title).toContain("Haiku");
@@ -705,13 +524,8 @@ describe("session.modelFallback", () => {
   });
 
   it("does not show toast for unknown model IDs (uses raw ID)", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.modelFallback",
-      params: {
-        requestedModel: "claude-unknown-model",
-        actualModel: "claude-another-unknown",
-      },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "modelFallback", threadId: "thread-1", requestedModel: "claude-unknown-model",
+        actualModel: "claude-another-unknown", } as AgentEvent);
 
     const toasts = useToastStore.getState().toasts;
     expect(toasts).toHaveLength(1);
@@ -746,10 +560,7 @@ describe("subagent count via markPriorToolCallsComplete", () => {
     // A subagent's child tool calls keep arriving on the same thread after a
     // peer top-level event. Completing the parent Agent here would zero the
     // subagent counter and hide the live LiveAgentGroup mid-run.
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: { toolCallId: "tc2", toolName: "Read", toolInput: {} },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "tc2", toolName: "Read", toolInput: {} } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -777,10 +588,7 @@ describe("subagent count via markPriorToolCallsComplete", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolUse",
-      params: { toolCallId: "tc3", toolName: "Bash", toolInput: {} },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "tc3", toolName: "Bash", toolInput: {} } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -795,15 +603,9 @@ describe("subagent count via markPriorToolCallsComplete", () => {
   });
 
   it("does not let goal receipts claim current turn response identity", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.message",
-      params: { messageId: "answer-1", content: "The rendering bug is fixed." },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "thread-1", messageId: "answer-1", content: "The rendering bug is fixed." } as AgentEvent);
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.message",
-      params: { messageId: "goal-1", content: "Goal achieved in 19s." },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "thread-1", messageId: "goal-1", content: "Goal achieved in 19s." } as AgentEvent);
 
     const rec = readThreadField("thread-1", (record) => record);
     expect(rec.currentTurnMessageId).toBe("answer-1");
@@ -813,10 +615,7 @@ describe("subagent count via markPriorToolCallsComplete", () => {
   });
 
   it("keeps near-match goal receipt text as a normal assistant response", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.message",
-      params: { messageId: "answer-1", content: "Goal achieved in 19s. Here is the summary." },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "thread-1", messageId: "answer-1", content: "Goal achieved in 19s. Here is the summary." } as AgentEvent);
 
     const rec = readThreadField("thread-1", (record) => record);
     expect(rec.currentTurnMessageId).toBe("answer-1");
@@ -824,10 +623,7 @@ describe("subagent count via markPriorToolCallsComplete", () => {
   });
 
   it("clears active goal state when a goal update is complete", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.goalUpdated",
-      params: {
-        goal: {
+    useThreadStore.getState().handleAgentEvent({ type: "goalUpdated", threadId: "thread-1", goal: {
           objective: "fix rendering",
           status: "active",
           tokenBudget: null,
@@ -837,15 +633,10 @@ describe("subagent count via markPriorToolCallsComplete", () => {
           updatedAt: 1,
           source: "claude",
           controls: { canInspect: true, canClear: true },
-        },
-      },
-    });
+        }, } as AgentEvent);
     expect(readThreadField("thread-1", (record) => record.goal?.status)).toBe("active");
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.goalUpdated",
-      params: {
-        goal: {
+    useThreadStore.getState().handleAgentEvent({ type: "goalUpdated", threadId: "thread-1", goal: {
           objective: "fix rendering",
           status: "complete",
           tokenBudget: null,
@@ -855,18 +646,13 @@ describe("subagent count via markPriorToolCallsComplete", () => {
           updatedAt: 20,
           source: "codex",
           controls: { canInspect: true, canClear: false },
-        },
-      },
-    });
+        }, } as AgentEvent);
 
     expect(readThreadField("thread-1", (record) => record.goal)).toBeNull();
   });
 
   it("clears active goal state when a goalCleared event arrives", () => {
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.goalUpdated",
-      params: {
-        goal: {
+    useThreadStore.getState().handleAgentEvent({ type: "goalUpdated", threadId: "thread-1", goal: {
           objective: "say hi",
           status: "active",
           tokenBudget: null,
@@ -876,15 +662,10 @@ describe("subagent count via markPriorToolCallsComplete", () => {
           updatedAt: 1,
           source: "codex",
           controls: { canInspect: true, canClear: true },
-        },
-      },
-    });
+        }, } as AgentEvent);
     expect(readThreadField("thread-1", (record) => record.goal?.objective)).toBe("say hi");
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.goalCleared",
-      params: { providerId: "codex", reason: "completed" },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "goalCleared", threadId: "thread-1", providerId: "codex", reason: "completed" } as AgentEvent);
 
     expect(readThreadField("thread-1", (record) => record.goal)).toBeNull();
   });

--- a/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
+++ b/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestActiveMessages,
@@ -70,10 +71,7 @@ describe("Agent event thread isolation", () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
       // Thread B errors while user views Thread A
-      handleAgentEvent(THREAD_B, {
-        method: "session.error",
-        error: "Out of tokens",
-      });
+      handleAgentEvent({ type: "error", threadId: THREAD_B, error: "Out of tokens" } as AgentEvent);
 
       // Thread B's error is recorded under its own key
       expect(getTestThreadError(THREAD_B)).toBe("Out of tokens");
@@ -84,10 +82,7 @@ describe("Agent event thread isolation", () => {
     it("session.error for active thread sets error on that thread only", () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
-      handleAgentEvent(THREAD_A, {
-        method: "session.error",
-        error: "CLI not found",
-      });
+      handleAgentEvent({ type: "error", threadId: THREAD_A, error: "CLI not found" } as AgentEvent);
 
       expect(getTestThreadError(THREAD_A)).toBe("CLI not found");
       expect(getTestThreadError(THREAD_B)).toBeUndefined();
@@ -96,14 +91,8 @@ describe("Agent event thread isolation", () => {
     it("errors from two concurrent threads are tracked independently", () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
-      handleAgentEvent(THREAD_A, {
-        method: "session.error",
-        error: "Error A",
-      });
-      handleAgentEvent(THREAD_B, {
-        method: "session.error",
-        error: "Error B",
-      });
+      handleAgentEvent({ type: "error", threadId: THREAD_A, error: "Error A" } as AgentEvent);
+      handleAgentEvent({ type: "error", threadId: THREAD_B, error: "Error B" } as AgentEvent);
 
       expect(getTestThreadError(THREAD_A)).toBe("Error A");
       expect(getTestThreadError(THREAD_B)).toBe("Error B");
@@ -135,11 +124,8 @@ describe("Agent event thread isolation", () => {
     it("does not show toast when modelFallback fires on a background thread", () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
-      handleAgentEvent(THREAD_B, {
-        method: "session.modelFallback",
-        requestedModel: "claude-opus-4-6",
-        actualModel: "claude-haiku-4-5-20251001",
-      });
+      handleAgentEvent({ type: "modelFallback", threadId: THREAD_B, requestedModel: "claude-opus-4-6",
+        actualModel: "claude-haiku-4-5-20251001" } as AgentEvent);
 
       expect(useToastStore.getState().toasts).toHaveLength(0);
     });
@@ -147,11 +133,8 @@ describe("Agent event thread isolation", () => {
     it("shows toast when modelFallback fires on the active thread", () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
-      handleAgentEvent(THREAD_A, {
-        method: "session.modelFallback",
-        requestedModel: "claude-opus-4-6",
-        actualModel: "claude-haiku-4-5-20251001",
-      });
+      handleAgentEvent({ type: "modelFallback", threadId: THREAD_A, requestedModel: "claude-opus-4-6",
+        actualModel: "claude-haiku-4-5-20251001" } as AgentEvent);
 
       expect(useToastStore.getState().toasts).toHaveLength(1);
     });
@@ -163,12 +146,9 @@ describe("Agent event thread isolation", () => {
     it("does not open task panel when TodoWrite fires on a background thread", async () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
-      handleAgentEvent(THREAD_B, {
-        method: "session.toolUse",
-        toolCallId: "tc-todo",
+      handleAgentEvent({ type: "toolUse", threadId: THREAD_B, toolCallId: "tc-todo",
         toolName: "TodoWrite",
-        toolInput: { todos: [{ id: "0", content: "Plan", status: "in_progress" }] },
-      });
+        toolInput: { todos: [{ id: "0", content: "Plan", status: "in_progress" }] } } as AgentEvent);
 
       // Give the dynamic import time to resolve
       if (vi.dynamicImportSettled) {
@@ -185,12 +165,9 @@ describe("Agent event thread isolation", () => {
     it("does not auto-open task panel on TodoWrite", async () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
-      handleAgentEvent(THREAD_A, {
-        method: "session.toolUse",
-        toolCallId: "tc-todo",
+      handleAgentEvent({ type: "toolUse", threadId: THREAD_A, toolCallId: "tc-todo",
         toolName: "TodoWrite",
-        toolInput: { todos: [{ id: "0", content: "Plan", status: "in_progress" }] },
-      });
+        toolInput: { todos: [{ id: "0", content: "Plan", status: "in_progress" }] } } as AgentEvent);
 
       await vi.advanceTimersByTime(0);
       await Promise.resolve();
@@ -207,10 +184,7 @@ describe("Agent event thread isolation", () => {
     it("textDelta for background thread does not appear in active thread's streaming", async () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
-      handleAgentEvent(THREAD_B, {
-        method: "session.textDelta",
-        delta: "background text",
-      });
+      handleAgentEvent({ type: "textDelta", threadId: THREAD_B, delta: "background text" } as AgentEvent);
 
       for (let i = 0; i < 8; i++) {
         await Promise.resolve();
@@ -226,12 +200,9 @@ describe("Agent event thread isolation", () => {
         ]),
       });
 
-      useThreadStore.getState().handleAgentEvent(THREAD_B, {
-        method: "session.turnComplete",
-        costUsd: null,
-        totalTokensIn: 100,
-        totalTokensOut: 50,
-      });
+      useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: THREAD_B, reason: "end_turn", costUsd: null,
+        tokensIn: 100,
+        tokensOut: 50 } as AgentEvent);
       vi.runAllTimers();
 
       // No message added to the visible list (user is on Thread A)
@@ -247,12 +218,9 @@ describe("Agent event thread isolation", () => {
     it("toolUse for background thread does not contaminate active thread's tool calls", () => {
       const { handleAgentEvent } = useThreadStore.getState();
 
-      handleAgentEvent(THREAD_B, {
-        method: "session.toolUse",
-        toolCallId: "tc-bg",
+      handleAgentEvent({ type: "toolUse", threadId: THREAD_B, toolCallId: "tc-bg",
         toolName: "Read",
-        toolInput: { path: "/bg" },
-      });
+        toolInput: { path: "/bg" } } as AgentEvent);
 
       expect(getTestThreadToolCalls(THREAD_A)).toEqual([]);
       expect(getTestThreadToolCalls(THREAD_B)).toHaveLength(1);

--- a/apps/web/src/__tests__/context-tracker.test.ts
+++ b/apps/web/src/__tests__/context-tracker.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useThreadStore } from "@/stores/threadStore";
 import { mockTransport, createMockThread } from "./mocks/transport";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import type { AgentEvent } from "@mcode/contracts";
 
 vi.mock("@/transport", async () => ({
   ...(await vi.importActual("@/transport")),
@@ -38,8 +39,8 @@ function setup(extra: Partial<ThreadRecord> = {}) {
   });
 }
 
-function dispatch(method: string, params: Record<string, unknown> = {}) {
-  useThreadStore.getState().handleAgentEvent(THREAD, { method, ...params });
+function dispatch(event: AgentEvent) {
+  useThreadStore.getState().handleAgentEvent(event);
 }
 
 describe("context tracker — Fix 2: output tokens included", () => {
@@ -48,9 +49,7 @@ describe("context tracker — Fix 2: output tokens included", () => {
   it("turnComplete stores tokensIn directly (server already adds output tokens)", () => {
     // The server (claude-provider) now includes output_tokens in tokensIn.
     // The frontend stores whatever value it receives.
-    dispatch("session.turnComplete", {
-      params: { reason: "end_turn", costUsd: null, tokensIn: 5000, tokensOut: 500, contextWindow: 200_000 },
-    });
+    dispatch({ type: "turnComplete", threadId: THREAD, reason: "end_turn", costUsd: null, tokensIn: 5000, tokensOut: 500, contextWindow: 200_000 });
 
     const ctx = getTestThreadContext(THREAD);
     expect(ctx?.lastTokensIn).toBe(5000);
@@ -67,9 +66,7 @@ describe("context tracker — Fix 1: turnComplete skipped during compaction", ()
   );
 
   it("turnComplete during compaction does NOT update contextByThread", () => {
-    dispatch("session.turnComplete", {
-      params: { reason: "end_turn", costUsd: null, tokensIn: 195_000, tokensOut: 500, contextWindow: 200_000 },
-    });
+    dispatch({ type: "turnComplete", threadId: THREAD, reason: "end_turn", costUsd: null, tokensIn: 195_000, tokensOut: 500, contextWindow: 200_000 });
 
     const ctx = getTestThreadContext(THREAD);
     // Must stay empty — no flash of pre-compaction tokens
@@ -77,9 +74,7 @@ describe("context tracker — Fix 1: turnComplete skipped during compaction", ()
   });
 
   it("turnComplete during compaction does NOT clear isCompactingByThread", () => {
-    dispatch("session.turnComplete", {
-      params: { reason: "end_turn", costUsd: null, tokensIn: 195_000, tokensOut: 500, contextWindow: 200_000 },
-    });
+    dispatch({ type: "turnComplete", threadId: THREAD, reason: "end_turn", costUsd: null, tokensIn: 195_000, tokensOut: 500, contextWindow: 200_000 });
 
     expect(getTestThreadIsCompacting(THREAD)).toBe(true);
   });
@@ -103,9 +98,7 @@ describe("context tracker — Fix 3: contextEstimate on compaction end", () => {
       ]),
     });
 
-    dispatch("session.contextEstimate", {
-      params: { tokensIn: 100_000, contextWindow: 200_000 },
-    });
+    dispatch({ type: "contextEstimate", threadId: THREAD, tokensIn: 100_000, contextWindow: 200_000 });
 
     const ctx = getTestThreadContext(THREAD);
     expect(ctx?.lastTokensIn).toBe(100_000);
@@ -114,9 +107,7 @@ describe("context tracker — Fix 3: contextEstimate on compaction end", () => {
 
   it("contextEstimate is ignored while compaction is still active", () => {
     // isCompactingByThread still set — estimate must not overwrite zero sentinel
-    dispatch("session.contextEstimate", {
-      params: { tokensIn: 100_000, contextWindow: 200_000 },
-    });
+    dispatch({ type: "contextEstimate", threadId: THREAD, tokensIn: 100_000, contextWindow: 200_000 });
 
     const ctx = getTestThreadContext(THREAD);
     expect(ctx?.lastTokensIn).toBe(0);
@@ -131,27 +122,23 @@ describe("context tracker — Fix 4: live estimation during turn", () => {
   );
 
   it("contextEstimate from toolResult accumulates into contextByThread", () => {
-    dispatch("session.contextEstimate", {
-      params: { tokensIn: 51_250, contextWindow: 200_000 },
-    });
+    dispatch({ type: "contextEstimate", threadId: THREAD, tokensIn: 51_250, contextWindow: 200_000 });
 
     const ctx = getTestThreadContext(THREAD);
     expect(ctx?.lastTokensIn).toBe(51_250);
   });
 
   it("multiple contextEstimates accumulate sequentially", () => {
-    dispatch("session.contextEstimate", { params: { tokensIn: 51_000, contextWindow: 200_000 } });
-    dispatch("session.contextEstimate", { params: { tokensIn: 52_500, contextWindow: 200_000 } });
+    dispatch({ type: "contextEstimate", threadId: THREAD, tokensIn: 51_000, contextWindow: 200_000 });
+    dispatch({ type: "contextEstimate", threadId: THREAD, tokensIn: 52_500, contextWindow: 200_000 });
 
     const ctx = getTestThreadContext(THREAD);
     expect(ctx?.lastTokensIn).toBe(52_500);
   });
 
   it("turnComplete after tool calls overwrites estimate with authoritative value", () => {
-    dispatch("session.contextEstimate", { params: { tokensIn: 52_500, contextWindow: 200_000 } });
-    dispatch("session.turnComplete", {
-      params: { reason: "end_turn", costUsd: null, tokensIn: 53_100, tokensOut: 600, contextWindow: 200_000 },
-    });
+    dispatch({ type: "contextEstimate", threadId: THREAD, tokensIn: 52_500, contextWindow: 200_000 });
+    dispatch({ type: "turnComplete", threadId: THREAD, reason: "end_turn", costUsd: null, tokensIn: 53_100, tokensOut: 600, contextWindow: 200_000 });
 
     const ctx = getTestThreadContext(THREAD);
     expect(ctx?.lastTokensIn).toBe(53_100);

--- a/apps/web/src/__tests__/message-cap.test.ts
+++ b/apps/web/src/__tests__/message-cap.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestActiveMessages,
@@ -161,10 +162,7 @@ describe("message sliding window", () => {
         : s.records,
     }));
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.message",
-      params: { content: "Agent reply" },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "thread-1", content: "Agent reply" } as AgentEvent);
     vi.runAllTimers();
 
     expect(getTestActiveMessages().length).toBe(MESSAGE_WINDOW_SIZE);

--- a/apps/web/src/__tests__/message-cap.test.ts
+++ b/apps/web/src/__tests__/message-cap.test.ts
@@ -162,7 +162,7 @@ describe("message sliding window", () => {
         : s.records,
     }));
 
-    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "thread-1", content: "Agent reply" } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "thread-1", content: "Agent reply", tokens: null } satisfies AgentEvent);
     vi.runAllTimers();
 
     expect(getTestActiveMessages().length).toBe(MESSAGE_WINDOW_SIZE);

--- a/apps/web/src/__tests__/record-cache.test.ts
+++ b/apps/web/src/__tests__/record-cache.test.ts
@@ -284,7 +284,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: THREAD_ID, delta: "hello " } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: THREAD_ID, delta: "hello " } satisfies AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
   });
@@ -293,7 +293,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: THREAD_ID, toolCallId: "tool-1", toolName: "Read", toolInput: {} } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: THREAD_ID, toolCallId: "tool-1", toolName: "Read", toolInput: {} } satisfies AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
   });
@@ -302,7 +302,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: THREAD_ID } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: THREAD_ID, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 } satisfies AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeUndefined();
   });
@@ -311,7 +311,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: THREAD_ID, content: "done", tokens: null } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: THREAD_ID, content: "done", tokens: null } satisfies AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeUndefined();
   });
@@ -320,7 +320,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent({ type: "error", threadId: THREAD_ID, error: "Something broke" } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "error", threadId: THREAD_ID, error: "Something broke" } satisfies AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeUndefined();
   });
@@ -329,7 +329,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent({ type: "ended", threadId: THREAD_ID } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "ended", threadId: THREAD_ID } satisfies AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeUndefined();
   });
@@ -339,7 +339,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
 
     const { handleAgentEvent } = useThreadStore.getState();
     for (let i = 0; i < 100; i++) {
-      handleAgentEvent({ type: "textDelta", threadId: THREAD_ID, delta: `token-${i} ` } as AgentEvent);
+      handleAgentEvent({ type: "textDelta", threadId: THREAD_ID, delta: `token-${i} ` } satisfies AgentEvent);
     }
 
     expect(getCachedRecord(THREAD_ID)).toBeDefined();

--- a/apps/web/src/__tests__/record-cache.test.ts
+++ b/apps/web/src/__tests__/record-cache.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import { resetThreadStoreForTests } from "@/stores/thread-store-test-utils";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
@@ -283,10 +284,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent(THREAD_ID, {
-      method: "session.textDelta",
-      params: { delta: "hello " },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: THREAD_ID, delta: "hello " } as AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
   });
@@ -295,10 +293,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent(THREAD_ID, {
-      method: "session.toolUse",
-      params: { id: "tool-1", name: "Read", input: "{}" },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: THREAD_ID, toolCallId: "tool-1", toolName: "Read", toolInput: {} } as AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
   });
@@ -307,10 +302,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent(THREAD_ID, {
-      method: "session.turnComplete",
-      params: {},
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: THREAD_ID } as AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeUndefined();
   });
@@ -319,10 +311,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent(THREAD_ID, {
-      method: "session.message",
-      params: { role: "assistant", content: "done" },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: THREAD_ID, content: "done", tokens: null } as AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeUndefined();
   });
@@ -331,10 +320,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent(THREAD_ID, {
-      method: "session.error",
-      error: "Something broke",
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "error", threadId: THREAD_ID, error: "Something broke" } as AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeUndefined();
   });
@@ -343,10 +329,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
     cacheRecord(THREAD_ID, makeRecord(THREAD_ID));
     expect(getCachedRecord(THREAD_ID)).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent(THREAD_ID, {
-      method: "session.ended",
-      params: {},
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "ended", threadId: THREAD_ID } as AgentEvent);
 
     expect(getCachedRecord(THREAD_ID)).toBeUndefined();
   });
@@ -356,10 +339,7 @@ describe("selective cache eviction in handleAgentEvent", () => {
 
     const { handleAgentEvent } = useThreadStore.getState();
     for (let i = 0; i < 100; i++) {
-      handleAgentEvent(THREAD_ID, {
-        method: "session.textDelta",
-        params: { delta: `token-${i} ` },
-      });
+      handleAgentEvent({ type: "textDelta", threadId: THREAD_ID, delta: `token-${i} ` } as AgentEvent);
     }
 
     expect(getCachedRecord(THREAD_ID)).toBeDefined();

--- a/apps/web/src/__tests__/running-session-signal.test.ts
+++ b/apps/web/src/__tests__/running-session-signal.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestThreadAgentStartTime,
@@ -24,11 +25,7 @@ describe("running-session signal", () => {
   });
 
   it("adds threadId to runningThreadIds on session.turnStarted", () => {
-    useThreadStore.getState().handleAgentEvent("t-1", {
-      method: "session.turnStarted",
-      type: "turnStarted",
-      threadId: "t-1",
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "turnStarted", threadId: "t-1" } as AgentEvent);
     expect(useThreadStore.getState().runningThreadIds.has("t-1")).toBe(true);
     expect(typeof getTestThreadAgentStartTime("t-1")).toBe("number");
   });
@@ -37,12 +34,7 @@ describe("running-session signal", () => {
     let now = 1000;
     vi.spyOn(Date, "now").mockImplementation(() => now++);
     const store = useThreadStore.getState();
-    store.handleAgentEvent("t-1", {
-      method: "session.turnStarted",
-      type: "turnStarted",
-      threadId: "t-1",
-      fileEffectTurnId: "turn-1",
-    });
+    store.handleAgentEvent({ type: "turnStarted", threadId: "t-1", fileEffectTurnId: "turn-1" } as AgentEvent);
     const firstStart = getTestThreadAgentStartTime("t-1");
     expect(firstStart).toBeDefined();
     useTaskStore.getState().setTasks("t-1", [{
@@ -51,12 +43,7 @@ describe("running-session signal", () => {
       status: "pending",
       group: "Tasks",
     }]);
-    store.handleAgentEvent("t-1", {
-      method: "session.turnStarted",
-      type: "turnStarted",
-      threadId: "t-1",
-      fileEffectTurnId: "turn-1",
-    });
+    store.handleAgentEvent({ type: "turnStarted", threadId: "t-1", fileEffectTurnId: "turn-1" } as AgentEvent);
     expect(useThreadStore.getState().runningThreadIds.size).toBe(1);
     expect(getTestThreadAgentStartTime("t-1")).toBe(firstStart);
     expect(useTaskStore.getState().taskBubbleByThread["t-1"]).toHaveLength(1);
@@ -66,16 +53,11 @@ describe("running-session signal", () => {
 
   it("turnStarted then turnComplete leaves the Set empty", () => {
     const store = useThreadStore.getState();
-    store.handleAgentEvent("t-1", { method: "session.turnStarted", type: "turnStarted", threadId: "t-1" });
-    store.handleAgentEvent("t-1", {
-      method: "session.turnComplete",
-      type: "turnComplete",
-      threadId: "t-1",
-      reason: "stop",
+    store.handleAgentEvent({ type: "turnStarted", threadId: "t-1" } as AgentEvent);
+    store.handleAgentEvent({ type: "turnComplete", threadId: "t-1", reason: "stop",
       costUsd: null,
       tokensIn: 0,
-      tokensOut: 0,
-    });
+      tokensOut: 0 } as AgentEvent);
     expect(useThreadStore.getState().runningThreadIds.has("t-1")).toBe(false);
   });
 
@@ -104,20 +86,11 @@ describe("running-session signal", () => {
     };
 
     const store = useThreadStore.getState();
-    store.handleAgentEvent("t-1", {
-      method: "session.goalUpdated",
-      type: "goalUpdated",
-      threadId: "t-1",
-      goal,
-    });
+    store.handleAgentEvent({ type: "goalUpdated", threadId: "t-1", goal } as AgentEvent);
 
     expect(readThreadField("t-1", (r) => r.goal?.objective)).toBe("ship the feature");
 
-    store.handleAgentEvent("t-1", {
-      method: "session.goalCleared",
-      type: "goalCleared",
-      threadId: "t-1",
-    });
+    store.handleAgentEvent({ type: "goalCleared", threadId: "t-1" } as AgentEvent);
 
     expect(readThreadField("t-1", (r) => r.goal)).toBeNull();
   });
@@ -133,11 +106,7 @@ describe("session.turnStarted clears interrupted status", () => {
   });
 
   it("updates workspace store thread status from interrupted to active on turnStarted", () => {
-    useThreadStore.getState().handleAgentEvent("t-1", {
-      method: "session.turnStarted",
-      type: "turnStarted",
-      threadId: "t-1",
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "turnStarted", threadId: "t-1" } as AgentEvent);
 
     const thread = useWorkspaceStore.getState().threads.find((t) => t.id === "t-1");
     expect(thread?.status).toBe("active");
@@ -149,11 +118,7 @@ describe("session.turnStarted clears interrupted status", () => {
       activeThreadId: "t-1",
     });
 
-    useThreadStore.getState().handleAgentEvent("t-1", {
-      method: "session.turnStarted",
-      type: "turnStarted",
-      threadId: "t-1",
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "turnStarted", threadId: "t-1" } as AgentEvent);
 
     const thread = useWorkspaceStore.getState().threads.find((t) => t.id === "t-1");
     expect(thread?.status).toBe("active");

--- a/apps/web/src/__tests__/streaming.test.ts
+++ b/apps/web/src/__tests__/streaming.test.ts
@@ -40,7 +40,7 @@ describe("Agent Message Flow", () => {
     useThreadStore.setState({ currentThreadId: threadId });
     const { handleAgentEvent } = useThreadStore.getState();
 
-    handleAgentEvent({ type: "message", threadId: threadId, content: "Hello world", tokens: 42 } as AgentEvent);
+    handleAgentEvent({ type: "message", threadId: threadId, content: "Hello world", tokens: 42 } satisfies AgentEvent);
     vi.runAllTimers();
 
     expect(getTestActiveMessages()).toHaveLength(1);
@@ -56,8 +56,8 @@ describe("Agent Message Flow", () => {
 
     // Codex narration turn: an assistant message lands mid-turn, then the
     // final response lands as a second message with different content.
-    handleAgentEvent({ type: "message", threadId: threadId, content: "Narration before tool batch", messageId: "msg-1" } as AgentEvent);
-    handleAgentEvent({ type: "message", threadId: threadId, content: "Final response", messageId: "msg-2" } as AgentEvent);
+    handleAgentEvent({ type: "message", threadId: threadId, content: "Narration before tool batch", messageId: "msg-1", tokens: null } satisfies AgentEvent);
+    handleAgentEvent({ type: "message", threadId: threadId, content: "Final response", messageId: "msg-2", tokens: null } satisfies AgentEvent);
     vi.runAllTimers();
 
     const keys = readThreadField(threadId, (r) => r.assistantResponseKeys)!;
@@ -77,12 +77,12 @@ describe("Agent Message Flow", () => {
     const { handleAgentEvent } = useThreadStore.getState();
 
     // Message for current thread is added
-    handleAgentEvent({ type: "message", threadId: "thread-a", content: "Alpha" } as AgentEvent);
+    handleAgentEvent({ type: "message", threadId: "thread-a", content: "Alpha", tokens: null } satisfies AgentEvent);
     vi.runAllTimers();
     expect(getTestActiveMessages()).toHaveLength(1);
 
     // The background message belongs to its target record, not the visible transcript.
-    handleAgentEvent({ type: "message", threadId: "thread-b", content: "Beta" } as AgentEvent);
+    handleAgentEvent({ type: "message", threadId: "thread-b", content: "Beta", tokens: null } satisfies AgentEvent);
     vi.runAllTimers();
     expect(getTestActiveMessages()).toHaveLength(1);
     expect(getTestActiveMessages()[0].content).toBe("Alpha");
@@ -99,7 +99,7 @@ describe("Agent Message Flow", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "ended", threadId: threadId } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "ended", threadId: threadId } satisfies AgentEvent);
     vi.runAllTimers();
 
     const state = useThreadStore.getState();
@@ -114,7 +114,7 @@ describe("Agent Message Flow", () => {
       currentThreadId: threadId,
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: threadId, costUsd: 0.01, tokensIn: 50, tokensOut: 50 } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: threadId, reason: "end_turn", costUsd: 0.01, tokensIn: 50, tokensOut: 50 } satisfies AgentEvent);
     vi.runAllTimers();
 
     const state = useThreadStore.getState();
@@ -129,9 +129,9 @@ describe("Agent Message Flow", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: "thread-1", costUsd: 0.005,
+    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: "thread-1", reason: "end_turn", costUsd: 0.005,
       tokensIn: 25,
-      tokensOut: 25 } as AgentEvent);
+      tokensOut: 25 } satisfies AgentEvent);
     vi.runAllTimers();
 
     expect(getTestThreadStreaming("thread-1")).toBeUndefined();
@@ -152,8 +152,8 @@ describe("Agent Message Flow", () => {
 
     const { handleAgentEvent, handleTurnPersisted } = useThreadStore.getState();
     handleAgentEvent({ type: "message", threadId: "thread-a", content: "Alpha completed while inactive",
-        messageId: "thread-a-completed", } as AgentEvent);
-    handleAgentEvent({ type: "turnComplete", threadId: "thread-a", costUsd: 0.005, tokensIn: 25, tokensOut: 25 } as AgentEvent);
+        messageId: "thread-a-completed", tokens: null } satisfies AgentEvent);
+    handleAgentEvent({ type: "turnComplete", threadId: "thread-a", reason: "end_turn", costUsd: 0.005, tokensIn: 25, tokensOut: 25 } satisfies AgentEvent);
 
     useThreadStore.setState({ currentThreadId: "thread-a" });
     handleTurnPersisted({
@@ -195,7 +195,7 @@ describe("duplicate message prevention", () => {
     const { handleAgentEvent } = useThreadStore.getState();
 
     // session.message arrives with the final content
-    handleAgentEvent({ type: "message", threadId: "thread-1", content: "Hello world", tokens: 10 } as AgentEvent);
+    handleAgentEvent({ type: "message", threadId: "thread-1", content: "Hello world", tokens: 10 } satisfies AgentEvent);
     vi.runAllTimers();
 
     // Both streaming fields must be cleared
@@ -203,7 +203,7 @@ describe("duplicate message prevention", () => {
     expect(getTestThreadStreamingPreview("thread-1")).toBeUndefined();
 
     // Now turnComplete fires — should NOT create a second message
-    handleAgentEvent({ type: "turnComplete", threadId: "thread-1", costUsd: 0.01, tokensIn: 50, tokensOut: 50 } as AgentEvent);
+    handleAgentEvent({ type: "turnComplete", threadId: "thread-1", reason: "end_turn", costUsd: 0.01, tokensIn: 50, tokensOut: 50 } satisfies AgentEvent);
     vi.runAllTimers();
 
     const messages = getTestActiveMessages();
@@ -238,7 +238,7 @@ describe("duplicate message prevention", () => {
     const { handleAgentEvent } = useThreadStore.getState();
     handleAgentEvent({ type: "message", threadId: "thread-1", content: "Hello world",
         messageId: "persisted-msg-id",
-        tokens: 10, } as AgentEvent);
+        tokens: 10, } satisfies AgentEvent);
     vi.runAllTimers();
 
     const messages = getTestActiveMessages();
@@ -282,8 +282,8 @@ describe("session.textDelta", () => {
 
   it("appends delta to streamingByThread", async () => {
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "Hello" } as AgentEvent);
-    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: " world" } as AgentEvent);
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "Hello" } satisfies AgentEvent);
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: " world" } satisfies AgentEvent);
 
     await flushRafChain();
     expect(getTestThreadStreaming("thread-1")).toBe("Hello world");
@@ -298,7 +298,7 @@ describe("session.textDelta", () => {
     });
     const { handleAgentEvent } = useThreadStore.getState();
 
-    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "end" } as AgentEvent);
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "end" } satisfies AgentEvent);
 
     await flushRafChain();
     // Full buffer is preserved
@@ -323,7 +323,7 @@ describe("session.textDelta", () => {
       ]),
     });
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "Hi" } as AgentEvent);
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "Hi" } satisfies AgentEvent);
 
     await flushRafChain();
     const calls = getTestThreadToolCalls("thread-1");
@@ -332,7 +332,7 @@ describe("session.textDelta", () => {
 
   it("does not affect other threads", async () => {
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "ping" } as AgentEvent);
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "ping" } satisfies AgentEvent);
 
     await flushRafChain();
     expect(getTestThreadStreaming("thread-2")).toBeUndefined();
@@ -361,7 +361,7 @@ describe("session.toolProgress", () => {
 
   it("updates elapsedSeconds on the matching tool call", () => {
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent({ type: "toolProgress", threadId: "thread-1", toolCallId: "tc1", toolName: "Bash", elapsedSeconds: 5 } as AgentEvent);
+    handleAgentEvent({ type: "toolProgress", threadId: "thread-1", toolCallId: "tc1", toolName: "Bash", elapsedSeconds: 5 } satisfies AgentEvent);
 
     const calls = getTestThreadToolCalls("thread-1");
     expect(calls[0].elapsedSeconds).toBe(5);
@@ -369,7 +369,7 @@ describe("session.toolProgress", () => {
 
   it("ignores toolProgress for unknown toolCallId", () => {
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent({ type: "toolProgress", threadId: "thread-1", toolCallId: "unknown", toolName: "Bash", elapsedSeconds: 3 } as AgentEvent);
+    handleAgentEvent({ type: "toolProgress", threadId: "thread-1", toolCallId: "unknown", toolName: "Bash", elapsedSeconds: 3 } satisfies AgentEvent);
 
     const calls = getTestThreadToolCalls("thread-1");
     expect(calls[0].elapsedSeconds).toBeUndefined();

--- a/apps/web/src/__tests__/streaming.test.ts
+++ b/apps/web/src/__tests__/streaming.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestActiveMessages,
@@ -39,10 +40,7 @@ describe("Agent Message Flow", () => {
     useThreadStore.setState({ currentThreadId: threadId });
     const { handleAgentEvent } = useThreadStore.getState();
 
-    handleAgentEvent(threadId, {
-      method: "session.message",
-      params: { content: "Hello world", tokens: 42 },
-    });
+    handleAgentEvent({ type: "message", threadId: threadId, content: "Hello world", tokens: 42 } as AgentEvent);
     vi.runAllTimers();
 
     expect(getTestActiveMessages()).toHaveLength(1);
@@ -58,14 +56,8 @@ describe("Agent Message Flow", () => {
 
     // Codex narration turn: an assistant message lands mid-turn, then the
     // final response lands as a second message with different content.
-    handleAgentEvent(threadId, {
-      method: "session.message",
-      params: { content: "Narration before tool batch", messageId: "msg-1" },
-    });
-    handleAgentEvent(threadId, {
-      method: "session.message",
-      params: { content: "Final response", messageId: "msg-2" },
-    });
+    handleAgentEvent({ type: "message", threadId: threadId, content: "Narration before tool batch", messageId: "msg-1" } as AgentEvent);
+    handleAgentEvent({ type: "message", threadId: threadId, content: "Final response", messageId: "msg-2" } as AgentEvent);
     vi.runAllTimers();
 
     const keys = readThreadField(threadId, (r) => r.assistantResponseKeys)!;
@@ -85,18 +77,12 @@ describe("Agent Message Flow", () => {
     const { handleAgentEvent } = useThreadStore.getState();
 
     // Message for current thread is added
-    handleAgentEvent("thread-a", {
-      method: "session.message",
-      params: { content: "Alpha" },
-    });
+    handleAgentEvent({ type: "message", threadId: "thread-a", content: "Alpha" } as AgentEvent);
     vi.runAllTimers();
     expect(getTestActiveMessages()).toHaveLength(1);
 
     // The background message belongs to its target record, not the visible transcript.
-    handleAgentEvent("thread-b", {
-      method: "session.message",
-      params: { content: "Beta" },
-    });
+    handleAgentEvent({ type: "message", threadId: "thread-b", content: "Beta" } as AgentEvent);
     vi.runAllTimers();
     expect(getTestActiveMessages()).toHaveLength(1);
     expect(getTestActiveMessages()[0].content).toBe("Alpha");
@@ -113,9 +99,7 @@ describe("Agent Message Flow", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent(threadId, {
-      method: "session.ended",
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "ended", threadId: threadId } as AgentEvent);
     vi.runAllTimers();
 
     const state = useThreadStore.getState();
@@ -130,10 +114,7 @@ describe("Agent Message Flow", () => {
       currentThreadId: threadId,
     });
 
-    useThreadStore.getState().handleAgentEvent(threadId, {
-      method: "session.turnComplete",
-      params: { costUsd: 0.01, tokensIn: 50, tokensOut: 50 },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: threadId, costUsd: 0.01, tokensIn: 50, tokensOut: 50 } as AgentEvent);
     vi.runAllTimers();
 
     const state = useThreadStore.getState();
@@ -148,12 +129,9 @@ describe("Agent Message Flow", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.turnComplete",
-      costUsd: 0.005,
+    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: "thread-1", costUsd: 0.005,
       tokensIn: 25,
-      tokensOut: 25,
-    });
+      tokensOut: 25 } as AgentEvent);
     vi.runAllTimers();
 
     expect(getTestThreadStreaming("thread-1")).toBeUndefined();
@@ -173,17 +151,9 @@ describe("Agent Message Flow", () => {
     });
 
     const { handleAgentEvent, handleTurnPersisted } = useThreadStore.getState();
-    handleAgentEvent("thread-a", {
-      method: "session.message",
-      params: {
-        content: "Alpha completed while inactive",
-        messageId: "thread-a-completed",
-      },
-    });
-    handleAgentEvent("thread-a", {
-      method: "session.turnComplete",
-      params: { costUsd: 0.005, tokensIn: 25, tokensOut: 25 },
-    });
+    handleAgentEvent({ type: "message", threadId: "thread-a", content: "Alpha completed while inactive",
+        messageId: "thread-a-completed", } as AgentEvent);
+    handleAgentEvent({ type: "turnComplete", threadId: "thread-a", costUsd: 0.005, tokensIn: 25, tokensOut: 25 } as AgentEvent);
 
     useThreadStore.setState({ currentThreadId: "thread-a" });
     handleTurnPersisted({
@@ -225,10 +195,7 @@ describe("duplicate message prevention", () => {
     const { handleAgentEvent } = useThreadStore.getState();
 
     // session.message arrives with the final content
-    handleAgentEvent("thread-1", {
-      method: "session.message",
-      params: { content: "Hello world", tokens: 10 },
-    });
+    handleAgentEvent({ type: "message", threadId: "thread-1", content: "Hello world", tokens: 10 } as AgentEvent);
     vi.runAllTimers();
 
     // Both streaming fields must be cleared
@@ -236,10 +203,7 @@ describe("duplicate message prevention", () => {
     expect(getTestThreadStreamingPreview("thread-1")).toBeUndefined();
 
     // Now turnComplete fires — should NOT create a second message
-    handleAgentEvent("thread-1", {
-      method: "session.turnComplete",
-      params: { costUsd: 0.01, tokensIn: 50, tokensOut: 50 },
-    });
+    handleAgentEvent({ type: "turnComplete", threadId: "thread-1", costUsd: 0.01, tokensIn: 50, tokensOut: 50 } as AgentEvent);
     vi.runAllTimers();
 
     const messages = getTestActiveMessages();
@@ -272,14 +236,9 @@ describe("duplicate message prevention", () => {
       ]),
     });
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent("thread-1", {
-      method: "session.message",
-      params: {
-        content: "Hello world",
+    handleAgentEvent({ type: "message", threadId: "thread-1", content: "Hello world",
         messageId: "persisted-msg-id",
-        tokens: 10,
-      },
-    });
+        tokens: 10, } as AgentEvent);
     vi.runAllTimers();
 
     const messages = getTestActiveMessages();
@@ -323,8 +282,8 @@ describe("session.textDelta", () => {
 
   it("appends delta to streamingByThread", async () => {
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: "Hello" } });
-    handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: " world" } });
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "Hello" } as AgentEvent);
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: " world" } as AgentEvent);
 
     await flushRafChain();
     expect(getTestThreadStreaming("thread-1")).toBe("Hello world");
@@ -339,7 +298,7 @@ describe("session.textDelta", () => {
     });
     const { handleAgentEvent } = useThreadStore.getState();
 
-    handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: "end" } });
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "end" } as AgentEvent);
 
     await flushRafChain();
     // Full buffer is preserved
@@ -364,7 +323,7 @@ describe("session.textDelta", () => {
       ]),
     });
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: "Hi" } });
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "Hi" } as AgentEvent);
 
     await flushRafChain();
     const calls = getTestThreadToolCalls("thread-1");
@@ -373,7 +332,7 @@ describe("session.textDelta", () => {
 
   it("does not affect other threads", async () => {
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent("thread-1", { method: "session.textDelta", params: { delta: "ping" } });
+    handleAgentEvent({ type: "textDelta", threadId: "thread-1", delta: "ping" } as AgentEvent);
 
     await flushRafChain();
     expect(getTestThreadStreaming("thread-2")).toBeUndefined();
@@ -402,10 +361,7 @@ describe("session.toolProgress", () => {
 
   it("updates elapsedSeconds on the matching tool call", () => {
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent("thread-1", {
-      method: "session.toolProgress",
-      params: { toolCallId: "tc1", toolName: "Bash", elapsedSeconds: 5 },
-    });
+    handleAgentEvent({ type: "toolProgress", threadId: "thread-1", toolCallId: "tc1", toolName: "Bash", elapsedSeconds: 5 } as AgentEvent);
 
     const calls = getTestThreadToolCalls("thread-1");
     expect(calls[0].elapsedSeconds).toBe(5);
@@ -413,10 +369,7 @@ describe("session.toolProgress", () => {
 
   it("ignores toolProgress for unknown toolCallId", () => {
     const { handleAgentEvent } = useThreadStore.getState();
-    handleAgentEvent("thread-1", {
-      method: "session.toolProgress",
-      params: { toolCallId: "unknown", toolName: "Bash", elapsedSeconds: 3 },
-    });
+    handleAgentEvent({ type: "toolProgress", threadId: "thread-1", toolCallId: "unknown", toolName: "Bash", elapsedSeconds: 3 } as AgentEvent);
 
     const calls = getTestThreadToolCalls("thread-1");
     expect(calls[0].elapsedSeconds).toBeUndefined();

--- a/apps/web/src/__tests__/threadStore-assistant-attachments.test.ts
+++ b/apps/web/src/__tests__/threadStore-assistant-attachments.test.ts
@@ -29,7 +29,7 @@ describe("threadStore assistant attachments", () => {
     useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "thread-images", messageId: "msg-1",
       content: "",
       tokens: null,
-      attachments: [attachment] } as AgentEvent);
+      attachments: [attachment] } satisfies AgentEvent);
 
     expect(getTestThreadMessages("thread-images")).toEqual([
       expect.objectContaining({

--- a/apps/web/src/__tests__/threadStore-assistant-attachments.test.ts
+++ b/apps/web/src/__tests__/threadStore-assistant-attachments.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getTestThreadMessages,
@@ -25,13 +26,10 @@ describe("threadStore assistant attachments", () => {
       sizeBytes: 128,
     };
 
-    useThreadStore.getState().handleAgentEvent("thread-images", {
-      method: "session.message",
-      messageId: "msg-1",
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "thread-images", messageId: "msg-1",
       content: "",
       tokens: null,
-      attachments: [attachment],
-    });
+      attachments: [attachment] } as AgentEvent);
 
     expect(getTestThreadMessages("thread-images")).toEqual([
       expect.objectContaining({

--- a/apps/web/src/__tests__/threadStore-assistant-message-boundary.test.ts
+++ b/apps/web/src/__tests__/threadStore-assistant-message-boundary.test.ts
@@ -32,12 +32,12 @@ describe("threadStore assistantMessageBoundary", () => {
     const tid = "thread-final";
     // Provider could not lookahead so it streamed deltas without
     // isFinalResponse=true — they landed in the thought segment buffer.
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "Autoclave is a sealed " } as AgentEvent);
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "pressure vessel." } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "Autoclave is a sealed " } satisfies AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "pressure vessel." } satisfies AgentEvent);
 
     // Boundary arrives with stop_reason=end_turn → the deltas were the final
     // response, not a thought.
-    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: true } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: true } satisfies AgentEvent);
 
     expect(getTestThreadThoughtSegments(tid) ?? []).toEqual([]);
     expect(getTestThreadStreaming(tid)).toBe(
@@ -53,9 +53,9 @@ describe("threadStore assistantMessageBoundary", () => {
     });
 
     const tid = "thread-preamble";
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "Let me look at the file." } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "Let me look at the file." } satisfies AgentEvent);
 
-    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: false } satisfies AgentEvent);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];
     expect(segs).toHaveLength(1);
@@ -65,7 +65,7 @@ describe("threadStore assistantMessageBoundary", () => {
 
   it("is a no-op when there is no open thought segment", () => {
     const tid = "thread-empty";
-    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: true } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: true } satisfies AgentEvent);
     expect(getTestThreadThoughtSegments(tid) ?? []).toEqual([]);
   });
 
@@ -90,7 +90,7 @@ describe("threadStore assistantMessageBoundary", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: true } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: true } satisfies AgentEvent);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];
     expect(segs).toEqual([{ text: "old thought", startedAt: 1, endedAt: 2 }]);

--- a/apps/web/src/__tests__/threadStore-assistant-message-boundary.test.ts
+++ b/apps/web/src/__tests__/threadStore-assistant-message-boundary.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestThreadStreaming,
@@ -31,21 +32,12 @@ describe("threadStore assistantMessageBoundary", () => {
     const tid = "thread-final";
     // Provider could not lookahead so it streamed deltas without
     // isFinalResponse=true — they landed in the thought segment buffer.
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "Autoclave is a sealed " },
-    });
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "pressure vessel." },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "Autoclave is a sealed " } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "pressure vessel." } as AgentEvent);
 
     // Boundary arrives with stop_reason=end_turn → the deltas were the final
     // response, not a thought.
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.assistantMessageBoundary",
-      isFinalResponse: true,
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: true } as AgentEvent);
 
     expect(getTestThreadThoughtSegments(tid) ?? []).toEqual([]);
     expect(getTestThreadStreaming(tid)).toBe(
@@ -61,15 +53,9 @@ describe("threadStore assistantMessageBoundary", () => {
     });
 
     const tid = "thread-preamble";
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "Let me look at the file." },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "Let me look at the file." } as AgentEvent);
 
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.assistantMessageBoundary",
-      isFinalResponse: false,
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: false } as AgentEvent);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];
     expect(segs).toHaveLength(1);
@@ -79,10 +65,7 @@ describe("threadStore assistantMessageBoundary", () => {
 
   it("is a no-op when there is no open thought segment", () => {
     const tid = "thread-empty";
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.assistantMessageBoundary",
-      isFinalResponse: true,
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: true } as AgentEvent);
     expect(getTestThreadThoughtSegments(tid) ?? []).toEqual([]);
   });
 
@@ -107,10 +90,7 @@ describe("threadStore assistantMessageBoundary", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.assistantMessageBoundary",
-      isFinalResponse: true,
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "assistantMessageBoundary", threadId: tid, isFinalResponse: true } as AgentEvent);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];
     expect(segs).toEqual([{ text: "old thought", startedAt: 1, endedAt: 2 }]);

--- a/apps/web/src/__tests__/threadStore-message-cache.test.ts
+++ b/apps/web/src/__tests__/threadStore-message-cache.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestActiveMessages,
@@ -125,7 +126,7 @@ describe("loadMessages cache eviction", () => {
     await useThreadStore.getState().loadMessages("t1");
     expect(getCachedRecord("t1")).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent("t1", { method: "session.message", content: "x" });
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "t1", content: "x" } as AgentEvent);
     expect(getCachedRecord("t1")).toBeUndefined();
   });
 

--- a/apps/web/src/__tests__/threadStore-message-cache.test.ts
+++ b/apps/web/src/__tests__/threadStore-message-cache.test.ts
@@ -126,7 +126,7 @@ describe("loadMessages cache eviction", () => {
     await useThreadStore.getState().loadMessages("t1");
     expect(getCachedRecord("t1")).toBeDefined();
 
-    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "t1", content: "x" } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "t1", content: "x", tokens: null } satisfies AgentEvent);
     expect(getCachedRecord("t1")).toBeUndefined();
   });
 

--- a/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
+++ b/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
@@ -39,7 +39,7 @@ describe("threadStore textDelta batching", () => {
 
     const tid = "thread-coalesce";
     for (let i = 0; i < 8; i++) {
-      useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: String(i) } as AgentEvent);
+      useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: String(i) } satisfies AgentEvent);
     }
 
     expect(queue).toHaveLength(1);
@@ -75,7 +75,7 @@ describe("threadStore textDelta batching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: " stale delta", isFinalResponse: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: " stale delta", isFinalResponse: false } satisfies AgentEvent);
     expect(queue).toHaveLength(1);
 
     useThreadStore.getState().hydrateRunningThreads([]);
@@ -100,8 +100,8 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-final-flag";
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "think ", isFinalResponse: false } as AgentEvent);
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "final", isFinalResponse: true } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "think ", isFinalResponse: false } satisfies AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "final", isFinalResponse: true } satisfies AgentEvent);
     expect(queue).toHaveLength(1);
 
     queue[0]!(0);
@@ -133,7 +133,7 @@ describe("threadStore textDelta batching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "final response", isFinalResponse: true } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "final response", isFinalResponse: true } satisfies AgentEvent);
     queue[0]!(0);
 
     expect(getTestThreadStreaming(tid)).toBe("final response");
@@ -162,7 +162,7 @@ describe("threadStore textDelta batching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "New narration", isFinalResponse: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "New narration", isFinalResponse: false } satisfies AgentEvent);
     queue[0]!(0);
 
     const nextSegments = readThreadField(tid, (record) => record.thoughtSegments);
@@ -181,7 +181,7 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-legacy-unclassified";
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "legacy " } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "legacy " } satisfies AgentEvent);
     expect(queue).toHaveLength(1);
 
     queue[0]!(0);
@@ -198,10 +198,10 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-flush";
-    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "hello " } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "hello " } satisfies AgentEvent);
     expect(queue).toHaveLength(1);
 
-    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: tid, costUsd: null, tokensIn: 0, tokensOut: 0 } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: tid, reason: "end_turn", costUsd: null, tokensIn: 0, tokensOut: 0 } satisfies AgentEvent);
 
     expect(getTestThreadStreaming(tid)).toBeUndefined();
   });

--- a/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
+++ b/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestThreadStreaming,
@@ -38,10 +39,7 @@ describe("threadStore textDelta batching", () => {
 
     const tid = "thread-coalesce";
     for (let i = 0; i < 8; i++) {
-      useThreadStore.getState().handleAgentEvent(tid, {
-        method: "session.textDelta",
-        params: { delta: String(i) },
-      });
+      useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: String(i) } as AgentEvent);
     }
 
     expect(queue).toHaveLength(1);
@@ -77,10 +75,7 @@ describe("threadStore textDelta batching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: " stale delta", isFinalResponse: false },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: " stale delta", isFinalResponse: false } as AgentEvent);
     expect(queue).toHaveLength(1);
 
     useThreadStore.getState().hydrateRunningThreads([]);
@@ -105,14 +100,8 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-final-flag";
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "think ", isFinalResponse: false },
-    });
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "final", isFinalResponse: true },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "think ", isFinalResponse: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "final", isFinalResponse: true } as AgentEvent);
     expect(queue).toHaveLength(1);
 
     queue[0]!(0);
@@ -144,10 +133,7 @@ describe("threadStore textDelta batching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "final response", isFinalResponse: true },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "final response", isFinalResponse: true } as AgentEvent);
     queue[0]!(0);
 
     expect(getTestThreadStreaming(tid)).toBe("final response");
@@ -176,10 +162,7 @@ describe("threadStore textDelta batching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "New narration", isFinalResponse: false },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "New narration", isFinalResponse: false } as AgentEvent);
     queue[0]!(0);
 
     const nextSegments = readThreadField(tid, (record) => record.thoughtSegments);
@@ -198,10 +181,7 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-legacy-unclassified";
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "legacy " },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "legacy " } as AgentEvent);
     expect(queue).toHaveLength(1);
 
     queue[0]!(0);
@@ -218,16 +198,10 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-flush";
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "hello " },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "hello " } as AgentEvent);
     expect(queue).toHaveLength(1);
 
-    useThreadStore.getState().handleAgentEvent(tid, {
-      method: "session.turnComplete",
-      params: { costUsd: null, tokensIn: 0, tokensOut: 0 },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "turnComplete", threadId: tid, costUsd: null, tokensIn: 0, tokensOut: 0 } as AgentEvent);
 
     expect(getTestThreadStreaming(tid)).toBeUndefined();
   });

--- a/apps/web/src/__tests__/threadStore-thought-merge.test.ts
+++ b/apps/web/src/__tests__/threadStore-thought-merge.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestThreadThoughtSegments,
@@ -42,21 +43,12 @@ describe("threadStore thought-segment coalescing", () => {
     const store = useThreadStore.getState();
 
     // Open segment with a short tail "the" and freeze it via a tool call.
-    store.handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "the", isFinalResponse: false },
-    });
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: "the", isFinalResponse: false } as AgentEvent);
     flush(queue);
-    store.handleAgentEvent(tid, {
-      method: "session.toolUse",
-      params: { toolCallId: "t1", toolName: "Bash", toolInput: {} },
-    });
+    store.handleAgentEvent({ type: "toolUse", threadId: tid, toolCallId: "t1", toolName: "Bash", toolInput: {} } as AgentEvent);
 
     // New delta continues the thought after the tool finishes.
-    store.handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: " changed set", isFinalResponse: false },
-    });
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: " changed set", isFinalResponse: false } as AgentEvent);
     flush(queue);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];
@@ -71,21 +63,12 @@ describe("threadStore thought-segment coalescing", () => {
     const store = useThreadStore.getState();
 
     const long = "I will read the file and then summarize what changed in this branch.";
-    store.handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: long, isFinalResponse: false },
-    });
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: long, isFinalResponse: false } as AgentEvent);
     flush(queue);
-    store.handleAgentEvent(tid, {
-      method: "session.toolUse",
-      params: { toolCallId: "t2", toolName: "Bash", toolInput: {} },
-    });
+    store.handleAgentEvent({ type: "toolUse", threadId: tid, toolCallId: "t2", toolName: "Bash", toolInput: {} } as AgentEvent);
 
     // Continuation starts uppercase and the prev ended with a period.
-    store.handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: "Now I have the result.", isFinalResponse: false },
-    });
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: "Now I have the result.", isFinalResponse: false } as AgentEvent);
     flush(queue);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];
@@ -100,20 +83,11 @@ describe("threadStore thought-segment coalescing", () => {
     const store = useThreadStore.getState();
 
     const prev = "I am inspecting the changeset closely so this review is";
-    store.handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: prev, isFinalResponse: false },
-    });
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: prev, isFinalResponse: false } as AgentEvent);
     flush(queue);
-    store.handleAgentEvent(tid, {
-      method: "session.toolUse",
-      params: { toolCallId: "t3", toolName: "Bash", toolInput: {} },
-    });
+    store.handleAgentEvent({ type: "toolUse", threadId: tid, toolCallId: "t3", toolName: "Bash", toolInput: {} } as AgentEvent);
 
-    store.handleAgentEvent(tid, {
-      method: "session.textDelta",
-      params: { delta: " entirely the uncommitted worktree delta.", isFinalResponse: false },
-    });
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: " entirely the uncommitted worktree delta.", isFinalResponse: false } as AgentEvent);
     flush(queue);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];

--- a/apps/web/src/__tests__/threadStore-thought-merge.test.ts
+++ b/apps/web/src/__tests__/threadStore-thought-merge.test.ts
@@ -43,12 +43,12 @@ describe("threadStore thought-segment coalescing", () => {
     const store = useThreadStore.getState();
 
     // Open segment with a short tail "the" and freeze it via a tool call.
-    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: "the", isFinalResponse: false } as AgentEvent);
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: "the", isFinalResponse: false } satisfies AgentEvent);
     flush(queue);
-    store.handleAgentEvent({ type: "toolUse", threadId: tid, toolCallId: "t1", toolName: "Bash", toolInput: {} } as AgentEvent);
+    store.handleAgentEvent({ type: "toolUse", threadId: tid, toolCallId: "t1", toolName: "Bash", toolInput: {} } satisfies AgentEvent);
 
     // New delta continues the thought after the tool finishes.
-    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: " changed set", isFinalResponse: false } as AgentEvent);
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: " changed set", isFinalResponse: false } satisfies AgentEvent);
     flush(queue);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];
@@ -63,12 +63,12 @@ describe("threadStore thought-segment coalescing", () => {
     const store = useThreadStore.getState();
 
     const long = "I will read the file and then summarize what changed in this branch.";
-    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: long, isFinalResponse: false } as AgentEvent);
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: long, isFinalResponse: false } satisfies AgentEvent);
     flush(queue);
-    store.handleAgentEvent({ type: "toolUse", threadId: tid, toolCallId: "t2", toolName: "Bash", toolInput: {} } as AgentEvent);
+    store.handleAgentEvent({ type: "toolUse", threadId: tid, toolCallId: "t2", toolName: "Bash", toolInput: {} } satisfies AgentEvent);
 
     // Continuation starts uppercase and the prev ended with a period.
-    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: "Now I have the result.", isFinalResponse: false } as AgentEvent);
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: "Now I have the result.", isFinalResponse: false } satisfies AgentEvent);
     flush(queue);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];
@@ -83,11 +83,11 @@ describe("threadStore thought-segment coalescing", () => {
     const store = useThreadStore.getState();
 
     const prev = "I am inspecting the changeset closely so this review is";
-    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: prev, isFinalResponse: false } as AgentEvent);
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: prev, isFinalResponse: false } satisfies AgentEvent);
     flush(queue);
-    store.handleAgentEvent({ type: "toolUse", threadId: tid, toolCallId: "t3", toolName: "Bash", toolInput: {} } as AgentEvent);
+    store.handleAgentEvent({ type: "toolUse", threadId: tid, toolCallId: "t3", toolName: "Bash", toolInput: {} } satisfies AgentEvent);
 
-    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: " entirely the uncommitted worktree delta.", isFinalResponse: false } as AgentEvent);
+    store.handleAgentEvent({ type: "textDelta", threadId: tid, delta: " entirely the uncommitted worktree delta.", isFinalResponse: false } satisfies AgentEvent);
     flush(queue);
 
     const segs = getTestThreadThoughtSegments(tid) ?? [];

--- a/apps/web/src/__tests__/threadStore-turn-persist.test.ts
+++ b/apps/web/src/__tests__/threadStore-turn-persist.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useThreadStore } from "@/stores/threadStore";
 import {
@@ -15,10 +16,7 @@ vi.mock("@/transport", async () => ({
 const THREAD_ID = "thread-turn-persist";
 
 function startTrackedTurn(turnId: string): void {
-  useThreadStore.getState().handleAgentEvent(THREAD_ID, {
-    method: "session.turnStarted",
-    fileEffectTurnId: turnId,
-  });
+  useThreadStore.getState().handleAgentEvent({ type: "turnStarted", threadId: THREAD_ID, fileEffectTurnId: turnId } as AgentEvent);
 }
 
 describe("handleTurnPersisted", () => {

--- a/apps/web/src/__tests__/tool-call-matching.test.ts
+++ b/apps/web/src/__tests__/tool-call-matching.test.ts
@@ -47,7 +47,7 @@ describe("Tool Call Matching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc2", output: "done", isError: true, exitCode: 1 } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc2", output: "done", isError: true, exitCode: 1 } satisfies AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -73,7 +73,7 @@ describe("Tool Call Matching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "unknown-id", output: "result", isError: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "unknown-id", output: "result", isError: false } satisfies AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -102,8 +102,8 @@ describe("Tool Call Matching", () => {
     });
 
     // Resolve out of order
-    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc3", output: "third", isError: false } as AgentEvent);
-    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc1", output: "first", isError: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc3", output: "third", isError: false } satisfies AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc1", output: "first", isError: false } satisfies AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -127,7 +127,7 @@ describe("Tool Call Matching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "unknown", output: "extra", isError: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "unknown", output: "extra", isError: false } satisfies AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -151,7 +151,7 @@ describe("Tool Call Matching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc2", output: "second-result", isError: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc2", output: "second-result", isError: false } satisfies AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -190,7 +190,7 @@ describe("Tool Call Matching", () => {
         toolInput: {
           model: "gpt-5.5",
           reasoningEffort: "high",
-        }, } as AgentEvent);
+        }, } satisfies AgentEvent);
     vi.runAllTimers();
 
     const [call] = getTestThreadToolCalls("thread-1");

--- a/apps/web/src/__tests__/tool-call-matching.test.ts
+++ b/apps/web/src/__tests__/tool-call-matching.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestThreadToolCalls,
@@ -46,10 +47,7 @@ describe("Tool Call Matching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "tc2", output: "done", isError: true, exitCode: 1 },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc2", output: "done", isError: true, exitCode: 1 } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -75,10 +73,7 @@ describe("Tool Call Matching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "unknown-id", output: "result", isError: false },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "unknown-id", output: "result", isError: false } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -107,14 +102,8 @@ describe("Tool Call Matching", () => {
     });
 
     // Resolve out of order
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "tc3", output: "third", isError: false },
-    });
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "tc1", output: "first", isError: false },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc3", output: "third", isError: false } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc1", output: "first", isError: false } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -138,10 +127,7 @@ describe("Tool Call Matching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "unknown", output: "extra", isError: false },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "unknown", output: "extra", isError: false } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -165,10 +151,7 @@ describe("Tool Call Matching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: { toolCallId: "tc2", output: "second-result", isError: false },
-    });
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "tc2", output: "second-result", isError: false } as AgentEvent);
     vi.runAllTimers();
 
     const calls = getTestThreadToolCalls("thread-1");
@@ -201,18 +184,13 @@ describe("Tool Call Matching", () => {
       ]),
     });
 
-    useThreadStore.getState().handleAgentEvent("thread-1", {
-      method: "session.toolResult",
-      params: {
-        toolCallId: "agent-1",
+    useThreadStore.getState().handleAgentEvent({ type: "toolResult", threadId: "thread-1", toolCallId: "agent-1",
         output: "done",
         isError: false,
         toolInput: {
           model: "gpt-5.5",
           reasoningEffort: "high",
-        },
-      },
-    });
+        }, } as AgentEvent);
     vi.runAllTimers();
 
     const [call] = getTestThreadToolCalls("thread-1");

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { Message, ToolCall, HookExecution, PermissionMode, InteractionMode, AttachmentMeta, StoredAttachment, ToolCallRecord, ThoughtSegmentRecord } from "@/transport";
-import type { ContextWindowMode, MessageMention, ReasoningLevel, OrchestrationMode, PlanQuestion, PlanAnswer, QuotaCategory, ProviderBillingMode, ProviderUsageInfo, GoalLookupResult, GoalState, PreviewAnnotationBundle, TurnFileEffectSummary } from "@mcode/contracts";
+import type { AgentEvent, ContextWindowMode, MessageMention, ReasoningLevel, OrchestrationMode, PlanQuestion, PlanAnswer, QuotaCategory, ProviderBillingMode, ProviderUsageInfo, GoalLookupResult, GoalState, PreviewAnnotationBundle, TurnFileEffectSummary } from "@mcode/contracts";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
 import type { ThoughtSegment } from "@/components/chat/narrative/types";
 import {
@@ -127,7 +127,7 @@ interface ThreadState {
   addPermissionRequest: (request: PermissionRequest) => void;
   /** Mark a permission request as settled with its decision. */
   resolvePermissionRequest: (requestId: string, decision: PermissionDecision) => void;
-  handleAgentEvent: (threadId: string, event: Record<string, unknown>) => void;
+  handleAgentEvent: (event: AgentEvent) => void;
   /** Refresh the provider-neutral goal lookup for a thread and update cached thread state. */
   refreshThreadGoal: (threadId: string) => Promise<GoalLookupResult>;
   /** Clear the active goal through the app RPC and update cached thread state. */
@@ -1771,11 +1771,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * On turn completion, commits any buffered streaming content as a
    * message and schedules tool call fade-out animations.
    */
-  handleAgentEvent: (threadId, event) => {
-    const method = (event.method as string) || "";
-    const params = (event.params as Record<string, unknown>) || event;
+  handleAgentEvent: (event) => {
+    const { threadId } = event;
 
-    if (method !== "session.textDelta") {
+    if (event.type !== "textDelta") {
       flushPendingTextDeltas();
     }
 
@@ -1783,10 +1782,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     // persisted messages. Streaming deltas (textDelta, toolProgress) are
     // ephemeral and don't change what loadMessages would return from the DB.
     const isStructuralEvent =
-      method === "session.turnComplete" ||
-      method === "session.ended" ||
-      method === "session.message" ||
-      method === "session.error";
+      event.type === "turnComplete" ||
+      event.type === "ended" ||
+      event.type === "message" ||
+      event.type === "error";
     if (isStructuralEvent) {
       evictCachedRecord(threadId);
     }
@@ -1820,12 +1819,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       });
     };
 
-    if (method !== "session.apiRetry" && getRec(threadId).apiRetry) {
+    if (event.type !== "apiRetry" && getRec(threadId).apiRetry) {
       patchRec(threadId, { apiRetry: undefined });
     }
 
-    if (method === "session.goalUpdated") {
-      const goal = params.goal as GoalState | undefined;
+    if (event.type === "goalUpdated") {
+      const goal = event.goal as GoalState | undefined;
       if (goal) {
         const openGoal = isGoalOpen(goal) ? goal : null;
         patchRec(threadId, { goal: openGoal });
@@ -1835,15 +1834,15 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.goalCleared") {
+    if (event.type === "goalCleared") {
       patchRec(threadId, { goal: null });
       const cached = getCachedRecord(threadId);
       if (cached) cacheRecord(threadId, { ...cached, goal: null });
       return;
     }
 
-    if (method === "session.system") {
-      const subtype = params.subtype as string;
+    if (event.type === "system") {
+      const subtype = event.subtype as string;
       // Both subtypes render as the quiet system-message hairline chapter-break.
       // `session_restarted`: the SDK silently restarted (lost in-memory context).
       // `sdk_session_invalidated`: a poison-pill provider state forced a reset;
@@ -1884,9 +1883,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.turnStarted") {
-      const fileEffectTurnId = typeof params.fileEffectTurnId === "string"
-        ? params.fileEffectTurnId
+    if (event.type === "turnStarted") {
+      const fileEffectTurnId = typeof event.fileEffectTurnId === "string"
+        ? event.fileEffectTurnId
         : "";
       const currentState = get();
       const currentRecord = getThreadRecord(currentState.records, threadId);
@@ -1925,27 +1924,27 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.message") {
+    if (event.type === "message") {
       markPriorToolCallsComplete();
-      const content = (params.content as string) || "";
+      const content = (event.content as string) || "";
       const isGoalNotice = isGoalStatusNotice(content);
-      const attachments = parseStoredAttachments(params.attachments);
-      if (content || attachments.length > 0 || params.messageId) {
+      const attachments = parseStoredAttachments(event.attachments);
+      if (content || attachments.length > 0 || event.messageId) {
         const message: Message = {
-          id: (params.messageId as string) || crypto.randomUUID(),
+          id: (event.messageId as string) || crypto.randomUUID(),
           thread_id: threadId,
           role: "assistant",
           content,
           tool_calls: null,
           files_changed: null,
           cost_usd: null,
-          tokens_used: (params.tokens as number) ?? null,
+          tokens_used: (event.tokens as number) ?? null,
           timestamp: new Date().toISOString(),
           sequence: messageSequenceFor(threadId),
           attachments: attachments.length > 0 ? attachments : null,
           // Server injects the model after persisting; defaults to null when
           // unknown (legacy clients, non-Claude providers without model info).
-          model: (params.model as string | null | undefined) ?? null,
+          model: (event.model as string | null | undefined) ?? null,
         };
         set((state) => {
           const rec = getThreadRecord(state.records, threadId);
@@ -2065,12 +2064,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.toolUse") {
-      const toolCallId = (params.toolCallId as string) || "";
+    if (event.type === "toolUse") {
+      const toolCallId = (event.toolCallId as string) || "";
       const existingCalls = getRec(threadId).toolCalls;
-      const toolName = (params.toolName as string) || "unknown";
-      const incomingInput = (params.toolInput as Record<string, unknown>) || {};
-      const parentToolCallId = params.parentToolCallId as string | undefined;
+      const toolName = (event.toolName as string) || "unknown";
+      const incomingInput = (event.toolInput as Record<string, unknown>) || {};
+      const parentToolCallId = event.parentToolCallId as string | undefined;
       const applyTodoWriteTasks = (
         toolInput: Record<string, unknown>,
         resolvedParentToolCallId: string | undefined,
@@ -2271,24 +2270,24 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.toolResult") {
-      const toolCallId = (params.toolCallId as string) || "";
-      const output = (params.output as string) || "";
-      const isError = (params.isError as boolean) || false;
+    if (event.type === "toolResult") {
+      const toolCallId = (event.toolCallId as string) || "";
+      const output = (event.output as string) || "";
+      const isError = (event.isError as boolean) || false;
       const exitCode =
-        typeof params.exitCode === "number" && Number.isInteger(params.exitCode)
-          ? params.exitCode
+        typeof event.exitCode === "number" && Number.isInteger(event.exitCode)
+          ? event.exitCode
           : undefined;
-      const outputTruncated = params.outputTruncated === true;
+      const outputTruncated = event.outputTruncated === true;
       const outputTotalBytes =
-        typeof params.outputTotalBytes === "number" && Number.isFinite(params.outputTotalBytes)
-          ? params.outputTotalBytes
+        typeof event.outputTotalBytes === "number" && Number.isFinite(event.outputTotalBytes)
+          ? event.outputTotalBytes
           : undefined;
       const outputArtifactPath =
-        typeof params.outputArtifactPath === "string" && params.outputArtifactPath.length > 0
-          ? params.outputArtifactPath
+        typeof event.outputArtifactPath === "string" && event.outputArtifactPath.length > 0
+          ? event.outputArtifactPath
           : undefined;
-      const rawToolInput = params.toolInput;
+      const rawToolInput = event.toolInput;
       const incomingInput =
         rawToolInput && typeof rawToolInput === "object" && !Array.isArray(rawToolInput)
           ? rawToolInput as Record<string, unknown>
@@ -2365,10 +2364,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     // session.textDelta: accumulate streaming text for live preview and finalization.
-    if (method === "session.textDelta") {
-      const delta = (params.delta as string) || "";
+    if (event.type === "textDelta") {
+      const delta = (event.delta as string) || "";
       if (!delta) return;
-      const rawIsFinalResponse = params.isFinalResponse;
+      const rawIsFinalResponse = event.isFinalResponse;
       const isFinalResponse =
         typeof rawIsFinalResponse === "boolean" ? rawIsFinalResponse : undefined;
       const hadPending = pendingTextDeltaByThread.has(threadId);
@@ -2388,7 +2387,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.assistantMessageBoundary") {
+    if (event.type === "assistantMessageBoundary") {
       // Authoritative classification of the text deltas just streamed for this
       // assistant message, derived from the Anthropic `stop_reason`.
       //
@@ -2400,7 +2399,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // - isFinalResponse=false (tool_use, pause_turn, anything else):
       //   the streamed text was preamble. Close the open thought so the next
       //   delta starts a fresh segment.
-      const isFinalResponse = params.isFinalResponse === true;
+      const isFinalResponse = event.isFinalResponse === true;
       // Flush any pending text delta chunks first so the open thought we
       // operate on reflects every delta that arrived for this message.
       flushPendingTextDeltas();
@@ -2423,9 +2422,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.toolProgress") {
-      const toolCallId = (params.toolCallId as string) || "";
-      const elapsedSeconds = (params.elapsedSeconds as number) ?? 0;
+    if (event.type === "toolProgress") {
+      const toolCallId = (event.toolCallId as string) || "";
+      const elapsedSeconds = (event.elapsedSeconds as number) ?? 0;
       if (!toolCallId) return;
       const lastActivityAt = Date.now();
       set((state) => {
@@ -2445,10 +2444,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.hookStarted") {
-      const hookName = (params.hookName as string) || "unknown";
-      const hookType = (params.hookType as "permission" | "stop") || "stop";
-      const toolName = params.toolName as string | undefined;
+    if (event.type === "hookStarted") {
+      const hookName = (event.hookName as string) || "unknown";
+      const hookType = (event.hookType as "permission" | "stop") || "stop";
+      const toolName = event.toolName as string | undefined;
       const hook: HookExecution = {
         hookName,
         hookType,
@@ -2466,9 +2465,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.hookProgress") {
-      const hookName = (params.hookName as string) || "";
-      const output = (params.output as string) || "";
+    if (event.type === "hookProgress") {
+      const hookName = (event.hookName as string) || "";
+      const output = (event.output as string) || "";
       if (!hookName || !output) return;
       set((state) => {
         const hooks = getThreadRecord(state.records, threadId).hooks;
@@ -2497,13 +2496,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.hookCompleted") {
-      const hookName = (params.hookName as string) || "";
-      const exitCode = (params.exitCode as number) ?? 1;
-      const durationMs = (params.durationMs as number) ?? 0;
-      const didBlock = (params.didBlock as boolean) ?? false;
-      const persistedMessageId = params.persistedMessageId as string | undefined;
-      const persistedHookId = params.persistedHookId as string | undefined;
+    if (event.type === "hookCompleted") {
+      const hookName = (event.hookName as string) || "";
+      const exitCode = (event.exitCode as number) ?? 1;
+      const durationMs = (event.durationMs as number) ?? 0;
+      const didBlock = (event.didBlock as boolean) ?? false;
+      const persistedMessageId = event.persistedMessageId as string | undefined;
+      const persistedHookId = event.persistedHookId as string | undefined;
       if (!hookName) return;
 
       // Late hooks (Stop/SessionEnd/PreCompact) arrive with persistedMessageId
@@ -2567,11 +2566,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.turnComplete" || method === "session.ended") {
+    if (event.type === "turnComplete" || event.type === "ended") {
       useTaskStore.getState().clearTaskBubbleIfAwaitingReplacement(threadId);
-      const costUsd = (params.costUsd as number) ?? null;
-      const tokensIn = ((params.tokensIn as number) ?? (params.totalTokensIn as number)) ?? 0;
-      const tokensOut = ((params.tokensOut as number) ?? (params.totalTokensOut as number)) ?? 0;
+      const turnComplete = event.type === "turnComplete" ? event : undefined;
+      const costUsd = turnComplete?.costUsd ?? null;
+      const tokensIn = turnComplete?.tokensIn ?? 0;
+      const tokensOut = turnComplete?.tokensOut ?? 0;
 
       // Commit any remaining streaming content and stop the agent,
       // Tool calls remain in-place and collapse into a summary.
@@ -2579,7 +2579,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
       // Build an ephemeral system message for guardrail stops (budget/turn limit).
       // Folded into the same set() call to avoid a double render pass.
-      const reason = method === "session.turnComplete" ? params.reason as string | undefined : undefined;
+      const reason = turnComplete?.reason;
       const isGuardrailStop = reason === "error_max_budget_usd" || reason === "max_turns";
       const guardrailMsg: Message | null = isGuardrailStop ? {
         id: crypto.randomUUID(),
@@ -2733,8 +2733,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Compaction cleanup (isCompactingByThread) is handled solely by the
       // session.compacting handler to keep lifecycle management in one place.
       if (tokensIn > 0 && !getRec(threadId).isCompacting) {
-        const sdkContextWindow = params.contextWindow as number | undefined;
-        const totalProcessedTokens = params.totalProcessedTokens as number | undefined;
+        const sdkContextWindow = turnComplete?.contextWindow;
+        const totalProcessedTokens = turnComplete?.totalProcessedTokens;
         // Prefer the actual model that ran (post-fallback) so context window
         // sizing reflects Haiku's limits rather than the requested Opus model.
         const fallback = getRec(threadId).lastFallback;
@@ -2762,9 +2762,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               contextWindow,
               totalProcessedTokens,
               tokensOut,
-              cacheReadTokens: params.cacheReadTokens as number | undefined,
-              cacheWriteTokens: params.cacheWriteTokens as number | undefined,
-              costMultiplier: params.costMultiplier as number | undefined,
+              cacheReadTokens: turnComplete?.cacheReadTokens,
+              cacheWriteTokens: turnComplete?.cacheWriteTokens,
+              costMultiplier: turnComplete?.costMultiplier,
             },
           }),
         }));
@@ -2794,7 +2794,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Uses tracked timers to prevent double-dequeue from duplicate events.
       // Skip dequeue when a guardrail stopped the session to avoid restarting
       // an agent that was intentionally capped by budget or turn limits.
-      if (method === "session.turnComplete" && !isGuardrailStop) {
+      if (event.type === "turnComplete" && !isGuardrailStop) {
         if (hasPendingPlanQuestions(threadId)) return;
         clearDequeueTimer(threadId);
         const timer = setTimeout(() => {
@@ -2847,16 +2847,16 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.quotaUpdate") {
-      const providerId = params.providerId as string;
-      const categories = Array.isArray(params.categories)
-        ? (params.categories as QuotaCategory[])
+    if (event.type === "quotaUpdate") {
+      const providerId = event.providerId as string;
+      const categories = Array.isArray(event.categories)
+        ? (event.categories as QuotaCategory[])
         : [];
-      const billingMode = params.billingMode as ProviderBillingMode | undefined;
-      const sessionCostUsd = params.sessionCostUsd as number | undefined;
-      const serviceTier = params.serviceTier as "standard" | "priority" | "batch" | undefined;
-      const numTurns = params.numTurns as number | undefined;
-      const durationMs = params.durationMs as number | undefined;
+      const billingMode = event.billingMode as ProviderBillingMode | undefined;
+      const sessionCostUsd = event.sessionCostUsd as number | undefined;
+      const serviceTier = event.serviceTier as "standard" | "priority" | "batch" | undefined;
+      const numTurns = event.numTurns as number | undefined;
+      const durationMs = event.durationMs as number | undefined;
       if (providerId) {
         const incoming: ProviderUsageInfo = {
           providerId,
@@ -2891,9 +2891,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.contextEstimate") {
-      const tokensIn = params.tokensIn as number;
-      const ctxWindow = params.contextWindow as number | undefined;
+    if (event.type === "contextEstimate") {
+      const tokensIn = event.tokensIn as number;
+      const ctxWindow = event.contextWindow as number | undefined;
       // Only apply if not compacting — the compaction-start zero sentinel is
       // authoritative while compaction is in progress.
       if (tokensIn > 0 && !getRec(threadId).isCompacting) {
@@ -2914,34 +2914,34 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.rateLimited") {
-      const active = params.active as boolean;
+    if (event.type === "rateLimited") {
+      const active = event.active as boolean;
       patchRec(threadId, {
         rateLimit: active
           ? {
-              retryAfterMs: params.retryAfterMs as number | undefined,
-              limitType: params.limitType as string | undefined,
-              utilization: params.utilization as number | undefined,
+              retryAfterMs: event.retryAfterMs as number | undefined,
+              limitType: event.limitType as string | undefined,
+              utilization: event.utilization as number | undefined,
             }
           : undefined,
       });
       return;
     }
 
-    if (method === "session.apiRetry") {
+    if (event.type === "apiRetry") {
       patchRec(threadId, {
         apiRetry: {
-          reason: params.reason as string,
-          attempt: params.attempt as number | undefined,
-          maxRetries: params.maxRetries as number | undefined,
-          delayMs: params.delayMs as number | undefined,
+          reason: event.reason as string,
+          attempt: event.attempt as number | undefined,
+          maxRetries: event.maxRetries as number | undefined,
+          delayMs: event.delayMs as number | undefined,
         },
       });
       return;
     }
 
-    if (method === "session.compacting") {
-      const active = params.active as boolean;
+    if (event.type === "compacting") {
+      const active = event.active as boolean;
       if (!active) {
         const wasCompacting = getRec(threadId).isCompacting;
         if (wasCompacting && get().currentThreadId === threadId) {
@@ -2983,9 +2983,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.modelFallback") {
-      const requestedModel = params.requestedModel as string;
-      const actualModel = params.actualModel as string;
+    if (event.type === "modelFallback") {
+      const requestedModel = event.requestedModel as string;
+      const actualModel = event.actualModel as string;
 
       const actualDefinition = findModelById(actualModel);
       const normalizedActual = actualDefinition?.id ?? actualModel;
@@ -3007,8 +3007,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
 
-    if (method === "session.error") {
-      const errorMsg = typeof params.error === "string" ? params.error : String(params.error ?? "Unknown error");
+    if (event.type === "error") {
+      const errorMsg = typeof event.error === "string" ? event.error : String(event.error ?? "Unknown error");
       const errorMessage: Message = {
         id: crypto.randomUUID(),
         thread_id: threadId,
@@ -3068,6 +3068,21 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       }));
       return;
     }
+
+    // These event types are either consumed server-side or have no thread
+    // conversation effect in the current web client.
+    if (
+      event.type === "generatedAttachment" ||
+      event.type === "compactSummary" ||
+      event.type === "toolInputDelta" ||
+      event.type === "providerUnavailable" ||
+      event.type === "mcpServerStartupStatus"
+    ) {
+      return;
+    }
+
+    const unsupportedEvent: never = event;
+    void unsupportedEvent;
 
   },
 

--- a/apps/web/src/transport/ws-events.test.ts
+++ b/apps/web/src/transport/ws-events.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "@mcode/contracts";
 import type { Thread } from "@/transport";
 
 vi.mock("@/transport", () => ({
@@ -10,6 +11,7 @@ import { startPushListeners, stopPushListeners } from "./ws-events";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useProviderCatalogStore } from "@/stores/providerCatalogStore";
 import { useDiffStore } from "@/stores/diffStore";
+import { useThreadStore } from "@/stores/threadStore";
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {
@@ -128,6 +130,38 @@ describe("ws-events provider.catalogChanged", () => {
     pushEmitter.emit("provider.catalogChanged", { request: { providerId: "codex" } });
 
     expect(reconcile).not.toHaveBeenCalled();
+  });
+});
+
+describe("ws-events agent.event", () => {
+  afterEach(() => {
+    stopPushListeners();
+    vi.restoreAllMocks();
+  });
+
+  it("drops malformed data before it reaches the thread store", () => {
+    const handleAgentEvent = vi.spyOn(useThreadStore.getState(), "handleAgentEvent");
+    startPushListeners();
+
+    pushEmitter.emit("agent.event", { type: "message", threadId: 42, content: "invalid" });
+
+    expect(handleAgentEvent).not.toHaveBeenCalled();
+  });
+
+  it("forwards a valid parsed event exactly once", () => {
+    const event = {
+      type: "message",
+      threadId: "thread-1",
+      content: "valid",
+      tokens: null,
+    } satisfies AgentEvent;
+    const handleAgentEvent = vi.spyOn(useThreadStore.getState(), "handleAgentEvent");
+    startPushListeners();
+
+    pushEmitter.emit("agent.event", event);
+
+    expect(handleAgentEvent).toHaveBeenCalledOnce();
+    expect(handleAgentEvent).toHaveBeenCalledWith(event);
   });
 });
 

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -1,6 +1,7 @@
 import {
   ProviderCatalogChangeSchema,
   WS_CHANNELS,
+  type AgentEvent,
   type ProviderAvailability,
   type Settings,
   type TurnFileEffectSummary,
@@ -81,15 +82,7 @@ export function startPushListeners(): void {
   // agent.event: the server wraps each sidecar event with { threadId, type, ... }
   unsubs.push(
     pushEmitter.on("agent.event", (data) => {
-      const event = data as Record<string, unknown>;
-      const threadId = event.threadId as string;
-      if (!threadId) return;
-
-      // Map the flat contract AgentEvent into the method-keyed shape
-      // that handleAgentEvent expects (method = "session.<type>").
-      const type = event.type as string;
-      const method = `session.${type}`;
-      handleAgentEvent(threadId, { method, ...event });
+      handleAgentEvent(data as AgentEvent);
     }),
   );
 

--- a/apps/web/src/transport/ws-events.ts
+++ b/apps/web/src/transport/ws-events.ts
@@ -1,7 +1,6 @@
 import {
   ProviderCatalogChangeSchema,
   WS_CHANNELS,
-  type AgentEvent,
   type ProviderAvailability,
   type Settings,
   type TurnFileEffectSummary,
@@ -82,7 +81,9 @@ export function startPushListeners(): void {
   // agent.event: the server wraps each sidecar event with { threadId, type, ... }
   unsubs.push(
     pushEmitter.on("agent.event", (data) => {
-      handleAgentEvent(data as AgentEvent);
+      const parsed = WS_CHANNELS["agent.event"].safeParse(data);
+      if (!parsed.success) return;
+      handleAgentEvent(parsed.data);
     }),
   );
 


### PR DESCRIPTION
## What
Consume validated `AgentEvent` objects directly in thread conversation updates.

## Why
Epic #923 establishes typed provider events as the shared runtime vocabulary. This change removes the web transport's legacy session-method projection while preserving provider, WebSocket, and inactive-thread cache behavior from prerequisite PR #931.

## Key Changes
- Accept `AgentEvent` directly in `threadStore.handleAgentEvent` and derive the thread from the event.
- Handle the event union exhaustively, including explicit no-op variants.
- Validate WebSocket `agent.event` payloads with the canonical schema and forward parsed events without reconstructing legacy session methods.
- Update maintained unit and E2E tests to use production-shaped typed events.

## Verification
- Runtime start, health response, and clean stop succeeded.
- Initial focused web tests passed: 3 files, 67 tests.
- Follow-up focused review tests passed: 10 files, 85 tests.
- Web typecheck and diff checks passed.
- `bun run verify` passed typecheck and lint, then reproduced an unrelated existing Windows short-path assertion failure in `apps/desktop/src/main/__tests__/preview-browser.test.ts:919` (76 tests passed, 1 failed in that file).
- Independent Reviewer/QA found no issue #925 defects.

## Known Gap
The local A to B to A browser interaction could not be completed because browser control became unavailable after the local UI loaded. CI E2E is the final browser oracle for the corrected production-shaped fixtures.

Related to #923

Closes #925