### PR TITLE
feat(web): restore conversation-owned cached state

### DIFF
--- a/apps/web/src/__tests__/goal-clear-unsupported.test.ts
+++ b/apps/web/src/__tests__/goal-clear-unsupported.test.ts
@@ -5,11 +5,12 @@ import {
   resetThreadStoreForTests,
   seedThreadRecord,
 } from "@/stores/thread-store-test-utils";
-import { createEmptyThreadRecord } from "@/stores/thread-record";
+import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 import {
-  cacheRecord,
+  cacheRecord as cacheConversationRecord,
   clearRecordCache,
   getCachedRecord,
+  projectConversationCacheState,
 } from "@/lib/thread-hydrator/record-cache";
 import { mockTransport } from "./mocks/transport";
 
@@ -32,6 +33,10 @@ const goal: GoalState = {
   controls: { canInspect: true, canClear: true },
 };
 
+function cacheRecord(threadId: string, record: ThreadRecord): void {
+  cacheConversationRecord(threadId, projectConversationCacheState(record));
+}
+
 describe("threadStore.clearThreadGoal", () => {
   beforeEach(() => {
     clearRecordCache();
@@ -39,7 +44,7 @@ describe("threadStore.clearThreadGoal", () => {
     vi.clearAllMocks();
   });
 
-  it("applies unsupported authoritative null clear results to live and cached goal state", async () => {
+  it("applies unsupported authoritative null clear results to resident goal state", async () => {
     const threadId = "thread-unsupported";
     useThreadStore.setState({
       records: seedThreadRecord(threadId, { goal }),
@@ -55,10 +60,10 @@ describe("threadStore.clearThreadGoal", () => {
     await useThreadStore.getState().clearThreadGoal(threadId);
 
     expect(useThreadStore.getState().records.get(threadId)?.goal).toBeNull();
-    expect(getCachedRecord(threadId)?.goal).toBeNull();
+    expect(getCachedRecord(threadId)).not.toHaveProperty("goal");
   });
 
-  it("preserves live and cached goals for non-authoritative null clear results", async () => {
+  it("preserves the resident goal for non-authoritative null clear results", async () => {
     const threadId = "thread-cache";
     useThreadStore.setState({
       records: seedThreadRecord(threadId, { goal }),
@@ -74,6 +79,6 @@ describe("threadStore.clearThreadGoal", () => {
     await useThreadStore.getState().clearThreadGoal(threadId);
 
     expect(useThreadStore.getState().records.get(threadId)?.goal).toEqual(goal);
-    expect(getCachedRecord(threadId)?.goal).toEqual(goal);
+    expect(getCachedRecord(threadId)).not.toHaveProperty("goal");
   });
 });

--- a/apps/web/src/__tests__/pagination.test.ts
+++ b/apps/web/src/__tests__/pagination.test.ts
@@ -11,7 +11,12 @@ import {
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { TurnSnapshot } from "@mcode/contracts";
 import { useThreadStore } from "@/stores/threadStore";
-import { cacheRecord, clearRecordCache, getCachedRecord } from "@/lib/thread-hydrator/record-cache";
+import {
+  cacheRecord as cacheConversationRecord,
+  clearRecordCache,
+  getCachedRecord,
+  projectConversationCacheState,
+} from "@/lib/thread-hydrator/record-cache";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 import { mockTransport, createMockMessage } from "./mocks/transport";
 import type { Message } from "@/transport";
@@ -20,6 +25,10 @@ vi.mock("@/transport", async () => ({
   ...(await vi.importActual("@/transport")),
   getTransport: () => mockTransport,
 }));
+
+function cacheRecord(threadId: string, record: ThreadRecord): void {
+  cacheConversationRecord(threadId, projectConversationCacheState(record));
+}
 
 /** Verifies cursor-based pagination: loadOlderMessages behavior and guards. */
 describe("Chat Pagination", () => {
@@ -253,6 +262,66 @@ describe("Chat Pagination", () => {
     const cached = getCachedRecord(threadId);
     expect(cached?.persistedFilesChanged[mOldId]).toEqual(["legacy.ts"]);
     expect(cached?.persistedFilesChanged.m3).toEqual(["kept.ts"]);
+  });
+
+  it("does not merge delayed pagination snapshots into a replacement cache", async () => {
+    const olderMessage = createMockMessage({
+      id: "older-message",
+      thread_id: threadId,
+      sequence: 1,
+    });
+    const replacementMessage = createMockMessage({
+      id: "replacement-message",
+      thread_id: threadId,
+      sequence: 9,
+    });
+    resetThreadStoreForTests({
+      currentThreadId: threadId,
+      records: new Map<string, ThreadRecord>([
+        [threadId, {
+          ...createEmptyThreadRecord(),
+          messages: [createMockMessage({ id: "current-message", thread_id: threadId, sequence: 2 })],
+          oldestLoadedSequence: 2,
+          hasMoreMessages: true,
+          loadEpoch: 1,
+        }],
+      ]),
+    });
+    (mockTransport.getMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      messages: [olderMessage],
+      hasMore: false,
+    });
+    let resolveSnapshots!: (snapshots: TurnSnapshot[]) => void;
+    (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise((resolve) => { resolveSnapshots = resolve; }),
+    );
+
+    await useThreadStore.getState().loadOlderMessages(threadId);
+    patchTestThreadLoadEpoch(threadId, 2);
+    cacheRecord(threadId, {
+      ...createEmptyThreadRecord(),
+      messages: [replacementMessage],
+      oldestLoadedSequence: replacementMessage.sequence,
+      persistedFilesChanged: { "replacement-message": ["replacement.ts"] },
+    });
+
+    resolveSnapshots([{
+      id: "delayed-snapshot",
+      message_id: olderMessage.id,
+      thread_id: threadId,
+      ref_before: "before",
+      ref_after: "after",
+      files_changed: ["stale.ts"],
+      worktree_path: null,
+      created_at: new Date().toISOString(),
+    }]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getCachedRecord(threadId)?.persistedFilesChanged).toEqual({
+      "replacement-message": ["replacement.ts"],
+    });
+    expect(getTestThreadPersistedFilesChanged(threadId)[olderMessage.id]).toBeUndefined();
   });
 
   it("loadOlderMessages resets isLoadingMore on network error", async () => {

--- a/apps/web/src/__tests__/prefetch.test.ts
+++ b/apps/web/src/__tests__/prefetch.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   getCachedRecord,
-  cacheRecord,
+  cacheRecord as cacheConversationRecord,
   clearRecordCache,
+  projectConversationCacheState,
 } from "@/lib/thread-hydrator/record-cache";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 import { mockTransport, createMockMessage } from "./mocks/transport";
@@ -23,6 +24,10 @@ function makeRecord(id: string): ThreadRecord {
     ],
     oldestLoadedSequence: 1,
   };
+}
+
+function cacheRecord(threadId: string, record: ThreadRecord): void {
+  cacheConversationRecord(threadId, projectConversationCacheState(record));
 }
 
 describe("prefetch", () => {

--- a/apps/web/src/__tests__/record-cache.test.ts
+++ b/apps/web/src/__tests__/record-cache.test.ts
@@ -3,7 +3,7 @@ import { resetThreadStoreForTests } from "@/stores/thread-store-test-utils";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   getCachedRecord,
-  cacheRecord,
+  cacheRecord as cacheConversationRecord,
   cachePrefetchedHistoryPage,
   takePrefetchedHistoryPage,
   evictCachedRecord,
@@ -11,6 +11,7 @@ import {
   resizeRecordCache,
   RECORD_CACHE_SIZE,
   RECORD_MESSAGE_CACHE_SIZE,
+  projectConversationCacheState,
 } from "@/lib/thread-hydrator/record-cache";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 import {
@@ -50,6 +51,10 @@ function makeRecord(id: string): ThreadRecord {
   };
 }
 
+function cacheRecord(threadId: string, record: ThreadRecord): void {
+  cacheConversationRecord(threadId, projectConversationCacheState(record));
+}
+
 describe("recordCache", () => {
   beforeEach(() => {
     clearRecordCache();
@@ -63,7 +68,24 @@ describe("recordCache", () => {
   it("caches and retrieves a record by threadId", () => {
     const rec = makeRecord("t1");
     cacheRecord("t1", rec);
-    expect(getCachedRecord("t1")).toEqual(rec);
+    expect(getCachedRecord("t1")).toEqual(projectConversationCacheState(rec));
+  });
+
+  it("stores only explicitly projected conversation fields", () => {
+    const rec = {
+      ...makeRecord("t1"),
+      loading: true,
+      streaming: "live response",
+      currentTurnMessageId: "turn-1",
+    };
+
+    cacheRecord("t1", rec);
+
+    const cached = getCachedRecord("t1");
+    expect(cached).not.toHaveProperty("loading");
+    expect(cached).not.toHaveProperty("streaming");
+    expect(cached).not.toHaveProperty("currentTurnMessageId");
+    expect(cached).not.toHaveProperty("goal");
   });
 
   it("evicts a single thread without affecting others", () => {

--- a/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { HYDRATION_TTL_MS } from "@/lib/thread-hydrator";
 import { AuxiliaryHydrator } from "@/lib/thread-hydrator/auxiliary-hydrator";
 import {
-  cacheRecord,
+  cacheRecord as cacheConversationRecord,
   clearRecordCache,
   getCachedRecord,
+  projectConversationCacheState,
 } from "@/lib/thread-hydrator/record-cache";
 import {
   createEmptyThreadRecord,
@@ -25,6 +26,10 @@ function makeThinRecord(): ThreadRecord {
     messages: [createMockMessage({ id: "m1", thread_id: THREAD_ID, sequence: 1 })],
     oldestLoadedSequence: 1,
   };
+}
+
+function cacheRecord(threadId: string, record: ThreadRecord): void {
+  cacheConversationRecord(threadId, projectConversationCacheState(record));
 }
 
 describe("AuxiliaryHydrator", () => {
@@ -413,7 +418,7 @@ describe("AuxiliaryHydrator", () => {
       });
     });
     expect(getThreadRecord(records, THREAD_ID).fileEffectSummary).toEqual(liveSummary);
-    expect(getCachedRecord(THREAD_ID)?.fileEffectSummary).toEqual(liveSummary);
+    expect(getCachedRecord(THREAD_ID)?.settledFileEffectSummary).toBeNull();
   });
 
   it("discarded file-change snapshots after the expected load epoch changed", async () => {

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -1,3 +1,4 @@
+import type { AgentEvent } from "@mcode/contracts";
 import {
   resetThreadStoreForTests,
   getTestActiveMessages,
@@ -18,9 +19,10 @@ import { useTaskStore } from "@/stores/taskStore";
 import { usePlanStore } from "@/stores/planStore";
 import {
   clearRecordCache,
-  cacheRecord,
+  cacheRecord as cacheConversationRecord,
   getCachedRecord,
   hasPrefetchedHistoryPage,
+  projectConversationCacheState,
 } from "@/lib/thread-hydrator/record-cache";
 import { createEmptyThreadRecord, patchThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 import {
@@ -72,6 +74,10 @@ function makeCachedRecord(messages = [msgA]): ThreadRecord {
     messages,
     oldestLoadedSequence: messages[0]?.sequence ?? 0,
   };
+}
+
+function cacheRecord(threadId: string, record: ThreadRecord): void {
+  cacheConversationRecord(threadId, projectConversationCacheState(record));
 }
 
 /** Build a hydrator wired to the live threadStore for integration-style tests. */
@@ -168,6 +174,67 @@ describe("ThreadHydrator", () => {
     expect(getTestActiveMessages()).toEqual([msgA]);
     expect(useThreadStore.getState().currentThreadId).toBe(THREAD_A);
     expect(getTestThreadLoadEpoch(THREAD_A)).toBe(beforeEpoch + 1);
+  });
+
+  it("preserves resident auxiliary state on an idle cache hit", async () => {
+    const goal = makeGoal();
+    cacheRecord(THREAD_A, makeCachedRecord());
+    resetThreadStoreForTests({
+      records: new Map<string, ThreadRecord>([
+        [THREAD_A, { ...createEmptyThreadRecord(), goal }],
+      ]),
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(readActiveThreadField((record) => record.goal)).toEqual(goal);
+    expect(getTestActiveMessages()).toEqual([msgA]);
+  });
+
+  it("prefers resident content and metadata when the cache has the same final sequence", async () => {
+    const cachedHistory = createMockMessage({
+      id: "cached-history",
+      thread_id: THREAD_A,
+      content: "older cached message",
+      sequence: 1,
+    });
+    const staleCachedMessage = createMockMessage({
+      id: "stale-cache-message",
+      thread_id: THREAD_A,
+      content: "stale cache message",
+      sequence: 2,
+    });
+    const residentMessage = createMockMessage({
+      id: "resident-message",
+      thread_id: THREAD_A,
+      content: "newer resident message",
+      sequence: 2,
+    });
+    cacheRecord(THREAD_A, {
+      ...makeCachedRecord([cachedHistory, staleCachedMessage]),
+      persistedToolCallCounts: { "stale-cache-message": 1 },
+      persistedFilesChanged: { "cached-history": ["older-change.ts"] },
+      latestTurnWithChanges: "cached-history",
+      serverMessageIds: { "stale-cache-message": "server-stale" },
+    });
+    resetThreadStoreForTests({
+      records: new Map<string, ThreadRecord>([[THREAD_A, {
+        ...makeCachedRecord([residentMessage]),
+        persistedToolCallCounts: { "resident-message": 2 },
+        serverMessageIds: { "resident-message": "server-resident" },
+      }]]),
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(getTestActiveMessages()).toEqual([cachedHistory, residentMessage]);
+    expect(readActiveThreadField((record) => record.persistedToolCallCounts)).toEqual({
+      "resident-message": 2,
+    });
+    expect(readActiveThreadField((record) => record.serverMessageIds)).toEqual({
+      "resident-message": "server-resident",
+    });
+    expect(readActiveThreadField((record) => record.latestTurnWithChanges)).toBe("cached-history");
   });
 
   it("cache miss fetches a conversation page, commits store, and populates cache", async () => {
@@ -325,10 +392,10 @@ describe("ThreadHydrator", () => {
     await hydrator.hydrate(THREAD_A, "active");
 
     expect(readActiveThreadField((r) => r.goal)).toEqual(goal);
-    expect(getCachedRecord(THREAD_A)?.goal).toEqual(goal);
+    expect(getCachedRecord(THREAD_A)).not.toHaveProperty("goal");
   });
 
-  it("clears live and cached goals when lookup returns authoritative null", async () => {
+  it("clears the resident goal when lookup returns authoritative null", async () => {
     const goal = makeGoal();
     cacheRecord(THREAD_A, { ...makeCachedRecord(), goal });
     (mockTransport.getThreadGoal as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -343,7 +410,7 @@ describe("ThreadHydrator", () => {
       expect(readActiveThreadField((r) => r.goal)).toBeNull();
     });
 
-    expect(getCachedRecord(THREAD_A)?.goal).toBeNull();
+    expect(getCachedRecord(THREAD_A)).not.toHaveProperty("goal");
   });
 
   it("applies lookup goals only to the requested thread", async () => {
@@ -475,7 +542,7 @@ describe("ThreadHydrator", () => {
 
     expect(useThreadStore.getState().records.has(THREAD_A)).toBe(false);
     expect(getCachedRecord(THREAD_A)?.messages).toEqual([]);
-    expect(getCachedRecord(THREAD_A)?.loading).toBe(false);
+    expect(getCachedRecord(THREAD_A)).not.toHaveProperty("loading");
   });
 
   it("restores messages added to a resident thread after its empty snapshot was cached", async () => {
@@ -742,7 +809,7 @@ describe("ThreadHydrator", () => {
     await Promise.resolve();
 
     expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
-    expect(getCachedRecord(THREAD_A)?.goal).toBeNull();
+    expect(getCachedRecord(THREAD_A)).not.toHaveProperty("goal");
     expect(getCachedRecord(THREAD_A)?.persistedFilesChanged).toEqual({});
   });
 
@@ -900,6 +967,59 @@ describe("ThreadHydrator", () => {
     expect(getCachedRecord(THREAD_A)?.messages).toEqual([msgA]);
     expect(useThreadStore.getState().currentThreadId).toBe(THREAD_B);
     expect(getTestActiveMessages()).toEqual([msgB]);
+  });
+
+  it("does not let a background prefetch replace an inactive WebSocket update", async () => {
+    const staleMessage = createMockMessage({
+      id: "stale-prefetch-message",
+      thread_id: THREAD_A,
+      content: "stale prefetch response",
+      sequence: 1,
+    });
+    let resolvePage!: (value: {
+      messages: typeof staleMessage[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_B,
+      records: new Map<string, ThreadRecord>([
+        [THREAD_A, createEmptyThreadRecord()],
+        [THREAD_B, { ...createEmptyThreadRecord(), messages: [msgB] }],
+      ]),
+    });
+
+    const backgroundHydrate = hydrator.hydrate(THREAD_A, "background");
+    await vi.waitFor(() => expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(
+      THREAD_A,
+      BACKGROUND_PREFETCH_LIMIT,
+    ));
+
+    useThreadStore.getState().handleAgentEvent({
+      type: "message",
+      threadId: THREAD_A,
+      content: "fresh WebSocket response",
+      messageId: "resident-websocket-message",
+      tokens: null,
+    } satisfies AgentEvent);
+    clearRecordCache();
+    resolvePage({ messages: [staleMessage], hasMore: false, narrativeByMessage: {} });
+    await backgroundHydrate;
+
+    expect(getCachedRecord(THREAD_A)?.messages).toEqual([
+      expect.objectContaining({ id: "resident-websocket-message", content: "fresh WebSocket response" }),
+    ]);
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(getTestActiveMessages()).toEqual([
+      expect.objectContaining({ id: "resident-websocket-message", content: "fresh WebSocket response" }),
+    ]);
   });
 
   it("commits messages and narrative from one conversation page fetch", async () => {

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -211,7 +211,9 @@ export class AuxiliaryHydrator {
             ...fileChanges.persistedFilesChanged,
           },
           latestTurnWithChanges: fileChanges.latestTurnWithChanges,
-          ...(!ownsLiveFileEffects ? { fileEffectSummary: fileChanges.fileEffectSummary } : {}),
+          ...(!ownsLiveFileEffects
+            ? { settledFileEffectSummary: fileChanges.fileEffectSummary }
+            : {}),
         });
 
         if (!commitToStore) return;

--- a/apps/web/src/lib/thread-hydrator/index.ts
+++ b/apps/web/src/lib/thread-hydrator/index.ts
@@ -19,11 +19,13 @@ export {
   hasCachedRecord,
   hasPrefetchedHistoryPage,
   takePrefetchedHistoryPage,
+  projectConversationCacheState,
   clearRecordCache,
   resizeRecordCache,
   RECORD_CACHE_SIZE,
   RECORD_MESSAGE_CACHE_SIZE,
 } from "./record-cache";
+export type { ConversationCacheState } from "./record-cache";
 export { AuxiliaryHydrator } from "./auxiliary-hydrator";
 export type { AuxiliaryHydratorOptions, AuxiliaryHydratorDeps } from "./auxiliary-hydrator";
 export type {

--- a/apps/web/src/lib/thread-hydrator/record-cache.ts
+++ b/apps/web/src/lib/thread-hydrator/record-cache.ts
@@ -16,11 +16,51 @@ export const RECORD_CACHE_SIZE = 15;
 export const RECORD_MESSAGE_CACHE_SIZE = 100;
 
 /**
- * Module-scoped LRU cache of evicted {@link ThreadRecord}s.
+ * Conversation-owned state retained for an inactive thread.
+ *
+ * This is intentionally not a `Pick<ThreadRecord, ...>`: adding a field to
+ * `ThreadRecord` cannot silently make it part of the cache contract.
+ */
+export interface ConversationCacheState {
+  messages: ThreadRecord["messages"];
+  oldestLoadedSequence: ThreadRecord["oldestLoadedSequence"];
+  hasMoreMessages: ThreadRecord["hasMoreMessages"];
+  persistedToolCallCounts: ThreadRecord["persistedToolCallCounts"];
+  persistedFilesChanged: ThreadRecord["persistedFilesChanged"];
+  latestTurnWithChanges: ThreadRecord["latestTurnWithChanges"];
+  serverMessageIds: ThreadRecord["serverMessageIds"];
+  narrativeByMessage: ThreadRecord["narrativeByMessage"];
+  answeredPlanMessageIds: ThreadRecord["answeredPlanMessageIds"];
+  assistantResponseKeys: ThreadRecord["assistantResponseKeys"];
+  /** Latest settled snapshot projection. Never populated from a live turn. */
+  settledFileEffectSummary: ThreadRecord["fileEffectSummary"] | null;
+}
+
+/** Build the explicit conversation cache contract from a resident thread record. */
+export function projectConversationCacheState(record: ThreadRecord): ConversationCacheState {
+  return {
+    messages: record.messages,
+    oldestLoadedSequence: record.oldestLoadedSequence,
+    hasMoreMessages: record.hasMoreMessages,
+    persistedToolCallCounts: record.persistedToolCallCounts,
+    persistedFilesChanged: record.persistedFilesChanged,
+    latestTurnWithChanges: record.latestTurnWithChanges,
+    serverMessageIds: record.serverMessageIds,
+    narrativeByMessage: record.narrativeByMessage,
+    answeredPlanMessageIds: record.answeredPlanMessageIds,
+    assistantResponseKeys: record.assistantResponseKeys,
+    settledFileEffectSummary: record.fileEffectTurnId.length === 0
+      ? record.fileEffectSummary
+      : null,
+  };
+}
+
+/**
+ * Module-scoped LRU cache of evicted {@link ConversationCacheState}s.
  * The hydrator owns this cache: an active-thread switch evicts records into
  * here so the next visit restores synchronously without an RPC round-trip.
  */
-const cache = new LruCache<string, ThreadRecord>(RECORD_CACHE_SIZE);
+const cache = new LruCache<string, ConversationCacheState>(RECORD_CACHE_SIZE);
 
 interface PrefetchedHistoryPage {
   before: number;
@@ -38,7 +78,7 @@ function filterMessageMetadata<T>(
   );
 }
 
-function boundRecord(threadId: string, record: ThreadRecord): ThreadRecord {
+function boundRecord(threadId: string, record: ConversationCacheState): ConversationCacheState {
   if (record.messages.length <= RECORD_MESSAGE_CACHE_SIZE) return record;
 
   const messages = record.messages.slice(-RECORD_MESSAGE_CACHE_SIZE);
@@ -110,7 +150,7 @@ function trimPrefetchedHistory(threadId: string, recordMessageCount: number): vo
 }
 
 /** Read the cached record for a thread, refreshing LRU recency on hit. */
-export function getCachedRecord(threadId: string): ThreadRecord | undefined {
+export function getCachedRecord(threadId: string): ConversationCacheState | undefined {
   return cache.get(threadId);
 }
 
@@ -120,7 +160,7 @@ export function hasCachedRecord(threadId: string): boolean {
 }
 
 /** Store a record for the given thread, evicting the LRU entry if at capacity. */
-export function cacheRecord(threadId: string, record: ThreadRecord): void {
+export function cacheRecord(threadId: string, record: ConversationCacheState): void {
   const boundedRecord = boundRecord(threadId, record);
   const evicted = cache.set(threadId, boundedRecord);
   trimPrefetchedHistory(threadId, boundedRecord.messages.length);

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -5,7 +5,9 @@ import {
   getCachedRecord,
   hasCachedRecord,
   hasPrefetchedHistoryPage,
+  projectConversationCacheState,
 } from "./record-cache";
+import type { ConversationCacheState } from "./record-cache";
 import {
   createEmptyThreadRecord,
   deleteThreadRecord,
@@ -40,10 +42,88 @@ function hasResidentLayer(record: ThreadRecord): boolean {
     || record.hooks.length > 0;
 }
 
-function hasNewerResidentMessages(resident: ThreadRecord, cached: ThreadRecord): boolean {
-  const residentSequence = resident.messages.at(-1)?.sequence;
+function mergeMessageMetadata<T>(
+  cached: Record<string, T>,
+  resident: Record<string, T>,
+  retainedMessageIds: Set<string>,
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries({ ...cached, ...resident }).filter(([messageId]) => retainedMessageIds.has(messageId)),
+  );
+}
+
+function findLatestTurnWithChanges(
+  messages: ConversationCacheState["messages"],
+  persistedFilesChanged: ConversationCacheState["persistedFilesChanged"],
+): string | null {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message && (persistedFilesChanged[message.id]?.length ?? 0) > 0) {
+      return message.id;
+    }
+  }
+  return null;
+}
+
+/** Prefer an equally recent resident update while retaining disjoint cached history. */
+function mergeResidentConversationCacheState(
+  resident: ThreadRecord,
+  cached: ConversationCacheState,
+): ConversationCacheState {
+  const residentCacheState = projectConversationCacheState(resident);
+  const residentSequence = residentCacheState.messages.at(-1)?.sequence;
   const cachedSequence = cached.messages.at(-1)?.sequence;
-  return residentSequence != null && (cachedSequence == null || residentSequence > cachedSequence);
+  if (residentSequence == null || (cachedSequence != null && cachedSequence > residentSequence)) {
+    return cached;
+  }
+
+  const messagesBySequence = new Map(cached.messages.map((message) => [message.sequence, message]));
+  for (const message of residentCacheState.messages) {
+    messagesBySequence.set(message.sequence, message);
+  }
+  const messages = [...messagesBySequence.values()].sort((left, right) => left.sequence - right.sequence);
+  const retainedMessageIds = new Set(messages.map((message) => message.id));
+  const persistedFilesChanged = mergeMessageMetadata(
+    cached.persistedFilesChanged,
+    residentCacheState.persistedFilesChanged,
+    retainedMessageIds,
+  );
+
+  return {
+    ...cached,
+    ...residentCacheState,
+    messages,
+    oldestLoadedSequence: messages[0]?.sequence ?? residentCacheState.oldestLoadedSequence,
+    hasMoreMessages: cached.hasMoreMessages || residentCacheState.hasMoreMessages,
+    persistedToolCallCounts: mergeMessageMetadata(
+      cached.persistedToolCallCounts,
+      residentCacheState.persistedToolCallCounts,
+      retainedMessageIds,
+    ),
+    persistedFilesChanged,
+    latestTurnWithChanges: findLatestTurnWithChanges(messages, persistedFilesChanged),
+    serverMessageIds: mergeMessageMetadata(
+      cached.serverMessageIds,
+      residentCacheState.serverMessageIds,
+      retainedMessageIds,
+    ),
+    narrativeByMessage: mergeMessageMetadata(
+      cached.narrativeByMessage,
+      residentCacheState.narrativeByMessage,
+      retainedMessageIds,
+    ),
+    answeredPlanMessageIds: new Set(
+      [...cached.answeredPlanMessageIds, ...residentCacheState.answeredPlanMessageIds]
+        .filter((messageId) => retainedMessageIds.has(messageId)),
+    ),
+    assistantResponseKeys: mergeMessageMetadata(
+      cached.assistantResponseKeys,
+      residentCacheState.assistantResponseKeys,
+      retainedMessageIds,
+    ),
+    settledFileEffectSummary:
+      residentCacheState.settledFileEffectSummary ?? cached.settledFileEffectSummary,
+  };
 }
 
 /** Build a conversation page containing only the supplied messages and their metadata. */
@@ -157,8 +237,6 @@ export class ThreadHydrator {
           : Promise.resolve([] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>),
       ]);
 
-      if (hasCachedRecord(threadId)) return;
-
       const tailStart = Math.max(0, pageResult.messages.length - MESSAGE_FETCH_SIZE);
       const earlierMessages = pageResult.messages.slice(0, tailStart);
       const tailPage = buildConversationPageSubset(
@@ -179,7 +257,15 @@ export class ThreadHydrator {
         narrativeByMessage: tailPage.narrativeByMessage,
         settings: this.deps.getWorkspaceThreadSettings(threadId),
       };
-      cacheRecord(threadId, record);
+      const cachedRecord = projectConversationCacheState(record);
+      const resident = this.deps.getState().records.get(threadId);
+      if (resident && hasResidentLayer(resident)) {
+        cacheRecord(threadId, mergeResidentConversationCacheState(resident, cachedRecord));
+        return;
+      }
+      if (hasCachedRecord(threadId)) return;
+
+      cacheRecord(threadId, cachedRecord);
       if (earlierMessages.length > 0 && tailPage.messages.length > 0) {
         cachePrefetchedHistoryPage(
           threadId,
@@ -233,7 +319,7 @@ export class ThreadHydrator {
     if (cached) {
       this.restoreCachedActive(
         threadId,
-        resident && hasNewerResidentMessages(resident, cached) ? resident : cached,
+        resident ? mergeResidentConversationCacheState(resident, cached) : cached,
         opts,
       );
       return;
@@ -264,7 +350,10 @@ export class ThreadHydrator {
       && (hadActiveHydrate || this.activeHydrates.has(threadId))
     ) return;
 
-    const cached = this.compactCachedRecordForRestore(threadId, resident);
+    const cached = this.compactCachedRecordForRestore(
+      threadId,
+      projectConversationCacheState(resident),
+    );
     cacheRecord(threadId, cached);
     this.deps.setState((latest: ThreadHydratorWriteState) => {
       if (latest.currentThreadId === threadId) return {};
@@ -323,7 +412,13 @@ export class ThreadHydrator {
 
       const cached = getCachedRecord(threadId);
       if (cached) {
-        this.restoreCachedActive(threadId, cached, opts, { bumpLoadEpoch: false });
+        const resident = this.deps.getState().records.get(threadId);
+        this.restoreCachedActive(
+          threadId,
+          resident ? mergeResidentConversationCacheState(resident, cached) : cached,
+          opts,
+          { bumpLoadEpoch: false },
+        );
         return;
       }
 
@@ -355,7 +450,7 @@ export class ThreadHydrator {
   /** Restore cached data to the active store and refresh auxiliary data. */
   private restoreCachedActive(
     threadId: string,
-    cached: ThreadRecord,
+    cached: ConversationCacheState,
     opts?: ThreadHydratorOptions,
     restoreOpts?: { bumpLoadEpoch?: boolean },
   ): void {
@@ -378,7 +473,10 @@ export class ThreadHydrator {
   }
 
   /** Keep cache-hit reconciliation bounded while retaining loaded history for upward pagination. */
-  private compactCachedRecordForRestore(threadId: string, cached: ThreadRecord): ThreadRecord {
+  private compactCachedRecordForRestore(
+    threadId: string,
+    cached: ConversationCacheState,
+  ): ConversationCacheState {
     cacheRecord(threadId, cached);
     const bounded = getCachedRecord(threadId) ?? cached;
     if (
@@ -424,66 +522,40 @@ export class ThreadHydrator {
     return compacted;
   }
 
-  /**
-   * Synchronously restore from a cached {@link ThreadRecord}.
-   *
-   * Auxiliary-owned fields (`permissions`, `lastHydratedAt`) are preserved from
-   * the live record because the cache snapshot is taken synchronously after
-   * `auxiliaryHydrator.hydrate()` fires its async RPCs, so the cached values
-   * are typically stale relative to whatever the auxiliary writes settle to.
-   * The auxiliary fanout that runs after restoration will refresh them anyway.
-   */
+  /** Restore cached conversation data without replacing resident live or auxiliary state. */
   private restoreFromCache(
     threadId: string,
-    cached: ThreadRecord,
+    cached: ConversationCacheState,
     opts?: { bumpLoadEpoch?: boolean },
   ): void {
     this.deps.setState((state: ThreadHydratorWriteState) => {
       const current = getThreadRecord(state.records, threadId);
-      // The cache snapshot predates in-flight narration, so for a running
-      // thread the live record wins (mirrors fetchAndCommit's isRunning guard).
       const isRunning = state.runningThreadIds.has(threadId);
       const ownsLiveFileEffects = isRunning || current.fileEffectTurnId.length > 0;
-      const liveVolatile: Partial<ThreadRecord> = isRunning
-        ? {
-            toolCalls: current.toolCalls,
-            thoughtSegments: current.thoughtSegments,
-            hooks: current.hooks,
-            streaming: current.streaming,
-            streamingPreview: current.streamingPreview,
-            agentStartTime: current.agentStartTime,
-            currentTurnMessageId: current.currentTurnMessageId,
-            isCompacting: current.isCompacting,
-          }
-        : {};
-      if (ownsLiveFileEffects) {
-        liveVolatile.fileEffectSummary = current.fileEffectSummary;
-        liveVolatile.fileEffectTurnId = current.fileEffectTurnId;
-      }
+      const { settledFileEffectSummary, ...conversation } = cached;
       return {
         records: patchThreadRecord(state.records, threadId, {
-          ...cached,
+          ...conversation,
+          ...(!ownsLiveFileEffects && settledFileEffectSummary
+            ? { fileEffectSummary: settledFileEffectSummary }
+            : {}),
           error: null,
           loading: false,
           loadEpoch: opts?.bumpLoadEpoch === false ? current.loadEpoch : current.loadEpoch + 1,
           isLoadingMore: false,
-          lastHydratedAt: current.lastHydratedAt,
-          permissions: current.permissions,
           settings: this.deps.getWorkspaceThreadSettings(threadId),
-          ...liveVolatile,
         }),
         currentThreadId: threadId,
       };
     });
   }
 
-  /** Apply lookup result semantics to the live record and record cache. */
+  /** Apply lookup result semantics to the resident auxiliary record. */
   private applyGoalLookup(
     threadId: string,
     lookup: GoalLookupResult,
     expectedEpoch?: number,
   ): void {
-    let applied = false;
     this.deps.setState((state: ThreadHydratorWriteState) => {
       const current = getThreadRecord(state.records, threadId);
       if (expectedEpoch != null && (
@@ -492,17 +564,11 @@ export class ThreadHydrator {
       )) {
         return {};
       }
-      applied = true;
       const goal = resolveGoalLookupGoal(lookup, current.goal);
       return {
         records: patchThreadRecord(state.records, threadId, { goal }),
       };
     });
-
-    const cached = getCachedRecord(threadId);
-    if (!cached || !applied) return;
-    const goal = resolveGoalLookupGoal(lookup, cached.goal);
-    cacheRecord(threadId, { ...cached, goal });
   }
 
   /** Merges file-change snapshots only into the load that requested them. */
@@ -539,7 +605,9 @@ export class ThreadHydrator {
       ...cached,
       persistedFilesChanged: fileChanges.persistedFilesChanged,
       latestTurnWithChanges: fileChanges.latestTurnWithChanges,
-      ...(!ownsLiveFileEffects ? { fileEffectSummary: fileChanges.fileEffectSummary } : {}),
+      ...(!ownsLiveFileEffects
+        ? { settledFileEffectSummary: fileChanges.fileEffectSummary }
+        : {}),
     });
   }
 
@@ -684,7 +752,10 @@ export class ThreadHydrator {
         }
       }
 
-      cacheRecord(threadId, getThreadRecord(getState().records, threadId));
+      cacheRecord(
+        threadId,
+        projectConversationCacheState(getThreadRecord(getState().records, threadId)),
+      );
       void snapshotsPromise.then((snapshots) => {
         this.applySnapshots(threadId, snapshots, expectedEpoch);
       });

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -26,6 +26,7 @@ import {
   cacheRecord,
   evictCachedRecord,
   getCachedRecord,
+  projectConversationCacheState,
   takePrefetchedHistoryPage,
 } from "@/lib/thread-hydrator/record-cache";
 import { shallowEqualBy } from "@/lib/shallowEqualBy";
@@ -779,7 +780,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (state.currentThreadId !== threadId) {
       // The response can arrive before its database commit, so the resident
       // transcript must replace any older snapshot used by thread switching.
-      cacheRecord(threadId, getThreadRecord(state.records, threadId));
+      cacheRecord(
+        threadId,
+        projectConversationCacheState(getThreadRecord(state.records, threadId)),
+      );
     }
   };
 
@@ -787,8 +791,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     const current = getRec(threadId);
     const goal = resolveGoalLookupGoal(lookup, current.goal);
     patchRec(threadId, { goal });
-    const cached = getCachedRecord(threadId);
-    if (cached) cacheRecord(threadId, { ...cached, goal: resolveGoalLookupGoal(lookup, cached.goal) });
   };
 
   /**
@@ -1016,7 +1018,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       }));
 
       const updated = getRec(threadId);
-      cacheRecord(threadId, updated);
+      cacheRecord(threadId, projectConversationCacheState(updated));
 
       // Hydrate file change data for older messages from snapshots
       const olderMsgIds = new Set(olderMessages.map((m) => m.id));
@@ -1028,10 +1030,17 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           );
           if (relevant.length === 0) return;
           set((state) => {
-            if (state.currentThreadId !== threadId) return {};
-            const rec = getThreadRecord(state.records, threadId);
+            const rec = state.records.get(threadId);
+            if (
+              state.currentThreadId !== threadId
+              || !rec
+              || rec.loadEpoch !== epoch
+            ) return {};
+            const retainedMessageIds = new Set(rec.messages.map((message) => message.id));
+            const retained = relevant.filter((snapshot) => retainedMessageIds.has(snapshot.message_id));
+            if (retained.length === 0) return {};
             const nextFilesChanged = { ...rec.persistedFilesChanged };
-            for (const snap of relevant) {
+            for (const snap of retained) {
               nextFilesChanged[snap.message_id] = snap.files_changed;
             }
             return {
@@ -1043,10 +1052,21 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           // Keep the LRU message cache in sync: the cache was written before this
           // async merge, so a cache-hit thread switch otherwise drops prepended
           // turns' file lists until a full reload.
+          const current = get().records.get(threadId);
+          if (
+            get().currentThreadId !== threadId
+            || !current
+            || current.loadEpoch !== epoch
+          ) return;
           const cached = getCachedRecord(threadId);
           if (!cached) return;
+          const retainedCachedMessageIds = new Set(cached.messages.map((message) => message.id));
+          const retained = relevant.filter((snapshot) =>
+            retainedCachedMessageIds.has(snapshot.message_id),
+          );
+          if (retained.length === 0) return;
           const mergedFiles = { ...cached.persistedFilesChanged };
-          for (const snap of relevant) {
+          for (const snap of retained) {
             mergedFiles[snap.message_id] = snap.files_changed;
           }
           cacheRecord(threadId, {
@@ -1828,16 +1848,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       if (goal) {
         const openGoal = isGoalOpen(goal) ? goal : null;
         patchRec(threadId, { goal: openGoal });
-        const cached = getCachedRecord(threadId);
-        if (cached) cacheRecord(threadId, { ...cached, goal: openGoal });
       }
       return;
     }
 
     if (event.type === "goalCleared") {
       patchRec(threadId, { goal: null });
-      const cached = getCachedRecord(threadId);
-      if (cached) cacheRecord(threadId, { ...cached, goal: null });
       return;
     }
 


### PR DESCRIPTION
## What

Restore only conversation-owned cached state and compose it with resident live and auxiliary state.

## Why

Whole-record caching allowed stale cached fields to replace newer resident state and made new thread fields part of the cache implicitly. An explicit cache contract preserves inactive-thread responses from #924 while preventing cache restoration from overwriting unrelated state.

## Key Changes

- Add an explicit bounded cache projection for conversation history, pagination, response identity, and persisted narrative metadata.
- Preserve resident live and auxiliary state during restoration, including equal-sequence and delayed-prefetch races.
- Guard asynchronous pagination metadata by load epoch and retained message membership.
- Add focused regression coverage for cache ownership, restoration precedence, file-change markers, and pagination ordering.

## Verification

- Focused web suite: 113 tests passed across 8 files.
- Live A-B-A assertions passed, including the inactive response appearing after returning to the thread. The local runner later encountered `ERR_NETWORK_ACCESS_DENIED` resource errors and timed out during cleanup.
- `bun run verify`: typecheck and lint passed. Unit tests reached one unchanged Windows path-alias failure in `apps/desktop/src/main/__tests__/preview-browser.test.ts:919`, where the assertion expects an 8.3 user path and the runtime returns the equivalent long path. The isolated unchanged test reproduces the failure, and this PR changes no desktop files.

Related to #923

Closes #927

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787328139&installation_model_id=20477&pr_number=935&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F935&signature=b0fa501ed520dc2f12d68b94f2668217c5d63d8b37b0d82ee949da77f61beeab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->