### PR TITLE
feat(web): canonicalize Turn response projection

### DIFF
--- a/apps/web/src/__tests__/streaming.test.ts
+++ b/apps/web/src/__tests__/streaming.test.ts
@@ -217,6 +217,7 @@ describe("duplicate message prevention", () => {
       records: new Map<string, ThreadRecord>([
         ["thread-1", {
           ...createEmptyThreadRecord(),
+          currentTurnMessageId: "client-provisional-id",
           messages: [
             {
               id: "client-provisional-id",

--- a/apps/web/src/__tests__/threadStore-turn-persist.test.ts
+++ b/apps/web/src/__tests__/threadStore-turn-persist.test.ts
@@ -56,7 +56,7 @@ describe("handleTurnPersisted", () => {
             content: "second answer",
           }),
         ],
-        pendingTurnPersistLocalMessageId: turnOneId,
+        pendingTurnPersistMessageIds: [turnOneId],
         currentTurnMessageId: turnTwoId,
       }),
     });
@@ -73,7 +73,7 @@ describe("handleTurnPersisted", () => {
     ]);
     expect(readThreadField(THREAD_ID, (r) => r.persistedFilesChanged[turnTwoId])).toBeUndefined();
     expect(readThreadField(THREAD_ID, (r) => r.serverMessageIds[turnOneId])).toBe("server-turn-1");
-    expect(readThreadField(THREAD_ID, (r) => r.pendingTurnPersistLocalMessageId)).toBe("");
+    expect(readThreadField(THREAD_ID, (r) => r.pendingTurnPersistMessageIds)).toEqual([]);
   });
 
   it("materializes an empty assistant row for tools-only turns", () => {
@@ -192,7 +192,7 @@ describe("handleTurnPersisted", () => {
     useThreadStore.setState({
       records: seedThreadRecord(THREAD_ID, {
         currentTurnMessageId: "assistant-turn-2",
-        pendingTurnPersistLocalMessageId: "assistant-turn-1",
+        pendingTurnPersistMessageIds: ["assistant-turn-1"],
         fileEffectTurnId: "turn-2",
         fileEffectSummary: {
           revision: 1,

--- a/apps/web/src/__tests__/turn-response-projection.test.ts
+++ b/apps/web/src/__tests__/turn-response-projection.test.ts
@@ -1,0 +1,258 @@
+import type { AgentEvent } from "@mcode/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useThreadStore } from "@/stores/threadStore";
+import { createEmptyThreadRecord, patchThreadRecord } from "@/stores/thread-record";
+import { readThreadField, resetThreadStoreForTests } from "@/stores/thread-store-test-utils";
+import { createMockMessage, mockTransport } from "./mocks/transport";
+
+vi.mock("@/transport", async () => ({
+  ...(await vi.importActual("@/transport")),
+  getTransport: () => mockTransport,
+}));
+
+const THREAD_ID = "turn-response-projection";
+
+function completeTurn(): void {
+  useThreadStore.getState().handleAgentEvent({
+    type: "turnComplete",
+    threadId: THREAD_ID,
+    reason: "end_turn",
+    costUsd: null,
+    tokensIn: 0,
+    tokensOut: 0,
+  } satisfies AgentEvent);
+}
+
+function startTurn(): void {
+  useThreadStore.getState().handleAgentEvent({
+    type: "turnStarted",
+    threadId: THREAD_ID,
+  } satisfies AgentEvent);
+}
+
+function persist(messageId: string, toolCallCount = 0): void {
+  useThreadStore.getState().handleTurnPersisted({
+    threadId: THREAD_ID,
+    messageId,
+    toolCallCount,
+    filesChanged: toolCallCount > 0 ? ["src/changed.ts"] : [],
+  });
+}
+
+function message(messageId: string, content = "final response"): void {
+  useThreadStore.getState().handleAgentEvent({
+    type: "message",
+    threadId: THREAD_ID,
+    messageId,
+    content,
+    tokens: 2,
+  } satisfies AgentEvent);
+}
+
+describe("Turn response projection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_ID,
+      runningThreadIds: new Set([THREAD_ID]),
+      records: new Map([[THREAD_ID, {
+        ...createEmptyThreadRecord(),
+        streaming: "final response",
+        streamingPreview: "final response",
+      }]]),
+    });
+  });
+
+  it("replaces a persisted fallback in place and retains newer transcript rows", () => {
+    completeTurn();
+    const fallbackId = readThreadField(THREAD_ID, (record) => record.messages[0]!.id);
+    const fallbackResponseKey = readThreadField(
+      THREAD_ID,
+      (record) => record.assistantResponseKeys[fallbackId],
+    );
+    useThreadStore.setState((state) => ({
+      records: patchThreadRecord(state.records, THREAD_ID, (record) => ({
+        messages: [...record.messages, createMockMessage({
+          id: "newer-row",
+          thread_id: THREAD_ID,
+          role: "user",
+          content: "newer transcript row",
+          sequence: 2,
+        })],
+        narrativeByMessage: {
+          ...record.narrativeByMessage,
+          [fallbackId]: { tools: [], thoughts: [], hooks: [] },
+        },
+      })),
+    }));
+
+    persist("server-final", 1);
+    message("server-final");
+
+    expect(readThreadField(THREAD_ID, (record) => record.messages.map(({ id, content }) => ({ id, content })))).toEqual([
+      { id: "server-final", content: "final response" },
+      { id: "newer-row", content: "newer transcript row" },
+    ]);
+    expect(readThreadField(THREAD_ID, (record) => record.persistedFilesChanged["server-final"])).toEqual([
+      "src/changed.ts",
+    ]);
+    expect(readThreadField(THREAD_ID, (record) => record.assistantResponseKeys["server-final"])).toBe(
+      fallbackResponseKey,
+    );
+    expect(readThreadField(THREAD_ID, (record) => record.narrativeByMessage["server-final"])).toEqual({
+      tools: [], thoughts: [], hooks: [],
+    });
+  });
+
+  it("projects message, completion, and persistence to the same canonical server row", () => {
+    message("server-final");
+    completeTurn();
+    persist("server-final");
+
+    expect(readThreadField(THREAD_ID, (record) => record.messages.map((entry) => entry.id))).toEqual([
+      "server-final",
+    ]);
+    expect(readThreadField(THREAD_ID, (record) => record.pendingTurnPersistMessageIds)).toEqual([]);
+    expect(readThreadField(THREAD_ID, (record) => record.persistedToolCallCounts["server-final"])).toBe(0);
+  });
+
+  it("keeps duplicate message and persistence signals idempotent", () => {
+    completeTurn();
+    persist("server-final", 1);
+    message("server-final");
+    persist("server-final", 1);
+    message("server-final");
+
+    expect(readThreadField(THREAD_ID, (record) => record.messages.filter((entry) => entry.role === "assistant"))).toHaveLength(1);
+    expect(readThreadField(THREAD_ID, (record) => record.messages[0]!.id)).toBe("server-final");
+    expect(readThreadField(THREAD_ID, (record) => record.persistedToolCallCounts)).toEqual({
+      "server-final": 1,
+    });
+  });
+
+  it("keeps distinct server ids distinct when assistant messages share content", () => {
+    resetThreadStoreForTests({ currentThreadId: THREAD_ID });
+
+    message("server-one", "same content");
+    message("server-two", "same content");
+
+    expect(readThreadField(THREAD_ID, (record) => record.messages.map((entry) => entry.id))).toEqual([
+      "server-one",
+      "server-two",
+    ]);
+  });
+
+  it("attributes overlapping persisted turns in completion order", () => {
+    completeTurn();
+    const firstFallbackId = readThreadField(THREAD_ID, (record) => record.messages[0]!.id);
+    useThreadStore.setState((state) => ({
+      records: patchThreadRecord(state.records, THREAD_ID, {
+        streaming: "second final response",
+        streamingPreview: "second final response",
+      }),
+      runningThreadIds: new Set([THREAD_ID]),
+    }));
+    completeTurn();
+    const secondFallbackId = readThreadField(THREAD_ID, (record) => record.messages[1]!.id);
+
+    persist("server-first", 1);
+    persist("server-second", 2);
+
+    expect(readThreadField(THREAD_ID, (record) => record.serverMessageIds[firstFallbackId])).toBe("server-first");
+    expect(readThreadField(THREAD_ID, (record) => record.serverMessageIds[secondFallbackId])).toBe("server-second");
+    expect(readThreadField(THREAD_ID, (record) => record.pendingTurnPersistMessageIds)).toEqual([]);
+  });
+
+  it("does not let a later turn message adopt an earlier turn's pending response", () => {
+    completeTurn();
+    const firstFallbackId = readThreadField(THREAD_ID, (record) => record.messages[0]!.id);
+
+    startTurn();
+    message("server-second", "second turn response");
+    persist("server-first", 1);
+
+    expect(readThreadField(THREAD_ID, (record) => record.messages.map((entry) => entry.id))).toEqual([
+      firstFallbackId,
+      "server-second",
+    ]);
+    expect(readThreadField(THREAD_ID, (record) => record.serverMessageIds[firstFallbackId])).toBe(
+      "server-first",
+    );
+    expect(readThreadField(THREAD_ID, (record) => record.persistedFilesChanged["server-second"])).toBeUndefined();
+  });
+
+  it("appends a post-turn goal receipt instead of adopting the pending response", () => {
+    completeTurn();
+    const fallbackId = readThreadField(THREAD_ID, (record) => record.messages[0]!.id);
+
+    message("goal-receipt", 'Goal set: "finish the task".');
+
+    expect(readThreadField(THREAD_ID, (record) => record.messages.map((entry) => entry.id))).toEqual([
+      fallbackId,
+      "goal-receipt",
+    ]);
+    expect(readThreadField(THREAD_ID, (record) => record.messages[0]!.content)).toBe("final response");
+  });
+
+  it("clears pending attribution with the transcript and fails closed on delayed persistence", () => {
+    completeTurn();
+    useThreadStore.getState().clearMessages();
+
+    persist("server-after-clear", 1);
+
+    expect(readThreadField(THREAD_ID, (record) => record.pendingTurnPersistMessageIds)).toEqual([]);
+    expect(readThreadField(THREAD_ID, (record) => record.messages.map((entry) => entry.id))).toEqual([
+      "server-after-clear",
+    ]);
+  });
+
+  it("prunes evicted pending attribution before delayed persistence arrives", () => {
+    const messages = Array.from({ length: 200 }, (_, index) => createMockMessage({
+      id: index === 0 ? "evicted-pending" : `retained-${index}`,
+      thread_id: THREAD_ID,
+      role: "assistant",
+      content: `message ${index}`,
+      sequence: index + 1,
+    }));
+    useThreadStore.setState({
+      records: new Map([[THREAD_ID, {
+        ...createEmptyThreadRecord(),
+        messages,
+        pendingTurnPersistMessageIds: ["evicted-pending"],
+      }]]),
+    });
+
+    useThreadStore.getState().addMessage(createMockMessage({
+      id: "cap-trigger",
+      thread_id: THREAD_ID,
+      role: "user",
+      content: "trigger cap",
+      sequence: 201,
+    }));
+    persist("server-after-eviction", 1);
+
+    expect(readThreadField(THREAD_ID, (record) => record.pendingTurnPersistMessageIds)).toEqual([]);
+    expect(readThreadField(THREAD_ID, (record) => record.persistedToolCallCounts["retained-1"])).toBeUndefined();
+    expect(readThreadField(THREAD_ID, (record) => record.persistedToolCallCounts["server-after-eviction"])).toBe(1);
+  });
+
+  it("preserves the message window and pagination signal when projection appends", () => {
+    const messages = Array.from({ length: 200 }, (_, index) => createMockMessage({
+      id: `user-${index}`,
+      thread_id: THREAD_ID,
+      role: "user",
+      content: `message ${index}`,
+      sequence: index + 1,
+    }));
+    useThreadStore.setState({
+      records: new Map([[THREAD_ID, { ...createEmptyThreadRecord(), messages }]]),
+    });
+
+    message("server-final");
+
+    expect(readThreadField(THREAD_ID, (record) => record.messages)).toHaveLength(200);
+    expect(readThreadField(THREAD_ID, (record) => record.messages[0]!.id)).toBe("user-1");
+    expect(readThreadField(THREAD_ID, (record) => record.messages.at(-1)!.id)).toBe("server-final");
+    expect(readThreadField(THREAD_ID, (record) => record.hasMoreMessages)).toBe(true);
+  });
+});

--- a/apps/web/src/__tests__/turn-response-projection.test.ts
+++ b/apps/web/src/__tests__/turn-response-projection.test.ts
@@ -1,7 +1,11 @@
 import type { AgentEvent } from "@mcode/contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useThreadStore } from "@/stores/threadStore";
-import { createEmptyThreadRecord, patchThreadRecord } from "@/stores/thread-record";
+import {
+  createEmptyThreadRecord,
+  patchThreadRecord,
+  type ThreadRecord,
+} from "@/stores/thread-record";
 import { readThreadField, resetThreadStoreForTests } from "@/stores/thread-store-test-utils";
 import { createMockMessage, mockTransport } from "./mocks/transport";
 
@@ -203,6 +207,73 @@ describe("Turn response projection", () => {
     expect(readThreadField(THREAD_ID, (record) => record.pendingTurnPersistMessageIds)).toEqual([]);
     expect(readThreadField(THREAD_ID, (record) => record.messages.map((entry) => entry.id))).toEqual([
       "server-after-clear",
+    ]);
+  });
+
+  it("normalizes reconstructed records missing pending persistence state", () => {
+    const reconstructedRecord = createEmptyThreadRecord();
+    delete (reconstructedRecord as Partial<ThreadRecord>).pendingTurnPersistMessageIds;
+    useThreadStore.setState({
+      records: new Map([[THREAD_ID, reconstructedRecord]]),
+    });
+
+    message("server-final");
+
+    expect(readThreadField(THREAD_ID, (record) => record.pendingTurnPersistMessageIds)).toEqual([]);
+  });
+
+  it("normalizes reconstructed records before turn completion queues a fallback", () => {
+    const reconstructedRecord = {
+      ...createEmptyThreadRecord(),
+      streaming: "final response",
+      streamingPreview: "final response",
+    };
+    delete (reconstructedRecord as Partial<ThreadRecord>).pendingTurnPersistMessageIds;
+    useThreadStore.setState({
+      records: new Map([[THREAD_ID, reconstructedRecord]]),
+      runningThreadIds: new Set([THREAD_ID]),
+    });
+
+    completeTurn();
+
+    expect(readThreadField(THREAD_ID, (record) => record.pendingTurnPersistMessageIds)).toHaveLength(1);
+  });
+
+  it("normalizes reconstructed records before turn persistence resolves and clears a row", () => {
+    const reconstructedRecord = createEmptyThreadRecord();
+    delete (reconstructedRecord as Partial<ThreadRecord>).pendingTurnPersistMessageIds;
+    useThreadStore.setState({
+      records: new Map([[THREAD_ID, reconstructedRecord]]),
+    });
+
+    persist("server-final", 1);
+
+    expect(readThreadField(THREAD_ID, (record) => record.pendingTurnPersistMessageIds)).toEqual([]);
+    expect(readThreadField(THREAD_ID, (record) => record.persistedToolCallCounts["server-final"])).toBe(1);
+  });
+
+  it("normalizes reconstructed records before an authoritative response adopts a provisional row", () => {
+    const provisional = createMockMessage({
+      id: "provisional-response",
+      thread_id: THREAD_ID,
+      role: "assistant",
+      content: "final response",
+      sequence: 1,
+    });
+    const reconstructedRecord = {
+      ...createEmptyThreadRecord(),
+      messages: [provisional],
+      currentTurnMessageId: provisional.id,
+    };
+    delete (reconstructedRecord as Partial<ThreadRecord>).pendingTurnPersistMessageIds;
+    useThreadStore.setState({
+      records: new Map([[THREAD_ID, reconstructedRecord]]),
+    });
+
+    message("server-final");
+
+    expect(readThreadField(THREAD_ID, (record) => record.messages.map((entry) => entry.id))).toEqual([
+      "server-final",
     ]);
   });
 

--- a/apps/web/src/stores/thread-record.ts
+++ b/apps/web/src/stores/thread-record.ts
@@ -206,6 +206,10 @@ export function patchThreadRecord(
   const current = getThreadRecord(records, threadId);
   const delta = typeof patch === "function" ? patch(current) : patch;
   const updated = { ...current, ...delta };
+  if (!("messages" in delta || "serverMessageIds" in delta || "pendingTurnPersistMessageIds" in delta)) {
+    next.set(threadId, updated);
+    return next;
+  }
   const retainedMessageIds = new Set(updated.messages.map((message) => message.id));
   next.set(threadId, {
     ...updated,

--- a/apps/web/src/stores/thread-record.ts
+++ b/apps/web/src/stores/thread-record.ts
@@ -102,12 +102,8 @@ export interface ThreadRecord {
   toolCalls: ToolCall[];
   agentStartTime?: number;
   currentTurnMessageId: string;
-  /**
-   * Local assistant message id for a turn whose `turn.persisted` event has not
-   * arrived yet. Survives `resetTurnEphemeral` so auto-dequeue cannot steal
-   * file-change attribution from the prior turn.
-   */
-  pendingTurnPersistLocalMessageId: string;
+  /** Ordered local response rows awaiting their `turn.persisted` signals. */
+  pendingTurnPersistMessageIds: string[];
   currentTurnResponseKey: string;
   assistantResponseKeys: Record<string, string>;
   thoughtSegments: ThoughtSegment[];
@@ -165,7 +161,7 @@ export function createEmptyThreadRecord(): ThreadRecord {
     streamingPreview: "",
     toolCalls: [],
     currentTurnMessageId: "",
-    pendingTurnPersistLocalMessageId: "",
+    pendingTurnPersistMessageIds: [],
     currentTurnResponseKey: "",
     assistantResponseKeys: {},
     thoughtSegments: [],
@@ -205,8 +201,28 @@ export function patchThreadRecord(
   const next = new Map(records);
   const current = getThreadRecord(records, threadId);
   const delta = typeof patch === "function" ? patch(current) : patch;
-  next.set(threadId, { ...current, ...delta });
+  const updated = { ...current, ...delta };
+  const retainedMessageIds = new Set(updated.messages.map((message) => message.id));
+  next.set(threadId, {
+    ...updated,
+    serverMessageIds: Object.fromEntries(
+      Object.entries(updated.serverMessageIds).filter(([messageId]) => retainedMessageIds.has(messageId)),
+    ),
+    pendingTurnPersistMessageIds: prunePendingTurnPersistMessageIds(
+      updated.pendingTurnPersistMessageIds,
+      updated.messages,
+    ),
+  });
   return next;
+}
+
+/** Retain pending persistence attribution only while its transcript row is resident. */
+export function prunePendingTurnPersistMessageIds(
+  pendingMessageIds: readonly string[],
+  messages: readonly Message[],
+): string[] {
+  const retainedMessageIds = new Set(messages.map((message) => message.id));
+  return pendingMessageIds.filter((messageId) => retainedMessageIds.has(messageId));
 }
 
 /** Remove one thread from the records Map. */

--- a/apps/web/src/stores/thread-record.ts
+++ b/apps/web/src/stores/thread-record.ts
@@ -187,7 +187,11 @@ export function getThreadRecord(
   records: Map<string, ThreadRecord>,
   threadId: string,
 ): ThreadRecord {
-  return records.get(threadId) ?? createEmptyThreadRecord();
+  const record = records.get(threadId);
+  if (!record) return createEmptyThreadRecord();
+  return record.pendingTurnPersistMessageIds === undefined
+    ? { ...record, pendingTurnPersistMessageIds: [] }
+    : record;
 }
 
 /** Immutable Map update with a partial or functional patch for one thread. */

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -29,6 +29,13 @@ import {
   projectConversationCacheState,
   takePrefetchedHistoryPage,
 } from "@/lib/thread-hydrator/record-cache";
+import {
+  clearPendingTurnPersistMessage,
+  projectTurnResponse,
+  queuePendingTurnPersistMessage,
+  resolveTurnPersistLocalMessageId,
+  transferTurnResponseMetadata,
+} from "./turn-response-projection";
 import { shallowEqualBy } from "@/lib/shallowEqualBy";
 import { forgetScrollTop } from "@/components/chat/scrollPositionMemory";
 import { releaseBrowserCaptureSpills } from "@/lib/browser-capture-spill";
@@ -398,35 +405,6 @@ function resetTurnEphemeral(_rec: ThreadRecord): Partial<ThreadRecord> {
  * payload. Never uses {@link ThreadRecord.currentTurnMessageId} alone because
  * auto-dequeue can advance it before the prior turn's async snapshot finishes.
  */
-function resolveTurnPersistLocalMessageId(
-  rec: ThreadRecord,
-  serverMessageId: string,
-): string {
-  if (rec.pendingTurnPersistLocalMessageId) {
-    return rec.pendingTurnPersistLocalMessageId;
-  }
-  for (const [localId, mappedServerId] of Object.entries(rec.serverMessageIds)) {
-    if (mappedServerId === serverMessageId) {
-      return localId;
-    }
-  }
-  if (rec.messages.some((m) => m.id === serverMessageId)) {
-    return serverMessageId;
-  }
-  return serverMessageId;
-}
-
-/** Queue the local assistant id until matching `turn.persisted` clears it. */
-function queuePendingTurnPersistLocalMessageId(
-  rec: ThreadRecord,
-  localMessageId: string,
-): string {
-  if (rec.pendingTurnPersistLocalMessageId) {
-    return rec.pendingTurnPersistLocalMessageId;
-  }
-  return localMessageId;
-}
-
 /**
  * Ensure the transcript contains an assistant row for persisted turn metadata.
  * Tools-only turns may materialize on the server without a client `session.message`.
@@ -1352,7 +1330,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           streamingPreview: "",
           toolCalls: [],
           currentTurnMessageId: "",
-          pendingTurnPersistLocalMessageId: "",
+          pendingTurnPersistMessageIds: [],
           currentTurnResponseKey: "",
           assistantResponseKeys: {},
           oldestLoadedSequence: 0,
@@ -1970,6 +1948,14 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             lastSeg && lastSeg.endedAt === undefined
               ? [...segments.slice(0, -1), { ...lastSeg, endedAt: Date.now() }]
               : segments;
+          const responseProjection = isGoalNotice
+            ? { messages: [...rec.messages, message] }
+            : projectTurnResponse(rec, message, event.messageId);
+          const transferredMetadata = transferTurnResponseMetadata(
+            rec,
+            responseProjection.replacedMessageId,
+            message.id,
+          );
 
           const responseIdentityPatch: Partial<
             Pick<
@@ -1979,16 +1965,18 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           > = isGoalNotice
             ? {}
             : (() => {
-                const { responseKey, nextLiveKey } = claimTurnResponseKey(
-                  rec,
-                  threadId,
-                  message.id,
-                );
+                const existingResponseKey = transferredMetadata.assistantResponseKeys[message.id];
+                const { responseKey, nextLiveKey } = existingResponseKey
+                  ? {
+                      responseKey: existingResponseKey,
+                      nextLiveKey: rec.currentTurnResponseKey || createTurnResponseKey(threadId),
+                    }
+                  : claimTurnResponseKey(rec, threadId, message.id);
                 return {
                   currentTurnMessageId: message.id,
                   currentTurnResponseKey: nextLiveKey,
                   assistantResponseKeys: {
-                    ...rec.assistantResponseKeys,
+                    ...transferredMetadata.assistantResponseKeys,
                     [message.id]: responseKey,
                   },
                 };
@@ -2000,76 +1988,23 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             streamingPreview: "",
             thoughtSegments: closedSegments,
           };
-
-          if (rec.messages.some((m) => m.id === message.id)) {
-            return { records: patchThreadRecord(state.records, threadId, turnPatch) };
-          }
-
-          const last = rec.messages[rec.messages.length - 1];
-          if (
-            last?.role === "assistant" &&
-            last.content === content &&
-            last.id !== message.id
-          ) {
-            const previousId = last.id;
-            const nextPersistedToolCallCounts = { ...rec.persistedToolCallCounts };
-            if (previousId in nextPersistedToolCallCounts) {
-              nextPersistedToolCallCounts[message.id] = nextPersistedToolCallCounts[previousId];
-              delete nextPersistedToolCallCounts[previousId];
-            }
-
-            const nextPersistedFilesChanged = { ...rec.persistedFilesChanged };
-            if (previousId in nextPersistedFilesChanged) {
-              nextPersistedFilesChanged[message.id] = nextPersistedFilesChanged[previousId];
-              delete nextPersistedFilesChanged[previousId];
-            }
-
-            const nextServerMessageIds = { ...rec.serverMessageIds };
-            if (previousId in nextServerMessageIds) {
-              nextServerMessageIds[message.id] = nextServerMessageIds[previousId];
-              delete nextServerMessageIds[previousId];
-            }
-
-            const nextAssistantResponseKeys = { ...rec.assistantResponseKeys };
-            if (previousId in nextAssistantResponseKeys) {
-              nextAssistantResponseKeys[message.id] = nextAssistantResponseKeys[previousId];
-              delete nextAssistantResponseKeys[previousId];
-            }
-
-            const replaced = rec.messages.slice(0, -1).concat({
-              ...last,
-              id: message.id,
-              content: message.content,
-              tokens_used: message.tokens_used,
-              timestamp: message.timestamp,
-              attachments: message.attachments,
-            });
-            const { messages: capped, evicted } = capMessages(replaced);
-            const prunedAssistantResponseKeys = pruneAssistantResponseKeys(nextAssistantResponseKeys, capped);
-            return {
-              records: patchThreadRecord(state.records, threadId, {
-                ...turnPatch,
-                messages: capped,
-                persistedToolCallCounts: nextPersistedToolCallCounts,
-                persistedFilesChanged: nextPersistedFilesChanged,
-                serverMessageIds: nextServerMessageIds,
-                assistantResponseKeys: prunedAssistantResponseKeys,
-                latestTurnWithChanges:
-                  rec.latestTurnWithChanges === previousId ? message.id : rec.latestTurnWithChanges,
-                ...(evicted ? { hasMoreMessages: true } : {}),
-              }),
-            };
-          }
-
-          const { messages: capped, evicted } = capMessages([...rec.messages, message]);
+          const { messages: capped, evicted } = capMessages(responseProjection.messages);
           const prunedAssistantResponseKeys = pruneAssistantResponseKeys(
-            responseIdentityPatch.assistantResponseKeys ?? rec.assistantResponseKeys,
+            responseIdentityPatch.assistantResponseKeys ?? transferredMetadata.assistantResponseKeys,
             capped,
           );
           return {
             records: patchThreadRecord(state.records, threadId, {
               ...turnPatch,
               messages: capped,
+              persistedToolCallCounts: transferredMetadata.persistedToolCallCounts,
+              persistedFilesChanged: transferredMetadata.persistedFilesChanged,
+              serverMessageIds: event.messageId
+                ? { ...transferredMetadata.serverMessageIds, [message.id]: event.messageId }
+                : transferredMetadata.serverMessageIds,
+              narrativeByMessage: transferredMetadata.narrativeByMessage,
+              latestTurnWithChanges: transferredMetadata.latestTurnWithChanges,
+              pendingTurnPersistMessageIds: transferredMetadata.pendingTurnPersistMessageIds,
               assistantResponseKeys: prunedAssistantResponseKeys,
               ...(evicted ? { hasMoreMessages: true } : {}),
             }),
@@ -2657,10 +2592,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             streaming: "",
             streamingPreview: "",
             currentTurnMessageId: message.id,
-            pendingTurnPersistLocalMessageId: queuePendingTurnPersistLocalMessageId(
-              rec,
-              message.id,
-            ),
+            ...queuePendingTurnPersistMessage(rec, message.id),
             currentTurnResponseKey: nextLiveKey,
             assistantResponseKeys: {
               ...rec.assistantResponseKeys,
@@ -2711,10 +2643,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             rateLimit: undefined,
             ...(rec.currentTurnMessageId
               ? {
-                  pendingTurnPersistLocalMessageId: queuePendingTurnPersistLocalMessageId(
-                    rec,
-                    rec.currentTurnMessageId,
-                  ),
+                  ...queuePendingTurnPersistMessage(rec, rec.currentTurnMessageId),
                 }
               : {}),
           };
@@ -3216,7 +3145,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const ownsLiveFileEffects = payload.turnId != null
         && payload.turnId === rec.fileEffectTurnId
         && (localMsgId === rec.currentTurnMessageId
-          || localMsgId === rec.pendingTurnPersistLocalMessageId);
+          || rec.pendingTurnPersistMessageIds.includes(localMsgId));
       const ensuredMessages =
         payload.filesChanged.length > 0 || payload.toolCallCount > 0
           ? ensureAssistantMessageForTurnPersist(rec, payload.threadId, localMsgId)
@@ -3241,10 +3170,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             ...rec.serverMessageIds,
             [localMsgId]: payload.messageId,
           },
-          pendingTurnPersistLocalMessageId:
-            rec.pendingTurnPersistLocalMessageId === localMsgId
-              ? ""
-              : rec.pendingTurnPersistLocalMessageId,
+          ...clearPendingTurnPersistMessage(rec, localMsgId),
           interruptStopFileNotice,
           awaitingUserStopPersist,
           ...(payload.fileEffects

--- a/apps/web/src/stores/turn-response-projection.ts
+++ b/apps/web/src/stores/turn-response-projection.ts
@@ -1,0 +1,157 @@
+import type { Message } from "@/transport";
+import type { ThreadRecord } from "./thread-record";
+
+/** The transcript result of reconciling one assistant response event. */
+export interface TurnResponseProjection {
+  messages: Message[];
+  replacedMessageId?: string;
+}
+
+/** Resolve the local response row that owns persisted metadata for a server message. */
+export function resolveTurnPersistLocalMessageId(
+  record: ThreadRecord,
+  serverMessageId: string,
+): string {
+  for (const [localId, mappedServerId] of Object.entries(record.serverMessageIds)) {
+    if (mappedServerId === serverMessageId && record.messages.some((message) => message.id === localId)) {
+      return localId;
+    }
+  }
+
+  if (record.messages.some((message) => message.id === serverMessageId)) return serverMessageId;
+  return record.pendingTurnPersistMessageIds[0] ?? serverMessageId;
+}
+
+/** Queue a local response row until its corresponding persistence signal arrives. */
+export function queuePendingTurnPersistMessage(
+  record: ThreadRecord,
+  localMessageId: string,
+): Pick<ThreadRecord, "pendingTurnPersistMessageIds"> {
+  return {
+    pendingTurnPersistMessageIds: record.pendingTurnPersistMessageIds.includes(localMessageId)
+      ? record.pendingTurnPersistMessageIds
+      : [...record.pendingTurnPersistMessageIds, localMessageId],
+  };
+}
+
+/** Remove a persisted local response row from the pending persistence queue. */
+export function clearPendingTurnPersistMessage(
+  record: ThreadRecord,
+  localMessageId: string,
+): Pick<ThreadRecord, "pendingTurnPersistMessageIds"> {
+  return {
+    pendingTurnPersistMessageIds: record.pendingTurnPersistMessageIds.filter(
+      (messageId) => messageId !== localMessageId,
+    ),
+  };
+}
+
+/** Project an assistant message into its canonical transcript position. */
+export function projectTurnResponse(
+  record: ThreadRecord,
+  message: Message,
+  serverMessageId: string | undefined,
+): TurnResponseProjection {
+  const exactIndex = record.messages.findIndex((existing) => existing.id === message.id);
+  if (exactIndex >= 0) {
+    const messages = [...record.messages];
+    messages[exactIndex] = { ...messages[exactIndex]!, ...message };
+    return { messages, replacedMessageId: message.id };
+  }
+
+  const mappedLocalMessageId = serverMessageId
+    ? Object.entries(record.serverMessageIds).find(([, mappedId]) => mappedId === serverMessageId)?.[0]
+    : undefined;
+  const localIndex = mappedLocalMessageId
+    ? record.messages.findIndex((existing) => existing.id === mappedLocalMessageId)
+    : -1;
+
+  if (localIndex >= 0) {
+    const messages = [...record.messages];
+    const localMessage = messages[localIndex]!;
+    messages[localIndex] = { ...localMessage, ...message, sequence: localMessage.sequence };
+    return { messages, replacedMessageId: localMessage.id };
+  }
+
+  const trailingMessage = record.messages.at(-1);
+  if (
+    serverMessageId
+    && trailingMessage?.role === "assistant"
+    && trailingMessage.content === message.content
+    && record.currentTurnMessageId === trailingMessage.id
+    && !record.serverMessageIds[trailingMessage.id]
+  ) {
+    const messages = [...record.messages];
+    messages[messages.length - 1] = {
+      ...trailingMessage,
+      ...message,
+      sequence: trailingMessage.sequence,
+    };
+    return { messages, replacedMessageId: trailingMessage.id };
+  }
+
+  if (!serverMessageId) {
+    const currentMessageIndex = record.messages.findIndex(
+      (existing) => existing.id === record.currentTurnMessageId && existing.role === "assistant" && existing.content === message.content,
+    );
+    if (currentMessageIndex >= 0) {
+      const messages = [...record.messages];
+      const localMessage = messages[currentMessageIndex]!;
+      messages[currentMessageIndex] = { ...localMessage, ...message, sequence: localMessage.sequence };
+      return { messages, replacedMessageId: localMessage.id };
+    }
+  }
+
+  return { messages: [...record.messages, message] };
+}
+
+/** Move response-scoped metadata from a provisional row to its server-authoritative row. */
+export function transferTurnResponseMetadata(
+  record: ThreadRecord,
+  previousMessageId: string | undefined,
+  messageId: string,
+): Pick<
+  ThreadRecord,
+  | "persistedToolCallCounts"
+  | "persistedFilesChanged"
+  | "serverMessageIds"
+  | "assistantResponseKeys"
+  | "narrativeByMessage"
+  | "latestTurnWithChanges"
+  | "pendingTurnPersistMessageIds"
+> {
+  if (!previousMessageId || previousMessageId === messageId) {
+    return {
+      persistedToolCallCounts: record.persistedToolCallCounts,
+      persistedFilesChanged: record.persistedFilesChanged,
+      serverMessageIds: record.serverMessageIds,
+      assistantResponseKeys: record.assistantResponseKeys,
+      narrativeByMessage: record.narrativeByMessage,
+      latestTurnWithChanges: record.latestTurnWithChanges,
+      pendingTurnPersistMessageIds: record.pendingTurnPersistMessageIds,
+    };
+  }
+
+  const transfer = <T>(metadata: Record<string, T>): Record<string, T> => {
+    if (!(previousMessageId in metadata)) return metadata;
+    const next = { ...metadata, [messageId]: metadata[previousMessageId] };
+    delete next[previousMessageId];
+    return next;
+  };
+  const pendingMessageIds = record.pendingTurnPersistMessageIds.map(
+    (pendingMessageId) => pendingMessageId === previousMessageId ? messageId : pendingMessageId,
+  );
+  const serverMessageIds = { ...record.serverMessageIds };
+  delete serverMessageIds[previousMessageId];
+
+  return {
+    persistedToolCallCounts: transfer(record.persistedToolCallCounts),
+    persistedFilesChanged: transfer(record.persistedFilesChanged),
+    serverMessageIds,
+    assistantResponseKeys: transfer(record.assistantResponseKeys),
+    narrativeByMessage: transfer(record.narrativeByMessage),
+    latestTurnWithChanges:
+      record.latestTurnWithChanges === previousMessageId ? messageId : record.latestTurnWithChanges,
+    pendingTurnPersistMessageIds: pendingMessageIds,
+  };
+}


### PR DESCRIPTION
## What
Project supported Turn event orders into one canonical assistant response row.

## Why
Completion fallback, persisted metadata, and authoritative message events can arrive in different orders. The conversation store must reconcile them without duplicate responses, lost newer content, or cross-turn metadata attribution.

## Key Changes
- Centralize Turn response projection and response-scoped metadata transfer.
- Keep pending persistence attribution ordered, bounded by resident transcript rows, and isolated across overlapping turns.
- Cover event permutations, duplicate signals, goal receipts, tools-only persistence, transcript reset, and message-window eviction.

Related to #923

Closes #926

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787334003&installation_model_id=20477&pr_number=938&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F938&signature=73b7f6b480cfd46f60a088d05d85f2c4f7a1d2d7bbe9b827b6c8a5ae54a4a3e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assistant message reconciliation when live and persisted responses arrive delayed, duplicated, or out of order.
  * Prevented duplicate transcript entries while preserving distinct server messages with matching content.
  * Preserved turn-related file changes, metadata, and pagination state during response updates.
  * Prevented stale messages and effects from previous turns from affecting the current conversation.

* **Tests**
  * Added comprehensive coverage for turn completion, persistence, attribution, message replacement, and transcript clearing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->