### PR TITLE
feat(web): centralize conversation residency

### DIFF
--- a/apps/web/e2e/architecture.spec.ts
+++ b/apps/web/e2e/architecture.spec.ts
@@ -205,10 +205,13 @@ async function setupWorkspaceState(
         workspaces,
         activeWorkspaceId,
         threads,
-        activeThreadId: activeThreadId ?? null,
+        activeThreadId: null,
         loading: false,
         error: null,
       });
+      if (activeThreadId) {
+        wsStore.getState().setActiveThread(activeThreadId);
+      }
     },
     opts,
   );

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -330,9 +330,7 @@ const WORKSPACE_STORE_KEYS = ["activeThreadId", "threads", "workspaces"] as cons
 const THREAD_STORE_KEYS = ["records", "loadMessages"] as const;
 
 /**
- * Activate a single workspace and thread so the chat view mounts and the app's
- * own `loadMessages` runs for the thread. Sets only workspace-store fields the
- * web app reads to pick and render the active thread.
+ * Seed one workspace and thread, then select it through the production action.
  */
 export async function activateThread(
   page: Page,
@@ -349,10 +347,15 @@ export async function activateThread(
         workspaces: [ws],
         threads: [th],
         activeWorkspaceId: ws.id,
-        activeThreadId: th.id,
+        activeThreadId: null,
         loading: false,
         error: null,
       });
+      (
+        wsStore.getState() as {
+          setActiveThread: (threadId: string | null) => void;
+        }
+      ).setActiveThread(th.id);
     },
     { ws: workspace, th: thread, wsKeys: [...WORKSPACE_STORE_KEYS] },
   );

--- a/apps/web/e2e/right-panel-tab-status.spec.ts
+++ b/apps/web/e2e/right-panel-tab-status.spec.ts
@@ -101,8 +101,15 @@ async function seedPanel(page: Page, tab: "tasks" | "changes"): Promise<void> {
           workspaces: [workspace],
           activeWorkspaceId: workspace.id,
           threads: [thread],
-          activeThreadId: tid,
+          activeThreadId: null,
         });
+        (
+          wsStore as {
+            getState: () => {
+              setActiveThread: (threadId: string | null) => void;
+            };
+          }
+        ).getState().setActiveThread(tid);
       }
 
       const diffStore = stores.find(

--- a/apps/web/src/__tests__/conversation-residency.test.ts
+++ b/apps/web/src/__tests__/conversation-residency.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { createConversationResidency } from "@/stores/conversation-residency";
+
+describe("ConversationResidency", () => {
+  it("activates only persisted selected threads through its restoration dependency", async () => {
+    const restoreConversation = vi.fn().mockResolvedValue(undefined);
+    const deactivateConversation = vi.fn();
+    const residency = createConversationResidency({ restoreConversation, deactivateConversation });
+
+    await residency.activate("thread-a", [{ id: "thread-a" }]);
+
+    expect(restoreConversation).toHaveBeenCalledWith("thread-a");
+    expect(deactivateConversation).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [null, []],
+    ["missing-thread", []],
+    ["preparing-thread", [{ id: "preparing-thread", clientPreparing: true }]],
+    ["failed-thread", [{ id: "failed-thread", clientError: "Creation failed" }]],
+  ])("deactivates without restoring unavailable selection %s", async (threadId, threads) => {
+    const restoreConversation = vi.fn().mockResolvedValue(undefined);
+    const deactivateConversation = vi.fn();
+    const residency = createConversationResidency({ restoreConversation, deactivateConversation });
+
+    await residency.activate(threadId, threads);
+
+    expect(restoreConversation).not.toHaveBeenCalled();
+    expect(deactivateConversation).toHaveBeenCalledOnce();
+  });
+
+  it("routes same-selection refresh restoration through the same boundary", async () => {
+    const restoreConversation = vi.fn().mockResolvedValue(undefined);
+    const deactivateConversation = vi.fn();
+    const residency = createConversationResidency({ restoreConversation, deactivateConversation });
+
+    await residency.restoreAfterThreadRefresh("thread-a", [{ id: "thread-a" }]);
+
+    expect(restoreConversation).toHaveBeenCalledWith("thread-a");
+    expect(deactivateConversation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
+++ b/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { useThreadStore } from "@/stores/threadStore";
 import { mockTransport, createMockWorkspace, createMockThread } from "./mocks/transport";
 
 vi.mock("@/transport", async () => ({
@@ -60,5 +61,24 @@ describe("thread status refresh after reconnect", () => {
     expect(threads.find((t) => t.id === myThread.id)?.status).toBe("interrupted");
     // Other workspace's thread is preserved unchanged
     expect(threads.find((t) => t.id === otherThread.id)?.status).toBe("active");
+  });
+
+  it("restores the unchanged selected conversation after a reconnect row refresh", async () => {
+    const thread = createMockThread({ workspace_id: ws.id, status: "active" });
+    const originalLoadMessages = useThreadStore.getState().loadMessages;
+    const loadMessages = vi.fn().mockResolvedValue(undefined);
+    useThreadStore.setState({ loadMessages });
+    useWorkspaceStore.setState({ threads: [thread], activeThreadId: thread.id });
+    (mockTransport.listThreads as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { ...thread, status: "interrupted" as const },
+    ]);
+
+    try {
+      await useWorkspaceStore.getState().loadThreads(ws.id);
+
+      expect(loadMessages).toHaveBeenCalledWith(thread.id);
+    } finally {
+      useThreadStore.setState({ loadMessages: originalLoadMessages });
+    }
   });
 });

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -4,7 +4,7 @@ import {
   hasTestThreadRecord,
 } from "@/stores/thread-store-test-utils";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { useWorkspaceStore, __resetThreadListMutationEpochForTests, __clearPendingThreadCreationsForTests } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useDiffStore } from "@/stores/diffStore";
@@ -377,6 +377,96 @@ describe("Workspace Behavior", () => {
     expect(state.threads).toHaveLength(1);
     expect(state.threads[0].id).toBe("t-2");
     expect(state.activeThreadId).toBeNull();
+  });
+
+  describe("selected conversation reconciliation after removal", () => {
+    let originalLoadMessages: ReturnType<typeof useThreadStore.getState>["loadMessages"];
+    let originalDeactivateConversation: ReturnType<typeof useThreadStore.getState>["deactivateConversation"];
+
+    beforeEach(() => {
+      originalLoadMessages = useThreadStore.getState().loadMessages;
+      originalDeactivateConversation = useThreadStore.getState().deactivateConversation;
+    });
+
+    afterEach(() => {
+      useThreadStore.setState({
+        loadMessages: originalLoadMessages,
+        deactivateConversation: originalDeactivateConversation,
+      });
+    });
+
+    function spyOnConversationResidency() {
+      const loadMessages = vi.fn().mockResolvedValue(undefined);
+      const deactivateConversation = vi.fn();
+      useThreadStore.setState({ loadMessages, deactivateConversation });
+      return { loadMessages, deactivateConversation };
+    }
+
+    type RemovalPath = "workspace" | "preparing" | "client-only" | "persisted";
+
+    async function removeThread(path: RemovalPath, threadId: string, workspaceId: string): Promise<void> {
+      switch (path) {
+        case "workspace":
+          await useWorkspaceStore.getState().deleteWorkspace(workspaceId);
+          return;
+        case "preparing":
+          useWorkspaceStore.getState().dismissPreparingThread(threadId);
+          return;
+        case "client-only":
+        case "persisted":
+          await useWorkspaceStore.getState().deleteThread(threadId, false);
+      }
+    }
+
+    it.each<RemovalPath>(["workspace", "preparing", "client-only", "persisted"])(
+      "does not reload the selected conversation after removing an unrelated %s",
+      async (path) => {
+        const activeWorkspace = createMockWorkspace({ id: "ws-active" });
+        const removedWorkspace = createMockWorkspace({ id: "ws-removed" });
+        const activeThread = createMockThread({ id: "thread-active", workspace_id: activeWorkspace.id });
+        const removedThread = {
+          ...createMockThread({ id: "thread-removed", workspace_id: path === "workspace" ? removedWorkspace.id : activeWorkspace.id }),
+          ...(path === "preparing" || path === "client-only" ? { clientPreparing: true } : {}),
+        };
+        const { loadMessages, deactivateConversation } = spyOnConversationResidency();
+
+        useWorkspaceStore.setState({
+          workspaces: path === "workspace" ? [activeWorkspace, removedWorkspace] : [activeWorkspace],
+          activeWorkspaceId: activeWorkspace.id,
+          threads: [activeThread, removedThread],
+          activeThreadId: activeThread.id,
+        });
+
+        await removeThread(path, path === "workspace" ? activeThread.id : removedThread.id, removedWorkspace.id);
+
+        expect(loadMessages).not.toHaveBeenCalled();
+        expect(deactivateConversation).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each<RemovalPath>(["workspace", "preparing", "client-only", "persisted"])(
+      "deactivates the selected conversation after removing the selected %s",
+      async (path) => {
+        const workspace = createMockWorkspace({ id: "ws-selected" });
+        const selectedThread = {
+          ...createMockThread({ id: "thread-selected", workspace_id: workspace.id }),
+          ...(path === "preparing" || path === "client-only" ? { clientPreparing: true } : {}),
+        };
+        const { deactivateConversation } = spyOnConversationResidency();
+
+        useWorkspaceStore.setState({
+          workspaces: [workspace],
+          activeWorkspaceId: workspace.id,
+          threads: [selectedThread],
+          activeThreadId: selectedThread.id,
+        });
+
+        await removeThread(path, selectedThread.id, workspace.id);
+
+        expect(deactivateConversation).toHaveBeenCalledOnce();
+        expect(useWorkspaceStore.getState().activeThreadId).toBeNull();
+      },
+    );
   });
 
   // ── deleteThread → clearThreadState integration ──────────────────────

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -334,6 +334,22 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
   });
 
+  it("keeps a live turn visible when hydration fails before any messages are resident", () => {
+    chatViewThreadMockRef.current = defaultThreadState({
+      runningThreadIds: new Set(["thread-1"]),
+      activeRecord: {
+        ...createEmptyThreadRecord(),
+        error: "Conversation refresh failed",
+      },
+    });
+
+    render(<ChatView />);
+
+    expect(screen.getByTestId("conversation-error-banner")).toHaveTextContent("Conversation refresh failed");
+    expect(screen.getByTestId("message-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("conversation-error")).not.toBeInTheDocument();
+  });
+
   it("keeps resident messages visible beside a generic hydration error", () => {
     chatViewThreadMockRef.current = defaultThreadState({
       activeRecord: {

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -55,10 +55,12 @@ vi.mock("@/stores/thread-selectors", async () => {
   const { createEmptyThreadRecord } = await import("@/stores/thread-record");
   const emptyRecord = createEmptyThreadRecord();
   return {
-    useActiveThreadRecord: (selector: (r: typeof emptyRecord) => unknown) => selector(emptyRecord),
+    useActiveThreadRecord: (selector: (r: typeof emptyRecord) => unknown) =>
+      selector((chatViewThreadMockRef.current?.activeRecord as typeof emptyRecord | undefined) ?? emptyRecord),
     useThreadRecord: (_threadId: string, selector: (r: typeof emptyRecord) => unknown) =>
-      selector(emptyRecord),
-    readThreadRecord: () => emptyRecord,
+      selector((chatViewThreadMockRef.current?.activeRecord as typeof emptyRecord | undefined) ?? emptyRecord),
+    readThreadRecord: () =>
+      (chatViewThreadMockRef.current?.activeRecord as typeof emptyRecord | undefined) ?? emptyRecord,
   };
 });
 
@@ -95,6 +97,8 @@ vi.mock("./CliErrorBanner", () => ({
 }));
 
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { createEmptyThreadRecord } from "@/stores/thread-record";
+import { createMockMessage } from "@/__tests__/mocks/transport";
 import { ChatView } from "./ChatView";
 
 /** Build a minimal Thread fixture. */
@@ -192,13 +196,16 @@ function setupWorkspaceMock(state: ReturnType<typeof defaultWorkspaceState>) {
 function defaultThreadState(overrides: Partial<{
   currentThreadId: string | null;
   runningThreadIds: Set<string>;
+  activeRecord: ReturnType<typeof createEmptyThreadRecord>;
 }> = {}) {
   return {
     records: new Map(),
     currentThreadId: overrides.currentThreadId ?? "thread-1",
     runningThreadIds: overrides.runningThreadIds ?? new Set<string>(),
+    activeRecord: overrides.activeRecord ?? createEmptyThreadRecord(),
     loadMessages: vi.fn(),
     clearMessages: vi.fn(),
+    deactivateConversation: vi.fn(),
     setForkMode: vi.fn(),
     sendMessage: vi.fn(),
   };
@@ -310,6 +317,37 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     expect(screen.getByTestId("chat-header-title")).toHaveTextContent("My Thread");
     expect(screen.getByTestId("conversation-loading")).toBeVisible();
     expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
+  });
+
+  it("renders a full-stage hydration error when no transcript is available", () => {
+    chatViewThreadMockRef.current = defaultThreadState({
+      activeRecord: {
+        ...createEmptyThreadRecord(),
+        error: "Conversation request failed",
+      },
+    });
+
+    render(<ChatView />);
+
+    expect(screen.getByTestId("conversation-error")).toHaveTextContent("Conversation request failed");
+    expect(screen.queryByTestId("conversation-loading")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
+  });
+
+  it("keeps resident messages visible beside a generic hydration error", () => {
+    chatViewThreadMockRef.current = defaultThreadState({
+      activeRecord: {
+        ...createEmptyThreadRecord(),
+        messages: [createMockMessage({ id: "resident-message", thread_id: "thread-1" })],
+        error: "Conversation refresh failed",
+      },
+    });
+
+    render(<ChatView />);
+
+    expect(screen.getByTestId("conversation-error-banner")).toHaveTextContent("Conversation refresh failed");
+    expect(screen.getByTestId("message-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("conversation-error")).not.toBeInTheDocument();
   });
 
   it("keeps running threads subscribed while another thread is selected", async () => {

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -698,8 +698,8 @@ export function ChatView() {
   const hasMessages = messageCount > 0;
   const conversationLoading = hydratedThreadId !== activeThreadId || historyLoading;
   const showEmptyState = !hasMessages && !isAgentRunning && !conversationLoading;
-  const showFullConversationError = showConversationError && !hasMessages;
-  const showConversationErrorBanner = showConversationError && hasMessages;
+  const showFullConversationError = showConversationError && !hasMessages && !isAgentRunning;
+  const showConversationErrorBanner = showConversationError && (hasMessages || isAgentRunning);
 
   return (
     <div ref={chatPaneRef} className="flex h-full flex-col bg-background" data-testid="chat-view">

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -298,6 +298,22 @@ function ConversationLoadingState() {
   );
 }
 
+/** Shows a selected conversation's non-provider hydration failure. */
+function ConversationErrorState({ error }: { error: string }) {
+  return (
+    <div
+      data-testid="conversation-error"
+      role="alert"
+      className="flex h-full items-center justify-center px-4"
+    >
+      <div className="max-w-md space-y-1 text-center">
+        <p className="font-medium text-foreground">Could not load conversation</p>
+        <p className="text-sm text-muted-foreground">{error}</p>
+      </div>
+    </div>
+  );
+}
+
 /** Renders the main chat UI for sending and receiving messages within a thread. */
 export function ChatView() {
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
@@ -310,8 +326,6 @@ export function ChatView() {
   const activeForkMode = useActiveThreadRecord((r) => r.forkMode);
   const branchFromMessageId = activeForkMode?.messageId;
   const branchFromMessageContent = activeForkMode?.content ?? undefined;
-  const loadMessages = useThreadStore((s) => s.loadMessages);
-  const clearMessages = useThreadStore((s) => s.clearMessages);
   const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
   const hydratedThreadId = useThreadStore((s) => s.currentThreadId);
   const messageCount = useActiveThreadRecord((r) => r.messages.length);
@@ -445,6 +459,7 @@ export function ChatView() {
     !!sessionError &&
     isCliError(sessionError) &&
     sessionError !== dismissedError;
+  const showConversationError = !!sessionError && !isCliError(sessionError);
 
   const activeWorkspaceName = useMemo(
     () => workspaces.find((w) => w.id === (activeThread?.workspace_id ?? activeWorkspaceId))?.name ?? "",
@@ -605,16 +620,6 @@ export function ChatView() {
   }, []);
 
   useLayoutEffect(() => {
-    if (!activeThreadId) {
-      clearMessages();
-    } else {
-      const row = useWorkspaceStore.getState().threads.find((t) => t.id === activeThreadId);
-      if (row?.clientPreparing || row?.clientError) {
-        clearMessages();
-      } else {
-        loadMessages(activeThreadId);
-      }
-    }
     // Only evict Blink's resource cache when it exceeds the pressure threshold.
     // Avoids unnecessary re-fetches on routine thread switches.
     // Gracefully no-ops in the web-only dev server.
@@ -625,7 +630,7 @@ export function ChatView() {
       }
     }
     prevThreadIdRef.current = activeThreadId;
-  }, [activeThreadId, loadMessages, clearMessages]);
+  }, [activeThreadId]);
 
   // A threadless workspace is always the new-thread workbench. This also covers
   // cold start before the user has chosen a project.
@@ -693,6 +698,8 @@ export function ChatView() {
   const hasMessages = messageCount > 0;
   const conversationLoading = hydratedThreadId !== activeThreadId || historyLoading;
   const showEmptyState = !hasMessages && !isAgentRunning && !conversationLoading;
+  const showFullConversationError = showConversationError && !hasMessages;
+  const showConversationErrorBanner = showConversationError && hasMessages;
 
   return (
     <div ref={chatPaneRef} className="flex h-full flex-col bg-background" data-testid="chat-view">
@@ -760,6 +767,14 @@ export function ChatView() {
         </div>
       ) : null}
 
+      {showConversationErrorBanner ? (
+        <div className="mx-3 mb-2 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+          <p data-testid="conversation-error-banner" role="alert" className="text-sm text-destructive">
+            Could not refresh conversation: {sessionError}
+          </p>
+        </div>
+      ) : null}
+
       {/* Fallback handoff banner: shown when the fork's handoff was produced
           locally because the AI provider was unavailable. */}
       <HandoffFallbackBanner threadId={activeThread.id} />
@@ -775,6 +790,8 @@ export function ChatView() {
       >
         {conversationLoading && !hasMessages && !isAgentRunning ? (
           <ConversationLoadingState />
+        ) : showFullConversationError ? (
+          <ConversationErrorState error={sessionError ?? ""} />
         ) : showEmptyState ? (
           <div className="flex h-full items-center justify-center">
             <EmptyState onPromptSelect={setPendingPrefill} />

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -342,7 +342,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const latestTurnWithChanges = useActiveThreadRecord((r) => r.latestTurnWithChanges);
   const hasMore = useActiveThreadRecord((r) => r.hasMoreMessages);
   const handoffStatus = useThreadStore((s) =>
-    activeThreadId ? getHandoffStatus(getThreadRecord(s.records, activeThreadId)) : undefined,
+    currentThreadId ? getHandoffStatus(getThreadRecord(s.records, currentThreadId)) : undefined,
   );
   const isLoadingMore = useActiveThreadRecord((r) => r.isLoadingMore);
   const loadOlderMessages = useThreadStore((s) => s.loadOlderMessages);

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -69,8 +69,9 @@ let messagesValue: {
 }[] = [{ id: "m1", sequence: 1 }];
 let hasMoreMessagesValue = false;
 let runningThreadIdsValue = new Set<string>();
+let handoffStatusByThread: Record<string, "generating" | "ready" | "fallback" | "error"> = {};
 
-function buildMockRecord() {
+function buildMockRecord(threadId = currentThreadIdValue) {
   return {
     messages: messagesValue,
     loading: loadingValue,
@@ -88,12 +89,16 @@ function buildMockRecord() {
     currentTurnMessageId: "",
     narrativeByMessage: {},
     agentStartTime: undefined,
+    ...(handoffStatusByThread[threadId] ? { handoffMeta: { status: handoffStatusByThread[threadId] } } : {}),
   };
 }
 
 vi.mock("@/stores/threadStore", () => ({
   useThreadStore: vi.fn((selector: (s: unknown) => unknown) => {
-    const records = new Map([[currentThreadIdValue, buildMockRecord()]]);
+    const records = new Map([
+      ["thread-A", buildMockRecord("thread-A")],
+      ["thread-B", buildMockRecord("thread-B")],
+    ]);
     return selector({
       records,
       currentThreadId: currentThreadIdValue,
@@ -149,6 +154,7 @@ beforeEach(() => {
   hasMoreMessagesValue = false;
   currentThreadIdValue = "thread-A";
   runningThreadIdsValue = new Set();
+  handoffStatusByThread = {};
   clearScrollMemory();
 });
 
@@ -184,6 +190,34 @@ describe("MessageList thread switch", () => {
     act(() => rerender(<MessageList />));
 
     expect(queryByText("Thinking")).not.toBeNull();
+  });
+
+  it("uses the rendered transcript thread for handoff skeletons", () => {
+    activeThreadIdValue = "thread-B";
+    currentThreadIdValue = "thread-A";
+    handoffStatusByThread = { "thread-B": "generating" };
+    messagesValue = [{
+      id: "a-user",
+      sequence: 1,
+      thread_id: "thread-A",
+      role: "user",
+      content: "Thread A request",
+    }];
+    const { container, rerender } = render(<MessageList />);
+
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(0);
+
+    currentThreadIdValue = "thread-B";
+    messagesValue = [{
+      id: "b-user",
+      sequence: 1,
+      thread_id: "thread-B",
+      role: "user",
+      content: "Thread B request",
+    }];
+    act(() => rerender(<MessageList />));
+
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(3);
   });
 
   it("records history posture before navigation can replace the active transcript", () => {

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -31,6 +31,8 @@ import {
   HYDRATION_TTL_MS,
   HISTORY_PREFETCH_SIZE,
   MESSAGE_FETCH_SIZE,
+  RECORD_CACHE_SIZE,
+  RECORD_MESSAGE_CACHE_SIZE,
   type ThreadHydrator,
 } from "@/lib/thread-hydrator";
 import { mockTransport, createMockMessage, createMockThread } from "@/__tests__/mocks/transport";
@@ -545,6 +547,37 @@ describe("ThreadHydrator", () => {
     expect(getCachedRecord(THREAD_A)).not.toHaveProperty("loading");
   });
 
+  it("bounds completed records that are repeatedly deselected", () => {
+    const threadIds = Array.from(
+      { length: RECORD_CACHE_SIZE + 1 },
+      (_, index) => `completed-thread-${index + 1}`,
+    );
+
+    for (const threadId of threadIds) {
+      const messages = Array.from(
+        { length: RECORD_MESSAGE_CACHE_SIZE + 1 },
+        (_, index) => createMockMessage({
+          id: `${threadId}-message-${index + 1}`,
+          thread_id: threadId,
+          sequence: index + 1,
+        }),
+      );
+      useThreadStore.setState({
+        currentThreadId: threadId,
+        records: new Map([[threadId, { ...createEmptyThreadRecord(), messages }]]),
+      });
+
+      hydrator.deactivate();
+    }
+
+    expect(useThreadStore.getState().currentThreadId).toBeNull();
+    expect(useThreadStore.getState().records.size).toBe(0);
+    expect(getCachedRecord(threadIds[0]!)).toBeUndefined();
+    const retainedMessages = getCachedRecord(threadIds.at(-1)!)?.messages.length;
+    expect(retainedMessages).toBeGreaterThan(0);
+    expect(retainedMessages).toBeLessThanOrEqual(RECORD_MESSAGE_CACHE_SIZE);
+  });
+
   it("restores messages added to a resident thread after its empty snapshot was cached", async () => {
     resetThreadStoreForTests({
       currentThreadId: THREAD_A,
@@ -1020,6 +1053,123 @@ describe("ThreadHydrator", () => {
     expect(getTestActiveMessages()).toEqual([
       expect.objectContaining({ id: "resident-websocket-message", content: "fresh WebSocket response" }),
     ]);
+  });
+
+  it("does not let an active hydration replace a live message", async () => {
+    const staleMessage = createMockMessage({
+      id: "stale-active-response",
+      thread_id: THREAD_A,
+      content: "stale active response",
+      sequence: 1,
+    });
+    let resolvePage!: (value: {
+      messages: typeof staleMessage[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+
+    const activeHydrate = hydrator.hydrate(THREAD_A, "active");
+    await vi.waitFor(() => expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1));
+
+    useThreadStore.getState().handleAgentEvent({
+      type: "message",
+      threadId: THREAD_A,
+      content: "live response",
+      messageId: "live-active-message",
+      tokens: null,
+    } satisfies AgentEvent);
+    resolvePage({ messages: [staleMessage], hasMore: false, narrativeByMessage: {} });
+    await activeHydrate;
+
+    expect(getTestActiveMessages()).toEqual([
+      expect.objectContaining({ id: "live-active-message", content: "live response" }),
+    ]);
+    expect(readActiveThreadField((record) => record.loading)).toBe(false);
+  });
+
+  it("invalidates pending hydration when a workspace switch clears selection", async () => {
+    const staleMessage = createMockMessage({
+      id: "stale-after-workspace-switch",
+      thread_id: THREAD_A,
+      content: "stale after workspace switch",
+      sequence: 1,
+    });
+    let resolvePage!: (value: {
+      messages: typeof staleMessage[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+    useWorkspaceStore.setState({ activeWorkspaceId: "workspace-a", activeThreadId: THREAD_A });
+
+    const activeHydrate = hydrator.hydrate(THREAD_A, "active");
+    await vi.waitFor(() => expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1));
+
+    useWorkspaceStore.getState().setActiveWorkspace("workspace-b", undefined, false);
+    resolvePage({ messages: [staleMessage], hasMore: false, narrativeByMessage: {} });
+    await activeHydrate;
+
+    expect(useWorkspaceStore.getState().activeThreadId).toBeNull();
+    expect(useThreadStore.getState().currentThreadId).toBeNull();
+    expect(useThreadStore.getState().records.get(THREAD_A)?.messages).not.toEqual([staleMessage]);
+  });
+
+  it("keeps resident messages after a cache eviction triggers same-selection restoration", async () => {
+    const resident = createMockMessage({
+      id: "resident-before-eviction",
+      thread_id: THREAD_A,
+      content: "resident before eviction",
+      sequence: 1,
+    });
+    const staleMessage = createMockMessage({
+      id: "stale-restoration-response",
+      thread_id: THREAD_A,
+      content: "stale restoration response",
+      sequence: 1,
+    });
+    let resolvePage!: (value: {
+      messages: typeof staleMessage[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_A,
+      records: new Map<string, ThreadRecord>([[
+        THREAD_A,
+        { ...makeCachedRecord([resident]), loadEpoch: 1 },
+      ]]),
+    });
+    cacheRecord(THREAD_A, makeCachedRecord([resident]));
+    useThreadStore.getState().handleAgentEvent({
+      type: "message",
+      threadId: THREAD_A,
+      content: "message after cache eviction",
+      messageId: "resident-after-eviction",
+      tokens: null,
+    } satisfies AgentEvent);
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+
+    const restoration = hydrator.hydrate(THREAD_A, "active");
+    await vi.waitFor(() => expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1));
+    resolvePage({ messages: [staleMessage], hasMore: false, narrativeByMessage: {} });
+    await restoration;
+
+    expect(getTestActiveMessages()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "resident-after-eviction", content: "message after cache eviction" }),
+    ]));
   });
 
   it("commits messages and narrative from one conversation page fetch", async () => {

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -42,6 +42,28 @@ function hasResidentLayer(record: ThreadRecord): boolean {
     || record.hooks.length > 0;
 }
 
+/** Snapshot the transcript and volatile layers that an active page fetch must not replace. */
+function conversationRevision(record: ThreadRecord): string {
+  return JSON.stringify({
+    messages: record.messages,
+    persistedToolCallCounts: record.persistedToolCallCounts,
+    persistedFilesChanged: record.persistedFilesChanged,
+    latestTurnWithChanges: record.latestTurnWithChanges,
+    serverMessageIds: record.serverMessageIds,
+    narrativeByMessage: record.narrativeByMessage,
+    answeredPlanMessageIds: [...record.answeredPlanMessageIds],
+    streaming: record.streaming,
+    streamingPreview: record.streamingPreview,
+    toolCalls: record.toolCalls,
+    thoughtSegments: record.thoughtSegments,
+    hooks: record.hooks,
+    currentTurnMessageId: record.currentTurnMessageId,
+    pendingTurnPersistMessageIds: record.pendingTurnPersistMessageIds,
+    currentTurnResponseKey: record.currentTurnResponseKey,
+    assistantResponseKeys: record.assistantResponseKeys,
+  });
+}
+
 function mergeMessageMetadata<T>(
   cached: Record<string, T>,
   resident: Record<string, T>,
@@ -69,11 +91,17 @@ function findLatestTurnWithChanges(
 function mergeResidentConversationCacheState(
   resident: ThreadRecord,
   cached: ConversationCacheState,
+  preserveResidentAtEqualSequence = true,
 ): ConversationCacheState {
   const residentCacheState = projectConversationCacheState(resident);
   const residentSequence = residentCacheState.messages.at(-1)?.sequence;
   const cachedSequence = cached.messages.at(-1)?.sequence;
-  if (residentSequence == null || (cachedSequence != null && cachedSequence > residentSequence)) {
+  if (
+    residentSequence == null
+    || (cachedSequence != null
+      && (cachedSequence > residentSequence
+        || (!preserveResidentAtEqualSequence && cachedSequence === residentSequence)))
+  ) {
     return cached;
   }
 
@@ -197,6 +225,27 @@ export class ThreadHydrator {
       return;
     }
     await this.hydrateActive(threadId, opts);
+  }
+
+  /** Retire the selected conversation when no thread remains active. */
+  deactivate(): void {
+    const threadId = this.deps.getState().currentThreadId;
+    if (!threadId) return;
+
+    this.deps.flushPendingTextDeltas();
+    const hadActiveHydrate = this.activeHydrates.has(threadId);
+    this.deps.setState((state: ThreadHydratorWriteState) => {
+      if (state.currentThreadId !== threadId) return {};
+      return {
+        records: patchThreadRecord(state.records, threadId, (record) => ({
+          loading: false,
+          isLoadingMore: false,
+          loadEpoch: record.loadEpoch + 1,
+        })),
+        currentThreadId: null,
+      };
+    });
+    this.retireInactiveRecord(threadId, hadActiveHydrate);
   }
 
   /** Speculative cache warm on sidebar hover — no live-store mutation. */
@@ -691,6 +740,9 @@ export class ThreadHydrator {
       this.prepareActiveLoad(threadId);
     }
     const expectedEpoch = getThreadRecord(getState().records, threadId).loadEpoch;
+    const expectedConversationRevision = conversationRevision(
+      getThreadRecord(getState().records, threadId),
+    );
 
     try {
       const workspaceThread = this.deps.getWorkspaceThread(threadId);
@@ -706,10 +758,23 @@ export class ThreadHydrator {
       );
 
       const stateAtCommit = getState();
-      if (
-        stateAtCommit.currentThreadId !== threadId
-        || getThreadRecord(stateAtCommit.records, threadId).loadEpoch !== expectedEpoch
-      ) return;
+      const recordAtCommit = getThreadRecord(stateAtCommit.records, threadId);
+      if (stateAtCommit.currentThreadId !== threadId || recordAtCommit.loadEpoch !== expectedEpoch) {
+        return;
+      }
+      if (conversationRevision(recordAtCommit) !== expectedConversationRevision) {
+        setState((state: ThreadHydratorWriteState) => {
+          const current = getThreadRecord(state.records, threadId);
+          if (state.currentThreadId !== threadId || current.loadEpoch !== expectedEpoch) return {};
+          return {
+            records: patchThreadRecord(state.records, threadId, {
+              loading: false,
+              isLoadingMore: false,
+            }),
+          };
+        });
+        return;
+      }
 
       const patch = snapshotBuilder.build({
         messages: pageResult.messages,
@@ -719,13 +784,20 @@ export class ThreadHydrator {
 
       setState((state: ThreadHydratorWriteState) => {
         const current = getThreadRecord(state.records, threadId);
+        const fetchedConversation = projectConversationCacheState({
+          ...createEmptyThreadRecord(),
+          ...patch,
+          narrativeByMessage: pageResult.narrativeByMessage,
+        });
+        const conversation = hasResidentLayer(current)
+          ? mergeResidentConversationCacheState(current, fetchedConversation, false)
+          : fetchedConversation;
         const ownsLiveFileEffects = current.fileEffectTurnId.length > 0
           || state.runningThreadIds.has(threadId);
         return {
           records: patchThreadRecord(state.records, threadId, {
-            ...patch,
+            ...conversation,
             ...(ownsLiveFileEffects ? { fileEffectSummary: current.fileEffectSummary } : {}),
-            narrativeByMessage: pageResult.narrativeByMessage,
             loading: false,
             isLoadingMore: false,
             settings: this.deps.getWorkspaceThreadSettings(threadId),

--- a/apps/web/src/stores/conversation-residency.ts
+++ b/apps/web/src/stores/conversation-residency.ts
@@ -1,0 +1,45 @@
+/** A sidebar row that can be activated as a persisted conversation. */
+export interface ConversationResidencyThread {
+  id: string;
+  clientPreparing?: boolean;
+  clientError?: string | null;
+}
+
+/** Collaborators used to restore or deactivate the selected conversation layer. */
+export interface ConversationResidencyDeps {
+  restoreConversation: (threadId: string) => Promise<void>;
+  deactivateConversation: () => void;
+}
+
+/**
+ * Owns selected-conversation activation and post-refresh restoration.
+ * Transport, cache freshness, and live-record precedence stay in ThreadHydrator.
+ */
+export class ConversationResidency {
+  constructor(private readonly deps: ConversationResidencyDeps) {}
+
+  /** Activate the selected thread when it has a persisted conversation identity. */
+  activate(threadId: string | null, threads: readonly ConversationResidencyThread[]): Promise<void> {
+    const thread = threadId ? threads.find((candidate) => candidate.id === threadId) : undefined;
+    if (!thread || thread.clientPreparing || thread.clientError) {
+      this.deps.deactivateConversation();
+      return Promise.resolve();
+    }
+    return this.deps.restoreConversation(thread.id);
+  }
+
+  /** Reconcile an unchanged selection after its workspace rows refresh. */
+  restoreAfterThreadRefresh(
+    selectedThreadId: string | null,
+    threads: readonly ConversationResidencyThread[],
+  ): Promise<void> {
+    return this.activate(selectedThreadId, threads);
+  }
+}
+
+/** Create the internal authority for selected conversation residency. */
+export function createConversationResidency(
+  deps: ConversationResidencyDeps,
+): ConversationResidency {
+  return new ConversationResidency(deps);
+}

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -103,6 +103,8 @@ interface ThreadState {
   hydrateRunningThreads: (ids: string[]) => void;
   addMessage: (message: Message) => void;
   clearMessages: () => void;
+  /** Deactivate the selected conversation and invalidate any active hydration commit. */
+  deactivateConversation: () => void;
   /** Returns true if an agent is actively executing on the given thread. */
   isThreadRunning: (threadId: string) => boolean;
   /** Set questions received from the model and show the wizard. */
@@ -1345,6 +1347,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         }),
       }));
     }
+  },
+
+  deactivateConversation: () => {
+    threadHydrator.deactivate();
   },
 
   /** Check whether an agent is currently executing on the given thread. */

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -15,6 +15,7 @@ import {
 import { getTransport } from "@/transport";
 import { useThreadStore } from "./threadStore";
 import { deleteThreadRecord, patchThreadRecord } from "./thread-record";
+import { createConversationResidency } from "./conversation-residency";
 import { useTerminalStore } from "./terminalStore";
 import { useQueueStore } from "./queueStore";
 import { useTaskStore } from "./taskStore";
@@ -347,6 +348,14 @@ interface WorkspaceState {
 
 /** Zustand store for workspace, thread, branch, and PR state management. */
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
+  const conversationResidency = createConversationResidency({
+    restoreConversation: (threadId) => useThreadStore.getState().loadMessages(threadId),
+    deactivateConversation: () => useThreadStore.getState().deactivateConversation(),
+  });
+  const reconcileSelectedConversation = () => {
+    void conversationResidency.activate(get().activeThreadId, get().threads);
+  };
+
   const applyOptimisticSuccess = (
     placeholderId: string,
     workspaceId: string,
@@ -407,7 +416,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       };
     });
     if (get().activeThreadId === thread.id) {
-      void useThreadStore.getState().loadMessages(thread.id);
+      void conversationResidency.restoreAfterThreadRefresh(thread.id, get().threads);
     }
   };
 
@@ -550,6 +559,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
           Object.entries(state.checksById).filter(([tid]) => !deletedIdSet.has(tid)),
         ),
       }));
+      reconcileSelectedConversation();
       // One batched Zustand set() for all threads instead of N sequential calls.
       useThreadStore.getState().clearThreadStateMany(deletedThreadIds);
     } catch (e) {
@@ -588,6 +598,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       fetchingBranch: null,
       branchManuallySelected: false,
     });
+    reconcileSelectedConversation();
     if (id) {
       if (loadThreads) get().loadThreads(id);
       // Optimistically bump the local last_opened_at so the project selector
@@ -720,6 +731,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
           loading: false,
         };
       });
+
+      if (get().activeWorkspaceId === workspaceId) {
+        void conversationResidency.restoreAfterThreadRefresh(
+          get().activeThreadId,
+          get().threads,
+        );
+      }
 
       const epochForPrSync = epochAtStart;
 
@@ -893,6 +911,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       newThreadBranchSource: "branch",
       error: null,
     }));
+    reconcileSelectedConversation();
 
     useThreadStore.setState((state) => ({
       runningThreadIds: new Set([...state.runningThreadIds, placeholderId]),
@@ -1020,6 +1039,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       newThreadBranchSource: "branch",
       error: null,
     }));
+    reconcileSelectedConversation();
 
     useThreadStore.setState((state) => ({
       runningThreadIds: new Set([...state.runningThreadIds, placeholderId]),
@@ -1074,6 +1094,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       threads: state.threads.filter((t) => t.id !== placeholderId),
       activeThreadId: state.activeThreadId === placeholderId ? null : state.activeThreadId,
     }));
+    reconcileSelectedConversation();
   },
 
   failPreparingThreadOnConnectionLost: (placeholderId) => {
@@ -1114,6 +1135,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
             checksById: remainingChecks,
           };
         });
+        reconcileSelectedConversation();
         useThreadStore.getState().clearThreadState(threadId);
         return;
       }
@@ -1146,6 +1168,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
           checksById: remainingChecks,
         };
       });
+      reconcileSelectedConversation();
       useThreadStore.getState().clearThreadState(threadId);
     } catch (e) {
       set({ error: String(e) });
@@ -1172,7 +1195,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
             t.id === id ? { ...t, status: "paused" as const } : t,
           )
         : state.threads,
-    }));
+      }));
+
+    reconcileSelectedConversation();
 
     if (isCompleted && id) {
       scheduleMarkThreadViewed(id);

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -545,6 +545,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       // Remove threads from store FIRST (same ordering as deleteThread) so
       // any in-flight timer callbacks see threads as gone before timers are cancelled.
       const deletedIdSet = new Set(deletedThreadIds);
+      const didClearActiveThread = deletedIdSet.has(get().activeThreadId ?? "");
       set((state) => ({
         workspaces: state.workspaces.filter((w) => w.id !== id),
         activeWorkspaceId:
@@ -559,7 +560,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
           Object.entries(state.checksById).filter(([tid]) => !deletedIdSet.has(tid)),
         ),
       }));
-      reconcileSelectedConversation();
+      if (didClearActiveThread) reconcileSelectedConversation();
       // One batched Zustand set() for all threads instead of N sequential calls.
       useThreadStore.getState().clearThreadStateMany(deletedThreadIds);
     } catch (e) {
@@ -1090,11 +1091,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
   dismissPreparingThread: (placeholderId) => {
     pendingThreadCreationByPlaceholderId.delete(placeholderId);
     useThreadStore.getState().clearThreadState(placeholderId);
+    const didClearActiveThread = get().activeThreadId === placeholderId;
     set((state) => ({
       threads: state.threads.filter((t) => t.id !== placeholderId),
       activeThreadId: state.activeThreadId === placeholderId ? null : state.activeThreadId,
     }));
-    reconcileSelectedConversation();
+    if (didClearActiveThread) reconcileSelectedConversation();
   },
 
   failPreparingThreadOnConnectionLost: (placeholderId) => {
@@ -1121,6 +1123,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         useComposerDraftStore.getState().clearDraft(threadId);
         useTaskStore.getState().clearTasks(threadId);
         useDiffStore.getState().clearThread(threadId);
+        const didClearActiveThread = get().activeThreadId === threadId;
         set((state) => {
           const remainingUrls = Object.fromEntries(
             Object.entries(state.prUrlsByThreadId).filter(([k]) => k !== threadId),
@@ -1135,7 +1138,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
             checksById: remainingChecks,
           };
         });
-        reconcileSelectedConversation();
+        if (didClearActiveThread) reconcileSelectedConversation();
         useThreadStore.getState().clearThreadState(threadId);
         return;
       }
@@ -1150,6 +1153,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       useComposerDraftStore.getState().clearDraft(threadId);
       useTaskStore.getState().clearTasks(threadId);
       useDiffStore.getState().clearThread(threadId);
+      const didClearActiveThread = get().activeThreadId === threadId;
       // Remove from threads[] FIRST so any in-flight dequeue timer callback's
       // threadExists guard sees the thread as deleted before clearThreadState
       // cancels the timer. This closes the race window between the timer
@@ -1168,7 +1172,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
           checksById: remainingChecks,
         };
       });
-      reconcileSelectedConversation();
+      if (didClearActiveThread) reconcileSelectedConversation();
       useThreadStore.getState().clearThreadState(threadId);
     } catch (e) {
       set({ error: String(e) });


### PR DESCRIPTION
## What

Centralize selected-thread activation, restoration, reconnect reconciliation, and deselection in one internal web-store conversation residency boundary.

## Why

Thread selection and conversation hydration previously used separate authorities. Same-selection reconnect restoration also sat outside the established resident state and bounded cache path.

## Key Changes

- Route selected-conversation transitions through `ConversationResidency`.
- Preserve fresher resident transcript and volatile state when older hydration completes.
- Keep completed inactive conversations within existing retention bounds while preserving running live layers.
- Keep resident messages visible when a reconnect refresh fails.
- Cover A-B-A restoration, reconnect, stale hydration, workspace deselection, bounds, and error states.

Related to #923

Closes #928

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787393769&installation_model_id=20477&pr_number=939&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F939&signature=4ffb2af8b7509d23010217e7ee49cf019707b20ef23c82970a933112a7543296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced “selected conversation residency” to restore or deactivate the current conversation appropriately during workspace changes and thread refreshes.
* **Bug Fixes**
  * Preserved the selected conversation and its messages after thread refreshes or WebSocket reconnects.
  * Prevented stale loading results from overwriting newer messages during concurrent hydration.
  * Improved conversation error handling with more accurate UI states, including inline error banners when messages are already present.
* **Tests**
  * Added coverage for refresh/reconnect selection retention, hydration concurrency, cache bounds, and error-state rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->