### PR TITLE
fix(web): keep thread lifecycle state coherent

### DIFF
--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -318,8 +318,9 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   const messages = useActiveThreadRecord((r) => r.messages);
   const loading = useActiveThreadRecord((r) => r.loading);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
+  const currentThreadId = useThreadStore((s) => s.currentThreadId);
   const isAgentRunning = useThreadStore((s) =>
-    activeThreadId ? s.runningThreadIds.has(activeThreadId) : false,
+    currentThreadId ? s.runningThreadIds.has(currentThreadId) : false,
   );
   const agentStartTime = useActiveThreadRecord((r) => r.agentStartTime);
   const streamingText = useActiveThreadRecord((r) => r.streaming);
@@ -345,7 +346,6 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   );
   const isLoadingMore = useActiveThreadRecord((r) => r.isLoadingMore);
   const loadOlderMessages = useThreadStore((s) => s.loadOlderMessages);
-  const currentThreadId = activeThreadId;
   const renderedThreadId = messages[0]?.thread_id ?? null;
   const permissions = useActiveThreadRecord((r) => r.permissions);
   const hooks = useActiveThreadRecord((r) => r.hooks);

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -24,10 +24,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const measureSpy = vi.fn();
 const scrollToIndexSpy = vi.fn();
 const loadOlderMessagesSpy = vi.fn();
+const loadNarrativeForMessageSpy = vi.fn();
 let totalSizeValue = 0;
+let virtualizerOptions: { count: number } | null = null;
 
 const mockVirtualizer = {
-  getVirtualItems: () => [],
+  getVirtualItems: () => Array.from(
+    { length: virtualizerOptions?.count ?? 0 },
+    (_, index) => ({ index, key: String(index), start: index * 80 }),
+  ),
   getTotalSize: () => totalSizeValue,
   measure: measureSpy,
   scrollToIndex: scrollToIndexSpy,
@@ -36,7 +41,10 @@ const mockVirtualizer = {
 };
 
 vi.mock("@tanstack/react-virtual", () => ({
-  useVirtualizer: vi.fn(() => mockVirtualizer),
+  useVirtualizer: vi.fn((options: { count: number }) => {
+    virtualizerOptions = options;
+    return mockVirtualizer;
+  }),
   defaultRangeExtractor: ({ startIndex, endIndex, overscan, count }: {
     startIndex: number;
     endIndex: number;
@@ -51,8 +59,16 @@ vi.mock("@tanstack/react-virtual", () => ({
 // Minimal store mocks; control `loading` and `activeThreadId` between renders.
 let loadingValue = false;
 let activeThreadIdValue = "thread-A";
-let messagesValue: { id: string; sequence: number; thread_id?: string }[] = [{ id: "m1", sequence: 1 }];
+let currentThreadIdValue = "thread-A";
+let messagesValue: {
+  id: string;
+  sequence: number;
+  thread_id?: string;
+  role?: "user" | "assistant";
+  content?: string;
+}[] = [{ id: "m1", sequence: 1 }];
 let hasMoreMessagesValue = false;
+let runningThreadIdsValue = new Set<string>();
 
 function buildMockRecord() {
   return {
@@ -77,12 +93,13 @@ function buildMockRecord() {
 
 vi.mock("@/stores/threadStore", () => ({
   useThreadStore: vi.fn((selector: (s: unknown) => unknown) => {
-    const records = new Map([[activeThreadIdValue, buildMockRecord()]]);
+    const records = new Map([[currentThreadIdValue, buildMockRecord()]]);
     return selector({
       records,
-      currentThreadId: activeThreadIdValue,
-      runningThreadIds: new Set(),
+      currentThreadId: currentThreadIdValue,
+      runningThreadIds: runningThreadIdsValue,
       loadOlderMessages: loadOlderMessagesSpy,
+      loadNarrativeForMessage: loadNarrativeForMessageSpy,
     });
   }),
 }));
@@ -100,14 +117,19 @@ vi.mock("@/stores/workspaceStore", () => ({
 }));
 
 // Stub heavy children.
-vi.mock("../MessageBubble", () => ({ MessageBubble: () => null }));
+vi.mock("../MessageBubble", () => ({
+  MessageBubble: ({ message }: { message: { content: string } }) => <div>{message.content}</div>,
+}));
 vi.mock("../ToolCallCard", () => ({ ToolCallCard: () => null }));
 vi.mock("../StreamingIndicator", () => ({ StreamingIndicator: () => null }));
 vi.mock("../StreamingCard", () => ({ StreamingCard: () => null }));
 vi.mock("../TurnChangeSummary", () => ({ TurnChangeSummary: () => null }));
 vi.mock("../PermissionRequestCard", () => ({ PermissionRequestCard: () => null }));
 vi.mock("../HookActivitySection", () => ({ HookActivitySection: () => null }));
-vi.mock("../narrative", () => ({ NarrativeFlow: () => null }));
+vi.mock("../narrative", () => ({
+  NarrativeFlow: ({ isAgentRunning }: { isAgentRunning: boolean }) =>
+    isAgentRunning ? <div>Thinking</div> : null,
+}));
 
 import { MessageList, preservePrependedVirtualRange } from "../MessageList";
 import {
@@ -122,8 +144,11 @@ beforeEach(() => {
   measureSpy.mockClear();
   scrollToIndexSpy.mockClear();
   loadOlderMessagesSpy.mockClear();
+  loadNarrativeForMessageSpy.mockClear();
   totalSizeValue = 0;
   hasMoreMessagesValue = false;
+  currentThreadIdValue = "thread-A";
+  runningThreadIdsValue = new Set();
   clearScrollMemory();
 });
 
@@ -132,6 +157,35 @@ afterEach(() => {
 });
 
 describe("MessageList thread switch", () => {
+  it("does not pair a cached transcript with another thread's running narrative", () => {
+    activeThreadIdValue = "thread-B";
+    currentThreadIdValue = "thread-A";
+    runningThreadIdsValue = new Set(["thread-B"]);
+    messagesValue = [{
+      id: "a-final",
+      sequence: 1,
+      thread_id: "thread-A",
+      role: "assistant",
+      content: "Thread A final response",
+    }];
+    const { queryByText, rerender } = render(<MessageList />);
+
+    expect(queryByText("Thread A final response")).not.toBeNull();
+    expect(queryByText("Thinking")).toBeNull();
+
+    currentThreadIdValue = "thread-B";
+    messagesValue = [{
+      id: "b-user",
+      sequence: 1,
+      thread_id: "thread-B",
+      role: "user",
+      content: "Thread B request",
+    }];
+    act(() => rerender(<MessageList />));
+
+    expect(queryByText("Thinking")).not.toBeNull();
+  });
+
   it("records history posture before navigation can replace the active transcript", () => {
     loadingValue = false;
     activeThreadIdValue = "thread-A";


### PR DESCRIPTION
## What

Keep the rendered transcript and running indicator scoped to the same hydrated thread during thread switches.

## Why

`MessageList` read cached transcript data through `threadStore.currentThreadId`, but read running state through `workspaceStore.activeThreadId`. Those identifiers can briefly disagree while a newly selected thread hydrates, which could show one thread's final response with another thread's Thinking indicator.

## Key Changes

- Read `runningThreadIds` with the same `currentThreadId` used by the rendered transcript.
- Add a regression test for the active-thread B and hydrated-thread A transition.
- Verify that thread B's running indicator appears after B becomes hydrated.

## Verification

- Focused `MessageList` suite: 18/18 passed.
- `bun run verify:changed`: passed.
- Independent static and state-coherence review: no findings.
- Full `bun run verify`: 2,497 tests passed, but the gate exited nonzero on an unrelated timing assertion in `pullRequestDetailStore.test.ts`; its focused reproduction passed.
- Live in-app browser verification was blocked by the browser's localhost URL policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787395539&installation_model_id=20477&pr_number=940&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F940&signature=08d42a07f520a896e283d51240820a2869eb5698b4485705c766090fe0fa7281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->