### PR TITLE
fix(web): preserve message order across thread switches

### DIFF
--- a/apps/web/src/__tests__/threadStore-message-cache.test.ts
+++ b/apps/web/src/__tests__/threadStore-message-cache.test.ts
@@ -80,6 +80,42 @@ describe("loadMessages cache integration", () => {
     expect(useThreadStore.getState().currentThreadId).toBe("t1");
   });
 
+  it("appends an optimistic user message after a restored high-sequence cache tail", async () => {
+    const cachedTail = [
+      createMockMessage({ id: "m99", thread_id: "t1", sequence: 99 }),
+      createMockMessage({ id: "m100", thread_id: "t1", sequence: 100 }),
+    ];
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messages: cachedTail,
+      hasMore: true,
+      narrativeByMessage: {},
+    });
+
+    await useThreadStore.getState().loadMessages("t1");
+    useThreadStore.setState((s) => ({
+      currentThreadId: "t2",
+      records: patchThreadRecord(s.records, "t2", { messages: [] }),
+    }));
+    await useThreadStore.getState().loadMessages("t1");
+
+    await useThreadStore.getState().sendMessage("t1", "new user message");
+
+    const messages = getTestActiveMessages();
+    expect(messages.map((message) => message.sequence)).toEqual([99, 100, 101]);
+    expect(messages.at(-1)?.content).toBe("new user message");
+  });
+
+  it("starts optimistic messages at sequence one for an empty record", async () => {
+    useThreadStore.setState((s) => ({
+      currentThreadId: "t1",
+      records: patchThreadRecord(s.records, "t1", { messages: [] }),
+    }));
+
+    await useThreadStore.getState().sendMessage("t1", "first user message");
+
+    expect(getTestActiveMessages().at(-1)?.sequence).toBe(1);
+  });
+
   it("does NOT clear toolCallRecordCache on cache hit", async () => {
     await useThreadStore.getState().loadMessages("t1");
     useThreadStore.getState().cacheToolCallRecords("t1:m1", [

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -877,7 +877,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
   };
 
-  const messageSequenceFor = (threadId: string) => getRec(threadId).messages.length + 1;
+  const messageSequenceFor = (threadId: string) =>
+    getRec(threadId).messages.reduce(
+      (latestSequence, message) => Math.max(latestSequence, message.sequence),
+      0,
+    ) + 1;
 
   const scheduleTextDeltaFlush = () => {
     if (textDeltaFlushRaf != null) return;


### PR DESCRIPTION
## What
Preserve chronological message order when switching between active Codex threads.

## Why
The thread cache keeps a compact message tail with original sequence numbers. New local messages previously used the tail length, which could assign stale sequence numbers and let cache reconciliation discard the active turn boundary.

## Key Changes
- Generate local message sequences from the highest resident sequence.
- Add regression coverage for restored high-sequence cache tails and empty threads.
- Verify concurrent Codex thread switching in the running app.

## Verification
- Focused thread cache and switching tests: 15 passed.
- bun run verify:changed
- bun run verify

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787400353&installation_model_id=20477&pr_number=941&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F941&signature=275ad5b0bf27ac8aed1241027bca561e32c7bc70943f63591b7f66fc42d4f9ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->