### PR TITLE
feat(web): route conversations through residency

### DIFF
--- a/apps/web/src/__tests__/conversation-residency.test.ts
+++ b/apps/web/src/__tests__/conversation-residency.test.ts
@@ -39,4 +39,34 @@ describe("ConversationResidency", () => {
     expect(restoreConversation).toHaveBeenCalledWith("thread-a");
     expect(deactivateConversation).not.toHaveBeenCalled();
   });
+
+  it("routes event retention, persisted invalidation, pagination, and prefetch through one boundary", async () => {
+    const restoreConversation = vi.fn().mockResolvedValue(undefined);
+    const deactivateConversation = vi.fn();
+    const retainInactiveConversation = vi.fn();
+    const invalidateConversation = vi.fn();
+    const synchronizeConversation = vi.fn();
+    const mergeCachedFileChanges = vi.fn();
+    const prefetchConversation = vi.fn().mockResolvedValue(undefined);
+    const residency = createConversationResidency({
+      restoreConversation,
+      deactivateConversation,
+      retainInactiveConversation,
+      invalidateConversation,
+      synchronizeConversation,
+      mergeCachedFileChanges,
+      prefetchConversation,
+    });
+    residency.invalidateConversation("thread-a");
+    residency.retainInactiveConversation("thread-a");
+    residency.commitPagination("thread-a");
+    residency.mergePaginationFileChanges("thread-a", { message: ["src/a.ts"] });
+    await residency.prefetch("thread-a");
+
+    expect(invalidateConversation).toHaveBeenCalledOnce();
+    expect(retainInactiveConversation).toHaveBeenCalledWith("thread-a");
+    expect(synchronizeConversation).toHaveBeenCalledWith("thread-a");
+    expect(mergeCachedFileChanges).toHaveBeenCalledWith("thread-a", { message: ["src/a.ts"] });
+    expect(prefetchConversation).toHaveBeenCalledWith("thread-a");
+  });
 });

--- a/apps/web/src/__tests__/conversation-residency.test.ts
+++ b/apps/web/src/__tests__/conversation-residency.test.ts
@@ -40,6 +40,33 @@ describe("ConversationResidency", () => {
     expect(deactivateConversation).not.toHaveBeenCalled();
   });
 
+  it("uses the refresh dependency when one is provided", async () => {
+    const restoreConversation = vi.fn().mockResolvedValue(undefined);
+    const refreshConversation = vi.fn().mockResolvedValue(undefined);
+    const residency = createConversationResidency({
+      restoreConversation,
+      refreshConversation,
+      deactivateConversation: vi.fn(),
+    });
+
+    await residency.refresh("thread-a", [{ id: "thread-a" }]);
+
+    expect(refreshConversation).toHaveBeenCalledWith("thread-a");
+    expect(restoreConversation).not.toHaveBeenCalled();
+  });
+
+  it("falls back to restoration when no refresh dependency is provided", async () => {
+    const restoreConversation = vi.fn().mockResolvedValue(undefined);
+    const residency = createConversationResidency({
+      restoreConversation,
+      deactivateConversation: vi.fn(),
+    });
+
+    await residency.refresh("thread-a", [{ id: "thread-a" }]);
+
+    expect(restoreConversation).toHaveBeenCalledWith("thread-a");
+  });
+
   it("routes event retention, persisted invalidation, pagination, and prefetch through one boundary", async () => {
     const restoreConversation = vi.fn().mockResolvedValue(undefined);
     const deactivateConversation = vi.fn();

--- a/apps/web/src/__tests__/pagination.test.ts
+++ b/apps/web/src/__tests__/pagination.test.ts
@@ -13,6 +13,7 @@ import type { TurnSnapshot } from "@mcode/contracts";
 import { useThreadStore } from "@/stores/threadStore";
 import {
   cacheRecord as cacheConversationRecord,
+  cachePrefetchedHistoryPage,
   clearRecordCache,
   getCachedRecord,
   projectConversationCacheState,
@@ -345,5 +346,91 @@ describe("Chat Pagination", () => {
 
     expect(getTestThreadIsLoadingMore(threadId)).toBe(false);
     expect(getTestActiveMessages()).toHaveLength(1);
+  });
+
+  it("merges an RPC page with resident rows by id and sequence without duplicates", async () => {
+    const residentAtSharedSequence = createMockMessage({
+      id: "resident-at-shared-sequence",
+      thread_id: threadId,
+      content: "live owner",
+      sequence: 5,
+    });
+    const live = createMockMessage({
+      id: "live",
+      thread_id: threadId,
+      content: "latest live row",
+      sequence: 102,
+    });
+    const older = createMockMessage({ id: "older", thread_id: threadId, sequence: 2 });
+    resetThreadStoreForTests({
+      currentThreadId: threadId,
+      records: new Map([[threadId, {
+        ...createEmptyThreadRecord(),
+        messages: [residentAtSharedSequence, live],
+        oldestLoadedSequence: 5,
+        hasMoreMessages: true,
+      }]]),
+    });
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      messages: [
+        createMockMessage({ id: "live", thread_id: threadId, content: "stale persisted row", sequence: 1 }),
+        createMockMessage({ id: "page-at-shared-sequence", thread_id: threadId, sequence: 5 }),
+        older,
+      ],
+      hasMore: false,
+      narrativeByMessage: {},
+    });
+
+    await useThreadStore.getState().loadOlderMessages(threadId);
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(threadId, 50, 5);
+    expect(getTestActiveMessages()).toEqual([
+      older,
+      residentAtSharedSequence,
+      live,
+    ]);
+  });
+
+  it("keeps deterministic resident precedence when a warmed page overlaps pagination", async () => {
+    const resident = createMockMessage({
+      id: "resident",
+      thread_id: threadId,
+      content: "live owner",
+      sequence: 10,
+    });
+    const duplicateIdAtEarlierSequence = createMockMessage({
+      id: "same-id-older-sequence",
+      thread_id: threadId,
+      sequence: 2,
+    });
+    const oldest = createMockMessage({ id: "oldest", thread_id: threadId, sequence: 1 });
+    resetThreadStoreForTests({
+      currentThreadId: threadId,
+      records: new Map([[threadId, {
+        ...createEmptyThreadRecord(),
+        messages: [resident],
+        oldestLoadedSequence: 10,
+        hasMoreMessages: true,
+      }]]),
+    });
+    cachePrefetchedHistoryPage(threadId, 10, {
+      messages: [
+        createMockMessage({ id: "stale-resident", thread_id: threadId, sequence: 10 }),
+        createMockMessage({ id: "same-id-older-sequence", thread_id: threadId, sequence: 3 }),
+        duplicateIdAtEarlierSequence,
+        oldest,
+      ],
+      hasMore: false,
+      narrativeByMessage: {},
+    });
+
+    await useThreadStore.getState().loadOlderMessages(threadId);
+
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
+    expect(getTestActiveMessages()).toEqual([
+      oldest,
+      duplicateIdAtEarlierSequence,
+      resident,
+    ]);
   });
 });

--- a/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
+++ b/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
@@ -144,7 +144,12 @@ describe("thread status refresh after reconnect", () => {
       }),
     );
     const thread = createMockThread({ workspace_id: ws.id, status: "active" });
-    const refreshConversation = vi.fn().mockResolvedValue(undefined);
+    const refreshConversation = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("refresh failed"))
+      .mockResolvedValueOnce(undefined);
+    const unhandledRejection = vi.fn();
+    process.on("unhandledRejection", unhandledRejection);
     const originalRefresh = useThreadStore.getState().refreshConversation;
     useThreadStore.setState({ refreshConversation });
     useWorkspaceStore.setState({
@@ -169,6 +174,8 @@ describe("thread status refresh after reconnect", () => {
         expect(mockTransport.listThreads).toHaveBeenCalledTimes(1);
         expect(refreshConversation).toHaveBeenCalledTimes(2);
       });
+      await Promise.resolve();
+      expect(unhandledRejection).not.toHaveBeenCalled();
 
       sockets[1]?.disconnect();
       await vi.advanceTimersByTimeAsync(1_000);
@@ -181,6 +188,7 @@ describe("thread status refresh after reconnect", () => {
       transport.close();
       vi.useRealTimers();
       vi.unstubAllGlobals();
+      process.off("unhandledRejection", unhandledRejection);
       useThreadStore.setState({ refreshConversation: originalRefresh });
     }
   });

--- a/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
+++ b/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
@@ -6,12 +6,46 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
+import { createWsTransport } from "@/transport/ws-transport";
 import { mockTransport, createMockWorkspace, createMockThread } from "./mocks/transport";
 
 vi.mock("@/transport", async () => ({
   ...(await vi.importActual("@/transport")),
   getTransport: () => mockTransport,
 }));
+
+class ReconnectWebSocket {
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  readyState = 0;
+
+  send(data: string): void {
+    const request = JSON.parse(data) as { id: string; method: string };
+    const result = request.method === "agent.listRunning" || request.method === "terminal.listActive"
+      ? []
+      : null;
+    queueMicrotask(() => {
+      this.onmessage?.({ data: JSON.stringify({ id: request.id, result }) });
+    });
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.onclose?.({ code: 1000, reason: "" });
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  disconnect(): void {
+    this.readyState = 3;
+    this.onclose?.({ code: 1006, reason: "" });
+  }
+}
 
 describe("thread status refresh after reconnect", () => {
   const ws = createMockWorkspace();
@@ -79,6 +113,75 @@ describe("thread status refresh after reconnect", () => {
       expect(loadMessages).toHaveBeenCalledWith(thread.id);
     } finally {
       useThreadStore.setState({ loadMessages: originalLoadMessages });
+    }
+  });
+
+  it("revalidates the selected conversation without replacing its resident rows", async () => {
+    const thread = createMockThread({ workspace_id: ws.id, status: "active" });
+    const refreshConversation = vi.fn().mockResolvedValue(undefined);
+    const original = useThreadStore.getState().refreshConversation;
+    useThreadStore.setState({ refreshConversation });
+    useWorkspaceStore.setState({ threads: [thread], activeThreadId: thread.id });
+    try {
+      await useWorkspaceStore.getState().refreshActiveConversation();
+      expect(refreshConversation).toHaveBeenCalledWith(thread.id);
+    } finally {
+      useThreadStore.setState({ refreshConversation: original });
+    }
+  });
+
+  it("refreshes the selected conversation on every reconnect while throttling thread lists", async () => {
+    vi.useFakeTimers();
+    const sockets: ReconnectWebSocket[] = [];
+    vi.stubGlobal(
+      "WebSocket",
+      new Proxy(ReconnectWebSocket, {
+        construct(Target) {
+          const socket = new Target();
+          sockets.push(socket);
+          return socket;
+        },
+      }),
+    );
+    const thread = createMockThread({ workspace_id: ws.id, status: "active" });
+    const refreshConversation = vi.fn().mockResolvedValue(undefined);
+    const originalRefresh = useThreadStore.getState().refreshConversation;
+    useThreadStore.setState({ refreshConversation });
+    useWorkspaceStore.setState({
+      threads: [thread],
+      activeWorkspaceId: ws.id,
+      activeThreadId: thread.id,
+    });
+    (mockTransport.listThreads as ReturnType<typeof vi.fn>).mockResolvedValue([thread]);
+    const transport = createWsTransport("ws://localhost:1234");
+
+    try {
+      sockets[0]?.open();
+      await vi.waitFor(() => {
+        expect(mockTransport.listThreads).toHaveBeenCalledTimes(1);
+        expect(refreshConversation).toHaveBeenCalledTimes(1);
+      });
+
+      sockets[0]?.disconnect();
+      await vi.advanceTimersByTimeAsync(1_000);
+      sockets[1]?.open();
+      await vi.waitFor(() => {
+        expect(mockTransport.listThreads).toHaveBeenCalledTimes(1);
+        expect(refreshConversation).toHaveBeenCalledTimes(2);
+      });
+
+      sockets[1]?.disconnect();
+      await vi.advanceTimersByTimeAsync(1_000);
+      sockets[2]?.open();
+      await vi.waitFor(() => {
+        expect(mockTransport.listThreads).toHaveBeenCalledTimes(1);
+        expect(refreshConversation).toHaveBeenCalledTimes(3);
+      });
+    } finally {
+      transport.close();
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+      useThreadStore.setState({ refreshConversation: originalRefresh });
     }
   });
 });

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -239,6 +239,29 @@ describe("ThreadHydrator", () => {
     expect(readActiveThreadField((record) => record.latestTurnWithChanges)).toBe("cached-history");
   });
 
+  it("deduplicates a resident message id when its cached sequence is stale", async () => {
+    const cachedMessage = createMockMessage({
+      id: "same-message",
+      thread_id: THREAD_A,
+      content: "stale cached content",
+      sequence: 1,
+    });
+    const residentMessage = createMockMessage({
+      id: "same-message",
+      thread_id: THREAD_A,
+      content: "resident content",
+      sequence: 2,
+    });
+    cacheRecord(THREAD_A, makeCachedRecord([cachedMessage]));
+    resetThreadStoreForTests({
+      records: new Map([[THREAD_A, makeCachedRecord([residentMessage])]]),
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(getTestActiveMessages()).toEqual([residentMessage]);
+  });
+
   it("cache miss fetches a conversation page, commits store, and populates cache", async () => {
     await hydrator.hydrate(THREAD_A, "active");
 

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -365,6 +365,105 @@ describe("ThreadHydrator", () => {
     expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
   });
 
+  it("keeps a newer resident row through compact cache restore, pagination, and refresh", async () => {
+    const persistedTail = Array.from({ length: 4 }, (_, index) => createMockMessage({
+      id: `persisted-high-${index + 97}`,
+      thread_id: THREAD_A,
+      sequence: index + 97,
+    }));
+    const resident = createMockMessage({
+      id: "resident-newer-than-cache",
+      thread_id: THREAD_A,
+      content: "live resident row",
+      sequence: 101,
+    });
+    const refreshedPersisted = createMockMessage({
+      id: "persisted-high-100",
+      thread_id: THREAD_A,
+      content: "persisted refresh",
+      sequence: 100,
+    });
+    cacheRecord(THREAD_A, {
+      ...makeCachedRecord(persistedTail),
+      hasMoreMessages: true,
+    });
+    resetThreadStoreForTests({
+      records: new Map([[THREAD_A, {
+        ...makeCachedRecord([resident]),
+        hasMoreMessages: true,
+      }]]),
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+
+    expect(getTestActiveMessages()).toEqual([persistedTail[3], resident]);
+    await useThreadStore.getState().loadOlderMessages(THREAD_A);
+    expect(getTestActiveMessages()).toEqual([...persistedTail, resident]);
+
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      messages: [refreshedPersisted],
+      hasMore: false,
+      narrativeByMessage: {},
+    });
+    await hydrator.hydrate(THREAD_A, "active", { force: true });
+
+    expect(getTestActiveMessages()).toEqual([
+      persistedTail[0],
+      persistedTail[1],
+      persistedTail[2],
+      refreshedPersisted,
+      resident,
+    ]);
+  });
+
+  it("chooses the highest settled file summary while preserving a live owner", async () => {
+    const low = { revision: 2, fileCount: 2, additions: 2, deletions: 2, effects: [] };
+    const high = { revision: 8, fileCount: 8, additions: 8, deletions: 8, effects: [] };
+    const live = { revision: 1, fileCount: 1, additions: 1, deletions: 1, effects: [] };
+
+    cacheConversationRecord(THREAD_A, {
+      ...projectConversationCacheState(makeCachedRecord()),
+      settledFileEffectSummary: low,
+    });
+    resetThreadStoreForTests({
+      records: new Map([[THREAD_A, { ...makeCachedRecord(), fileEffectSummary: high }]]),
+    });
+    await hydrator.hydrate(THREAD_A, "active");
+    expect(readActiveThreadField((record) => record.fileEffectSummary)).toEqual(high);
+
+    resetStores();
+    hydrator = createStoreHydrator();
+    cacheConversationRecord(THREAD_A, {
+      ...projectConversationCacheState(makeCachedRecord()),
+      settledFileEffectSummary: high,
+    });
+    expect(getCachedRecord(THREAD_A)?.settledFileEffectSummary).toEqual(high);
+    resetThreadStoreForTests({
+      records: new Map([[THREAD_A, { ...makeCachedRecord(), fileEffectSummary: low }]]),
+    });
+    await hydrator.hydrate(THREAD_A, "active");
+    expect(getCachedRecord(THREAD_A)?.settledFileEffectSummary).toEqual(high);
+    expect(readActiveThreadField((record) => record.fileEffectSummary)).toEqual(high);
+
+    resetStores();
+    hydrator = createStoreHydrator();
+    cacheConversationRecord(THREAD_A, {
+      ...projectConversationCacheState(makeCachedRecord()),
+      settledFileEffectSummary: high,
+    });
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_A,
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map([[THREAD_A, {
+        ...makeCachedRecord(),
+        fileEffectSummary: live,
+        fileEffectTurnId: "live-turn",
+      }]]),
+    });
+    await hydrator.hydrate(THREAD_A, "active");
+    expect(readActiveThreadField((record) => record.fileEffectSummary)).toEqual(live);
+  });
+
   it("restores the loaded window when returning to a cached history position", async () => {
     const history = Array.from({ length: 100 }, (_, index) => createMockMessage({
       id: `cached-history-${index + 1}`,

--- a/apps/web/src/lib/thread-hydrator/prefetch-scheduler.ts
+++ b/apps/web/src/lib/thread-hydrator/prefetch-scheduler.ts
@@ -1,5 +1,5 @@
 import { hasCachedRecord } from "./record-cache";
-import { getThreadHydrator } from "./thread-hydrator";
+import { getConversationResidency } from "@/stores/conversation-residency";
 
 /** Threads currently being prefetched, to avoid duplicate requests. */
 const inflight = new Set<string>();
@@ -41,7 +41,7 @@ async function prefetchThread(threadId: string): Promise<void> {
   if (hasCachedRecord(threadId) || inflight.has(threadId)) return;
   inflight.add(threadId);
   try {
-    await getThreadHydrator().hydrate(threadId, "background");
+    await getConversationResidency().prefetch(threadId);
   } catch {
     // Prefetch is speculative; swallow errors silently
   } finally {

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -114,8 +114,15 @@ function mergeResidentConversationCacheState(
   ) {
     return cached;
   }
+  const cachedMessageIds = new Set(cached.messages.map((message) => message.id));
   const messagesBySequence = new Map(cached.messages.map((message) => [message.sequence, message]));
   for (const message of residentCacheState.messages) {
+    if (!preferResidentAtEqualSequence && cachedMessageIds.has(message.id)) continue;
+    if (preferResidentAtEqualSequence) {
+      for (const [sequence, existing] of messagesBySequence) {
+        if (existing.id === message.id) messagesBySequence.delete(sequence);
+      }
+    }
     if (preferResidentAtEqualSequence || !messagesBySequence.has(message.sequence)) {
       messagesBySequence.set(message.sequence, message);
     }

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -6,6 +6,7 @@ import {
   hasCachedRecord,
   hasPrefetchedHistoryPage,
   projectConversationCacheState,
+  takePrefetchedHistoryPage,
 } from "./record-cache";
 import type { ConversationCacheState } from "./record-cache";
 import {
@@ -87,11 +88,20 @@ function findLatestTurnWithChanges(
   return null;
 }
 
+function chooseSettledFileEffectSummary(
+  resident: ConversationCacheState["settledFileEffectSummary"],
+  cached: ConversationCacheState["settledFileEffectSummary"],
+): ConversationCacheState["settledFileEffectSummary"] {
+  if (!resident) return cached;
+  if (!cached) return resident;
+  return resident.revision >= cached.revision ? resident : cached;
+}
+
 /** Prefer an equally recent resident update while retaining disjoint cached history. */
 function mergeResidentConversationCacheState(
   resident: ThreadRecord,
   cached: ConversationCacheState,
-  preserveResidentAtEqualSequence = true,
+  preferResidentAtEqualSequence = true,
 ): ConversationCacheState {
   const residentCacheState = projectConversationCacheState(resident);
   const residentSequence = residentCacheState.messages.at(-1)?.sequence;
@@ -100,16 +110,19 @@ function mergeResidentConversationCacheState(
     residentSequence == null
     || (cachedSequence != null
       && (cachedSequence > residentSequence
-        || (!preserveResidentAtEqualSequence && cachedSequence === residentSequence)))
+        || (!preferResidentAtEqualSequence && cachedSequence === residentSequence)))
   ) {
     return cached;
   }
-
   const messagesBySequence = new Map(cached.messages.map((message) => [message.sequence, message]));
   for (const message of residentCacheState.messages) {
-    messagesBySequence.set(message.sequence, message);
+    if (preferResidentAtEqualSequence || !messagesBySequence.has(message.sequence)) {
+      messagesBySequence.set(message.sequence, message);
+    }
   }
-  const messages = [...messagesBySequence.values()].sort((left, right) => left.sequence - right.sequence);
+  const messages = [...messagesBySequence.values()].sort((left, right) =>
+    left.sequence - right.sequence || left.id.localeCompare(right.id),
+  );
   const retainedMessageIds = new Set(messages.map((message) => message.id));
   const persistedFilesChanged = mergeMessageMetadata(
     cached.persistedFilesChanged,
@@ -149,8 +162,10 @@ function mergeResidentConversationCacheState(
       residentCacheState.assistantResponseKeys,
       retainedMessageIds,
     ),
-    settledFileEffectSummary:
-      residentCacheState.settledFileEffectSummary ?? cached.settledFileEffectSummary,
+    settledFileEffectSummary: chooseSettledFileEffectSummary(
+      residentCacheState.settledFileEffectSummary,
+      cached.settledFileEffectSummary,
+    ),
   };
 }
 
@@ -225,6 +240,44 @@ export class ThreadHydrator {
       return;
     }
     await this.hydrateActive(threadId, opts);
+  }
+
+  /** Retain an inactive resident transcript through the bounded conversation cache. */
+  retainInactiveConversation(threadId: string): void {
+    const state = this.deps.getState();
+    if (state.currentThreadId === threadId) return;
+    cacheRecord(threadId, projectConversationCacheState(getThreadRecord(state.records, threadId)));
+  }
+
+  /** Discard a stale cached conversation before an authoritative mutation. */
+  invalidateConversation(threadId: string): void {
+    evictCachedRecord(threadId);
+  }
+
+  /** Synchronize the current resident conversation into its bounded cache entry. */
+  synchronizeConversation(threadId: string): void {
+    const record = this.deps.getState().records.get(threadId);
+    if (record) cacheRecord(threadId, projectConversationCacheState(record));
+  }
+
+  /** Merge delayed file metadata only when the current cache still retains those messages. */
+  mergeCachedFileChanges(threadId: string, filesChanged: Record<string, string[]>): void {
+    const cached = getCachedRecord(threadId);
+    if (!cached) return;
+    const retainedMessageIds = new Set(cached.messages.map((message) => message.id));
+    const retainedChanges = Object.fromEntries(
+      Object.entries(filesChanged).filter(([messageId]) => retainedMessageIds.has(messageId)),
+    );
+    if (Object.keys(retainedChanges).length === 0) return;
+    cacheRecord(threadId, {
+      ...cached,
+      persistedFilesChanged: { ...cached.persistedFilesChanged, ...retainedChanges },
+    });
+  }
+
+  /** Consume a warmed older-history page through the conversation cache. */
+  takePrefetchedHistoryPage(threadId: string, before: number): ConversationPage | undefined {
+    return takePrefetchedHistoryPage(threadId, before);
   }
 
   /** Retire the selected conversation when no thread remains active. */
@@ -365,7 +418,7 @@ export class ThreadHydrator {
     }
 
     const cached = getCachedRecord(threadId);
-    if (cached) {
+    if (cached && !opts?.force) {
       this.restoreCachedActive(
         threadId,
         resident ? mergeResidentConversationCacheState(resident, cached) : cached,
@@ -794,10 +847,15 @@ export class ThreadHydrator {
           : fetchedConversation;
         const ownsLiveFileEffects = current.fileEffectTurnId.length > 0
           || state.runningThreadIds.has(threadId);
+        const { settledFileEffectSummary, ...conversationFields } = conversation;
         return {
           records: patchThreadRecord(state.records, threadId, {
-            ...conversation,
-            ...(ownsLiveFileEffects ? { fileEffectSummary: current.fileEffectSummary } : {}),
+            ...conversationFields,
+            ...(!ownsLiveFileEffects && settledFileEffectSummary
+              ? { fileEffectSummary: settledFileEffectSummary }
+              : ownsLiveFileEffects
+                ? { fileEffectSummary: current.fileEffectSummary }
+                : {}),
             loading: false,
             isLoadingMore: false,
             settings: this.deps.getWorkspaceThreadSettings(threadId),

--- a/apps/web/src/stores/conversation-residency.ts
+++ b/apps/web/src/stores/conversation-residency.ts
@@ -1,3 +1,5 @@
+import type { ConversationPage } from "@mcode/contracts";
+
 /** A sidebar row that can be activated as a persisted conversation. */
 export interface ConversationResidencyThread {
   id: string;
@@ -8,7 +10,14 @@ export interface ConversationResidencyThread {
 /** Collaborators used to restore or deactivate the selected conversation layer. */
 export interface ConversationResidencyDeps {
   restoreConversation: (threadId: string) => Promise<void>;
+  refreshConversation?: (threadId: string) => Promise<void>;
   deactivateConversation: () => void;
+  retainInactiveConversation?: (threadId: string) => void;
+  invalidateConversation?: (threadId: string) => void;
+  synchronizeConversation?: (threadId: string) => void;
+  mergeCachedFileChanges?: (threadId: string, filesChanged: Record<string, string[]>) => void;
+  takePrefetchedHistoryPage?: (threadId: string, before: number) => ConversationPage | undefined;
+  prefetchConversation?: (threadId: string) => Promise<void>;
 }
 
 /**
@@ -35,6 +44,43 @@ export class ConversationResidency {
   ): Promise<void> {
     return this.activate(selectedThreadId, threads);
   }
+
+  /** Revalidate the selected transcript without clearing its resident rendering. */
+  refresh(selectedThreadId: string | null, threads: readonly ConversationResidencyThread[]): Promise<void> {
+    const thread = selectedThreadId ? threads.find((candidate) => candidate.id === selectedThreadId) : undefined;
+    if (!thread || thread.clientPreparing || thread.clientError) return Promise.resolve();
+    return this.deps.refreshConversation?.(thread.id) ?? this.deps.restoreConversation(thread.id);
+  }
+
+  /** Retain a completed background conversation through the bounded cache. */
+  retainInactiveConversation(threadId: string): void {
+    this.deps.retainInactiveConversation?.(threadId);
+  }
+
+  /** Invalidate stale conversation cache state before an authoritative mutation. */
+  invalidateConversation(threadId: string): void {
+    this.deps.invalidateConversation?.(threadId);
+  }
+
+  /** Commit a pagination page after its state guards have accepted it. */
+  commitPagination(threadId: string): void {
+    this.deps.synchronizeConversation?.(threadId);
+  }
+
+  /** Merge delayed pagination file metadata only into the current cache entry. */
+  mergePaginationFileChanges(threadId: string, filesChanged: Record<string, string[]>): void {
+    this.deps.mergeCachedFileChanges?.(threadId, filesChanged);
+  }
+
+  /** Consume the matching warm history page through the cache authority. */
+  takePrefetchedHistoryPage(threadId: string, before: number): ConversationPage | undefined {
+    return this.deps.takePrefetchedHistoryPage?.(threadId, before);
+  }
+
+  /** Warm a non-selected conversation without mutating the live selection. */
+  prefetch(threadId: string): Promise<void> {
+    return this.deps.prefetchConversation?.(threadId) ?? Promise.resolve();
+  }
 }
 
 /** Create the internal authority for selected conversation residency. */
@@ -42,4 +88,19 @@ export function createConversationResidency(
   deps: ConversationResidencyDeps,
 ): ConversationResidency {
   return new ConversationResidency(deps);
+}
+
+let registeredConversationResidency: ConversationResidency | null = null;
+
+/** Register the internal residency authority used by transport-facing paths. */
+export function registerConversationResidency(residency: ConversationResidency): void {
+  registeredConversationResidency = residency;
+}
+
+/** Return the internal residency authority after the thread store initializes it. */
+export function getConversationResidency(): ConversationResidency {
+  if (!registeredConversationResidency) {
+    throw new Error("Conversation residency has not been initialized");
+  }
+  return registeredConversationResidency;
 }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -22,13 +22,7 @@ import { useToastStore } from "./toastStore";
 import { findModelById } from "@/lib/model-registry";
 import { resolveContextWindow } from "@/lib/resolve-context-window";
 import { useSettingsStore } from "./settingsStore";
-import {
-  cacheRecord,
-  evictCachedRecord,
-  getCachedRecord,
-  projectConversationCacheState,
-  takePrefetchedHistoryPage,
-} from "@/lib/thread-hydrator/record-cache";
+import { createConversationResidency, registerConversationResidency } from "./conversation-residency";
 import {
   clearPendingTurnPersistMessage,
   projectTurnResponse,
@@ -96,6 +90,7 @@ interface ThreadState {
 
   // Message actions
   loadMessages: (threadId: string) => Promise<void>;
+  refreshConversation: (threadId: string) => Promise<void>;
   loadOlderMessages: (threadId: string) => Promise<void>;
   sendMessage: (threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], displayContent?: string, reasoningLevel?: ReasoningLevel, provider?: string, copilotAgent?: string, contextWindow?: ContextWindowMode, thinking?: boolean, codexFastMode?: boolean, replyToMessageId?: string, quotedText?: string, planAction?: import("@mcode/contracts").PlanAction, mentions?: MessageMention[], previewAnnotations?: PreviewAnnotationBundle, goalObjective?: string, orchestrationMode?: OrchestrationMode) => Promise<void>;
   stopAgent: (threadId: string) => Promise<void>;
@@ -756,15 +751,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   };
 
   const cacheInactiveRecord = (threadId: string): void => {
-    const state = get();
-    if (state.currentThreadId !== threadId) {
-      // The response can arrive before its database commit, so the resident
-      // transcript must replace any older snapshot used by thread switching.
-      cacheRecord(
-        threadId,
-        projectConversationCacheState(getThreadRecord(state.records, threadId)),
-      );
-    }
+    conversationResidency.retainInactiveConversation(threadId);
   };
 
   const applyGoalLookup = (threadId: string, lookup: GoalLookupResult): void => {
@@ -917,6 +904,19 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     getWorkspaceThreadSettings: resolveWorkspaceThreadSettings,
   });
   registerThreadHydrator(threadHydrator);
+  const conversationResidency = createConversationResidency({
+    restoreConversation: (threadId) => get().loadMessages(threadId),
+    deactivateConversation: () => threadHydrator.deactivate(),
+    retainInactiveConversation: (threadId) => threadHydrator.retainInactiveConversation(threadId),
+    invalidateConversation: (threadId) => threadHydrator.invalidateConversation(threadId),
+    synchronizeConversation: (threadId) => threadHydrator.synchronizeConversation(threadId),
+    mergeCachedFileChanges: (threadId, filesChanged) =>
+      threadHydrator.mergeCachedFileChanges(threadId, filesChanged),
+    takePrefetchedHistoryPage: (threadId, before) =>
+      threadHydrator.takePrefetchedHistoryPage(threadId, before),
+    prefetchConversation: (threadId) => threadHydrator.hydrate(threadId, "background"),
+  });
+  registerConversationResidency(conversationResidency);
 
   return {
     records: new Map<string, ThreadRecord>(),
@@ -948,6 +948,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     await threadHydrator.hydrate(threadId, "active");
   },
 
+  refreshConversation: async (threadId) => {
+    await threadHydrator.hydrate(threadId, "active", { force: true });
+  },
+
   /**
    * Fetch the next batch of older messages for scroll-up pagination.
    * Uses sequence cursor to load messages older than what is currently in memory.
@@ -963,7 +967,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     try {
       const cursor = getRec(threadId).oldestLoadedSequence;
       const epoch = getRec(threadId).loadEpoch;
-      const prefetchedPage = takePrefetchedHistoryPage(threadId, cursor);
+      const prefetchedPage = conversationResidency.takePrefetchedHistoryPage(threadId, cursor);
       const {
         messages: olderMessages,
         hasMore,
@@ -989,8 +993,21 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const newOldest = olderMessages.length > 0 ? olderMessages[0].sequence : cursor;
 
       patchRec(threadId, (r) => ({
-        messages: [...olderMessages, ...r.messages],
-        persistedToolCallCounts: { ...r.persistedToolCallCounts, ...newCounts },
+        messages: (() => {
+          const residentIds = new Set(r.messages.map((message) => message.id));
+          const byId = new Map([...olderMessages, ...r.messages].map((message) => [message.id, message]));
+          const bySequence = new Map<number, Message>();
+          for (const message of byId.values()) {
+            const existing = bySequence.get(message.sequence);
+            if (!existing || (residentIds.has(message.id) && !residentIds.has(existing.id))) {
+              bySequence.set(message.sequence, message);
+            }
+          }
+          return [...bySequence.values()].sort((left, right) =>
+            left.sequence - right.sequence || left.id.localeCompare(right.id),
+          );
+        })(),
+        persistedToolCallCounts: { ...newCounts, ...r.persistedToolCallCounts },
         narrativeByMessage: { ...narrativeByMessage, ...r.narrativeByMessage },
         answeredPlanMessageIds: new Set([
           ...r.answeredPlanMessageIds,
@@ -1001,8 +1018,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         isLoadingMore: false,
       }));
 
-      const updated = getRec(threadId);
-      cacheRecord(threadId, projectConversationCacheState(updated));
+      conversationResidency.commitPagination(threadId);
 
       // Hydrate file change data for older messages from snapshots
       const olderMsgIds = new Set(olderMessages.map((m) => m.id));
@@ -1033,30 +1049,18 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               }),
             };
           });
-          // Keep the LRU message cache in sync: the cache was written before this
-          // async merge, so a cache-hit thread switch otherwise drops prepended
-          // turns' file lists until a full reload.
           const current = get().records.get(threadId);
           if (
             get().currentThreadId !== threadId
             || !current
             || current.loadEpoch !== epoch
           ) return;
-          const cached = getCachedRecord(threadId);
-          if (!cached) return;
-          const retainedCachedMessageIds = new Set(cached.messages.map((message) => message.id));
-          const retained = relevant.filter((snapshot) =>
-            retainedCachedMessageIds.has(snapshot.message_id),
+          const retainedMessageIds = new Set(current.messages.map((message) => message.id));
+          const retained = relevant.filter((snapshot) => retainedMessageIds.has(snapshot.message_id));
+          conversationResidency.mergePaginationFileChanges(
+            threadId,
+            Object.fromEntries(retained.map((snapshot) => [snapshot.message_id, snapshot.files_changed])),
           );
-          if (retained.length === 0) return;
-          const mergedFiles = { ...cached.persistedFilesChanged };
-          for (const snap of retained) {
-            mergedFiles[snap.message_id] = snap.files_changed;
-          }
-          cacheRecord(threadId, {
-            ...cached,
-            persistedFilesChanged: mergedFiles,
-          });
         })
         .catch(() => {});
     } catch {
@@ -1070,7 +1074,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * to the transport layer. On failure, rolls back the running state.
    */
   sendMessage: async (threadId, content, model, permissionMode, attachments, displayContent, reasoningLevel, provider, copilotAgent, contextWindow, thinking, codexFastMode, replyToMessageId, quotedText, planAction, mentions, previewAnnotations, goalObjective, orchestrationMode) => {
-    evictCachedRecord(threadId);
+    conversationResidency.invalidateConversation(threadId);
 
     // A `/goal` control form (show/clear/reset/bare) never starts a provider
     // turn - the server services it synchronously and returns. It must not
@@ -1324,7 +1328,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   clearMessages: () => {
     flushPendingTextDeltas();
     const current = get().currentThreadId;
-    if (current) evictCachedRecord(current);
+    if (current) conversationResidency.invalidateConversation(current);
 
     get().toolCallRecordCache.clear();
     if (current) {
@@ -1453,7 +1457,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   },
 
   clearThreadState: (threadId) => {
-    evictCachedRecord(threadId);
+    conversationResidency.invalidateConversation(threadId);
     clearDequeueTimer(threadId);
     forgetScrollTop(threadId);
 
@@ -1482,7 +1486,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (threadIds.length === 0) return;
 
     for (const threadId of threadIds) {
-      evictCachedRecord(threadId);
+      conversationResidency.invalidateConversation(threadId);
       clearDequeueTimer(threadId);
       forgetScrollTop(threadId);
     }
@@ -1795,7 +1799,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       event.type === "message" ||
       event.type === "error";
     if (isStructuralEvent) {
-      evictCachedRecord(threadId);
+      conversationResidency.invalidateConversation(threadId);
     }
 
     // Helper: mark all prior incomplete tool calls as complete.
@@ -3138,7 +3142,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
   handleTurnPersisted: (payload) => {
     flushPendingTextDeltas();
-    evictCachedRecord(payload.threadId);
+    conversationResidency.invalidateConversation(payload.threadId);
 
     set((state) => {
       const rec = getThreadRecord(state.records, payload.threadId);

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -906,6 +906,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   registerThreadHydrator(threadHydrator);
   const conversationResidency = createConversationResidency({
     restoreConversation: (threadId) => get().loadMessages(threadId),
+    refreshConversation: (threadId) => threadHydrator.hydrate(threadId, "active", { force: true }),
     deactivateConversation: () => threadHydrator.deactivate(),
     retainInactiveConversation: (threadId) => threadHydrator.retainInactiveConversation(threadId),
     invalidateConversation: (threadId) => threadHydrator.invalidateConversation(threadId),

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -216,6 +216,7 @@ interface WorkspaceState {
 
   // Thread actions
   loadThreads: (workspaceId: string) => Promise<void>;
+  refreshActiveConversation: () => Promise<void>;
   createThread: (
     title: string,
     mode: "direct" | "worktree",
@@ -350,6 +351,7 @@ interface WorkspaceState {
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
   const conversationResidency = createConversationResidency({
     restoreConversation: (threadId) => useThreadStore.getState().loadMessages(threadId),
+    refreshConversation: (threadId) => useThreadStore.getState().refreshConversation(threadId),
     deactivateConversation: () => useThreadStore.getState().deactivateConversation(),
   });
   const reconcileSelectedConversation = () => {
@@ -768,6 +770,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     } catch (e) {
       set({ error: String(e), loading: false });
     }
+  },
+
+  refreshActiveConversation: async () => {
+    await conversationResidency.refresh(get().activeThreadId, get().threads);
   },
 
   createThread: async (title, mode, branch) => {

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -216,6 +216,7 @@ interface WorkspaceState {
 
   // Thread actions
   loadThreads: (workspaceId: string) => Promise<void>;
+  /** Revalidate the selected conversation after reconnect. */
   refreshActiveConversation: () => Promise<void>;
   createThread: (
     title: string,

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -277,12 +277,17 @@ export function createWsTransport(
       // Deferred import avoids a circular dependency at module evaluation time.
       const nowForThreads = Date.now();
       import("@/stores/workspaceStore").then(({ useWorkspaceStore }) => {
-        const { activeWorkspaceId, loadThreads } = useWorkspaceStore.getState();
+        const { activeWorkspaceId, loadThreads, refreshActiveConversation } = useWorkspaceStore.getState();
         if (!activeWorkspaceId) return;
         const last = lastLoadThreadsAtByWorkspace.get(activeWorkspaceId) ?? 0;
-        if (nowForThreads - last <= LOAD_THREADS_RECONNECT_COOLDOWN_MS) return;
+        if (nowForThreads - last <= LOAD_THREADS_RECONNECT_COOLDOWN_MS) {
+          void refreshActiveConversation();
+          return;
+        }
         lastLoadThreadsAtByWorkspace.set(activeWorkspaceId, nowForThreads);
-        loadThreads(activeWorkspaceId).catch(() => {});
+        loadThreads(activeWorkspaceId)
+          .then(() => refreshActiveConversation())
+          .catch(() => {});
       });
 
       // Reattach active terminals after reconnect.

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -281,7 +281,7 @@ export function createWsTransport(
         if (!activeWorkspaceId) return;
         const last = lastLoadThreadsAtByWorkspace.get(activeWorkspaceId) ?? 0;
         if (nowForThreads - last <= LOAD_THREADS_RECONNECT_COOLDOWN_MS) {
-          void refreshActiveConversation();
+          void refreshActiveConversation().catch(() => {});
           return;
         }
         lastLoadThreadsAtByWorkspace.set(activeWorkspaceId, nowForThreads);


### PR DESCRIPTION
## What
Route conversation events, persisted turns, selection, pagination, prefetch, and reconnect restoration through the conversation residency boundary.

## Why
Conversation state had multiple direct cache writers, which could leave selected or background threads stale, duplicated, or out of order during switching, pagination, and reconnect races.

## Key Changes
- Centralize conversation cache mutation and restoration behind `ConversationResidency` and `ThreadHydrator`.
- Preserve resident precedence and canonical uniqueness across RPC and warmed pagination pages.
- Revalidate the selected conversation on every reconnect while retaining thread-list throttling.
- Add maintained regressions for switching, background updates, pagination overlap, reconnect cooldown, sequence freshness, and file-effect ownership.

## Verification
- Focused web tests: 10 files, 137 tests passed.
- `bun run verify`: typecheck, lint, and unit tests passed.
- Live browser transport checks passed for cache hydration, rapid reselection, running background agents, and inactive completion retention. The older-history browser oracle was blocked by its own navigation, with the same RPC and warmed-page paths covered by maintained tests.

Closes #929
Related to #923

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787407548&installation_model_id=20477&pr_number=942&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F942&signature=54dca180972b4019a0b9cfe7b296742d461e3fb7bf8db7d3b96324d930219a77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved conversation caching and pagination to prevent duplicate messages and preserve the correct message order.
  * Added reliable refresh behavior for active conversations after reconnects, including throttling for thread-list updates.
  * Preserved the most current file-change summaries during conversation hydration and pagination.
  * Enhanced background prefetching for conversation history.
* **Tests**
  * Added coverage for conversation refresh, reconnect handling, pagination merging, caching, prefetching, and file-effect summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->