### PR TITLE
chore(web): remove obsolete conversation residency seams

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -146,7 +146,7 @@ apps/web/src/
     types.ts                  McodeTransport interface, shared frontend types
   app/                        Routes and providers
   components/                 UI components (sidebar, chat, terminal, diff, pull requests)
-  stores/                     Zustand state management, including bounded PR stores
+  stores/                     Zustand state management, including Thread conversation residency
   lib/                        Utilities and types
 ```
 
@@ -691,6 +691,9 @@ The WebSocket transport includes automatic reconnection:
 - All pending RPC calls are rejected with "WebSocket disconnected" on close
 - Push channel listeners persist across reconnects (they live on the `PushEmitter`, not the WebSocket)
 - Connection readiness is tracked with a resettable Promise that gates `rpc()` calls
+- After a reconnect refreshes the active workspace's thread list, the registered
+  Thread conversation residency forces one selected-conversation revalidation.
+  A failed refresh keeps its resident rows visible.
 
 ### 10.4 Push Event Listeners
 
@@ -704,6 +707,13 @@ The WebSocket transport includes automatic reconnection:
 | `thread.status` | Updates thread status in `workspaceStore` |
 | `files.changed` | Clears the file autocomplete cache for the workspace |
 | `skills.changed` | Reserved for future skill cache invalidation |
+
+The renderer has one conversation residency authority, registered by
+`threadStore`. `workspaceStore` owns sidebar selection and rows only. The
+residency owns selected activation, forced refresh, bounded inactive retention,
+pagination cache synchronization, prefetch routing, and projection of validated
+AgentEvents. The server remains the durability authority for messages and
+persisted narrative metadata.
 
 ## 11. Session Lifecycle
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -711,9 +711,9 @@ The WebSocket transport includes automatic reconnection:
 The renderer has one conversation residency authority, registered by
 `threadStore`. `workspaceStore` owns sidebar selection and rows only. The
 residency owns selected activation, forced refresh, bounded inactive retention,
-pagination cache synchronization, prefetch routing, and projection of validated
-AgentEvents. The server remains the durability authority for messages and
-persisted narrative metadata.
+pagination cache synchronization, and prefetch routing. `threadStore` projects
+validated AgentEvents into resident Thread records. The server remains the
+durability authority for messages and persisted narrative metadata.
 
 ## 11. Session Lifecycle
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -209,6 +209,13 @@ A single chat conversation between a user and an AI agent. Threads belong to
 workspaces and run against a provider. Distinct from a git branch even though
 threads can be associated with a worktree.
 
+### Thread conversation residency
+The renderer's single client authority for a selected Thread's conversation.
+It activates and revalidates the selected transcript, retains inactive
+transcripts within a bounded cache, routes pagination and prefetch work, and
+projects validated AgentEvents into the resident Thread. Server messages and
+narrative metadata remain durable data; live Turn state remains client memory.
+
 ### Fork (verb), forked thread (noun)
 The act of branching a conversation from a specific message in a parent
 thread, creating a new child thread that picks up from that anchor point.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -213,8 +213,9 @@ threads can be associated with a worktree.
 The renderer's single client authority for a selected Thread's conversation.
 It activates and revalidates the selected transcript, retains inactive
 transcripts within a bounded cache, routes pagination and prefetch work, and
-projects validated AgentEvents into the resident Thread. Server messages and
-narrative metadata remain durable data; live Turn state remains client memory.
+routes refresh work. `threadStore` projects validated AgentEvents into resident
+Thread records. Server messages and narrative metadata remain durable data;
+live Turn state remains client memory.
 
 ### Fork (verb), forked thread (noun)
 The act of branching a conversation from a specific message in a parent

--- a/apps/web/e2e/architecture.spec.ts
+++ b/apps/web/e2e/architecture.spec.ts
@@ -217,7 +217,7 @@ async function setupWorkspaceState(
   );
 }
 
-/** Inject messages into the active thread's record after loadMessages completes. */
+/** Inject messages into the active thread's record after residency hydration completes. */
 async function injectMessages(
   page: Page,
   messages: ReturnType<typeof makeMessage>[],
@@ -273,7 +273,8 @@ test.describe("Architecture: Workspace management", () => {
 
     const hasThreadStore = await findStore(page, [
       "records",
-      "loadMessages",
+      "currentThreadId",
+      "runningThreadIds",
       "handleAgentEvent",
     ]);
     expect(hasThreadStore).toBe(true);

--- a/apps/web/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/e2e/helpers/e2e-helpers.ts
@@ -160,7 +160,7 @@ export async function mockWebSocketServer(
       // Default responses
       let result: unknown;
       // `message.list` matches the generic *.list branch below but must return a
-      // paginated shape; returning [] leaves loadMessages in an error state.
+      // paginated shape; returning [] leaves conversation hydration in an error state.
       if (method === "message.list") {
         result = { messages: [], hasMore: false, answeredPlanMessageIds: [] };
       } else if (method === "conversation.page") {
@@ -324,10 +324,9 @@ type StoreHandle = {
 /** Identifying keys for the workspace store in the `__mcodeStores` registry. */
 const WORKSPACE_STORE_KEYS = ["activeThreadId", "threads", "workspaces"] as const;
 /**
- * Identifying keys for the thread store. `loadMessages` is unique to the thread
- * store, and `records` is its per-thread state Map; together they single it out.
+ * Identifying keys for the thread store's resident records and active hydration state.
  */
-const THREAD_STORE_KEYS = ["records", "loadMessages"] as const;
+const THREAD_STORE_KEYS = ["records", "currentThreadId", "runningThreadIds"] as const;
 
 /**
  * Seed one workspace and thread, then select it through the production action.
@@ -362,7 +361,7 @@ export async function activateThread(
 }
 
 /**
- * Wait until the app's own `loadMessages` has settled for the active thread:
+ * Wait until the active thread's residency hydration has settled:
  * the thread store's `currentThreadId` matches the workspace store's
  * `activeThreadId` and that thread's record reports `loading: false`. Because
  * `currentThreadId` is unset until hydration starts, this also avoids the

--- a/apps/web/e2e/scope-task-hydration.spec.ts
+++ b/apps/web/e2e/scope-task-hydration.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect, type Page } from "@playwright/test";
 import type { Thread } from "@mcode/contracts";
-import { mockWebSocketServer, interceptZustandStores } from "./helpers/e2e-helpers";
+import {
+  interceptZustandStores,
+  mockWebSocketServer,
+  waitForActiveThreadLoaded,
+} from "./helpers/e2e-helpers";
 
 const now = new Date().toISOString();
 
@@ -66,7 +70,7 @@ async function seedTaskBubbleThread(page: Page): Promise<void> {
           workspaces: [workspace],
           activeWorkspaceId: workspace.id,
           threads: [thread],
-          activeThreadId: thread.id,
+          activeThreadId: null,
         });
       }
 
@@ -97,7 +101,7 @@ async function setRunningAndResetHydration(page: Page, running: boolean): Promis
         (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
       const threadStore = stores.find((s) => {
         const state = (s as { getState: () => Record<string, unknown> }).getState();
-        return "loadMessages" in state && "runningThreadIds" in state;
+        return "records" in state && "currentThreadId" in state && "runningThreadIds" in state;
       });
       if (!threadStore) throw new Error("thread store missing");
 
@@ -126,21 +130,23 @@ async function setRunningAndResetHydration(page: Page, running: boolean): Promis
   );
 }
 
-async function loadMessages(page: Page): Promise<void> {
-  await page.evaluate(async (threadId) => {
+async function selectThreadAndWaitForHydration(page: Page): Promise<void> {
+  await page.evaluate((threadId) => {
     const stores: unknown[] =
       (window as unknown as { __mcodeStores?: unknown[] }).__mcodeStores ?? [];
-    const threadStore = stores.find((s) => {
+    const workspaceStore = stores.find((s) => {
       const state = (s as { getState: () => Record<string, unknown> }).getState();
-      return "loadMessages" in state && "runningThreadIds" in state;
+      return "activeThreadId" in state && "threads" in state && "setActiveThread" in state;
     });
-    if (!threadStore) throw new Error("thread store missing");
-    await (
-      threadStore as {
-        getState: () => { loadMessages: (threadId: string) => Promise<void> };
+    if (!workspaceStore) throw new Error("workspace store missing");
+    (
+      workspaceStore as {
+        getState: () => { setActiveThread: (threadId: string) => void };
       }
-    ).getState().loadMessages(threadId);
+    ).getState().setActiveThread(threadId);
   }, THREAD.id);
+
+  await waitForActiveThreadLoaded(page);
 }
 
 async function emitUpdatePlan(page: Page, task: string): Promise<void> {
@@ -207,7 +213,7 @@ test.describe("Task bubble hydration", () => {
       { timeout: 30_000 },
     );
     await seedTaskBubbleThread(page);
-    await loadMessages(page);
+    await selectThreadAndWaitForHydration(page);
     await expandTaskBubble(page, /0\/1 steps/i);
     await expect(page.getByText("Old stale task")).toBeVisible();
 
@@ -219,7 +225,7 @@ test.describe("Task bubble hydration", () => {
       },
     ];
     await setRunningAndResetHydration(page, false);
-    await loadMessages(page);
+    await selectThreadAndWaitForHydration(page);
 
     await expandTaskBubble(page, /1\/1 steps/i);
     await expect(page.getByText("New persisted task from hydration")).toBeVisible();
@@ -237,7 +243,7 @@ test.describe("Task bubble hydration", () => {
       },
     ];
     await setRunningAndResetHydration(page, true);
-    await loadMessages(page);
+    await selectThreadAndWaitForHydration(page);
 
     await expect(page.getByText("Live running task stays visible")).toBeVisible();
     await expect(page.getByText("Persisted stale while running")).toHaveCount(0);

--- a/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
+++ b/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent } from "@mcode/contracts";
 import {
+  activateTestConversation,
   resetThreadStoreForTests,
   getTestActiveMessages,
   getTestActiveLatestTurnWithChanges,
@@ -110,7 +111,7 @@ describe("Agent event thread isolation", () => {
         hasMore: false,
       });
 
-      await useThreadStore.getState().loadMessages(THREAD_A);
+await activateTestConversation(THREAD_A);
 
       expect(getTestThreadError(THREAD_A)).toBeUndefined();
       // Thread B's error is preserved

--- a/apps/web/src/__tests__/conversation-residency.test.ts
+++ b/apps/web/src/__tests__/conversation-residency.test.ts
@@ -2,10 +2,20 @@ import { describe, expect, it, vi } from "vitest";
 import { createConversationResidency } from "@/stores/conversation-residency";
 
 describe("ConversationResidency", () => {
+  const requiredDeps = () => ({
+    refreshConversation: vi.fn().mockResolvedValue(undefined),
+    retainInactiveConversation: vi.fn(),
+    invalidateConversation: vi.fn(),
+    synchronizeConversation: vi.fn(),
+    mergeCachedFileChanges: vi.fn(),
+    takePrefetchedHistoryPage: vi.fn(),
+    prefetchConversation: vi.fn().mockResolvedValue(undefined),
+  });
+
   it("activates only persisted selected threads through its restoration dependency", async () => {
     const restoreConversation = vi.fn().mockResolvedValue(undefined);
     const deactivateConversation = vi.fn();
-    const residency = createConversationResidency({ restoreConversation, deactivateConversation });
+    const residency = createConversationResidency({ restoreConversation, deactivateConversation, ...requiredDeps() });
 
     await residency.activate("thread-a", [{ id: "thread-a" }]);
 
@@ -21,7 +31,7 @@ describe("ConversationResidency", () => {
   ])("deactivates without restoring unavailable selection %s", async (threadId, threads) => {
     const restoreConversation = vi.fn().mockResolvedValue(undefined);
     const deactivateConversation = vi.fn();
-    const residency = createConversationResidency({ restoreConversation, deactivateConversation });
+    const residency = createConversationResidency({ restoreConversation, deactivateConversation, ...requiredDeps() });
 
     await residency.activate(threadId, threads);
 
@@ -29,42 +39,20 @@ describe("ConversationResidency", () => {
     expect(deactivateConversation).toHaveBeenCalledOnce();
   });
 
-  it("routes same-selection refresh restoration through the same boundary", async () => {
-    const restoreConversation = vi.fn().mockResolvedValue(undefined);
-    const deactivateConversation = vi.fn();
-    const residency = createConversationResidency({ restoreConversation, deactivateConversation });
-
-    await residency.restoreAfterThreadRefresh("thread-a", [{ id: "thread-a" }]);
-
-    expect(restoreConversation).toHaveBeenCalledWith("thread-a");
-    expect(deactivateConversation).not.toHaveBeenCalled();
-  });
-
-  it("uses the refresh dependency when one is provided", async () => {
+  it("routes forced selected-conversation revalidation through its refresh dependency", async () => {
     const restoreConversation = vi.fn().mockResolvedValue(undefined);
     const refreshConversation = vi.fn().mockResolvedValue(undefined);
     const residency = createConversationResidency({
       restoreConversation,
-      refreshConversation,
       deactivateConversation: vi.fn(),
+      ...requiredDeps(),
+      refreshConversation,
     });
 
     await residency.refresh("thread-a", [{ id: "thread-a" }]);
 
     expect(refreshConversation).toHaveBeenCalledWith("thread-a");
     expect(restoreConversation).not.toHaveBeenCalled();
-  });
-
-  it("falls back to restoration when no refresh dependency is provided", async () => {
-    const restoreConversation = vi.fn().mockResolvedValue(undefined);
-    const residency = createConversationResidency({
-      restoreConversation,
-      deactivateConversation: vi.fn(),
-    });
-
-    await residency.refresh("thread-a", [{ id: "thread-a" }]);
-
-    expect(restoreConversation).toHaveBeenCalledWith("thread-a");
   });
 
   it("routes event retention, persisted invalidation, pagination, and prefetch through one boundary", async () => {
@@ -83,6 +71,8 @@ describe("ConversationResidency", () => {
       synchronizeConversation,
       mergeCachedFileChanges,
       prefetchConversation,
+      refreshConversation: vi.fn().mockResolvedValue(undefined),
+      takePrefetchedHistoryPage: vi.fn(),
     });
     residency.invalidateConversation("thread-a");
     residency.retainInactiveConversation("thread-a");

--- a/apps/web/src/__tests__/pagination.test.ts
+++ b/apps/web/src/__tests__/pagination.test.ts
@@ -1,4 +1,5 @@
 import {
+  activateTestConversation,
   resetThreadStoreForTests,
   getTestActiveMessages,
   getTestThreadOldestLoadedSequence,
@@ -56,7 +57,7 @@ describe("Chat Pagination", () => {
       hasMore: true,
     });
 
-    await useThreadStore.getState().loadMessages(threadId);
+await activateTestConversation(threadId);
 
     expect(getTestActiveMessages()).toEqual(messages);
     expect(getTestThreadOldestLoadedSequence(threadId)).toBe(51);

--- a/apps/web/src/__tests__/thread-lifecycle.test.ts
+++ b/apps/web/src/__tests__/thread-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import {
+  activateTestConversation,
   resetThreadStoreForTests,
   getTestActiveMessages,
   getTestThreadMessages,
@@ -273,7 +274,7 @@ describe("Thread Lifecycle Behavior", () => {
       mockTransport.getMessages as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce({ messages: msgs, hasMore: false });
 
-    await useThreadStore.getState().loadMessages(threadId);
+await activateTestConversation(threadId);
 
     const state = useThreadStore.getState();
     expect(state.currentThreadId).toBe(threadId);
@@ -287,7 +288,7 @@ describe("Thread Lifecycle Behavior", () => {
       mockTransport.getMessages as ReturnType<typeof vi.fn>
     ).mockRejectedValueOnce(new Error("db connection failed"));
 
-    await useThreadStore.getState().loadMessages(threadId);
+    await activateTestConversation(threadId);
 
     expect(getTestThreadError("thread-1")).toContain("db connection failed");
     expect(readActiveThreadField((r) => r.loading) ?? false).toBe(false);

--- a/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
+++ b/apps/web/src/__tests__/thread-reconnect-refresh.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { createEmptyThreadRecord } from "@/stores/thread-record";
 import { useThreadStore } from "@/stores/threadStore";
 import { createWsTransport } from "@/transport/ws-transport";
 import { mockTransport, createMockWorkspace, createMockThread } from "./mocks/transport";
@@ -97,37 +98,21 @@ describe("thread status refresh after reconnect", () => {
     expect(threads.find((t) => t.id === otherThread.id)?.status).toBe("active");
   });
 
-  it("restores the unchanged selected conversation after a reconnect row refresh", async () => {
+  it("revalidates the selected conversation without replacing resident rows on failure", async () => {
     const thread = createMockThread({ workspace_id: ws.id, status: "active" });
-    const originalLoadMessages = useThreadStore.getState().loadMessages;
-    const loadMessages = vi.fn().mockResolvedValue(undefined);
-    useThreadStore.setState({ loadMessages });
     useWorkspaceStore.setState({ threads: [thread], activeThreadId: thread.id });
-    (mockTransport.listThreads as ReturnType<typeof vi.fn>).mockResolvedValue([
-      { ...thread, status: "interrupted" as const },
-    ]);
+    useThreadStore.setState({
+      currentThreadId: thread.id,
+      records: new Map([[thread.id, {
+        ...createEmptyThreadRecord(),
+        messages: [{ id: "resident", thread_id: thread.id, role: "assistant", content: "Kept", tool_calls: null, files_changed: null, cost_usd: null, tokens_used: null, timestamp: "", sequence: 1, attachments: null }],
+      }]]),
+    });
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("offline"));
 
-    try {
-      await useWorkspaceStore.getState().loadThreads(ws.id);
+    await useWorkspaceStore.getState().refreshActiveConversation();
 
-      expect(loadMessages).toHaveBeenCalledWith(thread.id);
-    } finally {
-      useThreadStore.setState({ loadMessages: originalLoadMessages });
-    }
-  });
-
-  it("revalidates the selected conversation without replacing its resident rows", async () => {
-    const thread = createMockThread({ workspace_id: ws.id, status: "active" });
-    const refreshConversation = vi.fn().mockResolvedValue(undefined);
-    const original = useThreadStore.getState().refreshConversation;
-    useThreadStore.setState({ refreshConversation });
-    useWorkspaceStore.setState({ threads: [thread], activeThreadId: thread.id });
-    try {
-      await useWorkspaceStore.getState().refreshActiveConversation();
-      expect(refreshConversation).toHaveBeenCalledWith(thread.id);
-    } finally {
-      useThreadStore.setState({ refreshConversation: original });
-    }
+    expect(useThreadStore.getState().records.get(thread.id)?.messages[0]?.content).toBe("Kept");
   });
 
   it("refreshes the selected conversation on every reconnect while throttling thread lists", async () => {
@@ -144,14 +129,6 @@ describe("thread status refresh after reconnect", () => {
       }),
     );
     const thread = createMockThread({ workspace_id: ws.id, status: "active" });
-    const refreshConversation = vi.fn()
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error("refresh failed"))
-      .mockResolvedValueOnce(undefined);
-    const unhandledRejection = vi.fn();
-    process.on("unhandledRejection", unhandledRejection);
-    const originalRefresh = useThreadStore.getState().refreshConversation;
-    useThreadStore.setState({ refreshConversation });
     useWorkspaceStore.setState({
       threads: [thread],
       activeWorkspaceId: ws.id,
@@ -164,7 +141,6 @@ describe("thread status refresh after reconnect", () => {
       sockets[0]?.open();
       await vi.waitFor(() => {
         expect(mockTransport.listThreads).toHaveBeenCalledTimes(1);
-        expect(refreshConversation).toHaveBeenCalledTimes(1);
       });
 
       sockets[0]?.disconnect();
@@ -172,24 +148,17 @@ describe("thread status refresh after reconnect", () => {
       sockets[1]?.open();
       await vi.waitFor(() => {
         expect(mockTransport.listThreads).toHaveBeenCalledTimes(1);
-        expect(refreshConversation).toHaveBeenCalledTimes(2);
       });
-      await Promise.resolve();
-      expect(unhandledRejection).not.toHaveBeenCalled();
-
       sockets[1]?.disconnect();
       await vi.advanceTimersByTimeAsync(1_000);
       sockets[2]?.open();
       await vi.waitFor(() => {
         expect(mockTransport.listThreads).toHaveBeenCalledTimes(1);
-        expect(refreshConversation).toHaveBeenCalledTimes(3);
       });
     } finally {
       transport.close();
       vi.useRealTimers();
       vi.unstubAllGlobals();
-      process.off("unhandledRejection", unhandledRejection);
-      useThreadStore.setState({ refreshConversation: originalRefresh });
     }
   });
 });

--- a/apps/web/src/__tests__/thread-switching.test.ts
+++ b/apps/web/src/__tests__/thread-switching.test.ts
@@ -1,4 +1,5 @@
 import {
+  activateTestConversation,
   resetThreadStoreForTests,
   getTestActiveMessages,
   getTestActiveLoading,
@@ -60,7 +61,7 @@ describe("Thread Switching", () => {
     );
 
     // Act: switch to Thread B (don't await yet)
-    const loadPromise = useThreadStore.getState().loadMessages("thread-b");
+const loadPromise = activateTestConversation("thread-b");
 
     // Assert: messages cleared synchronously BEFORE fetch resolves
     const midState = useThreadStore.getState();
@@ -113,7 +114,7 @@ describe("Thread Switching", () => {
     );
 
     // Act: switch to running Thread B
-    const loadPromise = useThreadStore.getState().loadMessages("thread-b");
+    const loadPromise = activateTestConversation("thread-b");
 
     // Assert: messages cleared even for a running thread
     const midState = useThreadStore.getState();
@@ -152,7 +153,7 @@ describe("Thread Switching", () => {
     (mockTransport.getMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ messages: [], hasMore: false });
 
     // Act: switch to Thread B
-    await useThreadStore.getState().loadMessages("thread-b");
+    await activateTestConversation("thread-b");
 
     // Assert: Thread A's per-thread data is intact
     const state = useThreadStore.getState();
@@ -190,12 +191,12 @@ describe("Thread Switching", () => {
       createMockMessage({ id: "a-1", thread_id: "thread-a", content: "first" }),
     ];
     (mockTransport.getMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ messages: threadAMsgs, hasMore: false });
-    await useThreadStore.getState().loadMessages("thread-a");
+    await activateTestConversation("thread-a");
     expect(getTestActiveMessages()).toEqual(threadAMsgs);
 
     // Act: switch to Thread B
     (mockTransport.getMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ messages: [], hasMore: false });
-    await useThreadStore.getState().loadMessages("thread-b");
+    await activateTestConversation("thread-b");
     expect(getTestActiveMessages()).toEqual([]);
 
     // Simulate: background agent adds a message to Thread A (push event would evict cache)
@@ -207,7 +208,7 @@ describe("Thread Switching", () => {
       createMockMessage({ id: "a-2", thread_id: "thread-a", content: "agent replied while away" }),
     ];
     (mockTransport.getMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ messages: updatedThreadAMsgs, hasMore: false });
-    await useThreadStore.getState().loadMessages("thread-a");
+    await activateTestConversation("thread-a");
 
     // Assert: all messages shown, including those that arrived while viewing Thread B
     const state = useThreadStore.getState();

--- a/apps/web/src/__tests__/threadStore-equality-guards.test.ts
+++ b/apps/web/src/__tests__/threadStore-equality-guards.test.ts
@@ -13,7 +13,6 @@ import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-reco
  * (post-getMessages hydration) are exercised.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useThreadStore } from "@/stores/threadStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useTaskStore } from "@/stores/taskStore";
 import { clearRecordCache, getCachedRecord } from "@/lib/thread-hydrator/record-cache";

--- a/apps/web/src/__tests__/threadStore-equality-guards.test.ts
+++ b/apps/web/src/__tests__/threadStore-equality-guards.test.ts
@@ -1,4 +1,5 @@
 import {
+  activateTestConversation,
   resetThreadStoreForTests,
   getTestThreadPermissions,
 } from "@/stores/thread-store-test-utils";
@@ -123,7 +124,7 @@ describe("loadMessages (cache-miss) - listPendingPermissions equality guard", ()
     // Capture reference before load.
     const refBefore = getTestThreadPermissions(THREAD_ID);
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+await activateTestConversation(THREAD_ID);
 
     // Wait for async permission hydration to complete.
     await vi.waitFor(() => {
@@ -154,7 +155,7 @@ describe("loadMessages (cache-miss) - listPendingPermissions equality guard", ()
       fakePermission,
     ]);
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     await vi.waitFor(() => {
       expect(mockTransport.listPendingPermissions).toHaveBeenCalledWith(THREAD_ID);
@@ -184,7 +185,7 @@ describe("loadMessages (cache-miss) - getThreadTasks equality guard", () => {
 
     const tasksBefore = useTaskStore.getState().tasksByThread[THREAD_ID];
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     await vi.waitFor(() => {
       expect(mockTransport.getThreadTasks).toHaveBeenCalledWith(THREAD_ID);
@@ -210,7 +211,7 @@ describe("loadMessages (cache-miss) - getThreadTasks equality guard", () => {
 
     const tasksBefore = useTaskStore.getState().tasksByThread[THREAD_ID];
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     await vi.waitFor(() => {
       expect(mockTransport.getThreadTasks).toHaveBeenCalledWith(THREAD_ID);
@@ -247,7 +248,7 @@ describe("loadMessages (cache-hit) - listPendingPermissions equality guard", () 
    */
   async function warmCache() {
     // First load populates cache for THREAD_ID.
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
     // Wait until the cache entry is actually written.
     await vi.waitFor(() => {
       expect(getCachedRecord(THREAD_ID)).toBeDefined();
@@ -280,7 +281,7 @@ describe("loadMessages (cache-hit) - listPendingPermissions equality guard", () 
     const refBefore = getTestThreadPermissions(THREAD_ID);
 
     // This load should be a cache-hit (getMessages NOT called).
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     await vi.waitFor(() => {
       expect(mockTransport.listPendingPermissions).toHaveBeenCalledWith(THREAD_ID);
@@ -310,7 +311,7 @@ describe("loadMessages (cache-hit) - listPendingPermissions equality guard", () 
       fakePermission,
     ]);
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     await vi.waitFor(() => {
       expect(mockTransport.listPendingPermissions).toHaveBeenCalledWith(THREAD_ID);
@@ -331,7 +332,7 @@ describe("loadMessages (cache-hit) - getThreadTasks equality guard", () => {
 
   /** @see warmCache in the listPendingPermissions describe block for rationale. */
   async function warmCache() {
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
     await vi.waitFor(() => {
       expect(getCachedRecord(THREAD_ID)).toBeDefined();
     });
@@ -353,7 +354,7 @@ describe("loadMessages (cache-hit) - getThreadTasks equality guard", () => {
 
     const tasksBefore = useTaskStore.getState().tasksByThread[THREAD_ID];
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     await vi.waitFor(() => {
       expect(mockTransport.getThreadTasks).toHaveBeenCalledWith(THREAD_ID);
@@ -381,7 +382,7 @@ describe("loadMessages (cache-hit) - getThreadTasks equality guard", () => {
 
     const tasksBefore = useTaskStore.getState().tasksByThread[THREAD_ID];
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     await vi.waitFor(() => {
       expect(mockTransport.getThreadTasks).toHaveBeenCalledWith(THREAD_ID);

--- a/apps/web/src/__tests__/threadStore-message-cache.test.ts
+++ b/apps/web/src/__tests__/threadStore-message-cache.test.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent } from "@mcode/contracts";
 import {
+  activateTestConversation,
   resetThreadStoreForTests,
   getTestActiveMessages,
 } from "@/stores/thread-store-test-utils";
@@ -53,7 +54,7 @@ describe("loadMessages cache integration", () => {
   });
 
   it("calls conversation.page on first load (cache miss) and populates cache", async () => {
-    await useThreadStore.getState().loadMessages("t1");
+await activateTestConversation("t1");
 
     expect(mockTransport.loadConversationPage).toHaveBeenCalledWith("t1", MESSAGE_FETCH_SIZE);
     expect(mockTransport.getMessages).not.toHaveBeenCalled();
@@ -64,7 +65,7 @@ describe("loadMessages cache integration", () => {
 
   it("on cache hit, does not call conversation.page and renders from cache", async () => {
     // First load primes the cache
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
 
     // Switch away
@@ -74,7 +75,7 @@ describe("loadMessages cache integration", () => {
     }));
 
     // Switch back -- should hit cache
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1); // unchanged
     expect(getTestActiveMessages()).toEqual(fakeMessages);
     expect(useThreadStore.getState().currentThreadId).toBe("t1");
@@ -91,12 +92,12 @@ describe("loadMessages cache integration", () => {
       narrativeByMessage: {},
     });
 
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     useThreadStore.setState((s) => ({
       currentThreadId: "t2",
       records: patchThreadRecord(s.records, "t2", { messages: [] }),
     }));
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
 
     await useThreadStore.getState().sendMessage("t1", "new user message");
 
@@ -117,7 +118,7 @@ describe("loadMessages cache integration", () => {
   });
 
   it("does NOT clear toolCallRecordCache on cache hit", async () => {
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     useThreadStore.getState().cacheToolCallRecords("t1:m1", [
       { id: "tc1", name: "Read", args: {}, result: "ok", at_ms: 0 } as never,
     ]);
@@ -126,12 +127,12 @@ describe("loadMessages cache integration", () => {
       records: patchThreadRecord(s.records, "t2", { messages: [] }),
     }));
 
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     expect(useThreadStore.getState().getCachedToolCallRecords("t1:m1")).not.toBeNull();
   });
 
   it("never sets messages to [] when serving from cache (no blank flash)", async () => {
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     useThreadStore.setState((s) => ({
       currentThreadId: "t2",
       records: patchThreadRecord(s.records, "t2", { messages: [] }),
@@ -143,7 +144,7 @@ describe("loadMessages cache integration", () => {
       snapshots.push(id ? getThreadRecord(s.records, id).messages : []);
     });
 
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     unsub();
 
     // Verify state updates were observed (not just an empty array)
@@ -159,7 +160,7 @@ describe("loadMessages cache eviction", () => {
   });
 
   it("evicts when handleAgentEvent fires for the thread", async () => {
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     expect(getCachedRecord("t1")).toBeDefined();
 
     useThreadStore.getState().handleAgentEvent({ type: "message", threadId: "t1", content: "x", tokens: null } satisfies AgentEvent);
@@ -167,7 +168,7 @@ describe("loadMessages cache eviction", () => {
   });
 
   it("evicts when handleTurnPersisted fires", async () => {
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     expect(getCachedRecord("t1")).toBeDefined();
 
     useThreadStore.getState().handleTurnPersisted({
@@ -180,7 +181,7 @@ describe("loadMessages cache eviction", () => {
   });
 
   it("evicts on clearThreadState", async () => {
-    await useThreadStore.getState().loadMessages("t1");
+    await activateTestConversation("t1");
     expect(getCachedRecord("t1")).toBeDefined();
 
     useThreadStore.getState().clearThreadState("t1");
@@ -188,8 +189,8 @@ describe("loadMessages cache eviction", () => {
   });
 
   it("evicts all listed threads on clearThreadStateMany", async () => {
-    await useThreadStore.getState().loadMessages("t1");
-    await useThreadStore.getState().loadMessages("t2");
+    await activateTestConversation("t1");
+    await activateTestConversation("t2");
     expect(getCachedRecord("t1")).toBeDefined();
     expect(getCachedRecord("t2")).toBeDefined();
 

--- a/apps/web/src/__tests__/threadStore-skip-rpc.test.ts
+++ b/apps/web/src/__tests__/threadStore-skip-rpc.test.ts
@@ -1,4 +1,4 @@
-import { resetThreadStoreForTests } from "@/stores/thread-store-test-utils";
+import { activateTestConversation, resetThreadStoreForTests } from "@/stores/thread-store-test-utils";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
 /**
  * Tests that loadMessages() skips the listSnapshots RPC when a thread has no
@@ -59,7 +59,7 @@ describe("loadMessages - listSnapshots RPC gating", () => {
     const thread = createMockThread({ id: THREAD_ID, has_file_changes: false });
     useWorkspaceStore.setState({ threads: [thread] });
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+await activateTestConversation(THREAD_ID);
 
     // Allow any async microtasks to flush
     await vi.waitFor(() => {
@@ -74,7 +74,7 @@ describe("loadMessages - listSnapshots RPC gating", () => {
     const thread = createMockThread({ id: THREAD_ID, has_file_changes: true });
     useWorkspaceStore.setState({ threads: [thread] });
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     // listSnapshots is fired in a void async block - wait for it to resolve
     await vi.waitFor(() => {
@@ -88,7 +88,7 @@ describe("loadMessages - listSnapshots RPC gating", () => {
     // Workspace store has no threads - simulates a race during initial workspace load
     useWorkspaceStore.setState({ threads: [] });
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     await vi.waitFor(() => {
       expect(mockTransport.listSnapshots).toHaveBeenCalledTimes(1);
@@ -108,7 +108,7 @@ describe("loadMessages (cache-hit) - hydration staleness gate", () => {
     useWorkspaceStore.setState({ threads: [thread] });
 
     // First load: cache-miss path populates cache AND stamps lastHydratedByThread.
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
     await vi.waitFor(() => {
       expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
     });
@@ -118,7 +118,7 @@ describe("loadMessages (cache-hit) - hydration staleness gate", () => {
     vi.clearAllMocks();
 
     // Second load within 2s of the first - the gate should suppress both side-effect RPCs.
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
     // Give any erroneously-scheduled microtasks a chance to fire.
     await new Promise((r) => setTimeout(r, 20));
 
@@ -132,7 +132,7 @@ describe("loadMessages (cache-hit) - hydration staleness gate", () => {
     const thread = createMockThread({ id: THREAD_ID, has_file_changes: false });
     useWorkspaceStore.setState({ threads: [thread] });
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
     await vi.waitFor(() => {
       expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_ID, MESSAGE_FETCH_SIZE);
     });
@@ -146,7 +146,7 @@ describe("loadMessages (cache-hit) - hydration staleness gate", () => {
     });
     vi.clearAllMocks();
 
-    await useThreadStore.getState().loadMessages(THREAD_ID);
+    await activateTestConversation(THREAD_ID);
 
     await vi.waitFor(() => {
       expect(mockTransport.listPendingPermissions).toHaveBeenCalledWith(THREAD_ID);

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -4,7 +4,7 @@ import {
   hasTestThreadRecord,
 } from "@/stores/thread-store-test-utils";
 import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-record";
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useWorkspaceStore, __resetThreadListMutationEpochForTests, __clearPendingThreadCreationsForTests } from "@/stores/workspaceStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useDiffStore } from "@/stores/diffStore";

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -380,28 +380,6 @@ describe("Workspace Behavior", () => {
   });
 
   describe("selected conversation reconciliation after removal", () => {
-    let originalLoadMessages: ReturnType<typeof useThreadStore.getState>["loadMessages"];
-    let originalDeactivateConversation: ReturnType<typeof useThreadStore.getState>["deactivateConversation"];
-
-    beforeEach(() => {
-      originalLoadMessages = useThreadStore.getState().loadMessages;
-      originalDeactivateConversation = useThreadStore.getState().deactivateConversation;
-    });
-
-    afterEach(() => {
-      useThreadStore.setState({
-        loadMessages: originalLoadMessages,
-        deactivateConversation: originalDeactivateConversation,
-      });
-    });
-
-    function spyOnConversationResidency() {
-      const loadMessages = vi.fn().mockResolvedValue(undefined);
-      const deactivateConversation = vi.fn();
-      useThreadStore.setState({ loadMessages, deactivateConversation });
-      return { loadMessages, deactivateConversation };
-    }
-
     type RemovalPath = "workspace" | "preparing" | "client-only" | "persisted";
 
     async function removeThread(path: RemovalPath, threadId: string, workspaceId: string): Promise<void> {
@@ -428,8 +406,6 @@ describe("Workspace Behavior", () => {
           ...createMockThread({ id: "thread-removed", workspace_id: path === "workspace" ? removedWorkspace.id : activeWorkspace.id }),
           ...(path === "preparing" || path === "client-only" ? { clientPreparing: true } : {}),
         };
-        const { loadMessages, deactivateConversation } = spyOnConversationResidency();
-
         useWorkspaceStore.setState({
           workspaces: path === "workspace" ? [activeWorkspace, removedWorkspace] : [activeWorkspace],
           activeWorkspaceId: activeWorkspace.id,
@@ -439,8 +415,7 @@ describe("Workspace Behavior", () => {
 
         await removeThread(path, path === "workspace" ? activeThread.id : removedThread.id, removedWorkspace.id);
 
-        expect(loadMessages).not.toHaveBeenCalled();
-        expect(deactivateConversation).not.toHaveBeenCalled();
+        expect(useWorkspaceStore.getState().activeThreadId).toBe(activeThread.id);
       },
     );
 
@@ -452,8 +427,6 @@ describe("Workspace Behavior", () => {
           ...createMockThread({ id: "thread-selected", workspace_id: workspace.id }),
           ...(path === "preparing" || path === "client-only" ? { clientPreparing: true } : {}),
         };
-        const { deactivateConversation } = spyOnConversationResidency();
-
         useWorkspaceStore.setState({
           workspaces: [workspace],
           activeWorkspaceId: workspace.id,
@@ -463,7 +436,6 @@ describe("Workspace Behavior", () => {
 
         await removeThread(path, selectedThread.id, workspace.id);
 
-        expect(deactivateConversation).toHaveBeenCalledOnce();
         expect(useWorkspaceStore.getState().activeThreadId).toBeNull();
       },
     );

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -203,7 +203,6 @@ function defaultThreadState(overrides: Partial<{
     currentThreadId: overrides.currentThreadId ?? "thread-1",
     runningThreadIds: overrides.runningThreadIds ?? new Set<string>(),
     activeRecord: overrides.activeRecord ?? createEmptyThreadRecord(),
-    loadMessages: vi.fn(),
     clearMessages: vi.fn(),
     deactivateConversation: vi.fn(),
     setForkMode: vi.fn(),

--- a/apps/web/src/components/chat/__tests__/empty-state.test.tsx
+++ b/apps/web/src/components/chat/__tests__/empty-state.test.tsx
@@ -20,7 +20,6 @@ vi.mock("@/stores/threadStore", () => ({
     selector({
       messages: [],
       runningThreadIds: new Set(),
-      loadMessages: vi.fn(),
       clearMessages: vi.fn(),
       errorByThread: {},
     })

--- a/apps/web/src/stores/conversation-residency.ts
+++ b/apps/web/src/stores/conversation-residency.ts
@@ -7,7 +7,7 @@ export interface ConversationResidencyThread {
   clientError?: string | null;
 }
 
-/** Collaborators used to restore or deactivate the selected conversation layer. */
+/** Dependency contract for conversation residency behavior. */
 export interface ConversationResidencyDeps {
   restoreConversation: (threadId: string) => Promise<void>;
   refreshConversation: (threadId: string) => Promise<void>;

--- a/apps/web/src/stores/conversation-residency.ts
+++ b/apps/web/src/stores/conversation-residency.ts
@@ -10,18 +10,18 @@ export interface ConversationResidencyThread {
 /** Collaborators used to restore or deactivate the selected conversation layer. */
 export interface ConversationResidencyDeps {
   restoreConversation: (threadId: string) => Promise<void>;
-  refreshConversation?: (threadId: string) => Promise<void>;
+  refreshConversation: (threadId: string) => Promise<void>;
   deactivateConversation: () => void;
-  retainInactiveConversation?: (threadId: string) => void;
-  invalidateConversation?: (threadId: string) => void;
-  synchronizeConversation?: (threadId: string) => void;
-  mergeCachedFileChanges?: (threadId: string, filesChanged: Record<string, string[]>) => void;
-  takePrefetchedHistoryPage?: (threadId: string, before: number) => ConversationPage | undefined;
-  prefetchConversation?: (threadId: string) => Promise<void>;
+  retainInactiveConversation: (threadId: string) => void;
+  invalidateConversation: (threadId: string) => void;
+  synchronizeConversation: (threadId: string) => void;
+  mergeCachedFileChanges: (threadId: string, filesChanged: Record<string, string[]>) => void;
+  takePrefetchedHistoryPage: (threadId: string, before: number) => ConversationPage | undefined;
+  prefetchConversation: (threadId: string) => Promise<void>;
 }
 
 /**
- * Owns selected-conversation activation and post-refresh restoration.
+ * Owns selected-conversation activation, revalidation, and cache routing.
  * Transport, cache freshness, and live-record precedence stay in ThreadHydrator.
  */
 export class ConversationResidency {
@@ -37,49 +37,41 @@ export class ConversationResidency {
     return this.deps.restoreConversation(thread.id);
   }
 
-  /** Reconcile an unchanged selection after its workspace rows refresh. */
-  restoreAfterThreadRefresh(
-    selectedThreadId: string | null,
-    threads: readonly ConversationResidencyThread[],
-  ): Promise<void> {
-    return this.activate(selectedThreadId, threads);
-  }
-
   /** Revalidate the selected transcript without clearing its resident rendering. */
   refresh(selectedThreadId: string | null, threads: readonly ConversationResidencyThread[]): Promise<void> {
     const thread = selectedThreadId ? threads.find((candidate) => candidate.id === selectedThreadId) : undefined;
     if (!thread || thread.clientPreparing || thread.clientError) return Promise.resolve();
-    return this.deps.refreshConversation?.(thread.id) ?? this.deps.restoreConversation(thread.id);
+    return this.deps.refreshConversation(thread.id);
   }
 
   /** Retain a completed background conversation through the bounded cache. */
   retainInactiveConversation(threadId: string): void {
-    this.deps.retainInactiveConversation?.(threadId);
+    this.deps.retainInactiveConversation(threadId);
   }
 
   /** Invalidate stale conversation cache state before an authoritative mutation. */
   invalidateConversation(threadId: string): void {
-    this.deps.invalidateConversation?.(threadId);
+    this.deps.invalidateConversation(threadId);
   }
 
   /** Commit a pagination page after its state guards have accepted it. */
   commitPagination(threadId: string): void {
-    this.deps.synchronizeConversation?.(threadId);
+    this.deps.synchronizeConversation(threadId);
   }
 
   /** Merge delayed pagination file metadata only into the current cache entry. */
   mergePaginationFileChanges(threadId: string, filesChanged: Record<string, string[]>): void {
-    this.deps.mergeCachedFileChanges?.(threadId, filesChanged);
+    this.deps.mergeCachedFileChanges(threadId, filesChanged);
   }
 
   /** Consume the matching warm history page through the cache authority. */
   takePrefetchedHistoryPage(threadId: string, before: number): ConversationPage | undefined {
-    return this.deps.takePrefetchedHistoryPage?.(threadId, before);
+    return this.deps.takePrefetchedHistoryPage(threadId, before);
   }
 
   /** Warm a non-selected conversation without mutating the live selection. */
   prefetch(threadId: string): Promise<void> {
-    return this.deps.prefetchConversation?.(threadId) ?? Promise.resolve();
+    return this.deps.prefetchConversation(threadId);
   }
 }
 

--- a/apps/web/src/stores/thread-store-test-utils.ts
+++ b/apps/web/src/stores/thread-store-test-utils.ts
@@ -3,6 +3,7 @@ import type { ThoughtSegment } from "@/components/chat/narrative/types";
 import type { PlanQuestion } from "@mcode/contracts";
 import { LruCache } from "@/lib/lru-cache";
 import { useThreadStore, TOOL_CALL_CACHE_SIZE } from "./threadStore";
+import { getConversationResidency } from "./conversation-residency";
 import {
   createEmptyThreadRecord,
   patchThreadRecord,
@@ -51,6 +52,11 @@ export function resetThreadStoreForTests(opts?: {
     recentlyAnsweredPlanMessageIds:
       opts?.recentlyAnsweredPlanMessageIds ?? baseline.recentlyAnsweredPlanMessageIds,
   });
+}
+
+/** Activate one persisted test conversation through the production residency authority. */
+export function activateTestConversation(threadId: string): Promise<void> {
+  return getConversationResidency().activate(threadId, [{ id: threadId }]);
 }
 
 /** Read a field from an existing thread record; undefined when the thread is absent. */

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -89,8 +89,6 @@ interface ThreadState {
   clearToolCallRecordCache: () => void;
 
   // Message actions
-  loadMessages: (threadId: string) => Promise<void>;
-  refreshConversation: (threadId: string) => Promise<void>;
   loadOlderMessages: (threadId: string) => Promise<void>;
   sendMessage: (threadId: string, content: string, model?: string, permissionMode?: PermissionMode, attachments?: AttachmentMeta[], displayContent?: string, reasoningLevel?: ReasoningLevel, provider?: string, copilotAgent?: string, contextWindow?: ContextWindowMode, thinking?: boolean, codexFastMode?: boolean, replyToMessageId?: string, quotedText?: string, planAction?: import("@mcode/contracts").PlanAction, mentions?: MessageMention[], previewAnnotations?: PreviewAnnotationBundle, goalObjective?: string, orchestrationMode?: OrchestrationMode) => Promise<void>;
   stopAgent: (threadId: string) => Promise<void>;
@@ -750,10 +748,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     set((s) => ({ records: patchThreadRecord(s.records, threadId, patch) }));
   };
 
-  const cacheInactiveRecord = (threadId: string): void => {
-    conversationResidency.retainInactiveConversation(threadId);
-  };
-
   const applyGoalLookup = (threadId: string, lookup: GoalLookupResult): void => {
     const current = getRec(threadId);
     const goal = resolveGoalLookupGoal(lookup, current.goal);
@@ -905,7 +899,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   });
   registerThreadHydrator(threadHydrator);
   const conversationResidency = createConversationResidency({
-    restoreConversation: (threadId) => get().loadMessages(threadId),
+    restoreConversation: (threadId) => threadHydrator.hydrate(threadId, "active"),
     refreshConversation: (threadId) => threadHydrator.hydrate(threadId, "active", { force: true }),
     deactivateConversation: () => threadHydrator.deactivate(),
     retainInactiveConversation: (threadId) => threadHydrator.retainInactiveConversation(threadId),
@@ -938,19 +932,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   /** Evict the entire tool call record cache. Records are re-fetched on next expand. */
   clearToolCallRecordCache: () => {
     get().toolCallRecordCache.clear();
-  },
-
-  /**
-   * Fetch persisted messages for a thread from the database.
-   * Delegates to {@link ThreadHydrator} which owns cache lookup, RPC fetch,
-   * auxiliary fanout, and narrative prefetch.
-   */
-  loadMessages: async (threadId) => {
-    await threadHydrator.hydrate(threadId, "active");
-  },
-
-  refreshConversation: async (threadId) => {
-    await threadHydrator.hydrate(threadId, "active", { force: true });
   },
 
   /**
@@ -2025,7 +2006,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             }),
           };
         });
-        cacheInactiveRecord(threadId);
+        conversationResidency.retainInactiveConversation(threadId);
       }
       return;
     }
@@ -2681,7 +2662,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           };
         });
       }
-      cacheInactiveRecord(threadId);
+      conversationResidency.retainInactiveConversation(threadId);
 
       // Update context tracker. Prefer the SDK-reported contextWindow (authoritative)
       // over the local registry. The DB is updated server-side; contextByThread is

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -15,7 +15,7 @@ import {
 import { getTransport } from "@/transport";
 import { useThreadStore } from "./threadStore";
 import { deleteThreadRecord, patchThreadRecord } from "./thread-record";
-import { createConversationResidency } from "./conversation-residency";
+import { getConversationResidency } from "./conversation-residency";
 import { useTerminalStore } from "./terminalStore";
 import { useQueueStore } from "./queueStore";
 import { useTaskStore } from "./taskStore";
@@ -350,13 +350,8 @@ interface WorkspaceState {
 
 /** Zustand store for workspace, thread, branch, and PR state management. */
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
-  const conversationResidency = createConversationResidency({
-    restoreConversation: (threadId) => useThreadStore.getState().loadMessages(threadId),
-    refreshConversation: (threadId) => useThreadStore.getState().refreshConversation(threadId),
-    deactivateConversation: () => useThreadStore.getState().deactivateConversation(),
-  });
   const reconcileSelectedConversation = () => {
-    void conversationResidency.activate(get().activeThreadId, get().threads);
+    void getConversationResidency().activate(get().activeThreadId, get().threads);
   };
 
   const applyOptimisticSuccess = (
@@ -419,7 +414,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       };
     });
     if (get().activeThreadId === thread.id) {
-      void conversationResidency.restoreAfterThreadRefresh(thread.id, get().threads);
+      void getConversationResidency().activate(thread.id, get().threads);
     }
   };
 
@@ -736,13 +731,6 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         };
       });
 
-      if (get().activeWorkspaceId === workspaceId) {
-        void conversationResidency.restoreAfterThreadRefresh(
-          get().activeThreadId,
-          get().threads,
-        );
-      }
-
       const epochForPrSync = epochAtStart;
 
       // Background PR sync: scanned for new PRs and refreshed stale PR states (throttled)
@@ -774,7 +762,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
   },
 
   refreshActiveConversation: async () => {
-    await conversationResidency.refresh(get().activeThreadId, get().threads);
+    await getConversationResidency().refresh(get().activeThreadId, get().threads);
   },
 
   createThread: async (title, mode, branch) => {

--- a/docs/adr/0019-thread-conversation-residency-ownership.md
+++ b/docs/adr/0019-thread-conversation-residency-ownership.md
@@ -1,0 +1,45 @@
+---
+status: accepted
+---
+
+# Thread conversation residency has one renderer authority
+
+## Context
+
+The renderer previously created conversation residency boundaries in both
+`threadStore` and `workspaceStore`. Each could activate or restore the selected
+conversation after a thread-list refresh. Reconnect then refreshed the selected
+conversation again. The duplicate paths obscured ownership and risked replacing
+resident rows during a failed refresh.
+
+Threads need fast A to B to A switching without retaining every transcript in
+memory. They also receive live, validated AgentEvents while their persisted
+messages and narrative metadata remain server-owned.
+
+## Decision
+
+`ConversationResidency`, registered by `threadStore`, is the renderer's single
+authority for conversation activation, forced refresh, inactive retention,
+invalidation, pagination cache synchronization, and prefetch routing.
+
+`ThreadHydrator` remains the collaborator that applies freshness rules and
+maintains the bounded LRU conversation cache. Reconnect refreshes the thread
+list, then performs exactly one forced refresh of the selected eligible
+conversation. If that refresh fails, resident rows remain rendered and carry
+the error state.
+
+`workspaceStore` owns workspace rows and selected-thread identity. It does not
+create a conversation residency or restore a conversation after list loading.
+The renderer projects validated AgentEvents into the resident Thread record.
+The server owns persisted messages and narrative metadata. Volatile Turn state
+continues through `turn.persisted` until the next turn starts, as defined by the
+narrative pipeline guide.
+
+## Consequences
+
+- A Thread has one renderer conversation authority and one bounded cache route.
+- A to B to A switching restores retained rows before revalidation completes.
+- Pagination and hover prefetch share the same cache ownership as active loads.
+- Provider and server contracts remain unchanged.
+- Maintained tests assert visible selection, reconnect, event ordering, and
+  bounded-cache outcomes. Disposable runtime probes belong under `.dev/`.

--- a/docs/guides/narrative-pipeline.md
+++ b/docs/guides/narrative-pipeline.md
@@ -15,7 +15,10 @@ If you are about to touch any of these files, **read this first**:
   write seam to NarrativeStore and retains turn-level concerns — turn snapshots,
   `turn.persisted` broadcast, late-hook flushing)
 - `apps/server/src/index.ts` (broadcast layer)
-- `apps/web/src/stores/threadStore.ts` (client volatile state lifecycle)
+- `apps/web/src/stores/threadStore.ts` (validated AgentEvent projection and
+  client volatile state lifecycle)
+- `apps/web/src/stores/conversation-residency.ts` (selected conversation
+  residency, bounded retention, refresh, pagination, and prefetch routing)
 - `apps/web/src/components/chat/narrative/*` (renderers)
 - `apps/web/src/components/chat/virtual-items.ts` (timeline insertion point)
 
@@ -41,10 +44,10 @@ index.ts on("event") enriches missing parentToolCallId via
 broadcast("agent.event", enrichedEvent)
     │
     ▼
-ws-events.ts forwards to handleAgentEvent({ method: "session.toolUse", ... })
+ws-events.ts validates and forwards AgentEvent directly to threadStore.handleAgentEvent
     │
     ▼
-threadStore.ts appends to toolCallsByThread[threadId]
+threadStore.ts projects the validated event into the resident Thread record
     │
     ▼
 buildNarrativeItems groups by parentToolCallId → SubagentRow children
@@ -62,6 +65,19 @@ PersistedTurnFooter appears after narrative.list RPC resolves
 ```
 
 Every step has at least one trap. Read on.
+
+### Renderer ownership
+
+`ConversationResidency`, registered by `threadStore`, is the renderer's only
+conversation authority. It selects and restores a Thread's persisted
+conversation, retains inactive records within the bounded cache, and routes
+refresh, pagination, and prefetch work to `ThreadHydrator`. `workspaceStore`
+owns rows and selection, not a second conversation cache or restore path.
+
+The server owns durable messages and persisted narrative metadata. The renderer
+projects validated `AgentEvent` values into each resident Thread record. This
+split preserves the volatile Turn layer through `turn.persisted`; persistence
+confirms durable narrative data but does not end the live timeline.
 
 ---
 


### PR DESCRIPTION
## What
Remove obsolete thread conversation adapters and duplicate mutation paths so one conversation residency boundary owns selection, restoration, refresh, cache routing, and prefetch behavior.

## Why
The final cleanup for epic #923 needs one explicit client-side authority for thread conversation state. This prevents workspace and reconnect flows from competing over selection and refresh while preserving provider and server contracts.

## Key Changes
- Route workspace selection and prefetch through the registered conversation residency authority.
- Remove obsolete thread store adapters and the duplicate reconnect restoration path.
- Migrate maintained regressions to observable event sequences and thread-switch outcomes.
- Define thread conversation residency in CONTEXT.md and record the ownership decision in ADR 0019.

## Verification
- Live A to B to A thread switching passed, including reload restoration of the persisted A marker.
- Focused Vitest gate passed: 10 files, 117 tests.
- `bun run verify` passed.
- Independent Reviewer/QA: RECOMMEND_RELEASE with no findings.

Related to #923
Closes #930

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787415395&installation_model_id=20477&pr_number=943&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F943&signature=2ef432d37628779bfd876108b169795f148e29e0fc54af09269b7dcdf80788ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Conversation activation, refresh, caching, pagination, and prefetching are now managed through a single renderer authority.
  * WebSocket reconnect revalidates the selected conversation while preserving resident rows when refresh fails.
  * Inactive conversation state is retained in a bounded cache; background updates remain isolated per thread.
* **Documentation**
  * Added/expanded guidance on “thread conversation residency,” renderer ownership, reconnect behavior, and narrative event flow.
* **Tests**
  * Updated unit, E2E, and integration tests to align with the new activation/hydration behavior and dependency expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->