### PR TITLE
feat(release): clean up superseded nightlies

### DIFF
--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -12,6 +12,7 @@ on:
 concurrency:
   group: nightly-release-mutations
   cancel-in-progress: false
+  queue: max
 
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"

--- a/.github/workflows/nightly-desktop.yml
+++ b/.github/workflows/nightly-desktop.yml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: nightly-desktop
-  cancel-in-progress: true
+  group: nightly-release-mutations
+  cancel-in-progress: false
 
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ permissions:
 concurrency:
   group: nightly-release-mutations
   cancel-in-progress: false
+  queue: max
 
 jobs:
   release-please:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: nightly-release-mutations
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: blacksmith-2vcpu-ubuntu-2404
@@ -36,3 +40,38 @@ jobs:
           token: ${{ steps.bot-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  cleanup-superseded-nightlies:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate cleanup token
+        id: cleanup-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Delete superseded nightly releases
+        env:
+          GH_TOKEN: ${{ steps.cleanup-token.outputs.token }}
+          STABLE_TAG: ${{ needs.release-please.outputs.tag_name }}
+          STABLE_VERSION: ${{ needs.release-please.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$STABLE_TAG" != "mcode-v${STABLE_VERSION}" ]]; then
+            echo "Release Please outputs do not identify the same stable release."
+            exit 1
+          fi
+          node scripts/agent/cleanup-superseded-nightlies.mjs \
+            --repo "${{ github.repository }}" \
+            --stable-tag "$STABLE_TAG" \
+            --apply

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,6 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Generate cleanup token
         id: cleanup-token
@@ -59,6 +61,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Delete superseded nightly releases
         env:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1159,3 +1159,19 @@ A background preview tab whose renderer has been killed to reclaim memory,
 keeping only a cold placeholder (title, URL, favicon). Reopening reloads the
 page; scroll position and form state are not preserved. Governed by
 `preview.memorySaver.*` settings and ADR 0002.
+
+## Release channels
+
+### Stable release
+A supported Mcode version published for general use.
+_Avoid_: Major release, production release
+
+### Nightly release
+A prerelease build published from ongoing development for early use and
+testing.
+_Avoid_: Stable release
+
+### Superseded nightly
+A nightly release whose intended version has since shipped as a stable release.
+It has no continuing rollback or support role.
+_Avoid_: Supported release, archived nightly

--- a/docs/adr/0020-delete-superseded-nightly-releases.md
+++ b/docs/adr/0020-delete-superseded-nightly-releases.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+---
+
+# Delete superseded nightly releases
+
+After each stable release, Mcode deletes every nightly release and corresponding
+tag that is more than seven days old and whose intended version is equal to or
+older than that stable version. The cutoff is fixed relative to the triggering
+stable release, so a delayed retry cannot age newer nightlies into the deletion
+set. This includes eligible draft and incomplete nightlies. Stable releases,
+recent nightlies, and nightlies for later versions remain available.
+Superseded nightlies have no rollback or support role, so retaining them would
+only grow the release and tag lists without bound.

--- a/scripts/agent/__tests__/cleanup-superseded-nightlies.test.mjs
+++ b/scripts/agent/__tests__/cleanup-superseded-nightlies.test.mjs
@@ -182,14 +182,18 @@ test("apply re-fetches candidates, skips stale plans, then deletes release befor
   ]);
 });
 
-test("apply preserves every nightly tag with non-canonical grammar", () => {
-  for (const tag of [
+test("apply explicitly skips malformed tags returned by candidate revalidation", () => {
+  for (const malformedTag of [
     "v01.2.0-nightly.20251201.9",
     "v1.2.0-nightly.20261340.10",
     "v1.2.0-nightly.20251201.01",
   ]) {
+    const planned = nightly();
     const harness = createHarness({
-      releases: [nightly({ tag_name: tag })],
+      releases: [planned],
+      refetched: new Map([
+        [planned.id, { ...planned, tag_name: malformedTag }],
+      ]),
     });
 
     assert.equal(
@@ -199,10 +203,16 @@ test("apply preserves every nightly tag with non-canonical grammar", () => {
       }),
       0,
     );
+    assert.ok(
+      harness.stdout.includes(
+        `Skipped ${planned.tag_name}: release no longer matches the cleanup plan.`,
+      ),
+      malformedTag,
+    );
     assert.equal(
       harness.calls.some((args) => args.includes("DELETE")),
       false,
-      tag,
+      malformedTag,
     );
   }
 });
@@ -257,6 +267,36 @@ test("an invalid stable release fails before nightly enumeration", () => {
     1,
   );
   assert.equal(harness.calls.length, 1);
+});
+
+test("malformed stable tags fail before release enumeration", () => {
+  for (const stableTag of [
+    "mcode-v01.2.0",
+    "mcode-v1.02.0",
+    "mcode-v1.2.00",
+    "mcode-v1.2",
+  ]) {
+    const calls = [];
+    const stderr = [];
+    const gh = (args) => {
+      calls.push(args);
+      return JSON.stringify({
+        ...STABLE_RELEASE,
+        tag_name: stableTag,
+      });
+    };
+
+    assert.equal(
+      main(["--repo", REPO, "--stable-tag", stableTag], {
+        gh,
+        io: { stdout() {}, stderr: (line) => stderr.push(line) },
+      }),
+      1,
+      stableTag,
+    );
+    assert.equal(calls.length, 1, stableTag);
+    assert.match(stderr.join("\n"), /exactly match mcode-vX\.Y\.Z/, stableTag);
+  }
 });
 
 test("a full tenth page reaches the enumeration cap and fails closed", () => {

--- a/scripts/agent/__tests__/cleanup-superseded-nightlies.test.mjs
+++ b/scripts/agent/__tests__/cleanup-superseded-nightlies.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import { main } from "../cleanup-superseded-nightlies.mjs";
 
@@ -111,6 +112,18 @@ test("dry run selects only old superseded nightlies without mutating GitHub", ()
       tag_name: "v1.0.0-nightly.20251201.8",
       immutable: true,
     }),
+    nightly({
+      id: 9,
+      tag_name: "v01.2.0-nightly.20251201.9",
+    }),
+    nightly({
+      id: 10,
+      tag_name: "v1.2.0-nightly.20261340.10",
+    }),
+    nightly({
+      id: 11,
+      tag_name: "v1.2.0-nightly.20251201.01",
+    }),
   ];
   const harness = createHarness({ releases });
 
@@ -167,6 +180,31 @@ test("apply re-fetches candidates, skips stale plans, then deletes release befor
       `repos/${REPO}/git/refs/tags/v1.1.9-nightly.20251231.2`,
     ],
   ]);
+});
+
+test("apply preserves every nightly tag with non-canonical grammar", () => {
+  for (const tag of [
+    "v01.2.0-nightly.20251201.9",
+    "v1.2.0-nightly.20261340.10",
+    "v1.2.0-nightly.20251201.01",
+  ]) {
+    const harness = createHarness({
+      releases: [nightly({ tag_name: tag })],
+    });
+
+    assert.equal(
+      main(["--repo", REPO, "--stable-tag", STABLE_TAG, "--apply"], {
+        gh: harness.gh,
+        io: harness.io,
+      }),
+      0,
+    );
+    assert.equal(
+      harness.calls.some((args) => args.includes("DELETE")),
+      false,
+      tag,
+    );
+  }
 });
 
 test("apply reports a partial failure and exits nonzero", () => {
@@ -249,4 +287,18 @@ test("a full tenth page reaches the enumeration cap and fails closed", () => {
   );
   assert.match(stderr.join("\n"), /1,000-release safety cap/);
   assert.equal(calls.length, 11);
+});
+
+test("release workflows share the non-cancelling bounded mutation queue", () => {
+  for (const path of [
+    ".github/workflows/nightly-desktop.yml",
+    ".github/workflows/release-please.yml",
+  ]) {
+    const workflow = readFileSync(path, "utf8");
+    assert.match(
+      workflow,
+      /concurrency:\r?\n  group: nightly-release-mutations\r?\n  cancel-in-progress: false\r?\n  queue: max/,
+      path,
+    );
+  }
 });

--- a/scripts/agent/__tests__/cleanup-superseded-nightlies.test.mjs
+++ b/scripts/agent/__tests__/cleanup-superseded-nightlies.test.mjs
@@ -342,3 +342,19 @@ test("release workflows share the non-cancelling bounded mutation queue", () => 
     );
   }
 });
+
+test("stable release cleanup uses least-privilege checkout and token settings", () => {
+  const workflow = readFileSync(".github/workflows/release-please.yml", "utf8");
+  const cleanupJob = workflow.slice(
+    workflow.indexOf("  cleanup-superseded-nightlies:"),
+  );
+
+  assert.match(
+    cleanupJob,
+    /- uses: actions\/checkout@v4\r?\n\s+with:\r?\n\s+persist-credentials: false/,
+  );
+  assert.match(
+    cleanupJob,
+    /uses: actions\/create-github-app-token@v1\r?\n\s+with:\r?\n(?:\s+.+\r?\n)*?\s+permission-contents: write/,
+  );
+});

--- a/scripts/agent/__tests__/cleanup-superseded-nightlies.test.mjs
+++ b/scripts/agent/__tests__/cleanup-superseded-nightlies.test.mjs
@@ -1,0 +1,252 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { main } from "../cleanup-superseded-nightlies.mjs";
+
+const REPO = "Mzeey-Empire/mcode";
+const STABLE_TAG = "mcode-v1.2.0";
+const STABLE_RELEASE = {
+  id: 900,
+  tag_name: STABLE_TAG,
+  draft: false,
+  prerelease: false,
+  published_at: "2026-01-15T12:00:00Z",
+};
+
+function nightly(overrides = {}) {
+  return {
+    id: 1,
+    tag_name: "v1.2.0-nightly.20260101.1",
+    draft: false,
+    prerelease: true,
+    created_at: "2026-01-01T00:00:00Z",
+    published_at: "2026-01-01T01:00:00Z",
+    immutable: false,
+    ...overrides,
+  };
+}
+
+function createHarness({ releases, refetched = new Map(), failAt } = {}) {
+  const calls = [];
+  const stdout = [];
+  const stderr = [];
+
+  const gh = (args) => {
+    calls.push(args);
+    const signature = args.join(" ");
+    if (failAt && signature === failAt) {
+      throw new Error("simulated GitHub failure");
+    }
+    const endpoint = args.at(-1);
+    if (
+      args.includes("--method") &&
+      args[args.indexOf("--method") + 1] === "DELETE"
+    ) {
+      return "";
+    }
+    if (endpoint === `repos/${REPO}/releases/tags/${STABLE_TAG}`) {
+      return JSON.stringify(STABLE_RELEASE);
+    }
+    if (endpoint === `repos/${REPO}/releases?per_page=100&page=1`) {
+      return JSON.stringify(releases ?? []);
+    }
+    const releaseMatch = endpoint.match(/\/releases\/(\d+)$/);
+    if (releaseMatch) {
+      const id = Number(releaseMatch[1]);
+      return JSON.stringify(
+        refetched.get(id) ?? releases.find((release) => release.id === id),
+      );
+    }
+    throw new Error(`Unexpected gh call: ${signature}`);
+  };
+
+  return {
+    calls,
+    stdout,
+    stderr,
+    gh,
+    io: {
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+    },
+  };
+}
+
+test("dry run selects only old superseded nightlies without mutating GitHub", () => {
+  const eligiblePublished = nightly();
+  const eligibleDraft = nightly({
+    id: 2,
+    tag_name: "v1.1.9-nightly.20251231.2",
+    draft: true,
+    published_at: null,
+  });
+  const releases = [
+    eligiblePublished,
+    eligibleDraft,
+    nightly({
+      id: 3,
+      tag_name: "mcode-v1.1.0",
+      prerelease: false,
+    }),
+    nightly({
+      id: 4,
+      tag_name: "nightly",
+    }),
+    nightly({
+      id: 5,
+      tag_name: "v1.2.0-nightly.20260108.5",
+      created_at: "2026-01-08T12:00:00Z",
+    }),
+    nightly({
+      id: 6,
+      tag_name: "v1.2.0-nightly.20260109.6",
+      created_at: "2026-01-09T00:00:00Z",
+    }),
+    nightly({
+      id: 7,
+      tag_name: "v1.3.0-nightly.20251201.7",
+    }),
+    nightly({
+      id: 8,
+      tag_name: "v1.0.0-nightly.20251201.8",
+      immutable: true,
+    }),
+  ];
+  const harness = createHarness({ releases });
+
+  const result = main(["--repo", REPO, "--stable-tag", STABLE_TAG], {
+    gh: harness.gh,
+    io: harness.io,
+  });
+
+  assert.equal(result, 0);
+  assert.deepEqual(harness.stdout, [
+    `Stable tag: ${STABLE_TAG}`,
+    "Cutoff: 2026-01-08T12:00:00.000Z",
+    "Candidates (2):",
+    "  v1.2.0-nightly.20260101.1",
+    "  v1.1.9-nightly.20251231.2",
+    "Dry run: no releases or tags were deleted.",
+  ]);
+  assert.equal(
+    harness.calls.some((args) => args.includes("DELETE")),
+    false,
+  );
+});
+
+test("apply re-fetches candidates, skips stale plans, then deletes release before exact tag", () => {
+  const first = nightly();
+  const second = nightly({
+    id: 2,
+    tag_name: "v1.1.9-nightly.20251231.2",
+  });
+  const refetched = new Map([
+    [first.id, { ...first, immutable: true }],
+    [second.id, second],
+  ]);
+  const harness = createHarness({ releases: [first, second], refetched });
+
+  const result = main(["--repo", REPO, "--stable-tag", STABLE_TAG, "--apply"], {
+    gh: harness.gh,
+    io: harness.io,
+  });
+
+  assert.equal(result, 0);
+  assert.ok(
+    harness.stdout.includes(
+      "Skipped v1.2.0-nightly.20260101.1: release no longer matches the cleanup plan.",
+    ),
+  );
+  const mutations = harness.calls.filter((args) => args.includes("DELETE"));
+  assert.deepEqual(mutations, [
+    ["api", "--method", "DELETE", `repos/${REPO}/releases/2`],
+    [
+      "api",
+      "--method",
+      "DELETE",
+      `repos/${REPO}/git/refs/tags/v1.1.9-nightly.20251231.2`,
+    ],
+  ]);
+});
+
+test("apply reports a partial failure and exits nonzero", () => {
+  const release = nightly();
+  const tagEndpoint = `repos/${REPO}/git/refs/tags/v1.2.0-nightly.20260101.1`;
+  const harness = createHarness({
+    releases: [release],
+    failAt: `api --method DELETE ${tagEndpoint}`,
+  });
+
+  const result = main(["--repo", REPO, "--stable-tag", STABLE_TAG, "--apply"], {
+    gh: harness.gh,
+    io: harness.io,
+  });
+
+  assert.equal(result, 1);
+  assert.match(
+    harness.stderr.join("\n"),
+    /Release 1 was deleted, but exact tag v1\.2\.0-nightly\.20260101\.1 was not/,
+  );
+});
+
+test("invalid or ambiguous CLI arguments fail closed", () => {
+  for (const argv of [
+    [],
+    ["--repo", REPO],
+    ["--stable-tag", STABLE_TAG],
+    ["--repo", REPO, "--repo", REPO, "--stable-tag", STABLE_TAG],
+    ["--repo", REPO, "--stable-tag", STABLE_TAG, "--confirm"],
+    ["--repo", REPO, "--stable-tag", STABLE_TAG, "--apply", "--apply"],
+  ]) {
+    const harness = createHarness({ releases: [] });
+    assert.equal(main(argv, { gh: harness.gh, io: harness.io }), 1);
+    assert.equal(harness.calls.length, 0);
+  }
+});
+
+test("an invalid stable release fails before nightly enumeration", () => {
+  const harness = createHarness({ releases: [] });
+  harness.gh = (args) => {
+    harness.calls.push(args);
+    return JSON.stringify({ ...STABLE_RELEASE, prerelease: true });
+  };
+
+  assert.equal(
+    main(["--repo", REPO, "--stable-tag", STABLE_TAG], {
+      gh: harness.gh,
+      io: harness.io,
+    }),
+    1,
+  );
+  assert.equal(harness.calls.length, 1);
+});
+
+test("a full tenth page reaches the enumeration cap and fails closed", () => {
+  const calls = [];
+  const gh = (args) => {
+    calls.push(args);
+    const endpoint = args.at(-1);
+    if (endpoint.includes("/releases/tags/")) {
+      return JSON.stringify(STABLE_RELEASE);
+    }
+    return JSON.stringify(
+      Array.from({ length: 100 }, (_, index) =>
+        nightly({
+          id: Number(endpoint.match(/page=(\d+)/)[1]) * 100 + index,
+          tag_name: `v1.2.0-nightly.20250101.${index + 1}`,
+        }),
+      ),
+    );
+  };
+  const stderr = [];
+
+  assert.equal(
+    main(["--repo", REPO, "--stable-tag", STABLE_TAG], {
+      gh,
+      io: { stdout() {}, stderr: (line) => stderr.push(line) },
+    }),
+    1,
+  );
+  assert.match(stderr.join("\n"), /1,000-release safety cap/);
+  assert.equal(calls.length, 11);
+});

--- a/scripts/agent/cleanup-superseded-nightlies.mjs
+++ b/scripts/agent/cleanup-superseded-nightlies.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const PAGE_SIZE = 100;
+const MAX_RELEASES = 1_000;
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+const STABLE_TAG_PATTERN = /^mcode-v(\d+)\.(\d+)\.(\d+)$/;
+const NIGHTLY_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)-nightly\.(\d{8})\.(\d+)$/;
+
+function defaultGh(args) {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+function defaultIo() {
+  return {
+    stdout: (line) => console.log(line),
+    stderr: (line) => console.error(line),
+  };
+}
+
+function parseArguments(argv) {
+  const parsed = { apply: false };
+  const seen = new Set();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (!["--repo", "--stable-tag", "--apply"].includes(argument)) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    if (seen.has(argument)) {
+      throw new Error(`Duplicate argument: ${argument}`);
+    }
+    seen.add(argument);
+
+    if (argument === "--apply") {
+      parsed.apply = true;
+      continue;
+    }
+
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for ${argument}`);
+    }
+    parsed[argument === "--repo" ? "repo" : "stableTag"] = value;
+    index += 1;
+  }
+
+  if (!parsed.repo || !parsed.stableTag) {
+    throw new Error("Both --repo and --stable-tag are required.");
+  }
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(parsed.repo)) {
+    throw new Error("--repo must be an owner/name pair.");
+  }
+
+  return parsed;
+}
+
+function callApi(gh, method, endpoint) {
+  const output = gh(["api", "--method", method, endpoint]);
+  if (method === "DELETE") {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(output);
+  } catch {
+    throw new Error(`GitHub returned invalid JSON for ${endpoint}.`);
+  }
+}
+
+function parseTimestamp(value, field) {
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a timestamp.`);
+  }
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${field} must be a valid timestamp.`);
+  }
+  return timestamp;
+}
+
+function parseVersion(match) {
+  return match.slice(1, 4).map((part) => BigInt(part));
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] < right[index]) return -1;
+    if (left[index] > right[index]) return 1;
+  }
+  return 0;
+}
+
+function validateStableRelease(release, expectedTag) {
+  if (!release || typeof release !== "object" || Array.isArray(release)) {
+    throw new Error("GitHub did not return a stable release object.");
+  }
+  if (release.tag_name !== expectedTag) {
+    throw new Error(
+      `Stable release tag ${String(release.tag_name)} does not match ${expectedTag}.`,
+    );
+  }
+  const tagMatch = STABLE_TAG_PATTERN.exec(release.tag_name);
+  if (!tagMatch) {
+    throw new Error("Stable tag must exactly match mcode-vX.Y.Z.");
+  }
+  if (release.draft !== false || release.prerelease !== false) {
+    throw new Error("Stable release must be published and non-prerelease.");
+  }
+
+  return {
+    version: parseVersion(tagMatch),
+    publishedAt: parseTimestamp(
+      release.published_at,
+      "Stable release published_at",
+    ),
+  };
+}
+
+function isCandidate(release, stableVersion, cutoff) {
+  if (
+    !release ||
+    typeof release !== "object" ||
+    !Number.isSafeInteger(release.id) ||
+    release.id <= 0 ||
+    release.prerelease !== true ||
+    release.immutable !== false
+  ) {
+    return false;
+  }
+
+  const tagMatch =
+    typeof release.tag_name === "string"
+      ? NIGHTLY_TAG_PATTERN.exec(release.tag_name)
+      : null;
+  if (!tagMatch) {
+    return false;
+  }
+  if (compareVersions(parseVersion(tagMatch), stableVersion) > 0) {
+    return false;
+  }
+
+  let createdAt;
+  try {
+    createdAt = parseTimestamp(release.created_at, "Nightly created_at");
+  } catch {
+    return false;
+  }
+  return createdAt < cutoff;
+}
+
+function listReleases(gh, repo) {
+  const releases = [];
+  const pageCount = MAX_RELEASES / PAGE_SIZE;
+
+  for (let page = 1; page <= pageCount; page += 1) {
+    const endpoint = `repos/${repo}/releases?per_page=${PAGE_SIZE}&page=${page}`;
+    const response = callApi(gh, "GET", endpoint);
+    if (!Array.isArray(response)) {
+      throw new Error(`GitHub returned a non-array release page ${page}.`);
+    }
+    releases.push(...response);
+    if (response.length < PAGE_SIZE) {
+      return releases;
+    }
+  }
+
+  throw new Error(
+    "Release enumeration reached the 1,000-release safety cap; refusing cleanup.",
+  );
+}
+
+function printPlan(io, stableTag, cutoff, candidates) {
+  io.stdout(`Stable tag: ${stableTag}`);
+  io.stdout(`Cutoff: ${new Date(cutoff).toISOString()}`);
+  io.stdout(`Candidates (${candidates.length}):`);
+  for (const candidate of candidates) {
+    io.stdout(`  ${candidate.tag_name}`);
+  }
+}
+
+function applyPlan({ candidates, cutoff, gh, io, repo, stableVersion }) {
+  for (const planned of candidates) {
+    const endpoint = `repos/${repo}/releases/${planned.id}`;
+    const current = callApi(gh, "GET", endpoint);
+    if (
+      !isCandidate(current, stableVersion, cutoff) ||
+      current.id !== planned.id ||
+      current.tag_name !== planned.tag_name
+    ) {
+      io.stdout(
+        `Skipped ${planned.tag_name}: release no longer matches the cleanup plan.`,
+      );
+      continue;
+    }
+
+    try {
+      callApi(gh, "DELETE", endpoint);
+    } catch (error) {
+      throw new Error(
+        `Failed to delete release ${planned.id} (${planned.tag_name}): ${error.message}`,
+      );
+    }
+
+    const tagEndpoint = `repos/${repo}/git/refs/tags/${encodeURIComponent(planned.tag_name)}`;
+    try {
+      callApi(gh, "DELETE", tagEndpoint);
+    } catch (error) {
+      throw new Error(
+        `Release ${planned.id} was deleted, but exact tag ${planned.tag_name} was not: ${error.message}`,
+      );
+    }
+    io.stdout(`Deleted release and tag: ${planned.tag_name}`);
+  }
+}
+
+/**
+ * Runs the superseded-nightly cleanup CLI with injectable GitHub and I/O seams.
+ */
+export function main(argv, { gh = defaultGh, io = defaultIo() } = {}) {
+  try {
+    const { repo, stableTag, apply } = parseArguments(argv);
+    const stableEndpoint = `repos/${repo}/releases/tags/${encodeURIComponent(stableTag)}`;
+    const stableRelease = callApi(gh, "GET", stableEndpoint);
+    const { version: stableVersion, publishedAt } = validateStableRelease(
+      stableRelease,
+      stableTag,
+    );
+    const cutoff = publishedAt - RETENTION_MS;
+    const candidates = listReleases(gh, repo).filter((release) =>
+      isCandidate(release, stableVersion, cutoff),
+    );
+
+    printPlan(io, stableTag, cutoff, candidates);
+    if (!apply) {
+      io.stdout("Dry run: no releases or tags were deleted.");
+      return 0;
+    }
+
+    applyPlan({ candidates, cutoff, gh, io, repo, stableVersion });
+    return 0;
+  } catch (error) {
+    io.stderr(`Cleanup failed: ${error.message}`);
+    return 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/scripts/agent/cleanup-superseded-nightlies.mjs
+++ b/scripts/agent/cleanup-superseded-nightlies.mjs
@@ -6,8 +6,13 @@ import { pathToFileURL } from "node:url";
 const PAGE_SIZE = 100;
 const MAX_RELEASES = 1_000;
 const RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
-const STABLE_TAG_PATTERN = /^mcode-v(\d+)\.(\d+)\.(\d+)$/;
-const NIGHTLY_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)-nightly\.(\d{8})\.(\d+)$/;
+const NUMERIC_IDENTIFIER = "(0|[1-9]\\d*)";
+const STABLE_TAG_PATTERN = new RegExp(
+  `^mcode-v${NUMERIC_IDENTIFIER}\\.${NUMERIC_IDENTIFIER}\\.${NUMERIC_IDENTIFIER}$`,
+);
+const NIGHTLY_TAG_PATTERN = new RegExp(
+  `^v${NUMERIC_IDENTIFIER}\\.${NUMERIC_IDENTIFIER}\\.${NUMERIC_IDENTIFIER}-nightly\\.(\\d{8})\\.${NUMERIC_IDENTIFIER}$`,
+);
 
 function defaultGh(args) {
   return execFileSync("gh", args, {
@@ -96,6 +101,24 @@ function compareVersions(left, right) {
   return 0;
 }
 
+function isCalendarDate(value) {
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(4, 6));
+  const day = Number(value.slice(6, 8));
+  if (year === 0 || month === 0 || day === 0) {
+    return false;
+  }
+
+  const timestamp = Date.parse(
+    `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}T00:00:00Z`,
+  );
+  return (
+    Number.isFinite(timestamp) &&
+    new Date(timestamp).toISOString().slice(0, 10) ===
+      `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`
+  );
+}
+
 function validateStableRelease(release, expectedTag) {
   if (!release || typeof release !== "object" || Array.isArray(release)) {
     throw new Error("GitHub did not return a stable release object.");
@@ -139,6 +162,9 @@ function isCandidate(release, stableVersion, cutoff) {
       ? NIGHTLY_TAG_PATTERN.exec(release.tag_name)
       : null;
   if (!tagMatch) {
+    return false;
+  }
+  if (!isCalendarDate(tagMatch[4])) {
     return false;
   }
   if (compareVersions(parseVersion(tagMatch), stableVersion) > 0) {


### PR DESCRIPTION
## What

Add stable-release CI cleanup for superseded nightly GitHub releases and tags.

## Why

Daily nightlies were growing the release and tag lists without bound. Superseded nightlies have no rollback or support role once their target version ships as stable.

## Key Changes

- Add a dry-run-by-default cleanup command with strict tag, version, age, pagination, and pre-delete validation.
- Run cleanup after Release Please creates a stable release.
- Serialize nightly publication and stable cleanup through a shared retained concurrency queue.
- Document stable, nightly, and superseded-nightly terminology and the seven-day retention decision.

## Verification

- Focused cleanup tests: 9 passed.
- Agent script suite: 80 passed, 1 skipped.
- Real GitHub dry run: 13 exact candidates, zero mutations.
- Guarded apply: 13 superseded releases and tags deleted; post-apply dry run found zero candidates.
- Independent high-risk review: no findings.
- Canonical verification passed typecheck, lint, and agent-script stages. Server unit tests were environment-blocked by the local Node 26 `better-sqlite3` ABI mismatch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787525383&installation_model_id=20477&pr_number=949&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F949&signature=18c8f4a8381ef12fb8db6835163552eaa37f3228cd19e68e64cbf67525552b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a safe cleanup process for superseded nightly releases and their tags.
  * Supports previewing cleanup actions before applying deletions.
  * Includes safeguards to retain stable, recent, and later-version nightly releases.

* **Documentation**
  * Added guidance defining stable, nightly, and superseded nightly release channels.
  * Documented the policy for removing superseded nightly releases after stable releases.

* **Chores**
  * Improved release automation to serialize cleanup operations without canceling active runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->