### PR TITLE
docs: define repeatable terminal tabs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -736,15 +736,20 @@ Browser tabs — is defined on each tab type below, not here.)
 
 ### Tab availability
 The rule set governing which tab types a user can create at a given moment.
-Every top-level tab is a **singleton** — at most one Browser, one Terminal,
-one Review, one Plan, one Files. Multiplicity lives *inside* a tab (the
-Browser holds many pages, the Terminal many shells), never as duplicate
-top-level tabs. The set of **creatable** types is filtered twice: by
-**scope** (types needing a thread are dropped when no thread is active) and
-by **cardinality** (singletons already open are dropped). When exactly one
-type is creatable, the add affordance opens it directly instead of showing
-a menu; when none are, the add affordance is hidden. The empty panel and
-the add menu present this same creatable-types set.
+Browser, Review, Plan, and Files are **singletons** at the top level.
+Terminal is repeatable: each open Terminal tab represents one **shell
+session**. The set of **creatable** types is filtered by **scope** (types
+needing a thread are dropped when no thread is active) and by
+**cardinality** (open singleton types are dropped, while Terminal remains
+creatable until its limit of four shell sessions per terminal scope is
+reached). When exactly one type is creatable, the add affordance opens it
+directly instead of showing a menu; when none are, the add affordance is
+hidden. The empty panel and the add menu present this same creatable-types
+set. Tabs share one creation-ordered sequence regardless of type. A newly
+created tab appends to that sequence. The user can reorder any tab by pointer
+drag or keyboard movement without changing its content or the panel's size.
+Each thread preserves its own tab order. The workspace-level panel used with
+no active thread preserves a separate order.
 
 ### Plan tab
 The right-panel tab that shows a thread's saved plan documents. It is
@@ -777,10 +782,14 @@ attributed. It is separate from the Plan tab.
 _Avoid_: Scope task list
 
 ### Terminal tab
-The right-panel tab that hosts one or more **shell sessions** against the
-active **terminal scope** (a thread when one is active, otherwise the
-workspace root). Singleton at the panel level; multiplicity is internal
-(one tab, many shells).
+A repeatable right-panel tab that represents one **shell session** against
+the active **terminal scope** (a thread when one is active, otherwise the
+workspace root). Creating another shell session creates another Terminal
+tab. Selecting a Terminal tab shows only that tab's shell session. Closing
+a Terminal tab closes its shell session and terminates the entire process
+tree rooted at that shell. If closing it leaves no right-panel tabs, the
+right panel closes. When a shell exits on its own, its Terminal tab may show
+the exit status briefly, then closes automatically.
 
 ### Terminal scope
 The thread or workspace a shell session runs against. When a thread is
@@ -792,14 +801,15 @@ _Avoid_: Using "thread id" alone when the scope may be a workspace.
 ### Shell session
 A running shell process (e.g. PowerShell, bash) tied to one terminal scope.
 Survives thread switches and terminal-tab hides; the process keeps running
-until the user kills it or closes the shell. Output keeps draining into
-server-side scrollback even when no terminal view is mounted.
+until the user kills it or closes its Terminal tab. Closing it terminates the
+shell and every descendant process that it started. Output keeps draining
+into server-side scrollback even when no terminal view is mounted.
 _Avoid_: PTY (implementation term), terminal instance (ambiguous with the view).
 
 ### Active shell
-The one shell session whose terminal view is mounted. At most one terminal
-view exists in the app. Its view may stay warm while the Terminal tab or right
-panel is hidden; all other shells run without a view.
+The shell session represented by the selected Terminal tab. At most one
+terminal view exists in the app. Its view may stay warm while its Terminal tab
+or the right panel is hidden; all other shells run without a view.
 _Avoid_: Mounting a view for every open shell (background shells stay
 server-side only).
 
@@ -809,7 +819,8 @@ Only the **active shell** has a view; others keep running without one. Hiding
 the terminal surface preserves that view for a fast return. Switching shells
 replaces it. A returning view follows the latest output when the user was at
 the tail, or restores the same retained content when the user was reading
-history.
+history. Restoration preserves terminal text and ANSI styling without exposing
+control-sequence fragments as visible characters.
 _Avoid_: xterm (implementation term), conflating with shell session.
 
 ### Scrollback

--- a/docs/adr/0004-workspace-global-right-panel-singleton-tabs.md
+++ b/docs/adr/0004-workspace-global-right-panel-singleton-tabs.md
@@ -7,7 +7,8 @@ status: accepted
 > **Proposed revision:** ADR-0012 moves *all* panel container state (including
 > width and active tab) to per-thread, with a workspace-level fallback. If
 > accepted, it supersedes the state-split decision below; the singleton-tabs and
-> per-tab-scope decisions here still stand.
+> per-tab-scope decisions here still stand. ADR-0020 separately supersedes the
+> Terminal singleton and internal-multiplicity decision.
 
 ## Context
 

--- a/docs/adr/0012-right-panel-state-per-thread.md
+++ b/docs/adr/0012-right-panel-state-per-thread.md
@@ -4,6 +4,10 @@ status: proposed
 
 # Right-panel container state is per-thread, with a workspace-level fallback for the threadless and not-yet-customized cases
 
+> **Terminal revision:** ADR-0020 supersedes the Terminal singleton and
+> internal-multiplicity decision retained below. Other tool types remain
+> singletons.
+
 ## Context
 
 ADR-0004 split the panel container state: open/closed per-thread, but **width

--- a/docs/adr/0020-repeatable-terminal-tabs-in-right-panel-order.md
+++ b/docs/adr/0020-repeatable-terminal-tabs-in-right-panel-order.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+---
+
+# Shell sessions are repeatable Terminal tabs in the shared right-panel order
+
+The right panel previously treated every tool type as a singleton and kept
+multiple shell sessions inside one Terminal tab. That model added a second
+terminal navigator inside the panel and made shells behave differently from
+the tabs users already manage in the right-panel rail.
+
+Each shell session is now represented by its own Terminal tab. Terminal tabs
+are first-class peers of Browser, Review, Plan, and Files in one shared tab
+order. New tabs append in creation order, tool types may interleave, and users
+can reorder tabs by pointer drag or keyboard movement without changing panel
+geometry or tab content. Closing a Terminal tab terminates its shell process
+tree. A terminal scope remains bounded to four shell sessions.
+
+Each thread owns its tab order. The workspace-level panel used without an
+active thread owns a separate order, consistent with the existing terminal
+scope boundary.
+
+This supersedes ADR-0004's Terminal singleton and internal-multiplicity
+decision, and the same retained decision in ADR-0012. Other tool types remain
+singletons. ADR-0010's one-renderer bound remains: only the selected shell has
+a terminal view, while inactive shell sessions keep running with bounded
+server-side retention.
+
+The trade-off is a richer right-panel tab identity model. The panel can no
+longer represent open tabs as a unique list of tool-type strings; repeatable
+tabs need stable instance identities and a persistent user-controlled order.
+In return, the terminal loses its nested navigation layer and every shell
+follows the same visible tab interaction as the rest of the panel.


### PR DESCRIPTION
## What

Define shell sessions as repeatable first-class Terminal tabs in the right-panel order.

## Why

The accepted specification in #944 replaces the nested terminal-session navigator with one visible tab per shell. The domain glossary and prior ADRs need to state that model before implementation issues #945 through #948 begin.

## Key Changes

- Define repeatable Terminal-tab cardinality, per-thread ordering, reordering, close semantics, and restoration fidelity in the domain glossary.
- Add ADR-0020 for the shared ordered-tab model while preserving the one-renderer terminal bound.
- Mark the Terminal singleton decisions in ADR-0004 and ADR-0012 as superseded.
- Verify formatting with `git diff --check`; `bun run verify` reported `Verification skipped: no relevant changes` for this documentation-only diff.

Related to #944

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787526391&installation_model_id=20477&pr_number=950&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F950&signature=bde025c27ae61286f48457002c698595ea8c3bbfdbd82dd9e46ad42256a2888b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->