### PR TITLE
feat(claude): add Opus 5 model support

### DIFF
--- a/apps/server/src/providers/claude/__tests__/list-models.test.ts
+++ b/apps/server/src/providers/claude/__tests__/list-models.test.ts
@@ -130,13 +130,32 @@ describe("listClaudeModels", () => {
     });
   });
 
-  it("throws on non-OK response", async () => {
+  it("returns the static catalog when the request is rejected", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("network unavailable"));
+    const result = await listClaudeModels();
+    expect(result).toHaveLength(8);
+    expect(result[0]?.id).toBe("claude-opus-5");
+  });
+
+  it("returns the static catalog on a non-OK response", async () => {
     fetchSpy.mockResolvedValueOnce({
       ok: false,
       status: 401,
       statusText: "Unauthorized",
     });
-    await expect(listClaudeModels()).rejects.toThrow("401");
+    const result = await listClaudeModels();
+    expect(result).toHaveLength(8);
+    expect(result[0]?.id).toBe("claude-opus-5");
+  });
+
+  it("returns the static catalog when the response contains invalid JSON", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError("invalid JSON")),
+    });
+    const result = await listClaudeModels();
+    expect(result).toHaveLength(8);
+    expect(result[0]?.id).toBe("claude-opus-5");
   });
 
   it("returns cached result on second call without re-fetching", async () => {

--- a/apps/server/src/providers/claude/__tests__/list-models.test.ts
+++ b/apps/server/src/providers/claude/__tests__/list-models.test.ts
@@ -55,13 +55,21 @@ describe("listClaudeModels", () => {
 
   it("returns ProviderModelInfo[] filtered to claude models", async () => {
     const result = await listClaudeModels();
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(3);
     expect(result[0]).toEqual<ProviderModelInfo>({
+      id: "claude-opus-5",
+      name: "Claude Opus 5",
+      contextWindow: 1_000_000,
+      supportsReasoning: true,
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+      defaultReasoningEffort: "high",
+    });
+    expect(result[1]).toEqual<ProviderModelInfo>({
       id: "claude-sonnet-4-6-20250514",
       name: "Claude Sonnet 4.6",
       contextWindow: 1_000_000,
     });
-    expect(result[1]).toEqual<ProviderModelInfo>({
+    expect(result[2]).toEqual<ProviderModelInfo>({
       id: "claude-haiku-4-5-20251001",
       name: "Claude Haiku 4.5",
       contextWindow: 200_000,
@@ -81,10 +89,19 @@ describe("listClaudeModels", () => {
     );
   });
 
-  it("returns empty array when ANTHROPIC_API_KEY is missing", async () => {
+  it("returns the Opus 5 fallback when ANTHROPIC_API_KEY is missing", async () => {
     delete process.env.ANTHROPIC_API_KEY;
     const result = await listClaudeModels();
-    expect(result).toEqual([]);
+    expect(result).toEqual<ProviderModelInfo[]>([
+      {
+        id: "claude-opus-5",
+        name: "Claude Opus 5",
+        contextWindow: 1_000_000,
+        supportsReasoning: true,
+        supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+        defaultReasoningEffort: "high",
+      },
+    ]);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 

--- a/apps/server/src/providers/claude/__tests__/list-models.test.ts
+++ b/apps/server/src/providers/claude/__tests__/list-models.test.ts
@@ -133,8 +133,10 @@ describe("listClaudeModels", () => {
   it("returns the static catalog when the request is rejected", async () => {
     fetchSpy.mockRejectedValueOnce(new Error("network unavailable"));
     const result = await listClaudeModels();
+    await listClaudeModels();
     expect(result).toHaveLength(8);
     expect(result[0]?.id).toBe("claude-opus-5");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("returns the static catalog on a non-OK response", async () => {
@@ -144,8 +146,10 @@ describe("listClaudeModels", () => {
       statusText: "Unauthorized",
     });
     const result = await listClaudeModels();
+    await listClaudeModels();
     expect(result).toHaveLength(8);
     expect(result[0]?.id).toBe("claude-opus-5");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("returns the static catalog when the response contains invalid JSON", async () => {
@@ -156,6 +160,18 @@ describe("listClaudeModels", () => {
     const result = await listClaudeModels();
     expect(result).toHaveLength(8);
     expect(result[0]?.id).toBe("claude-opus-5");
+  });
+
+  it("retries discovery after the cached failure fallback expires", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("network unavailable"));
+    await listClaudeModels();
+
+    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 5 * 60 * 1001);
+    const result = await listClaudeModels();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(10);
+    dateSpy.mockRestore();
   });
 
   it("returns cached result on second call without re-fetching", async () => {

--- a/apps/server/src/providers/claude/__tests__/list-models.test.ts
+++ b/apps/server/src/providers/claude/__tests__/list-models.test.ts
@@ -55,7 +55,7 @@ describe("listClaudeModels", () => {
 
   it("returns ProviderModelInfo[] filtered to claude models", async () => {
     const result = await listClaudeModels();
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(10);
     expect(result[0]).toEqual<ProviderModelInfo>({
       id: "claude-opus-5",
       name: "Claude Opus 5",
@@ -64,12 +64,12 @@ describe("listClaudeModels", () => {
       supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
       defaultReasoningEffort: "high",
     });
-    expect(result[1]).toEqual<ProviderModelInfo>({
+    expect(result.find((model) => model.id === "claude-sonnet-4-6-20250514")).toEqual<ProviderModelInfo>({
       id: "claude-sonnet-4-6-20250514",
       name: "Claude Sonnet 4.6",
       contextWindow: 1_000_000,
     });
-    expect(result[2]).toEqual<ProviderModelInfo>({
+    expect(result.find((model) => model.id === "claude-haiku-4-5-20251001")).toEqual<ProviderModelInfo>({
       id: "claude-haiku-4-5-20251001",
       name: "Claude Haiku 4.5",
       contextWindow: 200_000,
@@ -89,20 +89,45 @@ describe("listClaudeModels", () => {
     );
   });
 
-  it("returns the Opus 5 fallback when ANTHROPIC_API_KEY is missing", async () => {
+  it("returns the complete static catalog when ANTHROPIC_API_KEY is missing", async () => {
     delete process.env.ANTHROPIC_API_KEY;
     const result = await listClaudeModels();
-    expect(result).toEqual<ProviderModelInfo[]>([
-      {
-        id: "claude-opus-5",
-        name: "Claude Opus 5",
-        contextWindow: 1_000_000,
-        supportsReasoning: true,
-        supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
-        defaultReasoningEffort: "high",
-      },
+    expect(result).toHaveLength(8);
+    expect(result.map((model) => model.id)).toEqual([
+      "claude-opus-5",
+      "claude-fable-5",
+      "claude-sonnet-5",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
     ]);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps fallback capabilities when the API omits Opus 5 fields", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        data: [{
+          id: "claude-opus-5",
+          display_name: "Claude Opus 5",
+          type: "model",
+          max_input_tokens: null,
+          max_tokens: null,
+        }],
+        has_more: false,
+      }),
+    });
+
+    const [opus5] = await listClaudeModels();
+    expect(opus5).toMatchObject({
+      id: "claude-opus-5",
+      contextWindow: 1_000_000,
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+      defaultReasoningEffort: "high",
+    });
   });
 
   it("throws on non-OK response", async () => {

--- a/apps/server/src/providers/claude/list-models.ts
+++ b/apps/server/src/providers/claude/list-models.ts
@@ -114,7 +114,10 @@ async function fetchModels(): Promise<ProviderModelInfo[]> {
     logger.warn("Claude model discovery failed; using static catalog", {
       errorName: error instanceof Error ? error.name : "UnknownError",
     });
-    return [...CLAUDE_STATIC_MODELS];
+    const fallbackModels = [...CLAUDE_STATIC_MODELS];
+    cachedModels = fallbackModels;
+    cacheTimestamp = Date.now();
+    return fallbackModels;
   }
 }
 

--- a/apps/server/src/providers/claude/list-models.ts
+++ b/apps/server/src/providers/claude/list-models.ts
@@ -72,45 +72,50 @@ async function fetchModels(): Promise<ProviderModelInfo[]> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     // The Claude Agent SDK uses its own auth mechanism, so this env var
-    // is often absent. Return empty and let the static registry provide
-    // model data instead of surfacing an error to the user.
+    // is often absent. Return the complete static catalog instead of
+    // surfacing an error to the user.
     logger.debug("ANTHROPIC_API_KEY not set, skipping models API fetch");
     return [...CLAUDE_STATIC_MODELS];
   }
 
-  // limit=100 covers all current Claude models without pagination.
-  // Anthropic has far fewer than 100 Claude models at present, so we
-  // intentionally do not follow has_more / last_id pagination.
-  const res = await fetch("https://api.anthropic.com/v1/models?limit=100", {
-    signal: AbortSignal.timeout(10_000),
-    headers: {
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-  });
+  try {
+    // limit=100 covers all current Claude models without pagination.
+    // Anthropic has far fewer than 100 Claude models at present, so we
+    // intentionally do not follow has_more / last_id pagination.
+    const res = await fetch("https://api.anthropic.com/v1/models?limit=100", {
+      signal: AbortSignal.timeout(10_000),
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+    });
 
-  if (!res.ok) {
-    throw new Error(
-      `Anthropic Models API returned ${res.status} ${res.statusText}`,
-    );
+    if (!res.ok) {
+      throw new Error("Anthropic Models API returned a non-OK response");
+    }
+
+    const body = (await res.json()) as AnthropicModelsResponse;
+
+    const models = mergeStaticCatalog(body.data
+      .filter((m) => m.id.startsWith("claude-"))
+      .map((m) => ({
+        id: m.id,
+        name: m.display_name,
+        contextWindow: m.max_input_tokens ?? undefined,
+      })));
+
+    cachedModels = models;
+    cacheTimestamp = Date.now();
+
+    logger.debug("Fetched Claude models from API", { count: models.length });
+
+    return models;
+  } catch (error) {
+    logger.warn("Claude model discovery failed; using static catalog", {
+      errorName: error instanceof Error ? error.name : "UnknownError",
+    });
+    return [...CLAUDE_STATIC_MODELS];
   }
-
-  const body = (await res.json()) as AnthropicModelsResponse;
-
-  const models = mergeStaticCatalog(body.data
-    .filter((m) => m.id.startsWith("claude-"))
-    .map((m) => ({
-      id: m.id,
-      name: m.display_name,
-      contextWindow: m.max_input_tokens ?? undefined,
-    })));
-
-  cachedModels = models;
-  cacheTimestamp = Date.now();
-
-  logger.debug("Fetched Claude models from API", { count: models.length });
-
-  return models;
 }
 
 /**

--- a/apps/server/src/providers/claude/list-models.ts
+++ b/apps/server/src/providers/claude/list-models.ts
@@ -7,20 +7,11 @@
  */
 
 import { logger } from "@mcode/shared";
+import { CLAUDE_STATIC_MODELS } from "@mcode/contracts";
 import type { ProviderModelInfo } from "@mcode/contracts";
 
 /** Cache TTL: 5 minutes, matching the design spec. */
 const CACHE_TTL_MS = 5 * 60 * 1000;
-
-/** Opus 5 metadata available even when the Anthropic Models API cannot be queried. */
-const OPUS_5_FALLBACK: ProviderModelInfo = {
-  id: "claude-opus-5",
-  name: "Claude Opus 5",
-  contextWindow: 1_000_000,
-  supportsReasoning: true,
-  supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
-  defaultReasoningEffort: "high",
-};
 
 /** Shape of a single model from the Anthropic Models API. */
 interface AnthropicModelInfo {
@@ -43,11 +34,19 @@ let cachedModels: ProviderModelInfo[] | null = null;
 let cacheTimestamp = 0;
 let inflight: Promise<ProviderModelInfo[]> | null = null;
 
-/** Adds Opus 5 capability metadata while preserving every model returned by the API. */
-function mergeOpus5Fallback(models: ProviderModelInfo[]): ProviderModelInfo[] {
-  const opus5 = models.find((model) => model.id === OPUS_5_FALLBACK.id);
-  const otherModels = models.filter((model) => model.id !== OPUS_5_FALLBACK.id);
-  return [{ ...OPUS_5_FALLBACK, ...opus5 }, ...otherModels];
+/** Merges API metadata into the complete fallback catalog without losing defined fallback fields. */
+function mergeStaticCatalog(models: ProviderModelInfo[]): ProviderModelInfo[] {
+  const dynamicById = new Map(models.map((model) => [model.id, model]));
+  const merged = CLAUDE_STATIC_MODELS.map((fallback) => {
+    const dynamic = dynamicById.get(fallback.id);
+    if (!dynamic) return fallback;
+    const definedDynamic = Object.fromEntries(
+      Object.entries(dynamic).filter(([, value]) => value !== undefined),
+    );
+    return { ...fallback, ...definedDynamic } as ProviderModelInfo;
+  });
+  const staticIds = new Set(CLAUDE_STATIC_MODELS.map((model) => model.id));
+  return [...merged, ...models.filter((model) => !staticIds.has(model.id))];
 }
 
 /**
@@ -76,7 +75,7 @@ async function fetchModels(): Promise<ProviderModelInfo[]> {
     // is often absent. Return empty and let the static registry provide
     // model data instead of surfacing an error to the user.
     logger.debug("ANTHROPIC_API_KEY not set, skipping models API fetch");
-    return [OPUS_5_FALLBACK];
+    return [...CLAUDE_STATIC_MODELS];
   }
 
   // limit=100 covers all current Claude models without pagination.
@@ -98,7 +97,7 @@ async function fetchModels(): Promise<ProviderModelInfo[]> {
 
   const body = (await res.json()) as AnthropicModelsResponse;
 
-  const models = mergeOpus5Fallback(body.data
+  const models = mergeStaticCatalog(body.data
     .filter((m) => m.id.startsWith("claude-"))
     .map((m) => ({
       id: m.id,

--- a/apps/server/src/providers/claude/list-models.ts
+++ b/apps/server/src/providers/claude/list-models.ts
@@ -12,6 +12,16 @@ import type { ProviderModelInfo } from "@mcode/contracts";
 /** Cache TTL: 5 minutes, matching the design spec. */
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
+/** Opus 5 metadata available even when the Anthropic Models API cannot be queried. */
+const OPUS_5_FALLBACK: ProviderModelInfo = {
+  id: "claude-opus-5",
+  name: "Claude Opus 5",
+  contextWindow: 1_000_000,
+  supportsReasoning: true,
+  supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+  defaultReasoningEffort: "high",
+};
+
 /** Shape of a single model from the Anthropic Models API. */
 interface AnthropicModelInfo {
   id: string;
@@ -32,6 +42,13 @@ interface AnthropicModelsResponse {
 let cachedModels: ProviderModelInfo[] | null = null;
 let cacheTimestamp = 0;
 let inflight: Promise<ProviderModelInfo[]> | null = null;
+
+/** Adds Opus 5 capability metadata while preserving every model returned by the API. */
+function mergeOpus5Fallback(models: ProviderModelInfo[]): ProviderModelInfo[] {
+  const opus5 = models.find((model) => model.id === OPUS_5_FALLBACK.id);
+  const otherModels = models.filter((model) => model.id !== OPUS_5_FALLBACK.id);
+  return [{ ...OPUS_5_FALLBACK, ...opus5 }, ...otherModels];
+}
 
 /**
  * Resets the in-memory model cache and any inflight request.
@@ -59,7 +76,7 @@ async function fetchModels(): Promise<ProviderModelInfo[]> {
     // is often absent. Return empty and let the static registry provide
     // model data instead of surfacing an error to the user.
     logger.debug("ANTHROPIC_API_KEY not set, skipping models API fetch");
-    return [];
+    return [OPUS_5_FALLBACK];
   }
 
   // limit=100 covers all current Claude models without pagination.
@@ -81,13 +98,13 @@ async function fetchModels(): Promise<ProviderModelInfo[]> {
 
   const body = (await res.json()) as AnthropicModelsResponse;
 
-  const models: ProviderModelInfo[] = body.data
+  const models = mergeOpus5Fallback(body.data
     .filter((m) => m.id.startsWith("claude-"))
     .map((m) => ({
       id: m.id,
       name: m.display_name,
       contextWindow: m.max_input_tokens ?? undefined,
-    }));
+    })));
 
   cachedModels = models;
   cacheTimestamp = Date.now();

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -30,6 +30,27 @@ describe("pickProviderModelsForSettings", () => {
     ]);
   });
 
+  it("preserves the settings context window when dynamic discovery reports provider capacity", () => {
+    const staticClaude = [{
+      id: "claude-opus-5",
+      label: "Claude Opus 5",
+      providerId: "claude",
+      contextWindow: 200_000,
+    }];
+    const dynamicClaude = [{
+      id: "claude-opus-5",
+      label: "Claude Opus 5",
+      providerId: "claude",
+      contextWindow: 1_000_000,
+      supportedReasoningLevels: ["low", "high", "max"] as const,
+    }];
+
+    expect(pickProviderModelsForSettings(staticClaude, dynamicClaude)).toEqual([{
+      ...dynamicClaude[0],
+      contextWindow: 200_000,
+    }]);
+  });
+
   it("falls back to static models when dynamic is undefined", () => {
     expect(pickProviderModelsForSettings(staticModels, undefined)).toEqual(staticModels);
   });

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -51,6 +51,23 @@ describe("pickProviderModelsForSettings", () => {
     }]);
   });
 
+  it("uses dynamic context updates for non-Claude models", () => {
+    const staticCodex = [{
+      id: "gpt-test",
+      label: "GPT Test",
+      providerId: "codex",
+      contextWindow: 200_000,
+    }];
+    const dynamicCodex = [{
+      id: "gpt-test",
+      label: "GPT Test",
+      providerId: "codex",
+      contextWindow: 400_000,
+    }];
+
+    expect(pickProviderModelsForSettings(staticCodex, dynamicCodex)).toEqual(dynamicCodex);
+  });
+
   it("falls back to static models when dynamic is undefined", () => {
     expect(pickProviderModelsForSettings(staticModels, undefined)).toEqual(staticModels);
   });

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -22,9 +22,12 @@ import {
 describe("pickProviderModelsForSettings", () => {
   const staticModels = [{ id: "a", label: "A", providerId: "cursor" }];
 
-  it("prefers a non-empty dynamic list", () => {
+  it("merges a non-empty dynamic list without hiding static models", () => {
     const dynamic = [{ id: "b", label: "B", providerId: "cursor" }];
-    expect(pickProviderModelsForSettings(staticModels, dynamic)).toEqual(dynamic);
+    expect(pickProviderModelsForSettings(staticModels, dynamic)).toEqual([
+      ...staticModels,
+      ...dynamic,
+    ]);
   });
 
   it("falls back to static models when dynamic is undefined", () => {

--- a/apps/web/src/__tests__/model-registry.test.ts
+++ b/apps/web/src/__tests__/model-registry.test.ts
@@ -37,11 +37,21 @@ describe("pickProviderModelsForSettings", () => {
 });
 
 describe("ModelRegistry", () => {
-  it("MODEL_PROVIDERS contains Claude with 7 models", () => {
+  it("MODEL_PROVIDERS contains Claude with 8 models", () => {
     const claude = MODEL_PROVIDERS.find((p) => p.id === "claude");
     expect(claude).toBeTruthy();
-    expect(claude?.models).toHaveLength(7);
+    expect(claude?.models).toHaveLength(8);
     expect(claude?.comingSoon).toBe(false);
+  });
+
+  it("findModelById returns Opus 5 with the standard-mode context clamp", () => {
+    const model = findModelById("claude-opus-5");
+    expect(model).toEqual({
+      id: "claude-opus-5",
+      label: "Claude Opus 5",
+      providerId: "claude",
+      contextWindow: 200_000,
+    });
   });
 
   it("findModelById returns Fable 5 with no availability end date", () => {

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -82,6 +82,8 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     comingSoon: false,
     supportsCompletion: true,
     models: [
+      { id: "claude-opus-5", label: "Claude Opus 5", providerId: "claude",
+        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-5"] },
       { id: "claude-fable-5", label: "Claude Fable 5", providerId: "claude",
         contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-fable-5"] },
       { id: "claude-sonnet-5", label: "Claude Sonnet 5", providerId: "claude",

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -151,10 +151,14 @@ export function pickProviderModelsForSettings(
 ): ModelDefinition[] {
   if (dynamicModels != null && dynamicModels.length > 0) {
     const dynamicById = new Map(dynamicModels.map((model) => [model.id, model]));
-    const merged = staticModels.map((model) => ({
-      ...model,
-      ...dynamicById.get(model.id),
-    }));
+    const merged = staticModels.map((model) => {
+      const dynamicModel = dynamicById.get(model.id);
+      return {
+        ...model,
+        ...dynamicModel,
+        contextWindow: model.contextWindow ?? dynamicModel?.contextWindow,
+      };
+    });
     const staticIds = new Set(staticModels.map((model) => model.id));
     return [...merged, ...dynamicModels.filter((model) => !staticIds.has(model.id))];
   }

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -156,7 +156,9 @@ export function pickProviderModelsForSettings(
       return {
         ...model,
         ...dynamicModel,
-        contextWindow: model.contextWindow ?? dynamicModel?.contextWindow,
+        contextWindow: model.providerId === "claude"
+          ? model.contextWindow ?? dynamicModel?.contextWindow
+          : dynamicModel?.contextWindow ?? model.contextWindow,
       };
     });
     const staticIds = new Set(staticModels.map((model) => model.id));

--- a/apps/web/src/lib/model-registry.ts
+++ b/apps/web/src/lib/model-registry.ts
@@ -1,5 +1,5 @@
 import { useSettingsStore } from "@/stores/settingsStore";
-import { CODEX_STATIC_MODELS, CURSOR_STATIC_MODEL_FALLBACK } from "@mcode/contracts";
+import { CLAUDE_STATIC_MODELS, CODEX_STATIC_MODELS, CURSOR_STATIC_MODEL_FALLBACK } from "@mcode/contracts";
 import type { ContextWindowMode, ProviderId, ReasoningLevel } from "@mcode/contracts";
 import {
   MODEL_CONTEXT_WINDOWS_DEFAULT,
@@ -81,24 +81,12 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
     name: "Claude",
     comingSoon: false,
     supportsCompletion: true,
-    models: [
-      { id: "claude-opus-5", label: "Claude Opus 5", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-5"] },
-      { id: "claude-fable-5", label: "Claude Fable 5", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-fable-5"] },
-      { id: "claude-sonnet-5", label: "Claude Sonnet 5", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-sonnet-5"] },
-      { id: "claude-opus-4-8", label: "Claude Opus 4.8", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-8"] },
-      { id: "claude-opus-4-7", label: "Claude Opus 4.7", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-7"] },
-      { id: "claude-opus-4-6", label: "Claude Opus 4.6", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-6"] },
-      { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-sonnet-4-6"] },
-      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", providerId: "claude",
-        contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT["claude-haiku-4-5"] },
-    ],
+    models: CLAUDE_STATIC_MODELS.map((model) => ({
+      id: model.id,
+      label: model.name,
+      providerId: "claude",
+      contextWindow: MODEL_CONTEXT_WINDOWS_DEFAULT[model.id],
+    })),
   },
   {
     id: "codex",
@@ -155,15 +143,20 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
 ];
 
 /**
- * Chooses model definitions for Settings pickers: prefers a non-empty live list
- * from the server; otherwise keeps static catalog entries when discovery fails or returns nothing.
+ * Merges live model definitions into the static Settings catalog by model ID.
  */
 export function pickProviderModelsForSettings(
   staticModels: readonly ModelDefinition[],
   dynamicModels: readonly ModelDefinition[] | undefined,
 ): ModelDefinition[] {
   if (dynamicModels != null && dynamicModels.length > 0) {
-    return [...dynamicModels];
+    const dynamicById = new Map(dynamicModels.map((model) => [model.id, model]));
+    const merged = staticModels.map((model) => ({
+      ...model,
+      ...dynamicById.get(model.id),
+    }));
+    const staticIds = new Set(staticModels.map((model) => model.id));
+    return [...merged, ...dynamicModels.filter((model) => !staticIds.has(model.id))];
   }
   return [...staticModels];
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -634,6 +634,7 @@ export * from "./providers/availability.js";
 export { CURSOR_STATIC_MODEL_FALLBACK } from "./providers/cursor-static-fallback.js";
 export { CURSOR_CLI_MODEL_SNAPSHOT } from "./providers/cursor-cli-models-snapshot.js";
 export { CODEX_STATIC_MODELS, supportsCodexUltraOrchestration } from "./providers/codex-static-fallback.js";
+export { CLAUDE_STATIC_MODELS } from "./providers/claude-static-fallback.js";
 
 export {
   ProviderModelInfoSchema,

--- a/packages/contracts/src/providers/claude-static-fallback.ts
+++ b/packages/contracts/src/providers/claude-static-fallback.ts
@@ -1,0 +1,52 @@
+import type { ProviderModelInfo } from "./models.js";
+
+/** Complete Claude fallback catalog shared by server discovery and web pickers. */
+export const CLAUDE_STATIC_MODELS: readonly ProviderModelInfo[] = [
+  {
+    id: "claude-opus-5",
+    name: "Claude Opus 5",
+    contextWindow: 1_000_000,
+    supportsReasoning: true,
+    supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+    defaultReasoningEffort: "high",
+  },
+  ...[
+    ["claude-fable-5", "Claude Fable 5"],
+    ["claude-sonnet-5", "Claude Sonnet 5"],
+  ].map(([id, name]) => ({
+    id,
+    name,
+    contextWindow: 1_000_000,
+    supportsReasoning: true,
+    supportedReasoningEfforts: ["low", "medium", "high", "max"] as const,
+    defaultReasoningEffort: "high" as const,
+  })),
+  ...[
+    ["claude-opus-4-8", "Claude Opus 4.8"],
+    ["claude-opus-4-7", "Claude Opus 4.7"],
+  ].map(([id, name]) => ({
+    id,
+    name,
+    contextWindow: 1_000_000,
+    supportsReasoning: true,
+    supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] as const,
+    defaultReasoningEffort: "high" as const,
+  })),
+  ...[
+    ["claude-opus-4-6", "Claude Opus 4.6"],
+    ["claude-sonnet-4-6", "Claude Sonnet 4.6"],
+  ].map(([id, name]) => ({
+    id,
+    name,
+    contextWindow: 1_000_000,
+    supportsReasoning: true,
+    supportedReasoningEfforts: ["low", "medium", "high", "max"] as const,
+    defaultReasoningEffort: "high" as const,
+  })),
+  {
+    id: "claude-haiku-4-5",
+    name: "Claude Haiku 4.5",
+    contextWindow: 200_000,
+    supportsReasoning: false,
+  },
+];

--- a/packages/contracts/src/providers/claude-static-fallback.ts
+++ b/packages/contracts/src/providers/claude-static-fallback.ts
@@ -13,35 +13,35 @@ export const CLAUDE_STATIC_MODELS: readonly ProviderModelInfo[] = [
   ...[
     ["claude-fable-5", "Claude Fable 5"],
     ["claude-sonnet-5", "Claude Sonnet 5"],
-  ].map(([id, name]) => ({
+  ].map(([id, name]): ProviderModelInfo => ({
     id,
     name,
     contextWindow: 1_000_000,
     supportsReasoning: true,
-    supportedReasoningEfforts: ["low", "medium", "high", "max"] as const,
-    defaultReasoningEffort: "high" as const,
+    supportedReasoningEfforts: ["low", "medium", "high", "max"],
+    defaultReasoningEffort: "high",
   })),
   ...[
     ["claude-opus-4-8", "Claude Opus 4.8"],
     ["claude-opus-4-7", "Claude Opus 4.7"],
-  ].map(([id, name]) => ({
+  ].map(([id, name]): ProviderModelInfo => ({
     id,
     name,
     contextWindow: 1_000_000,
     supportsReasoning: true,
-    supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] as const,
-    defaultReasoningEffort: "high" as const,
+    supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+    defaultReasoningEffort: "high",
   })),
   ...[
     ["claude-opus-4-6", "Claude Opus 4.6"],
     ["claude-sonnet-4-6", "Claude Sonnet 4.6"],
-  ].map(([id, name]) => ({
+  ].map(([id, name]): ProviderModelInfo => ({
     id,
     name,
     contextWindow: 1_000_000,
     supportsReasoning: true,
-    supportedReasoningEfforts: ["low", "medium", "high", "max"] as const,
-    defaultReasoningEffort: "high" as const,
+    supportedReasoningEfforts: ["low", "medium", "high", "max"],
+    defaultReasoningEffort: "high",
   })),
   {
     id: "claude-haiku-4-5",

--- a/packages/shared/src/model-context/__tests__/model-context.test.ts
+++ b/packages/shared/src/model-context/__tests__/model-context.test.ts
@@ -8,6 +8,7 @@ import {
 
 describe("MODEL_CONTEXT_WINDOWS_DEFAULT", () => {
   it("exposes 200K as the default for every Claude model (no opt-in)", () => {
+    expect(MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-5"]).toBe(200_000);
     expect(MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-8"]).toBe(200_000);
     expect(MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-7"]).toBe(200_000);
     expect(MODEL_CONTEXT_WINDOWS_DEFAULT["claude-opus-4-6"]).toBe(200_000);
@@ -21,6 +22,9 @@ describe("MODEL_CONTEXT_WINDOWS_DEFAULT", () => {
 });
 
 describe("MODEL_CONTEXT_WINDOWS_EXTENDED", () => {
+  it("exposes 1M for Opus 5", () => {
+    expect(MODEL_CONTEXT_WINDOWS_EXTENDED["claude-opus-5"]).toBe(1_000_000);
+  });
   it("exposes 1M for Opus 4.8", () => {
     expect(MODEL_CONTEXT_WINDOWS_EXTENDED["claude-opus-4-8"]).toBe(1_000_000);
   });
@@ -44,6 +48,7 @@ describe("getModelContextWindow", () => {
   // -------------------------------------------------------------------------
 
   it("returns 200K for every supported Claude model in 200k mode", () => {
+    expect(getModelContextWindow("claude-opus-5", "200k")).toBe(200_000);
     expect(getModelContextWindow("claude-opus-4-8", "200k")).toBe(200_000);
     expect(getModelContextWindow("claude-opus-4-7", "200k")).toBe(200_000);
     expect(getModelContextWindow("claude-opus-4-6", "200k")).toBe(200_000);
@@ -60,7 +65,8 @@ describe("getModelContextWindow", () => {
   // 1M mode -- only models in the extended map honor the opt-in.
   // -------------------------------------------------------------------------
 
-  it("returns 1M for opus-4-8/4-7/4-6 and sonnet-4-6 in 1m mode", () => {
+  it("returns 1M for opus-5/4-8/4-7/4-6 and sonnet-4-6 in 1m mode", () => {
+    expect(getModelContextWindow("claude-opus-5", "1m")).toBe(1_000_000);
     expect(getModelContextWindow("claude-opus-4-8", "1m")).toBe(1_000_000);
     expect(getModelContextWindow("claude-opus-4-7", "1m")).toBe(1_000_000);
     expect(getModelContextWindow("claude-opus-4-6", "1m")).toBe(1_000_000);

--- a/packages/shared/src/model-context/index.ts
+++ b/packages/shared/src/model-context/index.ts
@@ -10,6 +10,7 @@ import type { ContextWindowMode } from "@mcode/contracts";
  * (verified 2026-04-22).
  */
 export const MODEL_CONTEXT_WINDOWS_DEFAULT: Readonly<Record<string, number>> = {
+  "claude-opus-5": 200_000,
   "claude-fable-5": 200_000,
   "claude-sonnet-5": 200_000,
   "claude-opus-4-8": 200_000,
@@ -26,6 +27,7 @@ export const MODEL_CONTEXT_WINDOWS_DEFAULT: Readonly<Record<string, number>> = {
  * their default window.
  */
 export const MODEL_CONTEXT_WINDOWS_EXTENDED: Readonly<Record<string, number>> = {
+  "claude-opus-5": 1_000_000,
   "claude-fable-5": 1_000_000,
   "claude-sonnet-5": 1_000_000,
   "claude-opus-4-8": 1_000_000,

--- a/packages/shared/src/model-effort/__tests__/normalize.test.ts
+++ b/packages/shared/src/model-effort/__tests__/normalize.test.ts
@@ -7,6 +7,10 @@ import {
 } from "../index.js";
 
 describe("isXhighEffortModel", () => {
+  it("returns true for claude-opus-5", () => {
+    expect(isXhighEffortModel("claude-opus-5")).toBe(true);
+  });
+
   it("returns true for claude-opus-4-8", () => {
     expect(isXhighEffortModel("claude-opus-4-8")).toBe(true);
   });
@@ -41,6 +45,10 @@ describe("isXhighEffortModel", () => {
 });
 
 describe("isMaxEffortModel", () => {
+  it("returns true for claude-opus-5", () => {
+    expect(isMaxEffortModel("claude-opus-5")).toBe(true);
+  });
+
   it("returns true for claude-opus-4-8", () => {
     expect(isMaxEffortModel("claude-opus-4-8")).toBe(true);
   });
@@ -71,6 +79,10 @@ describe("isMaxEffortModel", () => {
 });
 
 describe("supportsEffortParameter", () => {
+  it("returns true for claude-opus-5", () => {
+    expect(supportsEffortParameter("claude-opus-5")).toBe(true);
+  });
+
   it("returns true for claude-opus-4-7", () => {
     expect(supportsEffortParameter("claude-opus-4-7")).toBe(true);
   });
@@ -97,6 +109,16 @@ describe("supportsEffortParameter", () => {
 });
 
 describe("normalizeReasoningLevelForModel", () => {
+  describe("claude-opus-5 (supports all tiers)", () => {
+    it("passes xhigh through unchanged", () => {
+      expect(normalizeReasoningLevelForModel("claude-opus-5", "xhigh")).toBe("xhigh");
+    });
+
+    it("passes max through unchanged", () => {
+      expect(normalizeReasoningLevelForModel("claude-opus-5", "max")).toBe("max");
+    });
+  });
+
   describe("claude-opus-4-8 (supports all tiers)", () => {
     it("passes xhigh through unchanged", () => {
       expect(normalizeReasoningLevelForModel("claude-opus-4-8", "xhigh")).toBe("xhigh");

--- a/packages/shared/src/model-effort/index.ts
+++ b/packages/shared/src/model-effort/index.ts
@@ -11,7 +11,7 @@ import type { ReasoningLevel } from "@mcode/contracts";
 // Ordered lowest to highest. Walking DOWN from a disallowed tier finds the best
 // supported level without silently escalating effort.
 //
-// xhigh sits below max because xhigh is exclusive to Opus 4.8/4.7, while max is
+// xhigh sits below max because xhigh is exclusive to Opus 5/4.8/4.7, while max is
 // a broader "extended thinking" tier supported by Opus 4.6 and Sonnet 4.6 as well.
 // "none" and "minimal" align with OpenAI Codex app-server ReasoningEffort and are filtered
 // out or mapped before Claude SDK calls.
@@ -26,10 +26,15 @@ const TIER_LADDER: readonly ReasoningLevel[] = [
 ];
 
 /** Claude model IDs that support the "xhigh" effort tier. */
-const XHIGH_EFFORT_MODEL_IDS: readonly string[] = ["claude-opus-4-8", "claude-opus-4-7"];
+const XHIGH_EFFORT_MODEL_IDS: readonly string[] = [
+  "claude-opus-5",
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+];
 
 /** Claude model IDs that support the "max" effort tier. */
 const MAX_EFFORT_MODEL_IDS: readonly string[] = [
+  "claude-opus-5",
   "claude-fable-5",
   "claude-sonnet-5",
   "claude-opus-4-8",
@@ -43,6 +48,7 @@ const MAX_EFFORT_MODEL_IDS: readonly string[] = [
  * The same Opus 4.8/4.7/4.6 + Sonnet 4.6 cohort that supports the max effort tier.
  */
 const ONE_M_CONTEXT_MODEL_IDS: readonly string[] = [
+  "claude-opus-5",
   "claude-fable-5",
   "claude-sonnet-5",
   "claude-opus-4-8",
@@ -137,7 +143,7 @@ function normalizeCodexReasoningLevel(modelId: string, level: ReasoningLevel): R
 /**
  * Returns true when the model supports the "xhigh" effort tier.
  *
- * Only the `claude-opus-4-8` and `claude-opus-4-7` families (including
+ * Only the `claude-opus-5`, `claude-opus-4-8`, and `claude-opus-4-7` families (including
  * their dated variants) expose this tier.
  */
 export function isXhighEffortModel(modelId: string): boolean {
@@ -147,7 +153,7 @@ export function isXhighEffortModel(modelId: string): boolean {
 /**
  * Returns true when the model supports the "max" effort tier.
  *
- * Applies to the fable-5, sonnet-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
+ * Applies to the opus-5, fable-5, sonnet-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6 families.
  */
 export function isMaxEffortModel(modelId: string): boolean {
   return MAX_EFFORT_MODEL_IDS.includes(normalizeModelId(modelId));
@@ -155,7 +161,7 @@ export function isMaxEffortModel(modelId: string): boolean {
 
 /**
  * Returns true when the model supports the extended 1,000,000-token context
- * window. Applies to fable-5, sonnet-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6.
+ * window. Applies to opus-5, fable-5, sonnet-5, opus-4-8, opus-4-7, opus-4-6, and sonnet-4-6.
  *
  * The window is opted into by appending `[1m]` to the model slug at send
  * time; the Claude Agent SDK handles the beta header internally.


### PR DESCRIPTION
## What

Add Claude Opus 5 to Mcode's Claude provider catalog and capability metadata.

## Why

Anthropic released Claude Opus 5 under the API model ID `claude-opus-5`. Mcode needs a complete fallback catalog because Claude Agent SDK sessions often run without `ANTHROPIC_API_KEY`.

## Key Changes

- Add a shared eight-model Claude fallback catalog.
- Expose Opus 5 through Claude provider discovery and the web model registry.
- Register Opus 5 support for `xhigh`, `max`, and the explicit 1M context mode.
- Preserve existing Claude models when live discovery is unavailable.
- Keep Settings on Mcode's 200K standard mode when discovery reports the provider's 1M capacity.
- Fall back to a bounded cached catalog when live discovery fails.
- Add focused provider, registry, context, and effort coverage.

## Verification

- Contracts typecheck: passed.
- Claude provider tests: 11 passed.
- Web model registry tests: 86 passed.
- Shared context and effort tests: 70 passed.
- Hosted Typecheck, Lint, Test, Build Check, PR Title, and all four Web E2E shards passed against commit `04d233f0`.
- CodeRabbit's two actionable comments were fixed and their threads were resolved. Its final incremental review was rate limited.
- Live picker verification remains blocked locally because Node 26 requests an unavailable `better-sqlite3` ABI 147 prebuild, which prevents Electron installation.

