### PR TITLE
feat(right-panel): add ordered instance tabs

### DIFF
--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -455,6 +455,64 @@ describe("diffStore", () => {
       expect(getRightPanel("ws-1").openTabs).toEqual(["preview", "terminal"]);
       expect(getRightPanel("ws-1").activeTab).toBe("preview");
     });
+
+    it("creates deterministic singleton instances in insertion order", () => {
+      const { setRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", null, "terminal");
+      setRightPanelTab("ws-1", null, "preview");
+      setRightPanelTab("ws-1", null, "changes");
+
+      expect(getRightPanel("ws-1").tabInstances).toEqual([
+        { id: "singleton:terminal", type: "terminal" },
+        { id: "singleton:preview", type: "preview" },
+        { id: "singleton:changes", type: "changes" },
+      ]);
+      expect(getRightPanel("ws-1").activeTabId).toBe("singleton:changes");
+    });
+  });
+
+  describe("reorderRightPanelTab", () => {
+    it("moves instances without regrouping types and stops at boundaries", () => {
+      const { setRightPanelTab, reorderRightPanelTab, getRightPanel } =
+        useDiffStore.getState();
+      setRightPanelTab("ws-1", null, "terminal");
+      setRightPanelTab("ws-1", null, "preview");
+      setRightPanelTab("ws-1", null, "changes");
+
+      reorderRightPanelTab("ws-1", null, "singleton:changes", -1);
+      expect(getRightPanel("ws-1").openTabs).toEqual([
+        "terminal",
+        "changes",
+        "preview",
+      ]);
+
+      reorderRightPanelTab("ws-1", null, "singleton:terminal", -1);
+      expect(getRightPanel("ws-1").openTabs).toEqual([
+        "terminal",
+        "changes",
+        "preview",
+      ]);
+    });
+
+    it("keeps thread and workspace fallback order independent", () => {
+      const { setRightPanelTab, reorderRightPanelTab, getRightPanel } =
+        useDiffStore.getState();
+      for (const tab of ["terminal", "preview", "changes"] as const) {
+        setRightPanelTab("ws-1", null, tab);
+      }
+      reorderRightPanelTab("ws-1", "thread-1", "singleton:preview", -1);
+
+      expect(getRightPanel("ws-1", "thread-1").openTabs).toEqual([
+        "preview",
+        "terminal",
+        "changes",
+      ]);
+      expect(getRightPanel("ws-1").openTabs).toEqual([
+        "terminal",
+        "preview",
+        "changes",
+      ]);
+    });
   });
 
   describe("closeRightPanelTab", () => {
@@ -473,6 +531,24 @@ describe("diffStore", () => {
       closeRightPanelTab("ws-1", null, "terminal");
       expect(getRightPanel("ws-1").openTabs).toEqual(["preview"]);
       expect(getRightPanel("ws-1").activeTab).toBe("preview");
+    });
+
+    it("selects the item now at the removed index, then the previous item", () => {
+      const {
+        setRightPanelTab,
+        closeRightPanelTabInstance,
+        getRightPanel,
+      } = useDiffStore.getState();
+      setRightPanelTab("ws-1", null, "terminal");
+      setRightPanelTab("ws-1", null, "preview");
+      setRightPanelTab("ws-1", null, "changes");
+      setRightPanelTab("ws-1", null, "preview");
+
+      closeRightPanelTabInstance("ws-1", null, "singleton:preview");
+      expect(getRightPanel("ws-1").activeTabId).toBe("singleton:changes");
+
+      closeRightPanelTabInstance("ws-1", null, "singleton:changes");
+      expect(getRightPanel("ws-1").activeTabId).toBe("singleton:terminal");
     });
 
     it("leaves the active tab unchanged when closing an inactive tab", () => {

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -469,6 +469,30 @@ describe("diffStore", () => {
       ]);
       expect(getRightPanel("ws-1").activeTabId).toBe("singleton:changes");
     });
+
+    it("selects a repeatable tab by stable instance identity", () => {
+      useDiffStore.setState({
+        rightPanelFallbackByWorkspace: {
+          "ws-1": {
+            ...useDiffStore.getState().getRightPanel("ws-1"),
+            tabInstances: [
+              { id: "terminal:first", type: "terminal" },
+              { id: "terminal:second", type: "terminal" },
+            ],
+            activeTabId: "terminal:first",
+          },
+        },
+      });
+
+      const { setRightPanelTabInstance, getRightPanel } = useDiffStore.getState();
+      setRightPanelTabInstance("ws-1", null, "terminal:second");
+
+      expect(getRightPanel("ws-1").activeTabId).toBe("terminal:second");
+      expect(getRightPanel("ws-1").tabInstances).toEqual([
+        { id: "terminal:first", type: "terminal" },
+        { id: "terminal:second", type: "terminal" },
+      ]);
+    });
   });
 
   describe("reorderRightPanelTab", () => {

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { BranchComparison, GitBranch } from "@mcode/contracts";
+import type { RightPanelState } from "../stores/diffStore";
 import {
   useDiffStore,
   PANEL_MIN_WIDTH,
@@ -8,6 +9,7 @@ import {
   maxPanelWidthInSplit,
   getDefaultPanelWidthPx,
   createDefaultRightPanelState,
+  createRightPanelState,
   DEFAULT_LINE_WRAP,
 } from "../stores/diffStore";
 
@@ -422,6 +424,57 @@ describe("diffStore", () => {
   });
 
   describe("setRightPanelTab", () => {
+    it("preserves an explicit canonical null over a stale compatibility active tab", () => {
+      const panel = createRightPanelState({
+        visible: true,
+        width: 500,
+        tabInstances: [{ id: "singleton:changes", type: "changes" }],
+        activeTabId: null,
+        activeTab: "changes",
+      });
+
+      expect(panel.activeTabId).toBeNull();
+      expect(panel.activeTab).toBe("tasks");
+      expect(panel.openTabs).toEqual(["changes"]);
+    });
+
+    it("normalizes conflicting fallback and thread records from canonical instance state", () => {
+      const conflictingFallback = {
+        ...createDefaultRightPanelState(),
+        visible: true,
+        tabInstances: [{ id: "singleton:changes", type: "changes" }] as const,
+        activeTabId: "singleton:changes",
+        openTabs: [] as const,
+        activeTab: "tasks" as const,
+      } satisfies RightPanelState;
+      const conflictingThread = {
+        ...createDefaultRightPanelState(),
+        visible: true,
+        tabInstances: [{ id: "singleton:terminal", type: "terminal" }] as const,
+        activeTabId: "singleton:terminal",
+        openTabs: ["preview"] as const,
+        activeTab: "preview" as const,
+      } satisfies RightPanelState;
+      useDiffStore.setState({
+        rightPanelFallbackByWorkspace: { "ws-1": conflictingFallback },
+        rightPanelByThread: { "thread-1": conflictingThread },
+      });
+
+      const { getRightPanel } = useDiffStore.getState();
+      expect(getRightPanel("ws-1", "thread-untouched")).toMatchObject({
+        tabInstances: [{ id: "singleton:changes", type: "changes" }],
+        activeTabId: "singleton:changes",
+        openTabs: ["changes"],
+        activeTab: "changes",
+      });
+      expect(getRightPanel("ws-1", "thread-1")).toMatchObject({
+        tabInstances: [{ id: "singleton:terminal", type: "terminal" }],
+        activeTabId: "singleton:terminal",
+        openTabs: ["terminal"],
+        activeTab: "terminal",
+      });
+    });
+
     it("should update active tab for one workspace only", () => {
       const { setRightPanelTab, getRightPanel } = useDiffStore.getState();
       setRightPanelTab("ws-1", null, "changes");

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -294,6 +294,37 @@ describe("ActivityRail expansion", () => {
     expect(handlers.onSelect).toHaveBeenCalledWith("singleton:terminal");
   });
 
+  it("selects normally after a cancelled drag gesture", () => {
+    renderRail();
+    const terminal = screen.getByRole("button", { name: "Terminal" });
+    const terminalItem = terminal.closest("[data-rail-instance]") as HTMLElement;
+    const changesItem = screen
+      .getByRole("button", { name: "Review, 3 files changed" })
+      .closest("[data-rail-instance]") as HTMLElement;
+    vi.spyOn(terminalItem, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      bottom: 40,
+    } as DOMRect);
+    vi.spyOn(changesItem, "getBoundingClientRect").mockReturnValue({
+      top: 48,
+      bottom: 88,
+    } as DOMRect);
+
+    fireEvent.pointerDown(terminal, { button: 0, pointerId: 5, clientY: 20 });
+    fireEvent.pointerMove(terminal, { pointerId: 5, clientY: 48 });
+    expect(handlers.onReorder).toHaveBeenCalledWith(
+      rightPanelSingletonId("terminal"),
+      1,
+    );
+    fireEvent.pointerCancel(terminal, { pointerId: 5, clientY: 48 });
+
+    fireEvent.pointerDown(terminal, { button: 0, pointerId: 6, clientY: 20 });
+    fireEvent.pointerUp(terminal, { pointerId: 6, clientY: 20 });
+    fireEvent.click(terminal);
+
+    expect(handlers.onSelect).toHaveBeenCalledWith("singleton:terminal");
+  });
+
   it("excludes close presses from drag and click activation", () => {
     renderRail();
     const terminal = screen.getByRole("button", { name: "Terminal" });

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -238,18 +238,90 @@ describe("ActivityRail expansion", () => {
     expect(handlers.onReorder).toHaveBeenCalledTimes(1);
   });
 
-  it("reorders a top-level tab after bounded pointer movement", () => {
+  it("reorders only after crossing the adjacent top-level item boundary", () => {
     renderRail();
     const terminal = screen.getByRole("button", { name: "Terminal" });
+    const terminalItem = terminal.closest("[data-rail-instance]") as HTMLElement;
+    const changesItem = screen
+      .getByRole("button", { name: "Review, 3 files changed" })
+      .closest("[data-rail-instance]") as HTMLElement;
+    vi.spyOn(terminalItem, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      bottom: 40,
+    } as DOMRect);
+    vi.spyOn(changesItem, "getBoundingClientRect").mockReturnValue({
+      top: 48,
+      bottom: 88,
+    } as DOMRect);
 
+    terminal.focus();
     fireEvent.pointerDown(terminal, { button: 0, pointerId: 1, clientY: 20 });
-    fireEvent.pointerMove(terminal, { pointerId: 1, clientY: 30 });
+    fireEvent.pointerMove(terminal, { pointerId: 1, clientY: 47 });
     expect(handlers.onReorder).not.toHaveBeenCalled();
 
-    fireEvent.pointerMove(terminal, { pointerId: 1, clientY: 40 });
+    fireEvent.pointerMove(terminal, { pointerId: 1, clientY: 48 });
     expect(handlers.onReorder).toHaveBeenCalledWith(
       rightPanelSingletonId("terminal"),
       1,
     );
+    fireEvent.click(terminal);
+    expect(handlers.onSelect).not.toHaveBeenCalled();
+    expect(terminal).toHaveFocus();
+  });
+
+  it("excludes close presses from drag and click activation", () => {
+    renderRail();
+    const terminal = screen.getByRole("button", { name: "Terminal" });
+    fireEvent.pointerEnter(terminal);
+    const close = screen.getByRole("button", { name: "Close Terminal" });
+
+    fireEvent.pointerDown(close, { button: 0, pointerId: 2, clientY: 20 });
+    fireEvent.pointerMove(close, { pointerId: 2, clientY: 100 });
+    fireEvent.click(close);
+
+    expect(handlers.onReorder).not.toHaveBeenCalled();
+    expect(handlers.onSelect).not.toHaveBeenCalled();
+    expect(handlers.onClose).toHaveBeenCalledWith("singleton:terminal");
+  });
+
+  it("treats Browser pages as one top-level drag item", () => {
+    render(
+      <ActivityRail
+        {...railElement(["preview", "terminal"]).props}
+        browserTabSet={browserTabSet}
+      />,
+    );
+    const page = screen.getByRole("button", { name: "Browser page: Example" });
+    const browserItem = page.closest("[data-rail-instance]") as HTMLElement;
+    const terminalItem = screen
+      .getByRole("button", { name: "Terminal" })
+      .closest("[data-rail-instance]") as HTMLElement;
+    vi.spyOn(browserItem, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      bottom: 80,
+    } as DOMRect);
+    vi.spyOn(terminalItem, "getBoundingClientRect").mockReturnValue({
+      top: 88,
+      bottom: 128,
+    } as DOMRect);
+
+    fireEvent.pointerDown(page, { button: 0, pointerId: 3, clientY: 20 });
+    fireEvent.pointerMove(page, { pointerId: 3, clientY: 70 });
+    expect(handlers.onReorder).not.toHaveBeenCalled();
+    fireEvent.pointerMove(page, { pointerId: 3, clientY: 88 });
+    expect(handlers.onReorder).toHaveBeenCalledWith("singleton:preview", 1);
+  });
+
+  it("leaves keyboard boundary handling to the store and does not intercept content", () => {
+    renderRail();
+    const terminal = screen.getByRole("button", { name: "Terminal" });
+    fireEvent.keyDown(terminal, { key: "ArrowUp", altKey: true, shiftKey: true });
+    expect(handlers.onReorder).toHaveBeenCalledWith("singleton:terminal", -1);
+
+    const content = document.createElement("textarea");
+    document.body.append(content);
+    fireEvent.keyDown(content, { key: "ArrowDown", altKey: true, shiftKey: true });
+    expect(handlers.onReorder).toHaveBeenCalledTimes(1);
+    content.remove();
   });
 });

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -269,6 +269,31 @@ describe("ActivityRail expansion", () => {
     expect(terminal).toHaveFocus();
   });
 
+  it("selects a tab when pointer jitter does not become a drag", () => {
+    renderRail();
+    const terminal = screen.getByRole("button", { name: "Terminal" });
+    const terminalItem = terminal.closest("[data-rail-instance]") as HTMLElement;
+    const changesItem = screen
+      .getByRole("button", { name: "Review, 3 files changed" })
+      .closest("[data-rail-instance]") as HTMLElement;
+    vi.spyOn(terminalItem, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      bottom: 40,
+    } as DOMRect);
+    vi.spyOn(changesItem, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      bottom: 88,
+    } as DOMRect);
+
+    fireEvent.pointerDown(terminal, { button: 0, pointerId: 4, clientY: 20 });
+    fireEvent.pointerMove(terminal, { pointerId: 4, clientY: 21 });
+    fireEvent.pointerUp(terminal, { pointerId: 4, clientY: 21 });
+    fireEvent.click(terminal);
+
+    expect(handlers.onReorder).not.toHaveBeenCalled();
+    expect(handlers.onSelect).toHaveBeenCalledWith("singleton:terminal");
+  });
+
   it("excludes close presses from drag and click activation", () => {
     renderRail();
     const terminal = screen.getByRole("button", { name: "Terminal" });

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserTabSet } from "@mcode/contracts";
-import type { RightPanelTab } from "@/stores/diffStore";
+import { rightPanelSingletonId, type RightPanelTab } from "@/stores/diffStore";
 import { usePreviewSuppressionStore } from "@/stores/previewSuppressionStore";
 import { ActivityRail } from "./ActivityRail";
 
@@ -29,6 +29,7 @@ const handlers = {
   onToggleMaximized: vi.fn(),
   onSelect: vi.fn(),
   onClose: vi.fn(),
+  onReorder: vi.fn(),
   onCreate: vi.fn(),
   onSelectBrowserPage: vi.fn(),
   onCloseBrowserPage: vi.fn(),
@@ -37,8 +38,8 @@ const handlers = {
 function railElement(openTabs: readonly RightPanelTab[] = ["terminal", "changes"]) {
   return (
     <ActivityRail
-      openTabs={openTabs}
-      activeTab="terminal"
+      tabInstances={openTabs.map((type) => ({ id: rightPanelSingletonId(type), type }))}
+      activeTabId={rightPanelSingletonId("terminal")}
       scope="thread"
       scopeProgress={{ done: 0, total: 0 }}
       changesCount={3}
@@ -119,8 +120,8 @@ describe("ActivityRail expansion", () => {
 
     rerender(
       <ActivityRail
-        openTabs={["preview"]}
-        activeTab="preview"
+        tabInstances={[{ id: rightPanelSingletonId("preview"), type: "preview" }]}
+        activeTabId={rightPanelSingletonId("preview")}
         scope="thread"
         scopeProgress={{ done: 0, total: 0 }}
         changesCount={0}
@@ -171,8 +172,11 @@ describe("ActivityRail expansion", () => {
 
     rerender(
       <ActivityRail
-        openTabs={["terminal", "changes"]}
-        activeTab="terminal"
+        tabInstances={["terminal", "changes"].map((type) => ({
+          id: rightPanelSingletonId(type as RightPanelTab),
+          type: type as RightPanelTab,
+        }))}
+        activeTabId={rightPanelSingletonId("terminal")}
         scope="thread"
         scopeProgress={{ done: 0, total: 0 }}
         changesCount={3}
@@ -211,5 +215,41 @@ describe("ActivityRail expansion", () => {
     unmount();
 
     expect(usePreviewSuppressionStore.getState().count).toBe(0);
+  });
+
+  it("reorders only from a focused rail tab keyboard shortcut", () => {
+    renderRail();
+    const terminal = screen.getByRole("button", { name: "Terminal" });
+    act(() => terminal.focus());
+
+    fireEvent.keyDown(terminal, { key: "ArrowDown", altKey: true, shiftKey: true });
+
+    expect(handlers.onReorder).toHaveBeenCalledWith(
+      rightPanelSingletonId("terminal"),
+      1,
+    );
+    expect(terminal).toHaveFocus();
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "Close panel" }), {
+      key: "ArrowDown",
+      altKey: true,
+      shiftKey: true,
+    });
+    expect(handlers.onReorder).toHaveBeenCalledTimes(1);
+  });
+
+  it("reorders a top-level tab after bounded pointer movement", () => {
+    renderRail();
+    const terminal = screen.getByRole("button", { name: "Terminal" });
+
+    fireEvent.pointerDown(terminal, { button: 0, pointerId: 1, clientY: 20 });
+    fireEvent.pointerMove(terminal, { pointerId: 1, clientY: 30 });
+    expect(handlers.onReorder).not.toHaveBeenCalled();
+
+    fireEvent.pointerMove(terminal, { pointerId: 1, clientY: 40 });
+    expect(handlers.onReorder).toHaveBeenCalledWith(
+      rightPanelSingletonId("terminal"),
+      1,
+    );
   });
 });

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -46,8 +46,6 @@ const RAIL_COLLAPSE_DELAY_MS = 250;
 
 /** Shared trailing anchor for expanded-rail actions. */
 const RAIL_TRAILING_CONTROL_CLASS = "absolute left-[7.75rem] top-0";
-const RAIL_REORDER_THRESHOLD_PX = 16;
-
 /** Pointer and keyboard reorder boundary for one top-level rail instance. */
 function ReorderableRailItem({
   instanceId,
@@ -58,28 +56,39 @@ function ReorderableRailItem({
   children: ReactNode;
   onReorder: (instanceId: string, direction: -1 | 1) => void;
 }) {
-  const pointerYRef = useRef<number | null>(null);
+  const draggingRef = useRef(false);
   const suppressClickRef = useRef(false);
 
   const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     const target = event.target as HTMLElement;
     if (target.closest("[data-rail-close]")) return;
-    pointerYRef.current = event.clientY;
+    draggingRef.current = true;
     event.currentTarget.setPointerCapture?.(event.pointerId);
   };
 
   const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (pointerYRef.current === null) return;
-    const delta = event.clientY - pointerYRef.current;
-    if (Math.abs(delta) < RAIL_REORDER_THRESHOLD_PX) return;
-    onReorder(instanceId, delta < 0 ? -1 : 1);
-    pointerYRef.current = event.clientY;
+    if (!draggingRef.current) return;
+    const item = event.currentTarget;
+    const siblings = Array.from(
+      item.parentElement?.querySelectorAll<HTMLElement>(":scope > [data-rail-instance]") ?? [],
+    );
+    const index = siblings.indexOf(item);
+    const previous = siblings[index - 1];
+    const next = siblings[index + 1];
+    const direction =
+      previous && event.clientY <= previous.getBoundingClientRect().bottom
+        ? -1
+        : next && event.clientY >= next.getBoundingClientRect().top
+          ? 1
+          : null;
+    if (direction === null) return;
+    onReorder(instanceId, direction);
     suppressClickRef.current = true;
   };
 
   const onPointerEnd = () => {
-    pointerYRef.current = null;
+    draggingRef.current = false;
   };
 
   const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -212,7 +221,7 @@ function RailTab({
   scope: ScopeProgress;
   changesCount: number;
   changesFresh: boolean;
-  onSelect: (id: RightPanelTab) => void;
+  onSelect: (instanceId: string) => void;
   onClose: (id: RightPanelTab) => void;
 }) {
   const meta = metaForTab(id);
@@ -582,7 +591,7 @@ export function ActivityRail({
   onClose: (instanceId: string) => void;
   onReorder: (instanceId: string, direction: -1 | 1) => void;
   onCreate: (id: RightPanelTab) => void;
-  onSelectBrowserPage: (pageId: string) => void;
+  onSelectBrowserPage: (instanceId: string, pageId: string) => void;
   onCloseBrowserPage: (pageId: string) => void;
 }) {
   const openTabs = tabInstances.map((instance) => instance.type);
@@ -738,7 +747,7 @@ export function ActivityRail({
                 tabSet={browserTabSet}
                 browserActive={activeTabId === instanceId}
                 expanded={expanded}
-                onSelectPage={onSelectBrowserPage}
+                onSelectPage={(pageId) => onSelectBrowserPage(instanceId, pageId)}
                 onClosePage={onCloseBrowserPage}
               />
             </ReorderableRailItem>
@@ -753,7 +762,7 @@ export function ActivityRail({
               scope={scopeProgress}
               changesCount={changesCount}
               changesFresh={changesFresh}
-              onSelect={onSelect}
+              onSelect={() => onSelect(instanceId)}
               onClose={() => onClose(instanceId)}
             />
           </ReorderableRailItem>

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -221,7 +221,7 @@ function RailTab({
   scope: ScopeProgress;
   changesCount: number;
   changesFresh: boolean;
-  onSelect: (instanceId: string) => void;
+  onSelect: (id: RightPanelTab) => void;
   onClose: (id: RightPanelTab) => void;
 }) {
   const meta = metaForTab(id);
@@ -587,7 +587,7 @@ export function ActivityRail({
   readonly maximized: boolean;
   onTogglePanel: () => void;
   onToggleMaximized: () => void;
-  onSelect: (id: RightPanelTab) => void;
+  onSelect: (instanceId: string) => void;
   onClose: (instanceId: string) => void;
   onReorder: (instanceId: string, direction: -1 | 1) => void;
   onCreate: (id: RightPanelTab) => void;

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -64,6 +64,7 @@ function ReorderableRailItem({
     if (event.button !== 0) return;
     const target = event.target as HTMLElement;
     if (target.closest("[data-rail-close]")) return;
+    suppressClickRef.current = false;
     draggingRef.current = true;
     dragStartYRef.current = event.clientY;
   };
@@ -93,9 +94,15 @@ function ReorderableRailItem({
     suppressClickRef.current = true;
   };
 
-  const onPointerEnd = () => {
+  const onPointerUp = () => {
     draggingRef.current = false;
     dragStartYRef.current = null;
+  };
+
+  const onPointerCancel = () => {
+    draggingRef.current = false;
+    dragStartYRef.current = null;
+    suppressClickRef.current = false;
   };
 
   const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -111,8 +118,8 @@ function ReorderableRailItem({
       data-rail-instance={instanceId}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
-      onPointerUp={onPointerEnd}
-      onPointerCancel={onPointerEnd}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
       onKeyDown={onKeyDown}
       onClickCapture={(event) => {
         if (!suppressClickRef.current) return;

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -57,6 +57,7 @@ function ReorderableRailItem({
   onReorder: (instanceId: string, direction: -1 | 1) => void;
 }) {
   const draggingRef = useRef(false);
+  const dragStartYRef = useRef<number | null>(null);
   const suppressClickRef = useRef(false);
 
   const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -64,11 +65,16 @@ function ReorderableRailItem({
     const target = event.target as HTMLElement;
     if (target.closest("[data-rail-close]")) return;
     draggingRef.current = true;
-    event.currentTarget.setPointerCapture?.(event.pointerId);
+    dragStartYRef.current = event.clientY;
   };
 
   const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (!draggingRef.current) return;
+    const dragStartY = dragStartYRef.current;
+    if (dragStartY === null || Math.abs(event.clientY - dragStartY) < 4) return;
+    if (!event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    }
     const item = event.currentTarget;
     const siblings = Array.from(
       item.parentElement?.querySelectorAll<HTMLElement>(":scope > [data-rail-instance]") ?? [],
@@ -89,6 +95,7 @@ function ReorderableRailItem({
 
   const onPointerEnd = () => {
     draggingRef.current = false;
+    dragStartYRef.current = null;
   };
 
   const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -1,4 +1,9 @@
-import type { FocusEvent as ReactFocusEvent, PointerEvent as ReactPointerEvent } from "react";
+import type {
+  FocusEvent as ReactFocusEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+  ReactNode,
+} from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Globe, Maximize2, Minimize2, PanelRight, Plus, X } from "lucide-react";
 import type { BrowserTabInfo, BrowserTabSet } from "@mcode/contracts";
@@ -20,7 +25,7 @@ import {
   type PanelScope,
   type PanelTabType,
 } from "@/lib/panel-tabs";
-import type { RightPanelTab } from "@/stores/diffStore";
+import type { RightPanelTab, RightPanelTabInstance } from "@/stores/diffStore";
 import { usePreviewSuppressionStore } from "@/stores/previewSuppressionStore";
 import { cn } from "@/lib/utils";
 
@@ -41,6 +46,69 @@ const RAIL_COLLAPSE_DELAY_MS = 250;
 
 /** Shared trailing anchor for expanded-rail actions. */
 const RAIL_TRAILING_CONTROL_CLASS = "absolute left-[7.75rem] top-0";
+const RAIL_REORDER_THRESHOLD_PX = 16;
+
+/** Pointer and keyboard reorder boundary for one top-level rail instance. */
+function ReorderableRailItem({
+  instanceId,
+  children,
+  onReorder,
+}: {
+  instanceId: string;
+  children: ReactNode;
+  onReorder: (instanceId: string, direction: -1 | 1) => void;
+}) {
+  const pointerYRef = useRef<number | null>(null);
+  const suppressClickRef = useRef(false);
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    const target = event.target as HTMLElement;
+    if (target.closest("[data-rail-close]")) return;
+    pointerYRef.current = event.clientY;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  };
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (pointerYRef.current === null) return;
+    const delta = event.clientY - pointerYRef.current;
+    if (Math.abs(delta) < RAIL_REORDER_THRESHOLD_PX) return;
+    onReorder(instanceId, delta < 0 ? -1 : 1);
+    pointerYRef.current = event.clientY;
+    suppressClickRef.current = true;
+  };
+
+  const onPointerEnd = () => {
+    pointerYRef.current = null;
+  };
+
+  const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!event.altKey || !event.shiftKey) return;
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+    event.preventDefault();
+    event.stopPropagation();
+    onReorder(instanceId, event.key === "ArrowUp" ? -1 : 1);
+  };
+
+  return (
+    <div
+      data-rail-instance={instanceId}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerEnd}
+      onPointerCancel={onPointerEnd}
+      onKeyDown={onKeyDown}
+      onClickCapture={(event) => {
+        if (!suppressClickRef.current) return;
+        suppressClickRef.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+    >
+      {children}
+    </div>
+  );
+}
 
 /** Catalog metadata (product label + icon) for an openable tab, by store id. */
 function metaForTab(id: RightPanelTab): PanelTabType | undefined {
@@ -204,6 +272,7 @@ function RailTab({
         variant="ghost"
         size="icon-xs"
         aria-label={`Close ${label}`}
+        data-rail-close
         title={expanded ? undefined : `Close ${label}`}
         onClick={() => onClose(id)}
         className={cn(
@@ -309,6 +378,7 @@ function BrowserPageRailTab({
         variant="ghost"
         size="icon-xs"
         aria-label={`Close page ${label}`}
+        data-rail-close
         title={expanded ? undefined : `Close ${label}`}
         onClick={(e) => {
           e.stopPropagation();
@@ -479,8 +549,8 @@ function RailAddControl({
  * list. The close action mirrors the chat-header toggle and right-panel shortcut.
  */
 export function ActivityRail({
-  openTabs,
-  activeTab,
+  tabInstances,
+  activeTabId,
   scope,
   scopeProgress,
   changesCount,
@@ -491,12 +561,13 @@ export function ActivityRail({
   onToggleMaximized,
   onSelect,
   onClose,
+  onReorder,
   onCreate,
   onSelectBrowserPage,
   onCloseBrowserPage,
 }: {
-  readonly openTabs: readonly RightPanelTab[];
-  readonly activeTab: RightPanelTab;
+  readonly tabInstances: readonly RightPanelTabInstance[];
+  readonly activeTabId: string | null;
   readonly scope: PanelScope;
   readonly scopeProgress: ScopeProgress;
   readonly changesCount: number;
@@ -508,11 +579,13 @@ export function ActivityRail({
   onTogglePanel: () => void;
   onToggleMaximized: () => void;
   onSelect: (id: RightPanelTab) => void;
-  onClose: (id: RightPanelTab) => void;
+  onClose: (instanceId: string) => void;
+  onReorder: (instanceId: string, direction: -1 | 1) => void;
   onCreate: (id: RightPanelTab) => void;
   onSelectBrowserPage: (pageId: string) => void;
   onCloseBrowserPage: (pageId: string) => void;
 }) {
+  const openTabs = tabInstances.map((instance) => instance.type);
   const [expanded, setExpanded] = useState(false);
   const railRef = useRef<HTMLDivElement>(null);
   const expandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -652,35 +725,38 @@ export function ActivityRail({
         </Button>
       </div>
 
-      {openTabs.map((id) => {
+      {tabInstances.map((instance) => {
+        const { id: instanceId, type: id } = instance;
         // The Browser tab becomes its page switcher: when its pages are known,
         // render them as a favicon group instead of the single tab glyph. With
         // none known yet (or a web build with no bridge), fall back to the tab
         // glyph so Browser is still selectable.
         if (id === "preview" && browserTabSet && browserTabSet.tabs.length > 0) {
           return (
-            <BrowserPageGroup
-              key={id}
-              tabSet={browserTabSet}
-              browserActive={activeTab === "preview"}
-              expanded={expanded}
-              onSelectPage={onSelectBrowserPage}
-              onClosePage={onCloseBrowserPage}
-            />
+            <ReorderableRailItem key={instanceId} instanceId={instanceId} onReorder={onReorder}>
+              <BrowserPageGroup
+                tabSet={browserTabSet}
+                browserActive={activeTabId === instanceId}
+                expanded={expanded}
+                onSelectPage={onSelectBrowserPage}
+                onClosePage={onCloseBrowserPage}
+              />
+            </ReorderableRailItem>
           );
         }
         return (
-          <RailTab
-            key={id}
-            id={id}
-            active={id === activeTab}
-            expanded={expanded}
-            scope={scopeProgress}
-            changesCount={changesCount}
-            changesFresh={changesFresh}
-            onSelect={onSelect}
-            onClose={onClose}
-          />
+          <ReorderableRailItem key={instanceId} instanceId={instanceId} onReorder={onReorder}>
+            <RailTab
+              id={id}
+              active={instanceId === activeTabId}
+              expanded={expanded}
+              scope={scopeProgress}
+              changesCount={changesCount}
+              changesFresh={changesFresh}
+              onSelect={onSelect}
+              onClose={() => onClose(instanceId)}
+            />
+          </ReorderableRailItem>
         );
       })}
       {/* The add control only appears once a tab is open; with none open the

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -8,8 +8,8 @@ import {
   COMPOSER_MIN_WIDTH,
   PANEL_SPLIT_GAP_PX,
   maxPanelWidthInSplit,
+  createRightPanelState,
   createDefaultRightPanelState,
-  rightPanelTabInstances,
   getDefaultPanelWidthPx,
 } from "@/stores/diffStore";
 import { PlanPanel } from "./plan";
@@ -86,19 +86,19 @@ export function RightPanel() {
   );
   /** Avoid a Zustand selector that allocates a fresh default object every evaluation. */
   const panelState = useMemo(
-    () => storedPanel ?? createDefaultRightPanelState(),
+    () =>
+      storedPanel
+        ? createRightPanelState(storedPanel)
+        : createDefaultRightPanelState(),
     [storedPanel],
   );
-  const { width: panelWidth, activeTab } = panelState;
-  // Tabs are singletons opened on demand; an empty set means no tab is open and
-  // the panel shows the card-grid empty state. Defensive default for any stored
-  // row that predates the openTabs field. See ADR-0004 / issue #610.
-  const openTabs = panelState.openTabs ?? [];
-  const tabInstances = rightPanelTabInstances(panelState);
-  const activeTabId =
-    panelState.activeTabId ??
-    tabInstances.find((instance) => instance.type === activeTab)?.id ??
-    null;
+  const {
+    width: panelWidth,
+    activeTab,
+    openTabs,
+    tabInstances,
+    activeTabId,
+  } = panelState;
   // Plan is creatable only in a thread; threadless the panel runs
   // against the workspace root and offers just Browser/Terminal/Files.
   const panelScope: PanelScope = activeThreadId ? "thread" : "threadless";

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -9,6 +9,7 @@ import {
   PANEL_SPLIT_GAP_PX,
   maxPanelWidthInSplit,
   createDefaultRightPanelState,
+  rightPanelTabInstances,
   getDefaultPanelWidthPx,
 } from "@/stores/diffStore";
 import { PlanPanel } from "./plan";
@@ -93,6 +94,11 @@ export function RightPanel() {
   // the panel shows the card-grid empty state. Defensive default for any stored
   // row that predates the openTabs field. See ADR-0004 / issue #610.
   const openTabs = panelState.openTabs ?? [];
+  const tabInstances = rightPanelTabInstances(panelState);
+  const activeTabId =
+    panelState.activeTabId ??
+    tabInstances.find((instance) => instance.type === activeTab)?.id ??
+    null;
   // Plan is creatable only in a thread; threadless the panel runs
   // against the workspace root and offers just Browser/Terminal/Files.
   const panelScope: PanelScope = activeThreadId ? "thread" : "threadless";
@@ -120,7 +126,13 @@ export function RightPanel() {
   // Zustand action refs are stable (same identity for the store's lifetime),
   // so destructuring from getState() at render time is safe and avoids
   // adding actions to useCallback/useEffect dependency arrays.
-  const { setRightPanelWidth, setRightPanelTab, closeRightPanelTab } =
+  const {
+    setRightPanelWidth,
+    setRightPanelTab,
+    closeRightPanelTab,
+    closeRightPanelTabInstance,
+    reorderRightPanelTab,
+  } =
     useDiffStore.getState();
 
   // Tab-strip glance status. Changes counts
@@ -247,8 +259,8 @@ export function RightPanel() {
           keeps those panel actions beside the empty-state create list. */}
       <div className="flex min-h-0 flex-1 flex-row overflow-hidden">
         <ActivityRail
-          openTabs={openTabs}
-          activeTab={activeTab}
+          tabInstances={tabInstances}
+          activeTabId={activeTabId}
           scope={panelScope}
           scopeProgress={scope}
           changesCount={changesCount}
@@ -262,8 +274,16 @@ export function RightPanel() {
           onSelect={(id) =>
             setRightPanelTab(activeWorkspaceId!, activeThreadId, id)
           }
-          onClose={(id) =>
-            closeRightPanelTab(activeWorkspaceId!, activeThreadId, id)
+          onClose={(instanceId) =>
+            closeRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId)
+          }
+          onReorder={(instanceId, direction) =>
+            reorderRightPanelTab(
+              activeWorkspaceId!,
+              activeThreadId,
+              instanceId,
+              direction,
+            )
           }
           onCreate={(id) =>
             setRightPanelTab(activeWorkspaceId!, activeThreadId, id)

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -129,6 +129,7 @@ export function RightPanel() {
   const {
     setRightPanelWidth,
     setRightPanelTab,
+    setRightPanelTabInstance,
     closeRightPanelTab,
     closeRightPanelTabInstance,
     reorderRightPanelTab,
@@ -271,8 +272,8 @@ export function RightPanel() {
             toggleRightPanelAdaptive(activeWorkspaceId, activeThreadId)
           }
           onToggleMaximized={toggleMaximized}
-          onSelect={(id) =>
-            setRightPanelTab(activeWorkspaceId!, activeThreadId, id)
+          onSelect={(instanceId) =>
+            setRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId)
           }
           onClose={(instanceId) =>
             closeRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId)
@@ -288,9 +289,9 @@ export function RightPanel() {
           onCreate={(id) =>
             setRightPanelTab(activeWorkspaceId!, activeThreadId, id)
           }
-          onSelectBrowserPage={(pageId) => {
+          onSelectBrowserPage={(instanceId, pageId) => {
             // Focus the Browser tab and switch the guest to that page.
-            setRightPanelTab(activeWorkspaceId!, activeThreadId, "preview");
+            setRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId);
             if (panelScopeId) {
               void usePreviewTabsStore
                 .getState()

--- a/apps/web/src/lib/__tests__/summon-tab.test.ts
+++ b/apps/web/src/lib/__tests__/summon-tab.test.ts
@@ -67,7 +67,7 @@ describe("summonTab", () => {
       useDiffStore.getState().closeRightPanelTab(WID, TID, "terminal");
       expect(panel()).toMatchObject({
         visible: true,
-        activeTab: "terminal",
+        activeTab: "tasks",
         openTabs: [],
       });
 

--- a/apps/web/src/lib/__tests__/turn-snapshot-refresh.test.ts
+++ b/apps/web/src/lib/__tests__/turn-snapshot-refresh.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useDiffStore } from "@/stores/diffStore";
+import { createRightPanelState, useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { refreshTurnSnapshotsAfterPersist } from "@/lib/turn-snapshot-refresh";
 import { mockTransport, createMockThread } from "@/__tests__/mocks/transport";
@@ -58,7 +58,12 @@ describe("refreshTurnSnapshotsAfterPersist", () => {
     useDiffStore.setState({
       snapshotsByThread: { [THREAD_ID]: [] },
       rightPanelByThread: {
-        [THREAD_ID]: { visible: true, activeTab: "changes", openTabs: ["changes"], width: 400 },
+        [THREAD_ID]: createRightPanelState({
+          visible: true,
+          width: 400,
+          tabInstances: [{ id: "singleton:changes", type: "changes" }],
+          activeTabId: "singleton:changes",
+        }),
       },
       viewMode: "cumulative",
     });

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -147,9 +147,9 @@ export type RightPanelState = {
   readonly openTabs: readonly RightPanelTab[];
   readonly activeTab: RightPanelTab;
   /** Ordered tab instances. Singleton tools use deterministic IDs. */
-  readonly tabInstances?: readonly RightPanelTabInstance[];
+  readonly tabInstances: readonly RightPanelTabInstance[];
   /** Stable identity of the active tab instance. */
-  readonly activeTabId?: string | null;
+  readonly activeTabId: string | null;
 };
 
 /** One open right-panel tab, identified independently from its tool type. */
@@ -173,6 +173,51 @@ export function rightPanelTabInstances(
   }));
 }
 
+/** Resolve the active tool type from canonical instance state. */
+export function rightPanelActiveTab(state: RightPanelState): RightPanelTab {
+  return (
+    state.tabInstances.find((instance) => instance.id === state.activeTabId)?.type ??
+    "tasks"
+  );
+}
+
+type RightPanelStateInput = Omit<
+  RightPanelState,
+  "openTabs" | "activeTab" | "tabInstances" | "activeTabId"
+> & {
+  readonly openTabs?: readonly RightPanelTab[];
+  readonly activeTab?: RightPanelTab;
+  readonly tabInstances?: readonly RightPanelTabInstance[];
+  readonly activeTabId?: string | null;
+};
+
+/** Normalize legacy type-based fields into one canonical instance representation. */
+function canonicalRightPanelState(input: RightPanelStateInput): RightPanelState {
+  const tabInstances =
+    input.tabInstances ??
+    (input.openTabs ?? []).map((type) => ({ id: rightPanelSingletonId(type), type }));
+  const activeTabId =
+    input.activeTabId ??
+    tabInstances.find((instance) => instance.type === input.activeTab)?.id ??
+    null;
+  const state = {
+    ...input,
+    tabInstances,
+    activeTabId,
+  } as RightPanelState;
+  Object.defineProperties(state, {
+    openTabs: {
+      enumerable: true,
+      get: () => state.tabInstances.map((instance) => instance.type),
+    },
+    activeTab: {
+      enumerable: true,
+      get: () => rightPanelActiveTab(state),
+    },
+  });
+  return state;
+}
+
 /** Default line-wrap preference for a thread with no stored override. */
 export const DEFAULT_LINE_WRAP = true;
 
@@ -181,15 +226,13 @@ export const DEFAULT_LINE_WRAP = true;
  * fallback has a stored record yet (default width, closed, no open tabs).
  */
 export function createDefaultRightPanelState(): RightPanelState {
-  return {
+  return canonicalRightPanelState({
     visible: false,
     width: getDefaultPanelWidthPx(),
     widthSource: "auto",
-    openTabs: [],
-    activeTab: "tasks",
     tabInstances: [],
     activeTabId: null,
-  };
+  });
 }
 
 /** Stable cache key for one inline diff payload. */
@@ -245,9 +288,10 @@ function effectiveRightPanel(
 ): RightPanelState {
   if (threadId) {
     const own = state.rightPanelByThread[threadId];
-    if (own) return own;
+    if (own) return canonicalRightPanelState(own);
   }
-  return state.rightPanelFallbackByWorkspace[workspaceId] ?? createDefaultRightPanelState();
+  const fallback = state.rightPanelFallbackByWorkspace[workspaceId];
+  return fallback ? canonicalRightPanelState(fallback) : createDefaultRightPanelState();
 }
 
 /**
@@ -264,13 +308,16 @@ function writeRightPanel(
 ): Partial<DiffState> {
   if (threadId) {
     return {
-      rightPanelByThread: { ...state.rightPanelByThread, [threadId]: next },
+      rightPanelByThread: {
+        ...state.rightPanelByThread,
+        [threadId]: canonicalRightPanelState(next),
+      },
     };
   }
   return {
     rightPanelFallbackByWorkspace: {
       ...state.rightPanelFallbackByWorkspace,
-      [workspaceId]: next,
+      [workspaceId]: canonicalRightPanelState(next),
     },
   };
 }
@@ -297,15 +344,13 @@ function setPanelVisible(
  * Static defaults for workspaces with no panel store row; live width uses
  * {@link getDefaultPanelWidthPx} through {@link createDefaultRightPanelState}.
  */
-export const RIGHT_PANEL_DEFAULTS: RightPanelState = {
+export const RIGHT_PANEL_DEFAULTS: RightPanelState = canonicalRightPanelState({
   visible: false,
   width: PANEL_DEFAULT_WIDTH,
   widthSource: "auto",
-  openTabs: [],
-  activeTab: "tasks",
   tabInstances: [],
   activeTabId: null,
-} as const;
+});
 
 /** Zustand state shape for the diff panel. */
 interface DiffState {
@@ -467,6 +512,11 @@ interface DiffState {
     source?: "auto" | "user" | "preserve",
   ) => void;
   setRightPanelTab: (workspaceId: string, threadId: string | null | undefined, tab: RightPanelTab) => void;
+  setRightPanelTabInstance: (
+    workspaceId: string,
+    threadId: string | null | undefined,
+    instanceId: string,
+  ) => void;
   /** Move one tab instance by one bounded position in its scope. */
   reorderRightPanelTab: (
     workspaceId: string,
@@ -636,9 +686,6 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       // Activating a tab opens it: tabs are singletons created on demand, so
       // focusing one that is not yet open adds it to the open set (the card grid
       // is the create surface). Already-open tabs are just refocused.
-      const openTabs = current.openTabs.includes(tab)
-        ? current.openTabs
-        : [...current.openTabs, tab];
       const instanceId = rightPanelSingletonId(tab);
       const currentInstances = rightPanelTabInstances(current);
       const tabInstances = currentInstances.some((instance) => instance.id === instanceId)
@@ -646,12 +693,23 @@ export const useDiffStore = create<DiffState>((set, get) => ({
         : [...currentInstances, { id: instanceId, type: tab }];
       const panelUpdate = writeRightPanel(state, workspaceId, threadId, {
         ...current,
-        openTabs,
-        activeTab: tab,
         tabInstances,
         activeTabId: instanceId,
       });
       return panelUpdate;
+    }),
+
+  setRightPanelTabInstance: (workspaceId, threadId, instanceId) =>
+    set((state) => {
+      const current = effectiveRightPanel(state, workspaceId, threadId);
+      const instance = rightPanelTabInstances(current).find(
+        (candidate) => candidate.id === instanceId,
+      );
+      if (!instance) return {};
+      return writeRightPanel(state, workspaceId, threadId, {
+        ...current,
+        activeTabId: instance.id,
+      });
     }),
 
   reorderRightPanelTab: (workspaceId, threadId, instanceId, direction) =>
@@ -666,7 +724,6 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       return writeRightPanel(state, workspaceId, threadId, {
         ...current,
         tabInstances,
-        openTabs: tabInstances.map((instance) => instance.type),
       });
     }),
 
@@ -681,7 +738,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       const tabInstances = currentInstances.filter(
         (instance) => instance.id !== instanceId,
       );
-      const activeTabId = current.activeTabId ?? rightPanelSingletonId(current.activeTab);
+      const activeTabId = current.activeTabId;
       const nextActive =
         activeTabId === instanceId
           ? (tabInstances[removedIndex] ?? tabInstances[removedIndex - 1] ?? null)
@@ -689,9 +746,7 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       return writeRightPanel(state, workspaceId, threadId, {
         ...current,
         tabInstances,
-        openTabs: tabInstances.map((instance) => instance.type),
         activeTabId: activeTabId === instanceId ? nextActive?.id ?? null : activeTabId,
-        activeTab: nextActive?.type ?? current.activeTab,
       });
     }),
 

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -146,7 +146,32 @@ export type RightPanelState = {
    */
   readonly openTabs: readonly RightPanelTab[];
   readonly activeTab: RightPanelTab;
+  /** Ordered tab instances. Singleton tools use deterministic IDs. */
+  readonly tabInstances?: readonly RightPanelTabInstance[];
+  /** Stable identity of the active tab instance. */
+  readonly activeTabId?: string | null;
 };
+
+/** One open right-panel tab, identified independently from its tool type. */
+export type RightPanelTabInstance = {
+  readonly id: string;
+  readonly type: RightPanelTab;
+};
+
+/** Stable identity for an open singleton tool. */
+export function rightPanelSingletonId(type: RightPanelTab): string {
+  return `singleton:${type}`;
+}
+
+/** Resolve ordered instances from current or legacy in-memory panel state. */
+export function rightPanelTabInstances(
+  state: Pick<RightPanelState, "openTabs"> & Partial<Pick<RightPanelState, "tabInstances">>,
+): readonly RightPanelTabInstance[] {
+  return state.tabInstances ?? state.openTabs.map((type) => ({
+    id: rightPanelSingletonId(type),
+    type,
+  }));
+}
 
 /** Default line-wrap preference for a thread with no stored override. */
 export const DEFAULT_LINE_WRAP = true;
@@ -162,6 +187,8 @@ export function createDefaultRightPanelState(): RightPanelState {
     widthSource: "auto",
     openTabs: [],
     activeTab: "tasks",
+    tabInstances: [],
+    activeTabId: null,
   };
 }
 
@@ -276,6 +303,8 @@ export const RIGHT_PANEL_DEFAULTS: RightPanelState = {
   widthSource: "auto",
   openTabs: [],
   activeTab: "tasks",
+  tabInstances: [],
+  activeTabId: null,
 } as const;
 
 /** Zustand state shape for the diff panel. */
@@ -438,6 +467,19 @@ interface DiffState {
     source?: "auto" | "user" | "preserve",
   ) => void;
   setRightPanelTab: (workspaceId: string, threadId: string | null | undefined, tab: RightPanelTab) => void;
+  /** Move one tab instance by one bounded position in its scope. */
+  reorderRightPanelTab: (
+    workspaceId: string,
+    threadId: string | null | undefined,
+    instanceId: string,
+    direction: -1 | 1,
+  ) => void;
+  /** Close one tab by stable instance identity. */
+  closeRightPanelTabInstance: (
+    workspaceId: string,
+    threadId: string | null | undefined,
+    instanceId: string,
+  ) => void;
   /**
    * Close (remove) a singleton tab from the open set. When the closed tab was
    * active, focus falls back to the most-recently-opened remaining tab; with
@@ -597,33 +639,64 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       const openTabs = current.openTabs.includes(tab)
         ? current.openTabs
         : [...current.openTabs, tab];
+      const instanceId = rightPanelSingletonId(tab);
+      const currentInstances = rightPanelTabInstances(current);
+      const tabInstances = currentInstances.some((instance) => instance.id === instanceId)
+        ? currentInstances
+        : [...currentInstances, { id: instanceId, type: tab }];
       const panelUpdate = writeRightPanel(state, workspaceId, threadId, {
         ...current,
         openTabs,
         activeTab: tab,
+        tabInstances,
+        activeTabId: instanceId,
       });
       return panelUpdate;
     }),
 
-  closeRightPanelTab: (workspaceId, threadId, tab) =>
+  reorderRightPanelTab: (workspaceId, threadId, instanceId, direction) =>
     set((state) => {
       const current = effectiveRightPanel(state, workspaceId, threadId);
-      if (!current.openTabs.includes(tab)) return {};
-      const openTabs = current.openTabs.filter((t) => t !== tab);
-      // Closing the active tab hands focus to the most-recently-opened survivor
-      // (the rail's right-most/last entry); with none left, activeTab is left
-      // untouched and inert — the empty-state grid renders and the panel's
-      // content guards on openTabs.includes(activeTab).
-      const activeTab =
-        current.activeTab === tab
-          ? (openTabs[openTabs.length - 1] ?? current.activeTab)
-          : current.activeTab;
+      const currentInstances = rightPanelTabInstances(current);
+      const from = currentInstances.findIndex((instance) => instance.id === instanceId);
+      const to = from + direction;
+      if (from < 0 || to < 0 || to >= currentInstances.length) return {};
+      const tabInstances = [...currentInstances];
+      [tabInstances[from], tabInstances[to]] = [tabInstances[to], tabInstances[from]];
       return writeRightPanel(state, workspaceId, threadId, {
         ...current,
-        openTabs,
-        activeTab,
+        tabInstances,
+        openTabs: tabInstances.map((instance) => instance.type),
       });
     }),
+
+  closeRightPanelTabInstance: (workspaceId, threadId, instanceId) =>
+    set((state) => {
+      const current = effectiveRightPanel(state, workspaceId, threadId);
+      const currentInstances = rightPanelTabInstances(current);
+      const removedIndex = currentInstances.findIndex(
+        (instance) => instance.id === instanceId,
+      );
+      if (removedIndex < 0) return {};
+      const tabInstances = currentInstances.filter(
+        (instance) => instance.id !== instanceId,
+      );
+      const activeTabId = current.activeTabId ?? rightPanelSingletonId(current.activeTab);
+      const nextActive =
+        activeTabId === instanceId
+          ? (tabInstances[removedIndex] ?? tabInstances[removedIndex - 1] ?? null)
+          : null;
+      return writeRightPanel(state, workspaceId, threadId, {
+        ...current,
+        tabInstances,
+        openTabs: tabInstances.map((instance) => instance.type),
+        activeTabId: activeTabId === instanceId ? nextActive?.id ?? null : activeTabId,
+        activeTab: nextActive?.type ?? current.activeTab,
+      });
+    }),
+
+  closeRightPanelTab: (workspaceId, threadId, tab) =>
+    get().closeRightPanelTabInstance(workspaceId, threadId, rightPanelSingletonId(tab)),
 
   getSubagentRosterTab: (threadId) => get().subagentRosterTabByThread[threadId],
   setSubagentRosterTab: (threadId, tab) =>

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -191,8 +191,8 @@ type RightPanelStateInput = Omit<
   readonly activeTabId?: string | null;
 };
 
-/** Normalize legacy type-based fields into one canonical instance representation. */
-function canonicalRightPanelState(input: RightPanelStateInput): RightPanelState {
+/** Build panel state whose compatibility fields are derived from canonical instances. */
+export function createRightPanelState(input: RightPanelStateInput): RightPanelState {
   const tabInstances =
     input.tabInstances ??
     (input.openTabs ?? []).map((type) => ({ id: rightPanelSingletonId(type), type }));
@@ -226,7 +226,7 @@ export const DEFAULT_LINE_WRAP = true;
  * fallback has a stored record yet (default width, closed, no open tabs).
  */
 export function createDefaultRightPanelState(): RightPanelState {
-  return canonicalRightPanelState({
+  return createRightPanelState({
     visible: false,
     width: getDefaultPanelWidthPx(),
     widthSource: "auto",
@@ -288,10 +288,10 @@ function effectiveRightPanel(
 ): RightPanelState {
   if (threadId) {
     const own = state.rightPanelByThread[threadId];
-    if (own) return canonicalRightPanelState(own);
+    if (own) return createRightPanelState(own);
   }
   const fallback = state.rightPanelFallbackByWorkspace[workspaceId];
-  return fallback ? canonicalRightPanelState(fallback) : createDefaultRightPanelState();
+  return fallback ? createRightPanelState(fallback) : createDefaultRightPanelState();
 }
 
 /**
@@ -310,14 +310,14 @@ function writeRightPanel(
     return {
       rightPanelByThread: {
         ...state.rightPanelByThread,
-        [threadId]: canonicalRightPanelState(next),
+        [threadId]: createRightPanelState(next),
       },
     };
   }
   return {
     rightPanelFallbackByWorkspace: {
       ...state.rightPanelFallbackByWorkspace,
-      [workspaceId]: canonicalRightPanelState(next),
+      [workspaceId]: createRightPanelState(next),
     },
   };
 }
@@ -344,7 +344,7 @@ function setPanelVisible(
  * Static defaults for workspaces with no panel store row; live width uses
  * {@link getDefaultPanelWidthPx} through {@link createDefaultRightPanelState}.
  */
-export const RIGHT_PANEL_DEFAULTS: RightPanelState = canonicalRightPanelState({
+export const RIGHT_PANEL_DEFAULTS: RightPanelState = createRightPanelState({
   visible: false,
   width: PANEL_DEFAULT_WIDTH,
   widthSource: "auto",

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -196,10 +196,9 @@ export function createRightPanelState(input: RightPanelStateInput): RightPanelSt
   const tabInstances =
     input.tabInstances ??
     (input.openTabs ?? []).map((type) => ({ id: rightPanelSingletonId(type), type }));
-  const activeTabId =
-    input.activeTabId ??
-    tabInstances.find((instance) => instance.type === input.activeTab)?.id ??
-    null;
+  const activeTabId = Object.prototype.hasOwnProperty.call(input, "activeTabId")
+    ? input.activeTabId ?? null
+    : tabInstances.find((instance) => instance.type === input.activeTab)?.id ?? null;
   const state = {
     ...input,
     tabInstances,


### PR DESCRIPTION
## What
Add stable instance identities and user-controlled ordering to right-panel tabs.

## Why
Right-panel tabs previously used their tool type as both identity and order. Issue #945 requires an instance-capable state model, per-thread ordering, a separate workspace fallback, and pointer and keyboard reordering without changing panel content or geometry.

## Key Changes
- Make `tabInstances` and `activeTabId` the canonical right-panel state while deriving compatibility fields from that record.
- Preserve singleton behavior for current tools and support stable instance selection, ordered insertion, pointer reorder, and `Alt+Shift+ArrowUp/Down` reorder.
- Restore independent thread and workspace fallback orders and select a deterministic adjacent tab after close.
- Add focused coverage for identity, insertion, interleaving, reorder boundaries, close selection, raw restored-state conflicts, and explicit null precedence.
- Verify pointer and keyboard reorder, focus retention, active Terminal preservation, reduced motion, rail geometry, thread switching, and workspace fallback in Playwright.

## Verification
- Focused right-panel tests: 100 passed.
- Web typecheck: passed.
- Lint: passed.
- Live Playwright order matrix: passed.
- Independent high-risk review: no findings, `RECOMMEND_RELEASE`.
- `bun run verify`: typecheck and lint passed. Unit tests remain red from reproducible timeouts in unrelated server tests (`turn-file-tracker` and `codex-protocol-coverage`); review classified these as baseline and nonblocking for this change.

Closes #945

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787535868&installation_model_id=20477&pr_number=952&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F952&signature=f1349d2b38e31797793a0f8f5287eaecdb8547eb4e162675f61c1299c2593328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->