### PR TITLE
fix(terminal): harden process lifecycle and exit reporting

### DIFF
--- a/apps/server/src/__tests__/process-kill.integration.test.ts
+++ b/apps/server/src/__tests__/process-kill.integration.test.ts
@@ -41,5 +41,5 @@ describe.runIf(process.platform === "win32")("killProcessTree integration", () =
 
     await expect.poll(() => isRunning(root.pid!), { timeout: 5_000 }).toBe(false);
     await expect.poll(() => isRunning(childPid), { timeout: 5_000 }).toBe(false);
-  }, 30_000);
+  }, 60_000);
 });

--- a/apps/server/src/__tests__/process-kill.integration.test.ts
+++ b/apps/server/src/__tests__/process-kill.integration.test.ts
@@ -52,6 +52,7 @@ describe.runIf(process.platform === "win32")("killProcessTree integration", () =
       root.stdout.once("data", (chunk) => resolve(Number(String(chunk).trim())));
       root.once("error", reject);
     });
+    spawnedRoots.add(childPid);
     expect(await isRunning(root.pid)).toBe(true);
     expect(await isRunning(childPid)).toBe(true);
 
@@ -59,6 +60,7 @@ describe.runIf(process.platform === "win32")("killProcessTree integration", () =
     await killProcessTree(root.pid);
     const durationMs = performance.now() - startedAt;
     spawnedRoots.delete(root.pid);
+    spawnedRoots.delete(childPid);
 
     expect(durationMs).toBeLessThan(12_000);
     await expect.poll(() => isRunning(root.pid!), { timeout: 5_000 }).toBe(false);

--- a/apps/server/src/__tests__/process-kill.integration.test.ts
+++ b/apps/server/src/__tests__/process-kill.integration.test.ts
@@ -17,6 +17,25 @@ describe.runIf(process.platform === "win32")("killProcessTree integration", () =
     spawnedRoots.clear();
   });
 
+  it("terminates a real idle process within the bounded close window", async () => {
+    const root = spawn(
+      "powershell.exe",
+      ["-NoProfile", "-Command", "Start-Sleep -Seconds 60"],
+      { stdio: "ignore" },
+    );
+    if (!root.pid) throw new Error("Root process did not start");
+    spawnedRoots.add(root.pid);
+    expect(await isRunning(root.pid)).toBe(true);
+
+    const startedAt = performance.now();
+    await killProcessTree(root.pid);
+    const durationMs = performance.now() - startedAt;
+    spawnedRoots.delete(root.pid);
+
+    expect(durationMs).toBeLessThan(12_000);
+    await expect.poll(() => isRunning(root.pid!), { timeout: 5_000 }).toBe(false);
+  }, 30_000);
+
   it("terminates a real root process and its descendant", async () => {
     const root = spawn(
       "powershell.exe",
@@ -36,9 +55,12 @@ describe.runIf(process.platform === "win32")("killProcessTree integration", () =
     expect(await isRunning(root.pid)).toBe(true);
     expect(await isRunning(childPid)).toBe(true);
 
+    const startedAt = performance.now();
     await killProcessTree(root.pid);
+    const durationMs = performance.now() - startedAt;
     spawnedRoots.delete(root.pid);
 
+    expect(durationMs).toBeLessThan(12_000);
     await expect.poll(() => isRunning(root.pid!), { timeout: 5_000 }).toBe(false);
     await expect.poll(() => isRunning(childPid), { timeout: 5_000 }).toBe(false);
   }, 60_000);

--- a/apps/server/src/__tests__/process-kill.integration.test.ts
+++ b/apps/server/src/__tests__/process-kill.integration.test.ts
@@ -1,0 +1,45 @@
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { killProcessTree } from "../services/process-kill";
+
+const execFileAsync = promisify(execFile);
+const spawnedRoots = new Set<number>();
+
+async function isRunning(pid: number): Promise<boolean> {
+  const { stdout } = await execFileAsync("tasklist", ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"]);
+  return stdout.includes(`"${pid}"`);
+}
+
+describe.runIf(process.platform === "win32")("killProcessTree integration", () => {
+  afterEach(async () => {
+    await Promise.all([...spawnedRoots].map((pid) => killProcessTree(pid).catch(() => undefined)));
+    spawnedRoots.clear();
+  });
+
+  it("terminates a real root process and its descendant", async () => {
+    const root = spawn(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-Command",
+        "$child = Start-Process powershell.exe -ArgumentList '-NoProfile','-Command','Start-Sleep -Seconds 60' -PassThru; Write-Output $child.Id; Start-Sleep -Seconds 60",
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    if (!root.pid) throw new Error("Root process did not start");
+    spawnedRoots.add(root.pid);
+    const childPid = await new Promise<number>((resolve, reject) => {
+      root.stdout.once("data", (chunk) => resolve(Number(String(chunk).trim())));
+      root.once("error", reject);
+    });
+    expect(await isRunning(root.pid)).toBe(true);
+    expect(await isRunning(childPid)).toBe(true);
+
+    await killProcessTree(root.pid);
+    spawnedRoots.delete(root.pid);
+
+    await expect.poll(() => isRunning(root.pid!), { timeout: 5_000 }).toBe(false);
+    await expect.poll(() => isRunning(childPid), { timeout: 5_000 }).toBe(false);
+  }, 30_000);
+});

--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -31,6 +31,10 @@ function stableThenGone(stableReads = 2): (pid: number) => Promise<string | null
   return async (pid) => ++reads <= stableReads ? `start-${pid}` : null;
 }
 
+const ROOT_SNAPSHOT = [
+  { pid: 1234, parentPid: 1, startMarker: "root", name: "pwsh.exe" },
+] as const;
+
 describe("killProcessTree", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -46,7 +50,8 @@ describe("killProcessTree", () => {
       await killProcessTree(1234, {
         platform: "win32",
         execFile: mockExecFile,
-        getProcessStartMarker: stableThenGone(),
+        getWindowsProcessSnapshot: vi.fn().mockResolvedValue(ROOT_SNAPSHOT),
+        isProcessAlive: () => false,
       });
 
       expect(mockExecFile).toHaveBeenCalledWith(
@@ -64,14 +69,13 @@ describe("killProcessTree", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
-      mockExecFile
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })
-        .mockRejectedValueOnce(new Error("process not found"));
+      mockExecFile.mockRejectedValue(new Error("process not found"));
 
       await expect(killProcessTree(1234, {
         platform: "win32",
         execFile: mockExecFile,
-        getProcessStartMarker: stableThenGone(),
+        getWindowsProcessSnapshot: vi.fn().mockResolvedValue(ROOT_SNAPSHOT),
+        isProcessAlive: () => false,
       })).rejects.toThrow("process not found");
       expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
         expect.any(String),
@@ -251,13 +255,18 @@ describe("killProcessTree", () => {
 
   it("does not taskkill a Windows root after the captured root is replaced", async () => {
     mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
-    let markerRead = 0;
+    const snapshot = vi.fn()
+      .mockResolvedValueOnce(ROOT_SNAPSHOT)
+      .mockResolvedValueOnce([
+        { pid: 1234, parentPid: 1, startMarker: "replacement", name: "other.exe" },
+      ]);
 
     await killProcessTree(1234, {
       platform: "win32",
       processKill: vi.fn(),
       execFile: mockExecFile,
-      getProcessStartMarker: async () => ++markerRead === 1 ? "original" : "replacement",
+      getWindowsProcessSnapshot: snapshot,
+      isProcessAlive: () => false,
     });
 
     expect(mockExecFile).not.toHaveBeenCalledWith(
@@ -265,6 +274,119 @@ describe("killProcessTree", () => {
       expect.arrayContaining(["1234"]),
       expect.any(Object),
     );
+  });
+
+  it("captures a multi-process Windows tree with one snapshot", async () => {
+    const snapshot = vi.fn()
+      .mockResolvedValueOnce([
+        { pid: 1234, parentPid: 1, startMarker: "root", name: "pwsh.exe" },
+        { pid: 2345, parentPid: 1234, startMarker: "child", name: "node.exe" },
+        { pid: 3456, parentPid: 2345, startMarker: "grandchild", name: "cmd.exe" },
+      ])
+      .mockResolvedValueOnce([
+        { pid: 1234, parentPid: 1, startMarker: "root", name: "pwsh.exe" },
+        { pid: 2345, parentPid: 1234, startMarker: "child", name: "node.exe" },
+        { pid: 3456, parentPid: 2345, startMarker: "grandchild", name: "cmd.exe" },
+      ]);
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+
+    await killProcessTree(1234, {
+      platform: "win32",
+      execFile: mockExecFile,
+      getWindowsProcessSnapshot: snapshot,
+      isProcessAlive: () => false,
+    });
+
+    expect(snapshot).toHaveBeenCalledTimes(2);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "taskkill",
+      ["/T", "/F", "/PID", "1234"],
+      expect.any(Object),
+    );
+  });
+
+  it("verifies multiple already-gone Windows identities without marker CIM commands", async () => {
+    const snapshot = vi.fn().mockResolvedValue([
+      { pid: 1234, parentPid: 1, startMarker: "root", name: "pwsh.exe" },
+      { pid: 2345, parentPid: 1234, startMarker: "child", name: "node.exe" },
+    ]);
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+
+    await killProcessTree(1234, {
+      platform: "win32",
+      execFile: mockExecFile,
+      getWindowsProcessSnapshot: snapshot,
+      isProcessAlive: () => false,
+    });
+
+    expect(
+      mockExecFile.mock.calls.filter(([command]) => command === "powershell.exe"),
+    ).toEqual([]);
+    expect(snapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("classifies Windows survivors and reused PIDs with one post-kill snapshot", async () => {
+    const snapshot = vi.fn()
+      .mockResolvedValueOnce([
+        { pid: 1234, parentPid: 1, startMarker: "root", name: "pwsh.exe" },
+        { pid: 2345, parentPid: 1234, startMarker: "child", name: "node.exe" },
+        { pid: 3456, parentPid: 1234, startMarker: "old", name: "cmd.exe" },
+      ])
+      .mockResolvedValueOnce([
+        { pid: 1234, parentPid: 1, startMarker: "root", name: "pwsh.exe" },
+        { pid: 2345, parentPid: 1234, startMarker: "child", name: "node.exe" },
+        { pid: 3456, parentPid: 1234, startMarker: "old", name: "cmd.exe" },
+      ])
+      .mockResolvedValueOnce([
+        { pid: 2345, parentPid: 1, startMarker: "child", name: "node.exe" },
+        { pid: 3456, parentPid: 1, startMarker: "replacement", name: "other.exe" },
+      ]);
+    const apparentlyAlive = new Set<number>();
+    mockExecFile.mockImplementation(async (command: string, args: string[]) => {
+      if (command === "taskkill" && args.includes("/T")) {
+        apparentlyAlive.add(2345);
+        apparentlyAlive.add(3456);
+      }
+      if (command === "taskkill" && args.includes("/F") && !args.includes("/T")) {
+        apparentlyAlive.delete(Number(args.at(-1)));
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    await killProcessTree(1234, {
+      platform: "win32",
+      execFile: mockExecFile,
+      getWindowsProcessSnapshot: snapshot,
+      isProcessAlive: (pid) => apparentlyAlive.has(pid),
+    });
+
+    expect(snapshot).toHaveBeenCalledTimes(3);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "taskkill",
+      ["/F", "/PID", "2345"],
+      expect.any(Object),
+    );
+    expect(mockExecFile).not.toHaveBeenCalledWith(
+      "taskkill",
+      ["/F", "/PID", "3456"],
+      expect.any(Object),
+    );
+  });
+
+  it("treats a missing Windows process after taskkill as successful termination", async () => {
+    const snapshot = vi.fn().mockResolvedValue([
+      { pid: 1234, parentPid: 1, startMarker: "root", name: "pwsh.exe" },
+    ]);
+    mockExecFile.mockRejectedValue(
+      Object.assign(new Error("not found"), { code: 128 }),
+    );
+
+    await expect(killProcessTree(1234, {
+      platform: "win32",
+      execFile: mockExecFile,
+      getWindowsProcessSnapshot: snapshot,
+      isProcessAlive: () => false,
+    })).resolves.toBeUndefined();
   });
 
   it("rejects when a captured process remains after the verification timeout", async () => {
@@ -303,7 +425,8 @@ describe("killProcessTree", () => {
       platform: "win32",
       processKill,
       execFile: mockExecFile,
-      getProcessStartMarker: stableThenGone(),
+      getWindowsProcessSnapshot: vi.fn().mockResolvedValue(ROOT_SNAPSHOT),
+      isProcessAlive: () => false,
     });
 
     expect(mockExecFile).toHaveBeenCalledWith(
@@ -315,27 +438,20 @@ describe("killProcessTree", () => {
   });
 
   it("runs taskkill then rejects honestly when CIM enumeration is unavailable", async () => {
-    mockExecFile
-      .mockRejectedValueOnce(new Error("powershell unavailable"))
-      .mockResolvedValueOnce({ stdout: "", stderr: "" });
+    mockExecFile.mockRejectedValue(new Error("powershell unavailable"));
 
     await expect(
       killProcessTree(1234, {
         platform: "win32",
         processKill: vi.fn(),
-        getProcessStartMarker: stableThenGone(),
         execFile: mockExecFile,
       }),
-    ).rejects.toThrow("descendant verification was unavailable");
+    ).rejects.toThrow("powershell unavailable");
 
-    expect(mockExecFile).toHaveBeenCalledWith(
+    expect(mockExecFile).not.toHaveBeenCalledWith(
       "taskkill",
-      ["/T", "/F", "/PID", "1234"],
+      expect.any(Array),
       expect.any(Object),
-    );
-    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
-      "killProcessTree: descendant verification unavailable",
-      expect.objectContaining({ pid: 1234, capturedProcessCount: 1 }),
     );
   });
 
@@ -456,6 +572,9 @@ describe("killDescendantsByName", () => {
   it("finds and kills matching descendants on Windows", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "win32" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    });
     try {
       // First call: findDescendantsByName queries children
       mockExecFile
@@ -468,19 +587,23 @@ describe("killDescendantsByName", () => {
           stderr: "",
         })
         .mockResolvedValueOnce({
-          stdout: "start-5555",
+          stdout: JSON.stringify({
+            Name: "claude.exe",
+            ProcessId: 5555,
+            ParentProcessId: 1234,
+            CreationDate: "start-5555",
+          }),
           stderr: "",
         })
         .mockResolvedValueOnce({
-          stdout: "",
+          stdout: JSON.stringify({
+            Name: "claude.exe",
+            ProcessId: 5555,
+            ParentProcessId: 1234,
+            CreationDate: "start-5555",
+          }),
           stderr: "",
         })
-        .mockResolvedValueOnce({
-          stdout: "start-5555",
-          stderr: "",
-        })
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })
         .mockResolvedValueOnce({ stdout: "", stderr: "" });
 
       await killDescendantsByName(1234, "claude.exe");
@@ -491,6 +614,7 @@ describe("killDescendantsByName", () => {
         expect.any(Object),
       );
     } finally {
+      killSpy.mockRestore();
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }
   });

--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -171,6 +171,40 @@ describe("killProcessTree", () => {
     expect(processKill).toHaveBeenCalledWith(-5678, "SIGKILL");
   });
 
+  it("batches default Unix verification markers once per poll", async () => {
+    let batchRead = 0;
+    mockExecFile.mockImplementation(async (command: string, args: string[]) => {
+      if (command === "pgrep" && args.includes("5678")) {
+        return { stdout: "6789\n", stderr: "" };
+      }
+      if (command === "pgrep") {
+        throw Object.assign(new Error("no matches"), { code: 1 });
+      }
+      if (command === "ps" && args.includes("pid=,lstart=")) {
+        batchRead += 1;
+        return batchRead === 1
+          ? { stdout: "5678 Mon Jan  1 00:00:00 2024\n6789 replacement\n", stderr: "" }
+          : { stdout: "", stderr: "" };
+      }
+      return { stdout: "Mon Jan  1 00:00:00 2024\n", stderr: "" };
+    });
+    const processKill = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    await killProcessTree(5678, {
+      platform: "linux",
+      execFile: mockExecFile,
+    });
+
+    const batchCalls = mockExecFile.mock.calls.filter(
+      ([command, args]) => command === "ps" && args.includes("pid=,lstart="),
+    );
+    expect(batchCalls).toHaveLength(2);
+    expect(batchCalls[0]?.[1]).toContain("5678,6789");
+    expect(batchCalls[1]?.[1]).toContain("5678");
+    expect(batchCalls[1]?.[1]).not.toContain("6789");
+    processKill.mockRestore();
+  });
+
   it("explicitly kills an escaped descendant deepest-first after the root group signal", async () => {
     mockExecFile.mockImplementation(async (_command: string, args: string[]) => {
       if (args.includes("5678")) return { stdout: "6789\n", stderr: "" };
@@ -437,7 +471,7 @@ describe("killProcessTree", () => {
     expect(mockExecFile.mock.calls.some(([command]) => command === "wmic")).toBe(false);
   });
 
-  it("runs taskkill then rejects honestly when CIM enumeration is unavailable", async () => {
+  it("rejects before taskkill when CIM enumeration is unavailable", async () => {
     mockExecFile.mockRejectedValue(new Error("powershell unavailable"));
 
     await expect(

--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -81,14 +81,14 @@ describe("killProcessTree", () => {
         return true;
       });
 
-      await killProcessTree(5678);
+      await killProcessTree(5678, {
+        platform: "linux",
+        processKill: killSpy,
+        execFile: mockExecFile,
+        getProcessStartMarker: async () => null,
+      });
 
       expect(killSpy).toHaveBeenCalledWith(-5678, "SIGKILL");
-      expect(mockExecFile).toHaveBeenCalledWith(
-        "pgrep",
-        ["-P", "5678"],
-        expect.objectContaining({ timeout: expect.any(Number) }),
-      );
       killSpy.mockRestore();
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
@@ -121,15 +121,13 @@ describe("killProcessTree", () => {
 
   it("polls captured identities until every process is absent", async () => {
     let now = 0;
-    let probes = 0;
+    let markerReads = 0;
     const sleep = vi.fn(async (ms: number) => {
       now += ms;
     });
     const processKill = vi.fn((targetPid: number) => {
       if (targetPid < 0) return;
-      probes += 1;
-      if (probes < 3) return;
-      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      return;
     });
     mockExecFile.mockRejectedValue(
       Object.assign(new Error("no matches"), { code: 1 }),
@@ -141,10 +139,78 @@ describe("killProcessTree", () => {
       sleep,
       now: () => now,
       execFile: mockExecFile,
+      getProcessStartMarker: async () => {
+        markerReads += 1;
+        return markerReads < 5 ? "start-5678" : null;
+      },
     });
 
     expect(sleep).toHaveBeenCalledTimes(2);
     expect(processKill).toHaveBeenCalledWith(-5678, "SIGKILL");
+  });
+
+  it("explicitly kills an escaped descendant deepest-first after the root group signal", async () => {
+    mockExecFile.mockImplementation(async (_command: string, args: string[]) => {
+      if (args.includes("5678")) return { stdout: "6789\n", stderr: "" };
+      if (args.includes("6789")) return { stdout: "7890\n", stderr: "" };
+      throw Object.assign(new Error("no matches"), { code: 1 });
+    });
+    const alive = new Set([5678, 6789, 7890]);
+    const calls: Array<[number, string | number]> = [];
+    const processKill = vi.fn((targetPid: number, signal: string | number) => {
+      calls.push([targetPid, signal]);
+      if (targetPid === -5678) {
+        alive.delete(5678);
+        return;
+      }
+      if (signal === "SIGKILL") {
+        alive.delete(targetPid);
+        return;
+      }
+      if (!alive.has(targetPid)) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+    });
+
+    await killProcessTree(5678, {
+      platform: "linux",
+      processKill,
+      execFile: mockExecFile,
+      getProcessStartMarker: async (pid) => alive.has(pid) ? `start-${pid}` : null,
+    });
+
+    expect(calls).toContainEqual([-5678, "SIGKILL"]);
+    expect(calls).toContainEqual([6789, "SIGKILL"]);
+    expect(calls).toContainEqual([7890, "SIGKILL"]);
+    expect(calls.findIndex(([pid, signal]) => pid === 7890 && signal === "SIGKILL")).toBeLessThan(
+      calls.findIndex(([pid, signal]) => pid === 6789 && signal === "SIGKILL"),
+    );
+  });
+
+  it("never signals a captured PID after its start marker changes", async () => {
+    mockExecFile.mockImplementation(async (_command: string, args: string[]) => {
+      if (args.includes("5678")) return { stdout: "6789\n", stderr: "" };
+      throw Object.assign(new Error("no matches"), { code: 1 });
+    });
+    const markerReads = new Map<number, number>();
+    const processKill = vi.fn((targetPid: number, signal: string | number) => {
+      if (targetPid === -5678) return;
+      if (signal === 0) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    });
+
+    await killProcessTree(5678, {
+      platform: "linux",
+      processKill,
+      execFile: mockExecFile,
+      getProcessStartMarker: async (pid) => {
+        const read = (markerReads.get(pid) ?? 0) + 1;
+        markerReads.set(pid, read);
+        if (pid === 5678 && read > 1) return null;
+        return pid === 6789 && read > 1 ? "replacement" : `start-${pid}`;
+      },
+    });
+
+    expect(processKill).not.toHaveBeenCalledWith(6789, "SIGKILL");
   });
 
   it("rejects when a captured process remains after the verification timeout", async () => {
@@ -194,6 +260,7 @@ describe("killProcessTree", () => {
   });
 
   it("runs taskkill then rejects honestly when CIM enumeration is unavailable", async () => {
+    let markerRead = 0;
     mockExecFile
       .mockRejectedValueOnce(new Error("powershell unavailable"))
       .mockResolvedValueOnce({ stdout: "", stderr: "" });
@@ -201,9 +268,8 @@ describe("killProcessTree", () => {
     await expect(
       killProcessTree(1234, {
         platform: "win32",
-        processKill: vi.fn(() => {
-          throw Object.assign(new Error("gone"), { code: "ESRCH" });
-        }),
+        processKill: vi.fn(),
+        getProcessStartMarker: async () => ++markerRead === 1 ? "start-1234" : null,
         execFile: mockExecFile,
       }),
     ).rejects.toThrow("descendant verification was unavailable");

--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -29,6 +29,7 @@ import { logger } from "@mcode/shared";
 describe("killProcessTree", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockExecFile.mockReset();
   });
 
   it("calls taskkill with /T /F on Windows", async () => {
@@ -54,7 +55,9 @@ describe("killProcessTree", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
-      mockExecFile.mockRejectedValue(new Error("process not found"));
+      mockExecFile
+        .mockResolvedValueOnce({ stdout: "Name,ProcessId\r\n", stderr: "" })
+        .mockRejectedValueOnce(new Error("process not found"));
 
       await expect(killProcessTree(1234)).rejects.toThrow("process not found");
       expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
@@ -70,12 +73,22 @@ describe("killProcessTree", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "linux" });
     try {
-      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+      mockExecFile.mockRejectedValue(
+        Object.assign(new Error("no matches"), { code: 1 }),
+      );
+      const killSpy = vi.spyOn(process, "kill").mockImplementation((pid) => {
+        if (pid > 0) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+        return true;
+      });
 
       await killProcessTree(5678);
 
       expect(killSpy).toHaveBeenCalledWith(-5678, "SIGKILL");
-      expect(mockExecFile).not.toHaveBeenCalled();
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "pgrep",
+        ["-P", "5678"],
+        expect.objectContaining({ timeout: expect.any(Number) }),
+      );
       killSpy.mockRestore();
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
@@ -86,6 +99,9 @@ describe("killProcessTree", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "linux" });
     try {
+      mockExecFile.mockRejectedValue(
+        Object.assign(new Error("no matches"), { code: 1 }),
+      );
       const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
         throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
       });
@@ -101,6 +117,60 @@ describe("killProcessTree", () => {
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }
+  });
+
+  it("polls captured identities until every process is absent", async () => {
+    let now = 0;
+    let probes = 0;
+    const sleep = vi.fn(async (ms: number) => {
+      now += ms;
+    });
+    const processKill = vi.fn((targetPid: number) => {
+      if (targetPid < 0) return;
+      probes += 1;
+      if (probes < 3) return;
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    });
+    mockExecFile.mockRejectedValue(
+      Object.assign(new Error("no matches"), { code: 1 }),
+    );
+
+    await killProcessTree(5678, {
+      platform: "linux",
+      processKill,
+      sleep,
+      now: () => now,
+      execFile: mockExecFile,
+    });
+
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(processKill).toHaveBeenCalledWith(-5678, "SIGKILL");
+  });
+
+  it("rejects when a captured process remains after the verification timeout", async () => {
+    let now = 0;
+    const sleep = vi.fn(async (ms: number) => {
+      now += ms;
+    });
+    mockExecFile.mockRejectedValue(
+      Object.assign(new Error("no matches"), { code: 1 }),
+    );
+
+    await expect(
+      killProcessTree(5678, {
+        platform: "linux",
+        processKill: vi.fn(),
+        sleep,
+        now: () => now,
+        execFile: mockExecFile,
+      }),
+    ).rejects.toThrow("termination verification timed out");
+
+    expect(sleep).toHaveBeenCalledTimes(40);
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "killProcessTree: termination verification timed out",
+      expect.objectContaining({ pid: 5678, remainingPids: [5678] }),
+    );
   });
 
   it("does nothing when pid is 0 on Unix", async () => {
@@ -122,6 +192,7 @@ describe("killProcessTree", () => {
 describe("findDescendantsByName", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockExecFile.mockReset();
   });
 
   it("returns matching PIDs from wmic output on Windows", async () => {
@@ -190,6 +261,11 @@ describe("findDescendantsByName", () => {
 });
 
 describe("listDirectChildren", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecFile.mockReset();
+  });
+
   it("treats pgrep exit code 1 as an idle process with no children", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "linux" });
@@ -206,6 +282,7 @@ describe("listDirectChildren", () => {
 describe("killDescendantsByName", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockExecFile.mockReset();
   });
 
   it("finds and kills matching descendants on Windows", async () => {

--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -18,7 +18,12 @@ vi.mock("@mcode/shared", () => ({
   logger: { warn: vi.fn(), debug: vi.fn(), info: vi.fn() },
 }));
 
-import { killProcessTree, findDescendantsByName, killDescendantsByName } from "../services/process-kill";
+import {
+  killProcessTree,
+  findDescendantsByName,
+  killDescendantsByName,
+  listDirectChildren,
+} from "../services/process-kill";
 import { logger } from "@mcode/shared";
 
 describe("killProcessTree", () => {
@@ -45,13 +50,13 @@ describe("killProcessTree", () => {
     }
   });
 
-  it("does not throw when taskkill fails (process already exited)", async () => {
+  it("rejects when taskkill fails unexpectedly", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
       mockExecFile.mockRejectedValue(new Error("process not found"));
 
-      await expect(killProcessTree(1234)).resolves.toBeUndefined();
+      await expect(killProcessTree(1234)).rejects.toThrow("process not found");
       expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ pid: 1234 }),
@@ -178,6 +183,20 @@ describe("findDescendantsByName", () => {
       const pids = await findDescendantsByName(1234, "claude.exe");
 
       expect(pids).toEqual([]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+});
+
+describe("listDirectChildren", () => {
+  it("treats pgrep exit code 1 as an idle process with no children", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    try {
+      mockExecFile.mockRejectedValue(Object.assign(new Error("no matches"), { code: 1 }));
+
+      await expect(listDirectChildren(1234)).resolves.toEqual([]);
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }

--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -26,6 +26,11 @@ import {
 } from "../services/process-kill";
 import { logger } from "@mcode/shared";
 
+function stableThenGone(stableReads = 2): (pid: number) => Promise<string | null> {
+  let reads = 0;
+  return async (pid) => ++reads <= stableReads ? `start-${pid}` : null;
+}
+
 describe("killProcessTree", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -38,7 +43,11 @@ describe("killProcessTree", () => {
     try {
       mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
 
-      await killProcessTree(1234);
+      await killProcessTree(1234, {
+        platform: "win32",
+        execFile: mockExecFile,
+        getProcessStartMarker: stableThenGone(),
+      });
 
       expect(mockExecFile).toHaveBeenCalledWith(
         "taskkill",
@@ -59,7 +68,11 @@ describe("killProcessTree", () => {
         .mockResolvedValueOnce({ stdout: "", stderr: "" })
         .mockRejectedValueOnce(new Error("process not found"));
 
-      await expect(killProcessTree(1234)).rejects.toThrow("process not found");
+      await expect(killProcessTree(1234, {
+        platform: "win32",
+        execFile: mockExecFile,
+        getProcessStartMarker: stableThenGone(),
+      })).rejects.toThrow("process not found");
       expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ pid: 1234 }),
@@ -85,7 +98,7 @@ describe("killProcessTree", () => {
         platform: "linux",
         processKill: killSpy,
         execFile: mockExecFile,
-        getProcessStartMarker: async () => null,
+        getProcessStartMarker: stableThenGone(),
       });
 
       expect(killSpy).toHaveBeenCalledWith(-5678, "SIGKILL");
@@ -106,7 +119,12 @@ describe("killProcessTree", () => {
         throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
       });
 
-      await expect(killProcessTree(5678)).resolves.toBeUndefined();
+      await expect(killProcessTree(5678, {
+        platform: "linux",
+        processKill: killSpy,
+        execFile: mockExecFile,
+        getProcessStartMarker: stableThenGone(),
+      })).resolves.toBeUndefined();
       // ESRCH means process already gone - expected; logged at debug, not warn.
       expect(vi.mocked(logger.debug)).toHaveBeenCalledWith(
         expect.any(String),
@@ -141,7 +159,7 @@ describe("killProcessTree", () => {
       execFile: mockExecFile,
       getProcessStartMarker: async () => {
         markerReads += 1;
-        return markerReads < 5 ? "start-5678" : null;
+        return markerReads < 6 ? "start-5678" : null;
       },
     });
 
@@ -213,6 +231,42 @@ describe("killProcessTree", () => {
     expect(processKill).not.toHaveBeenCalledWith(6789, "SIGKILL");
   });
 
+  it("does not signal a Unix root group after the captured root is replaced", async () => {
+    mockExecFile.mockRejectedValue(
+      Object.assign(new Error("no matches"), { code: 1 }),
+    );
+    let markerRead = 0;
+    const processKill = vi.fn();
+
+    await killProcessTree(5678, {
+      platform: "linux",
+      processKill,
+      execFile: mockExecFile,
+      getProcessStartMarker: async () => ++markerRead === 1 ? "original" : "replacement",
+    });
+
+    expect(processKill).not.toHaveBeenCalledWith(-5678, "SIGKILL");
+    expect(processKill).not.toHaveBeenCalledWith(5678, "SIGKILL");
+  });
+
+  it("does not taskkill a Windows root after the captured root is replaced", async () => {
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+    let markerRead = 0;
+
+    await killProcessTree(1234, {
+      platform: "win32",
+      processKill: vi.fn(),
+      execFile: mockExecFile,
+      getProcessStartMarker: async () => ++markerRead === 1 ? "original" : "replacement",
+    });
+
+    expect(mockExecFile).not.toHaveBeenCalledWith(
+      "taskkill",
+      expect.arrayContaining(["1234"]),
+      expect.any(Object),
+    );
+  });
+
   it("rejects when a captured process remains after the verification timeout", async () => {
     let now = 0;
     const sleep = vi.fn(async (ms: number) => {
@@ -249,6 +303,7 @@ describe("killProcessTree", () => {
       platform: "win32",
       processKill,
       execFile: mockExecFile,
+      getProcessStartMarker: stableThenGone(),
     });
 
     expect(mockExecFile).toHaveBeenCalledWith(
@@ -260,7 +315,6 @@ describe("killProcessTree", () => {
   });
 
   it("runs taskkill then rejects honestly when CIM enumeration is unavailable", async () => {
-    let markerRead = 0;
     mockExecFile
       .mockRejectedValueOnce(new Error("powershell unavailable"))
       .mockResolvedValueOnce({ stdout: "", stderr: "" });
@@ -269,7 +323,7 @@ describe("killProcessTree", () => {
       killProcessTree(1234, {
         platform: "win32",
         processKill: vi.fn(),
-        getProcessStartMarker: async () => ++markerRead === 1 ? "start-1234" : null,
+        getProcessStartMarker: stableThenGone(),
         execFile: mockExecFile,
       }),
     ).rejects.toThrow("descendant verification was unavailable");
@@ -414,17 +468,28 @@ describe("killDescendantsByName", () => {
           stderr: "",
         })
         .mockResolvedValueOnce({
+          stdout: "start-5555",
+          stderr: "",
+        })
+        .mockResolvedValueOnce({
           stdout: "",
           stderr: "",
         })
+        .mockResolvedValueOnce({
+          stdout: "start-5555",
+          stderr: "",
+        })
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })
         .mockResolvedValueOnce({ stdout: "", stderr: "" });
 
       await killDescendantsByName(1234, "claude.exe");
 
-      // Last call should be taskkill
-      const lastCall = mockExecFile.mock.calls[mockExecFile.mock.calls.length - 1];
-      expect(lastCall?.[0]).toBe("taskkill");
-      expect(lastCall?.[1]).toEqual(["/T", "/F", "/PID", "5555"]);
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "taskkill",
+        ["/T", "/F", "/PID", "5555"],
+        expect.any(Object),
+      );
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }

--- a/apps/server/src/__tests__/process-kill.test.ts
+++ b/apps/server/src/__tests__/process-kill.test.ts
@@ -56,7 +56,7 @@ describe("killProcessTree", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
       mockExecFile
-        .mockResolvedValueOnce({ stdout: "Name,ProcessId\r\n", stderr: "" })
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })
         .mockRejectedValueOnce(new Error("process not found"));
 
       await expect(killProcessTree(1234)).rejects.toThrow("process not found");
@@ -173,6 +173,52 @@ describe("killProcessTree", () => {
     );
   });
 
+  it("kills and verifies on Windows without invoking wmic", async () => {
+    const processKill = vi.fn(() => {
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    });
+    mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+
+    await killProcessTree(1234, {
+      platform: "win32",
+      processKill,
+      execFile: mockExecFile,
+    });
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "taskkill",
+      ["/T", "/F", "/PID", "1234"],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+    expect(mockExecFile.mock.calls.some(([command]) => command === "wmic")).toBe(false);
+  });
+
+  it("runs taskkill then rejects honestly when CIM enumeration is unavailable", async () => {
+    mockExecFile
+      .mockRejectedValueOnce(new Error("powershell unavailable"))
+      .mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+    await expect(
+      killProcessTree(1234, {
+        platform: "win32",
+        processKill: vi.fn(() => {
+          throw Object.assign(new Error("gone"), { code: "ESRCH" });
+        }),
+        execFile: mockExecFile,
+      }),
+    ).rejects.toThrow("descendant verification was unavailable");
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "taskkill",
+      ["/T", "/F", "/PID", "1234"],
+      expect.any(Object),
+    );
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "killProcessTree: descendant verification unavailable",
+      expect.objectContaining({ pid: 1234, capturedProcessCount: 1 }),
+    );
+  });
+
   it("does nothing when pid is 0 on Unix", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "linux" });
@@ -195,26 +241,28 @@ describe("findDescendantsByName", () => {
     mockExecFile.mockReset();
   });
 
-  it("returns matching PIDs from wmic output on Windows", async () => {
+  it("returns matching PIDs from PowerShell CIM output on Windows", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
-      // wmic outputs CSV-like lines: first call for direct children, recursive
       mockExecFile
         .mockResolvedValueOnce({
-          stdout: "Name,ProcessId\r\nclaude.exe,5555\r\nnode.exe,6666\r\n",
+          stdout: JSON.stringify([
+            { Name: "claude.exe", ProcessId: 5555 },
+            { Name: "node.exe", ProcessId: 6666 },
+          ]),
           stderr: "",
         })
         .mockResolvedValueOnce({
-          stdout: "Name,ProcessId\r\n",
+          stdout: "",
           stderr: "",
         })
         .mockResolvedValueOnce({
-          stdout: "Name,ProcessId\r\nclaude.exe,7777\r\n",
+          stdout: JSON.stringify({ Name: "claude.exe", ProcessId: 7777 }),
           stderr: "",
         })
         .mockResolvedValueOnce({
-          stdout: "Name,ProcessId\r\n",
+          stdout: "",
           stderr: "",
         });
 
@@ -233,7 +281,7 @@ describe("findDescendantsByName", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
       mockExecFile.mockResolvedValue({
-        stdout: "Name,ProcessId\r\n",
+        stdout: "",
         stderr: "",
       });
 
@@ -245,11 +293,11 @@ describe("findDescendantsByName", () => {
     }
   });
 
-  it("returns empty array when wmic fails", async () => {
+  it("returns empty array when PowerShell CIM fails", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
-      mockExecFile.mockRejectedValue(new Error("wmic not found"));
+      mockExecFile.mockRejectedValue(new Error("powershell unavailable"));
 
       const pids = await findDescendantsByName(1234, "claude.exe");
 
@@ -292,14 +340,17 @@ describe("killDescendantsByName", () => {
       // First call: findDescendantsByName queries children
       mockExecFile
         .mockResolvedValueOnce({
-          stdout: "Name,ProcessId\r\nclaude.exe,5555\r\n",
+          stdout: JSON.stringify({ Name: "claude.exe", ProcessId: 5555 }),
           stderr: "",
         })
         .mockResolvedValueOnce({
-          stdout: "Name,ProcessId\r\n",
+          stdout: "",
           stderr: "",
         })
-        // Second call: taskkill for the found PID
+        .mockResolvedValueOnce({
+          stdout: "",
+          stderr: "",
+        })
         .mockResolvedValueOnce({ stdout: "", stderr: "" });
 
       await killDescendantsByName(1234, "claude.exe");
@@ -318,13 +369,13 @@ describe("killDescendantsByName", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
       mockExecFile.mockResolvedValue({
-        stdout: "Name,ProcessId\r\n",
+        stdout: "",
         stderr: "",
       });
 
       await killDescendantsByName(1234, "claude.exe");
 
-      // Only the wmic query calls, no taskkill
+      // Only PowerShell CIM enumeration runs when no descendants match.
       for (const call of mockExecFile.mock.calls) {
         expect(call[0]).not.toBe("taskkill");
       }

--- a/apps/server/src/services/job-object.ts
+++ b/apps/server/src/services/job-object.ts
@@ -57,10 +57,10 @@ export class JobObject {
     }
   }
 
-  /** Attach a process to the job. No-op on non-Windows or if the job failed to init. */
-  assign(pid: number): void {
-    if (!this.initialized) return;
-    this.assignWindows(pid);
+  /** Attach a process to the job and report whether required Windows assignment succeeded. */
+  assign(pid: number): boolean {
+    if (!this.initialized) return !this.isWindowsJob;
+    return this.assignWindows(pid);
   }
 
   /** Close the job handle, terminating all assigned processes (Windows). */
@@ -128,24 +128,27 @@ export class JobObject {
     }
   }
 
-  private assignWindows(pid: number): void {
+  private assignWindows(pid: number): boolean {
     const s = this.windowsState!;
     let procHandle: unknown = null;
     try {
       procHandle = s.OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
       if (!procHandle) {
         // Process may already be dead, or we lack access. Best-effort.
-        return;
+        return false;
       }
       const ok = s.AssignProcessToJobObject(s.jobHandle, procHandle);
       if (!ok) {
         logger.debug("JobObject: AssignProcessToJobObject failed", { pid });
+        return false;
       }
+      return true;
     } catch (err) {
       logger.debug("JobObject: assign threw", {
         pid,
         error: err instanceof Error ? err.message : String(err),
       });
+      return false;
     } finally {
       if (procHandle) {
         try { s.CloseHandle(procHandle); } catch { /* ignore */ }

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -2,7 +2,8 @@
  * Platform-aware process tree termination.
  * On Windows, uses taskkill /T /F to kill the entire tree.
  * On Unix, sends SIGKILL to the process group.
- * Never throws - logs warnings on failure (process may already be dead).
+ * Expected already-gone errors are harmless. Other failures reject so callers
+ * cannot report a successful close while descendants may still be running.
  */
 
 import { execFile as execFileCb } from "child_process";
@@ -32,7 +33,7 @@ function isProcessGoneError(err: unknown): boolean {
 
 /**
  * Kill an entire process tree rooted at the given PID.
- * Best-effort: never throws. The process may already be dead.
+ * Rejects when termination fails for a reason other than an already-gone root.
  */
 export async function killProcessTree(pid: number): Promise<void> {
   try {
@@ -55,6 +56,7 @@ export async function killProcessTree(pid: number): Promise<void> {
         pid,
         error: err instanceof Error ? err.message : String(err),
       });
+      throw err;
     }
   }
 }
@@ -255,9 +257,16 @@ export async function listDirectChildren(
   }
 
   // Unix: pgrep -P returns child PIDs, one per line
-  const { stdout } = await execFile("pgrep", ["-P", String(pid)], {
-    timeout: TASKKILL_TIMEOUT_MS,
-  });
+  let stdout: string;
+  try {
+    ({ stdout } = await execFile("pgrep", ["-P", String(pid)], {
+      timeout: TASKKILL_TIMEOUT_MS,
+    }));
+  } catch (err) {
+    const code = (err as { code?: unknown }).code;
+    if (code === 1 || code === "1") return [];
+    throw err;
+  }
   return stdout
     .trim()
     .split("\n")

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -16,8 +16,13 @@ const execFile = promisify(execFileCb);
 // without blocking server shutdown or the cleanup worker's retry loop.
 const TASKKILL_TIMEOUT_MS = 5_000;
 const PROCESS_TREE_LIMIT = 128;
+const PROCESS_ENUMERATION_MAX_BUFFER = 256 * 1024;
 const TERMINATION_VERIFY_TIMEOUT_MS = 2_000;
 const TERMINATION_VERIFY_POLL_MS = 50;
+const POWERSHELL_CHILD_PROCESS_SCRIPT =
+  "& { param([int]$ParentPid) $ErrorActionPreference = 'Stop'; " +
+  "Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $ParentPid) | " +
+  "Select-Object Name,ProcessId | ConvertTo-Json -Compress }";
 
 /** Injectable process-tree termination dependencies for focused verification tests. */
 export interface KillProcessTreeDeps {
@@ -62,16 +67,8 @@ export async function killProcessTree(
     deps?.sleep ??
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const now = deps?.now ?? Date.now;
-  let identities: number[];
-  try {
-    identities = await captureProcessTree(pid, platform, ef);
-  } catch (err) {
-    logger.warn("killProcessTree: failed to capture process identities", {
-      pid,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    throw err;
-  }
+  const capture = await captureProcessTree(pid, platform, ef);
+  const identities = capture.identities;
 
   try {
     if (platform === "win32") {
@@ -124,6 +121,17 @@ export async function killProcessTree(
       `Process-tree termination verification timed out for PTY PID ${pid}; ${remaining.length} process(es) remain`,
     );
   }
+  if (capture.error) {
+    logger.warn("killProcessTree: descendant verification unavailable", {
+      pid,
+      capturedProcessCount: identities.length,
+      error: capture.error instanceof Error ? capture.error.message : String(capture.error),
+    });
+    throw new Error(
+      `Process tree rooted at PTY PID ${pid} was terminated, but descendant verification was unavailable`,
+      { cause: capture.error },
+    );
+  }
   logger.info("Process tree termination verified", {
     pid,
     capturedProcessCount: identities.length,
@@ -134,8 +142,8 @@ async function captureProcessTree(
   rootPid: number,
   platform: NodeJS.Platform,
   ef: typeof execFile,
-): Promise<number[]> {
-  if (rootPid <= 0) return [];
+): Promise<{ identities: number[]; error?: unknown }> {
+  if (rootPid <= 0) return { identities: [] };
   const identities: number[] = [];
   const pending = [rootPid];
   const visited = new Set<number>();
@@ -144,7 +152,12 @@ async function captureProcessTree(
     if (visited.has(currentPid)) continue;
     visited.add(currentPid);
     identities.push(currentPid);
-    const children = await listDirectChildrenWith(currentPid, platform, ef);
+    let children: Array<{ name: string; pid: number }>;
+    try {
+      children = await listDirectChildrenWith(currentPid, platform, ef);
+    } catch (error) {
+      return { identities, error };
+    }
     pending.push(...children.map((child) => child.pid));
   }
   if (pending.length > 0) {
@@ -152,7 +165,7 @@ async function captureProcessTree(
       `Process tree rooted at PTY PID ${rootPid} exceeds the ${PROCESS_TREE_LIMIT}-process verification limit`,
     );
   }
-  return identities;
+  return { identities };
 }
 
 function isProcessRunning(
@@ -170,7 +183,7 @@ function isProcessRunning(
 
 /**
  * Recursively find descendant processes matching a given name.
- * On Windows uses wmic to query the process tree (returns name + PID).
+ * On Windows uses PowerShell CIM to query the process tree (returns name + PID).
  * On Unix uses pgrep (returns PIDs only, without names), so name matching
  * will never produce results there. Callers that need name-based filtering
  * should guard with a platform check (see {@link killDescendantsByName}).
@@ -214,7 +227,7 @@ export async function findDescendantsByName(
  *
  * Windows-only: on Unix, process cwd does not hold ancestor directory
  * handles, so the directory locking problem this solves does not occur.
- * The wmic-based process tree scan also has no Unix equivalent that
+ * The Windows process tree scan also has no Unix equivalent that
  * returns process names without additional per-PID lookups.
  */
 export async function killDescendantsByName(
@@ -364,11 +377,22 @@ async function listDirectChildrenWith(
 ): Promise<Array<{ name: string; pid: number }>> {
   if (platform === "win32") {
     const { stdout } = await ef(
-      "wmic",
-      ["process", "where", `ParentProcessId=${pid}`, "get", "Name,ProcessId", "/format:csv"],
-      { timeout: TASKKILL_TIMEOUT_MS },
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        POWERSHELL_CHILD_PROCESS_SCRIPT,
+        String(pid),
+      ],
+      {
+        timeout: TASKKILL_TIMEOUT_MS,
+        maxBuffer: PROCESS_ENUMERATION_MAX_BUFFER,
+        windowsHide: true,
+      },
     );
-    return parseWmicCsv(stdout);
+    return parsePowerShellProcesses(stdout);
   }
 
   // Unix: pgrep -P returns child PIDs, one per line
@@ -390,21 +414,27 @@ async function listDirectChildrenWith(
     .filter((entry) => !isNaN(entry.pid));
 }
 
-/** Parse wmic CSV output into name/pid pairs. */
-function parseWmicCsv(output: string): Array<{ name: string; pid: number }> {
-  const lines = output.split(/\r?\n/).filter((l) => l.trim());
-  if (lines.length < 2) return [];
-
-  const header = lines[0]!.toLowerCase();
-  const nameIdx = header.split(",").findIndex((col) => col.trim() === "name");
-  const pidIdx = header.split(",").findIndex((col) => col.trim() === "processid");
-  if (nameIdx === -1 || pidIdx === -1) return [];
-
-  return lines.slice(1).reduce<Array<{ name: string; pid: number }>>((acc, line) => {
-    const cols = line.split(",");
-    const name = cols[nameIdx]?.trim() ?? "";
-    const pid = parseInt(cols[pidIdx]?.trim() ?? "", 10);
-    if (name && !isNaN(pid)) acc.push({ name, pid });
-    return acc;
-  }, []);
+/** Parse bounded PowerShell CIM JSON into validated name/PID pairs. */
+function parsePowerShellProcesses(
+  output: string,
+): Array<{ name: string; pid: number }> {
+  if (!output.trim()) return [];
+  const parsed: unknown = JSON.parse(output);
+  const values = Array.isArray(parsed) ? parsed : [parsed];
+  return values.flatMap((value) => {
+    if (typeof value !== "object" || value === null) return [];
+    const record = value as Record<string, unknown>;
+    const name = record["Name"];
+    const pid = record["ProcessId"];
+    if (
+      typeof name !== "string" ||
+      name.length === 0 ||
+      typeof pid !== "number" ||
+      !Number.isSafeInteger(pid) ||
+      pid <= 0
+    ) {
+      return [];
+    }
+    return [{ name, pid }];
+  });
 }

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -123,6 +123,17 @@ export async function killProcessTree(
           }
         }
       : (targetPid: number) => readUnixProcessStartMarker(targetPid, ef));
+  const getRemainingProcessStartMarkers =
+    deps?.getProcessStartMarker || deps?.processKill
+    ? async (identities: readonly ProcessIdentity[]) => {
+        const markers = new Map<number, string | null>();
+        for (const identity of identities) {
+          markers.set(identity.pid, await getProcessStartMarker(identity.pid));
+        }
+        return markers;
+      }
+    : (identities: readonly ProcessIdentity[]) =>
+        readUnixProcessStartMarkers(identities.map((identity) => identity.pid), ef);
   const capture = await captureProcessTree(pid, platform, ef, getProcessStartMarker);
   const identities = capture.identities;
   const capturedRoot = identities.find((identity) => identity.depth === 0);
@@ -160,19 +171,16 @@ export async function killProcessTree(
   const deadline = now() + TERMINATION_VERIFY_TIMEOUT_MS;
   let remaining: ProcessIdentity[];
   try {
-    remaining = [];
-    for (const identity of identities) {
-      if (await identityStillMatches(identity, getProcessStartMarker)) remaining.push(identity);
-    }
+    remaining = matchingIdentities(
+      identities,
+      await getRemainingProcessStartMarkers(identities),
+    );
     while (remaining.length > 0 && now() < deadline) {
       await sleep(TERMINATION_VERIFY_POLL_MS);
-      const stillRunning: ProcessIdentity[] = [];
-      for (const identity of remaining) {
-        if (await identityStillMatches(identity, getProcessStartMarker)) {
-          stillRunning.push(identity);
-        }
-      }
-      remaining = stillRunning;
+      remaining = matchingIdentities(
+        remaining,
+        await getRemainingProcessStartMarkers(remaining),
+      );
     }
   } catch (err) {
     logger.warn("killProcessTree: termination verification failed", {
@@ -443,6 +451,39 @@ async function identityStillMatches(
   getProcessStartMarker: (pid: number) => Promise<string | null>,
 ): Promise<boolean> {
   return (await getProcessStartMarker(identity.pid)) === identity.startMarker;
+}
+
+function matchingIdentities(
+  identities: readonly ProcessIdentity[],
+  markers: ReadonlyMap<number, string | null>,
+): ProcessIdentity[] {
+  return identities.filter(
+    (identity) => markers.get(identity.pid) === identity.startMarker,
+  );
+}
+
+async function readUnixProcessStartMarkers(
+  pids: readonly number[],
+  ef: typeof execFile,
+): Promise<Map<number, string>> {
+  if (pids.length === 0) return new Map();
+  try {
+    const { stdout } = await ef(
+      "ps",
+      ["-o", "pid=,lstart=", "-p", pids.join(",")],
+      { timeout: TASKKILL_TIMEOUT_MS },
+    );
+    const markers = new Map<number, string>();
+    for (const line of stdout.split(/\r?\n/)) {
+      const match = /^\s*(\d+)\s+(.+?)\s*$/.exec(line);
+      if (!match) continue;
+      markers.set(Number(match[1]), match[2]);
+    }
+    return markers;
+  } catch (err) {
+    if (isProcessGoneError(err) || (err as { code?: unknown }).code === 1) return new Map();
+    throw err;
+  }
 }
 
 async function readUnixProcessStartMarker(

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -23,10 +23,17 @@ const POWERSHELL_CHILD_PROCESS_SCRIPT =
   "& { param([int]$ParentPid) $ErrorActionPreference = 'Stop'; " +
   "Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $ParentPid) | " +
   "Select-Object Name,ProcessId | ConvertTo-Json -Compress }";
-const POWERSHELL_START_MARKER_SCRIPT =
-  "& { param([int]$ProcessId) $ErrorActionPreference = 'Stop'; " +
-  "Get-CimInstance Win32_Process -Filter ('ProcessId = ' + $ProcessId) | " +
-  "Select-Object -ExpandProperty CreationDate }";
+const POWERSHELL_PROCESS_SNAPSHOT_SCRIPT =
+  "$ErrorActionPreference = 'Stop'; Get-CimInstance Win32_Process | " +
+  "Select-Object Name,ProcessId,ParentProcessId,CreationDate | ConvertTo-Json -Compress";
+
+/** Validated process record returned by a bounded Windows CIM snapshot. */
+export interface WindowsProcessSnapshotEntry {
+  readonly pid: number;
+  readonly parentPid: number;
+  readonly startMarker: string;
+  readonly name: string;
+}
 
 interface ProcessIdentity {
   readonly pid: number;
@@ -43,6 +50,8 @@ export interface KillProcessTreeDeps {
   readonly sleep?: (ms: number) => Promise<void>;
   readonly now?: () => number;
   readonly getProcessStartMarker?: (pid: number) => Promise<string | null>;
+  readonly getWindowsProcessSnapshot?: () => Promise<readonly WindowsProcessSnapshotEntry[]>;
+  readonly isProcessAlive?: (pid: number) => boolean;
 }
 
 /**
@@ -79,6 +88,28 @@ export async function killProcessTree(
     deps?.sleep ??
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const now = deps?.now ?? Date.now;
+  if (platform === "win32") {
+    return killWindowsProcessTree(pid, {
+      execFile: ef,
+      processKill,
+      sleep,
+      now,
+      getSnapshot:
+        deps?.getWindowsProcessSnapshot ??
+        (() => readWindowsProcessSnapshot(ef)),
+      isProcessAlive:
+        deps?.isProcessAlive ??
+        ((targetPid) => {
+          try {
+            processKill(targetPid, 0);
+            return true;
+          } catch (err) {
+            if (isProcessGoneError(err)) return false;
+            throw err;
+          }
+        }),
+    });
+  }
   const getProcessStartMarker =
     deps?.getProcessStartMarker ??
     (deps?.processKill
@@ -91,7 +122,7 @@ export async function killProcessTree(
             throw err;
           }
         }
-      : (targetPid: number) => readProcessStartMarker(targetPid, platform, ef));
+      : (targetPid: number) => readUnixProcessStartMarker(targetPid, ef));
   const capture = await captureProcessTree(pid, platform, ef, getProcessStartMarker);
   const identities = capture.identities;
   const capturedRoot = identities.find((identity) => identity.depth === 0);
@@ -100,17 +131,9 @@ export async function killProcessTree(
     await identityStillMatches(capturedRoot, getProcessStartMarker);
 
   try {
-    if (platform === "win32") {
-      if (rootStillMatches) {
-        await ef("taskkill", ["/T", "/F", "/PID", String(pid)], {
-          timeout: TASKKILL_TIMEOUT_MS,
-        });
-      }
-    } else {
-      // Guard against pid <= 0: process.kill(0) would kill the server's own group.
-      if (pid > 0 && rootStillMatches) {
-        processKill(-pid, "SIGKILL");
-      }
+    // Guard against pid <= 0: process.kill(0) would kill the server's own group.
+    if (pid > 0 && rootStillMatches) {
+      processKill(-pid, "SIGKILL");
     }
   } catch (err) {
     if (isProcessGoneError(err)) {
@@ -128,13 +151,7 @@ export async function killProcessTree(
   for (const identity of [...identities].sort((a, b) => b.depth - a.depth)) {
     if (!(await identityStillMatches(identity, getProcessStartMarker))) continue;
     try {
-      if (platform === "win32") {
-        await ef("taskkill", ["/F", "/PID", String(identity.pid)], {
-          timeout: TASKKILL_TIMEOUT_MS,
-        });
-      } else {
-        processKill(identity.pid, "SIGKILL");
-      }
+      processKill(identity.pid, "SIGKILL");
     } catch (err) {
       if (!isProcessGoneError(err)) throw err;
     }
@@ -193,6 +210,189 @@ export async function killProcessTree(
   });
 }
 
+interface WindowsKillContext {
+  readonly execFile: typeof execFile;
+  readonly processKill: (pid: number, signal: string | number) => void;
+  readonly sleep: (ms: number) => Promise<void>;
+  readonly now: () => number;
+  readonly getSnapshot: () => Promise<readonly WindowsProcessSnapshotEntry[]>;
+  readonly isProcessAlive: (pid: number) => boolean;
+}
+
+async function killWindowsProcessTree(
+  pid: number,
+  context: WindowsKillContext,
+): Promise<void> {
+  if (pid <= 0) return;
+  const captured = buildWindowsProcessTree(pid, await context.getSnapshot());
+  const root = captured.find((identity) => identity.depth === 0);
+  const beforeKill = indexWindowsSnapshot(await context.getSnapshot());
+  const rootStillMatches =
+    root !== undefined &&
+    beforeKill.get(root.pid)?.startMarker === root.startMarker;
+
+  if (rootStillMatches) {
+    try {
+      await context.execFile("taskkill", ["/T", "/F", "/PID", String(pid)], {
+        timeout: TASKKILL_TIMEOUT_MS,
+      });
+    } catch (err) {
+      if (isProcessGoneError(err)) {
+        logger.debug("killProcessTree: process already gone", { pid });
+      } else {
+        logger.warn("killProcessTree: unexpected error killing process tree", {
+          pid,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+    }
+  }
+
+  const survivors = await classifyMatchingWindowsProcesses(captured, context);
+  const signaled: ProcessIdentity[] = [];
+  for (const identity of [...survivors].sort((a, b) => b.depth - a.depth)) {
+    try {
+      await context.execFile("taskkill", ["/F", "/PID", String(identity.pid)], {
+        timeout: TASKKILL_TIMEOUT_MS,
+      });
+      signaled.push(identity);
+    } catch (err) {
+      if (!isProcessGoneError(err)) throw err;
+    }
+  }
+
+  const deadline = context.now() + TERMINATION_VERIFY_TIMEOUT_MS;
+  let remaining = await classifyMatchingWindowsProcesses(signaled, context);
+  while (remaining.length > 0 && context.now() < deadline) {
+    await context.sleep(TERMINATION_VERIFY_POLL_MS);
+    remaining = await classifyMatchingWindowsProcesses(remaining, context);
+  }
+  if (remaining.length > 0) {
+    logger.warn("killProcessTree: termination verification timed out", {
+      pid,
+      capturedProcessCount: captured.length,
+      remainingPids: remaining.map((identity) => identity.pid),
+      timeoutMs: TERMINATION_VERIFY_TIMEOUT_MS,
+    });
+    throw new Error(
+      `Process-tree termination verification timed out for PTY PID ${pid}; ${remaining.length} process(es) remain`,
+    );
+  }
+  logger.info("Process tree termination verified", {
+    pid,
+    capturedProcessCount: captured.length,
+  });
+}
+
+async function classifyMatchingWindowsProcesses(
+  identities: readonly ProcessIdentity[],
+  context: WindowsKillContext,
+): Promise<ProcessIdentity[]> {
+  const apparentlyAlive = identities.filter((identity) =>
+    context.isProcessAlive(identity.pid));
+  if (apparentlyAlive.length === 0) return [];
+  const snapshot = indexWindowsSnapshot(await context.getSnapshot());
+  return apparentlyAlive.filter(
+    (identity) => snapshot.get(identity.pid)?.startMarker === identity.startMarker,
+  );
+}
+
+function buildWindowsProcessTree(
+  rootPid: number,
+  snapshot: readonly WindowsProcessSnapshotEntry[],
+): ProcessIdentity[] {
+  const byPid = indexWindowsSnapshot(snapshot);
+  const root = byPid.get(rootPid);
+  if (!root) return [];
+  const childrenByParent = new Map<number, WindowsProcessSnapshotEntry[]>();
+  for (const entry of snapshot) {
+    const children = childrenByParent.get(entry.parentPid) ?? [];
+    children.push(entry);
+    childrenByParent.set(entry.parentPid, children);
+  }
+  const identities: ProcessIdentity[] = [];
+  const pending = [{ pid: rootPid, parentPid: null as number | null, depth: 0 }];
+  const visited = new Set<number>();
+  while (pending.length > 0 && identities.length < PROCESS_TREE_LIMIT) {
+    const current = pending.shift()!;
+    if (visited.has(current.pid)) continue;
+    visited.add(current.pid);
+    const entry = byPid.get(current.pid);
+    if (!entry) continue;
+    identities.push({ ...current, startMarker: entry.startMarker });
+    pending.push(
+      ...(childrenByParent.get(current.pid) ?? []).map((child) => ({
+        pid: child.pid,
+        parentPid: current.pid,
+        depth: current.depth + 1,
+      })),
+    );
+  }
+  if (pending.length > 0) {
+    throw new Error(
+      `Process tree rooted at PTY PID ${rootPid} exceeds the ${PROCESS_TREE_LIMIT}-process verification limit`,
+    );
+  }
+  return identities;
+}
+
+function indexWindowsSnapshot(
+  snapshot: readonly WindowsProcessSnapshotEntry[],
+): Map<number, WindowsProcessSnapshotEntry> {
+  return new Map(snapshot.map((entry) => [entry.pid, entry]));
+}
+
+async function readWindowsProcessSnapshot(
+  ef: typeof execFile,
+): Promise<WindowsProcessSnapshotEntry[]> {
+  const { stdout } = await ef(
+    "powershell.exe",
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      POWERSHELL_PROCESS_SNAPSHOT_SCRIPT,
+    ],
+    {
+      timeout: TASKKILL_TIMEOUT_MS,
+      maxBuffer: PROCESS_ENUMERATION_MAX_BUFFER,
+      windowsHide: true,
+    },
+  );
+  return parseWindowsProcessSnapshot(stdout);
+}
+
+function parseWindowsProcessSnapshot(output: string): WindowsProcessSnapshotEntry[] {
+  if (!output.trim()) return [];
+  const parsed: unknown = JSON.parse(output);
+  const values = Array.isArray(parsed) ? parsed : [parsed];
+  return values.flatMap((value) => {
+    if (typeof value !== "object" || value === null) return [];
+    const record = value as Record<string, unknown>;
+    const pid = record["ProcessId"];
+    const parentPid = record["ParentProcessId"];
+    const startMarker = record["CreationDate"];
+    const name = record["Name"];
+    if (
+      typeof pid !== "number" ||
+      !Number.isSafeInteger(pid) ||
+      pid <= 0 ||
+      typeof parentPid !== "number" ||
+      !Number.isSafeInteger(parentPid) ||
+      parentPid < 0 ||
+      typeof startMarker !== "string" ||
+      startMarker.length === 0 ||
+      typeof name !== "string" ||
+      name.length === 0
+    ) {
+      return [];
+    }
+    return [{ pid, parentPid, startMarker, name }];
+  });
+}
+
 async function captureProcessTree(
   rootPid: number,
   platform: NodeJS.Platform,
@@ -245,31 +445,11 @@ async function identityStillMatches(
   return (await getProcessStartMarker(identity.pid)) === identity.startMarker;
 }
 
-async function readProcessStartMarker(
+async function readUnixProcessStartMarker(
   pid: number,
-  platform: NodeJS.Platform,
   ef: typeof execFile,
 ): Promise<string | null> {
   try {
-    if (platform === "win32") {
-      const { stdout } = await ef(
-        "powershell.exe",
-        [
-          "-NoLogo",
-          "-NoProfile",
-          "-NonInteractive",
-          "-Command",
-          POWERSHELL_START_MARKER_SCRIPT,
-          String(pid),
-        ],
-        {
-          timeout: TASKKILL_TIMEOUT_MS,
-          maxBuffer: PROCESS_ENUMERATION_MAX_BUFFER,
-          windowsHide: true,
-        },
-      );
-      return stdout.trim() || null;
-    }
     const { stdout } = await ef("ps", ["-o", "lstart=", "-p", String(pid)], {
       timeout: TASKKILL_TIMEOUT_MS,
     });

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -23,6 +23,17 @@ const POWERSHELL_CHILD_PROCESS_SCRIPT =
   "& { param([int]$ParentPid) $ErrorActionPreference = 'Stop'; " +
   "Get-CimInstance Win32_Process -Filter ('ParentProcessId = ' + $ParentPid) | " +
   "Select-Object Name,ProcessId | ConvertTo-Json -Compress }";
+const POWERSHELL_START_MARKER_SCRIPT =
+  "& { param([int]$ProcessId) $ErrorActionPreference = 'Stop'; " +
+  "Get-CimInstance Win32_Process -Filter ('ProcessId = ' + $ProcessId) | " +
+  "Select-Object -ExpandProperty CreationDate }";
+
+interface ProcessIdentity {
+  readonly pid: number;
+  readonly parentPid: number | null;
+  readonly startMarker: string;
+  readonly depth: number;
+}
 
 /** Injectable process-tree termination dependencies for focused verification tests. */
 export interface KillProcessTreeDeps {
@@ -31,6 +42,7 @@ export interface KillProcessTreeDeps {
   readonly processKill?: (pid: number, signal: string | number) => void;
   readonly sleep?: (ms: number) => Promise<void>;
   readonly now?: () => number;
+  readonly getProcessStartMarker?: (pid: number) => Promise<string | null>;
 }
 
 /**
@@ -67,7 +79,20 @@ export async function killProcessTree(
     deps?.sleep ??
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const now = deps?.now ?? Date.now;
-  const capture = await captureProcessTree(pid, platform, ef);
+  const getProcessStartMarker =
+    deps?.getProcessStartMarker ??
+    (deps?.processKill
+      ? async (targetPid: number) => {
+          try {
+            processKill(targetPid, 0);
+            return `probe:${targetPid}`;
+          } catch (err) {
+            if (isProcessGoneError(err)) return null;
+            throw err;
+          }
+        }
+      : (targetPid: number) => readProcessStartMarker(targetPid, platform, ef));
+  const capture = await captureProcessTree(pid, platform, ef, getProcessStartMarker);
   const identities = capture.identities;
 
   try {
@@ -94,13 +119,37 @@ export async function killProcessTree(
     }
   }
 
+  for (const identity of [...identities].sort((a, b) => b.depth - a.depth)) {
+    if (!(await identityStillMatches(identity, getProcessStartMarker))) continue;
+    try {
+      if (platform === "win32") {
+        await ef("taskkill", ["/F", "/PID", String(identity.pid)], {
+          timeout: TASKKILL_TIMEOUT_MS,
+        });
+      } else {
+        processKill(identity.pid, "SIGKILL");
+      }
+    } catch (err) {
+      if (!isProcessGoneError(err)) throw err;
+    }
+  }
+
   const deadline = now() + TERMINATION_VERIFY_TIMEOUT_MS;
-  let remaining: number[];
+  let remaining: ProcessIdentity[];
   try {
-    remaining = identities.filter((identity) => isProcessRunning(identity, processKill));
+    remaining = [];
+    for (const identity of identities) {
+      if (await identityStillMatches(identity, getProcessStartMarker)) remaining.push(identity);
+    }
     while (remaining.length > 0 && now() < deadline) {
       await sleep(TERMINATION_VERIFY_POLL_MS);
-      remaining = remaining.filter((identity) => isProcessRunning(identity, processKill));
+      const stillRunning: ProcessIdentity[] = [];
+      for (const identity of remaining) {
+        if (await identityStillMatches(identity, getProcessStartMarker)) {
+          stillRunning.push(identity);
+        }
+      }
+      remaining = stillRunning;
     }
   } catch (err) {
     logger.warn("killProcessTree: termination verification failed", {
@@ -114,7 +163,7 @@ export async function killProcessTree(
     logger.warn("killProcessTree: termination verification timed out", {
       pid,
       capturedProcessCount: identities.length,
-      remainingPids: remaining,
+      remainingPids: remaining.map((identity) => identity.pid),
       timeoutMs: TERMINATION_VERIFY_TIMEOUT_MS,
     });
     throw new Error(
@@ -142,23 +191,38 @@ async function captureProcessTree(
   rootPid: number,
   platform: NodeJS.Platform,
   ef: typeof execFile,
-): Promise<{ identities: number[]; error?: unknown }> {
+  getProcessStartMarker: (pid: number) => Promise<string | null>,
+): Promise<{ identities: ProcessIdentity[]; error?: unknown }> {
   if (rootPid <= 0) return { identities: [] };
-  const identities: number[] = [];
-  const pending = [rootPid];
+  const identities: ProcessIdentity[] = [];
+  const pending = [{ pid: rootPid, parentPid: null as number | null, depth: 0 }];
   const visited = new Set<number>();
   while (pending.length > 0 && identities.length < PROCESS_TREE_LIMIT) {
-    const currentPid = pending.shift()!;
+    const current = pending.shift()!;
+    const currentPid = current.pid;
     if (visited.has(currentPid)) continue;
     visited.add(currentPid);
-    identities.push(currentPid);
+    let startMarker: string | null;
+    try {
+      startMarker = await getProcessStartMarker(currentPid);
+    } catch (error) {
+      return { identities, error };
+    }
+    if (startMarker === null) continue;
+    identities.push({ ...current, startMarker });
     let children: Array<{ name: string; pid: number }>;
     try {
       children = await listDirectChildrenWith(currentPid, platform, ef);
     } catch (error) {
       return { identities, error };
     }
-    pending.push(...children.map((child) => child.pid));
+    pending.push(
+      ...children.map((child) => ({
+        pid: child.pid,
+        parentPid: currentPid,
+        depth: current.depth + 1,
+      })),
+    );
   }
   if (pending.length > 0) {
     throw new Error(
@@ -168,15 +232,44 @@ async function captureProcessTree(
   return { identities };
 }
 
-function isProcessRunning(
+async function identityStillMatches(
+  identity: ProcessIdentity,
+  getProcessStartMarker: (pid: number) => Promise<string | null>,
+): Promise<boolean> {
+  return (await getProcessStartMarker(identity.pid)) === identity.startMarker;
+}
+
+async function readProcessStartMarker(
   pid: number,
-  processKill: (pid: number, signal: string | number) => void,
-): boolean {
+  platform: NodeJS.Platform,
+  ef: typeof execFile,
+): Promise<string | null> {
   try {
-    processKill(pid, 0);
-    return true;
+    if (platform === "win32") {
+      const { stdout } = await ef(
+        "powershell.exe",
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          POWERSHELL_START_MARKER_SCRIPT,
+          String(pid),
+        ],
+        {
+          timeout: TASKKILL_TIMEOUT_MS,
+          maxBuffer: PROCESS_ENUMERATION_MAX_BUFFER,
+          windowsHide: true,
+        },
+      );
+      return stdout.trim() || null;
+    }
+    const { stdout } = await ef("ps", ["-o", "lstart=", "-p", String(pid)], {
+      timeout: TASKKILL_TIMEOUT_MS,
+    });
+    return stdout.trim() || null;
   } catch (err) {
-    if (isProcessGoneError(err)) return false;
+    if (isProcessGoneError(err) || (err as { code?: unknown }).code === 1) return null;
     throw err;
   }
 }

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -15,6 +15,18 @@ const execFile = promisify(execFileCb);
 // 5 s gives taskkill enough time to propagate through a deep process tree
 // without blocking server shutdown or the cleanup worker's retry loop.
 const TASKKILL_TIMEOUT_MS = 5_000;
+const PROCESS_TREE_LIMIT = 128;
+const TERMINATION_VERIFY_TIMEOUT_MS = 2_000;
+const TERMINATION_VERIFY_POLL_MS = 50;
+
+/** Injectable process-tree termination dependencies for focused verification tests. */
+export interface KillProcessTreeDeps {
+  readonly execFile?: typeof execFile;
+  readonly platform?: NodeJS.Platform;
+  readonly processKill?: (pid: number, signal: string | number) => void;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly now?: () => number;
+}
 
 /**
  * Returns true when the error indicates the process was already gone.
@@ -35,16 +47,41 @@ function isProcessGoneError(err: unknown): boolean {
  * Kill an entire process tree rooted at the given PID.
  * Rejects when termination fails for a reason other than an already-gone root.
  */
-export async function killProcessTree(pid: number): Promise<void> {
+export async function killProcessTree(
+  pid: number,
+  deps?: KillProcessTreeDeps,
+): Promise<void> {
+  const ef = deps?.execFile ?? execFile;
+  const platform = deps?.platform ?? process.platform;
+  const processKill =
+    deps?.processKill ??
+    ((targetPid: number, signal: string | number) => {
+      process.kill(targetPid, signal as NodeJS.Signals);
+    });
+  const sleep =
+    deps?.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const now = deps?.now ?? Date.now;
+  let identities: number[];
   try {
-    if (process.platform === "win32") {
-      await execFile("taskkill", ["/T", "/F", "/PID", String(pid)], {
+    identities = await captureProcessTree(pid, platform, ef);
+  } catch (err) {
+    logger.warn("killProcessTree: failed to capture process identities", {
+      pid,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+
+  try {
+    if (platform === "win32") {
+      await ef("taskkill", ["/T", "/F", "/PID", String(pid)], {
         timeout: TASKKILL_TIMEOUT_MS,
       });
     } else {
       // Guard against pid <= 0: process.kill(0) would kill the server's own group.
       if (pid > 0) {
-        process.kill(-pid, "SIGKILL");
+        processKill(-pid, "SIGKILL");
       }
     }
   } catch (err) {
@@ -58,6 +95,76 @@ export async function killProcessTree(pid: number): Promise<void> {
       });
       throw err;
     }
+  }
+
+  const deadline = now() + TERMINATION_VERIFY_TIMEOUT_MS;
+  let remaining: number[];
+  try {
+    remaining = identities.filter((identity) => isProcessRunning(identity, processKill));
+    while (remaining.length > 0 && now() < deadline) {
+      await sleep(TERMINATION_VERIFY_POLL_MS);
+      remaining = remaining.filter((identity) => isProcessRunning(identity, processKill));
+    }
+  } catch (err) {
+    logger.warn("killProcessTree: termination verification failed", {
+      pid,
+      capturedProcessCount: identities.length,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+  if (remaining.length > 0) {
+    logger.warn("killProcessTree: termination verification timed out", {
+      pid,
+      capturedProcessCount: identities.length,
+      remainingPids: remaining,
+      timeoutMs: TERMINATION_VERIFY_TIMEOUT_MS,
+    });
+    throw new Error(
+      `Process-tree termination verification timed out for PTY PID ${pid}; ${remaining.length} process(es) remain`,
+    );
+  }
+  logger.info("Process tree termination verified", {
+    pid,
+    capturedProcessCount: identities.length,
+  });
+}
+
+async function captureProcessTree(
+  rootPid: number,
+  platform: NodeJS.Platform,
+  ef: typeof execFile,
+): Promise<number[]> {
+  if (rootPid <= 0) return [];
+  const identities: number[] = [];
+  const pending = [rootPid];
+  const visited = new Set<number>();
+  while (pending.length > 0 && identities.length < PROCESS_TREE_LIMIT) {
+    const currentPid = pending.shift()!;
+    if (visited.has(currentPid)) continue;
+    visited.add(currentPid);
+    identities.push(currentPid);
+    const children = await listDirectChildrenWith(currentPid, platform, ef);
+    pending.push(...children.map((child) => child.pid));
+  }
+  if (pending.length > 0) {
+    throw new Error(
+      `Process tree rooted at PTY PID ${rootPid} exceeds the ${PROCESS_TREE_LIMIT}-process verification limit`,
+    );
+  }
+  return identities;
+}
+
+function isProcessRunning(
+  pid: number,
+  processKill: (pid: number, signal: string | number) => void,
+): boolean {
+  try {
+    processKill(pid, 0);
+    return true;
+  } catch (err) {
+    if (isProcessGoneError(err)) return false;
+    throw err;
   }
 }
 
@@ -247,8 +354,16 @@ function isEsrch(err: unknown): boolean {
 export async function listDirectChildren(
   pid: number,
 ): Promise<Array<{ name: string; pid: number }>> {
-  if (process.platform === "win32") {
-    const { stdout } = await execFile(
+  return listDirectChildrenWith(pid, process.platform, execFile);
+}
+
+async function listDirectChildrenWith(
+  pid: number,
+  platform: NodeJS.Platform,
+  ef: typeof execFile,
+): Promise<Array<{ name: string; pid: number }>> {
+  if (platform === "win32") {
+    const { stdout } = await ef(
       "wmic",
       ["process", "where", `ParentProcessId=${pid}`, "get", "Name,ProcessId", "/format:csv"],
       { timeout: TASKKILL_TIMEOUT_MS },
@@ -259,7 +374,7 @@ export async function listDirectChildren(
   // Unix: pgrep -P returns child PIDs, one per line
   let stdout: string;
   try {
-    ({ stdout } = await execFile("pgrep", ["-P", String(pid)], {
+    ({ stdout } = await ef("pgrep", ["-P", String(pid)], {
       timeout: TASKKILL_TIMEOUT_MS,
     }));
   } catch (err) {

--- a/apps/server/src/services/process-kill.ts
+++ b/apps/server/src/services/process-kill.ts
@@ -94,15 +94,21 @@ export async function killProcessTree(
       : (targetPid: number) => readProcessStartMarker(targetPid, platform, ef));
   const capture = await captureProcessTree(pid, platform, ef, getProcessStartMarker);
   const identities = capture.identities;
+  const capturedRoot = identities.find((identity) => identity.depth === 0);
+  const rootStillMatches =
+    capturedRoot !== undefined &&
+    await identityStillMatches(capturedRoot, getProcessStartMarker);
 
   try {
     if (platform === "win32") {
-      await ef("taskkill", ["/T", "/F", "/PID", String(pid)], {
-        timeout: TASKKILL_TIMEOUT_MS,
-      });
+      if (rootStillMatches) {
+        await ef("taskkill", ["/T", "/F", "/PID", String(pid)], {
+          timeout: TASKKILL_TIMEOUT_MS,
+        });
+      }
     } else {
       // Guard against pid <= 0: process.kill(0) would kill the server's own group.
-      if (pid > 0) {
+      if (pid > 0 && rootStillMatches) {
         processKill(-pid, "SIGKILL");
       }
     }

--- a/apps/server/src/services/terminal-service.test.ts
+++ b/apps/server/src/services/terminal-service.test.ts
@@ -159,6 +159,10 @@ describe("TerminalService Windows teardown", () => {
       pty,
       dataDisposable: { dispose: vi.fn() },
       exitDisposable: { dispose: vi.fn() },
+      processScope: {
+        ownsProcessTree: false,
+        close: vi.fn(),
+      },
     };
     const internals = service as unknown as {
       sessions: Map<string, typeof session>;
@@ -295,7 +299,130 @@ describe("TerminalService Windows teardown", () => {
     expect(service.listActiveSessions()).toEqual([]);
   });
 
-  function createService(): TerminalService {
+  it("uses the healthy Windows process scope without the slow process-tree fallback", async () => {
+    const terminate = vi.fn(() => ({ ok: true }));
+    const waitForEmpty = vi.fn().mockResolvedValue({ ok: true });
+    const close = vi.fn();
+    const processScope = {
+      ready: true,
+      ownsProcessTree: true,
+      assign: vi.fn(() => ({ ok: true })),
+      terminate,
+      waitForEmpty,
+      close,
+    };
+    const service = createService(
+      { assign: vi.fn(() => true), setDescription: vi.fn() },
+      { create: () => processScope },
+    );
+    const { ptyId } = service.create("thread-1");
+
+    await service.kill(ptyId);
+
+    expect(terminate).toHaveBeenCalledOnce();
+    expect(waitForEmpty).toHaveBeenCalledWith(1_900);
+    expect(killProcessTree).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("assigns the global job before the terminal child job", () => {
+    const calls: string[] = [];
+    const service = createService(
+      { assign: vi.fn(() => { calls.push("global"); return true; }), setDescription: vi.fn() },
+      {
+        create: () => ({
+          ready: true,
+          ownsProcessTree: true,
+          assign: vi.fn(() => { calls.push("child"); return { ok: true }; }),
+          terminate: vi.fn(),
+          waitForEmpty: vi.fn(),
+          close: vi.fn(),
+        }),
+      },
+    );
+
+    service.create("thread-1");
+
+    expect(calls).toEqual(["global", "child"]);
+  });
+
+  it("closes the child scope when the terminal exits naturally", () => {
+    const close = vi.fn();
+    const service = createService(
+      { assign: vi.fn(() => true), setDescription: vi.fn() },
+      {
+        create: () => ({
+          ready: true,
+          ownsProcessTree: true,
+          assign: vi.fn(() => ({ ok: true })),
+          terminate: vi.fn(),
+          waitForEmpty: vi.fn(),
+          close,
+        }),
+      },
+    );
+    service.create("thread-1");
+
+    onExit?.({ exitCode: 0, signal: 0 });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("checks the healthy Windows scope without launching child-process discovery", async () => {
+    const queryProcessIds = vi.fn(() => ({
+      ok: true,
+      processIds: [10_001, 10_002],
+      overflow: false,
+    }));
+    const service = createService(
+      { assign: vi.fn(() => true), setDescription: vi.fn() },
+      {
+        create: () => ({
+          ready: true,
+          ownsProcessTree: true,
+          assign: vi.fn(() => ({ ok: true })),
+          queryProcessIds,
+          terminate: vi.fn(),
+          waitForEmpty: vi.fn(),
+          close: vi.fn(),
+        }),
+      },
+    );
+    const { ptyId } = service.create("thread-1");
+
+    await expect(service.hasChildren(ptyId)).resolves.toEqual({ hasChildren: true });
+    expect(queryProcessIds).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the session and listeners when scoped termination fails", async () => {
+    const close = vi.fn();
+    const service = createService(
+      { assign: vi.fn(() => true), setDescription: vi.fn() },
+      {
+        create: () => ({
+          ready: true,
+          ownsProcessTree: true,
+          assign: vi.fn(() => ({ ok: true })),
+          terminate: vi.fn(() => ({ ok: false, error: "native termination failed" })),
+          waitForEmpty: vi.fn(),
+          close,
+        }),
+      },
+    );
+    const { ptyId } = service.create("thread-1");
+
+    await expect(service.kill(ptyId)).rejects.toThrow("native termination failed");
+
+    expect(service.listActiveSessions()).toEqual([{ ptyId, threadId: "thread-1" }]);
+    expect(dataDispose).not.toHaveBeenCalled();
+    expect(exitDispose).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  function createService(
+    jobObject: object = { assign: vi.fn(), setDescription: vi.fn() },
+    processScopeFactory?: object,
+  ): TerminalService {
     const cwd = process.cwd();
     return new TerminalService(
       { findById: () => ({ workspace_id: "workspace-1", mode: "direct", worktree_path: null }) } as never,
@@ -312,7 +439,8 @@ describe("TerminalService Windows teardown", () => {
       } as never,
       { getEnv: () => ({}) } as never,
       { register: vi.fn(), deregister: vi.fn(), clear: vi.fn() } as never,
-      { assign: vi.fn(), setDescription: vi.fn() } as never,
+      jobObject as never,
+      processScopeFactory as never,
     );
   }
 });

--- a/apps/server/src/services/terminal-service.test.ts
+++ b/apps/server/src/services/terminal-service.test.ts
@@ -426,12 +426,15 @@ describe("TerminalService Windows teardown", () => {
     expect(close).not.toHaveBeenCalled();
   });
 
-  it("falls back when descendant reconciliation cannot establish authority", async () => {
+  it("falls back when descendant reconciliation rejects a partial enumeration", async () => {
     const processScope = {
       ready: true,
       ownsProcessTree: false,
       assign: vi.fn(() => ({ ok: true })),
-      reconcile: vi.fn().mockResolvedValue({ ok: false, error: "identity changed" }),
+      reconcile: vi.fn().mockResolvedValue({
+        ok: false,
+        error: "Process32NextW failed (5)",
+      }),
       terminate: vi.fn(),
       waitForEmpty: vi.fn(),
       close: vi.fn(),

--- a/apps/server/src/services/terminal-service.test.ts
+++ b/apps/server/src/services/terminal-service.test.ts
@@ -2,10 +2,19 @@ import "reflect-metadata";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IPty } from "node-pty";
 
-const { killProcessTree, gracefulKillProcessTree } = vi.hoisted(() => ({
+const { killProcessTree, gracefulKillProcessTree, spawnPty } = vi.hoisted(() => ({
   killProcessTree: vi.fn().mockResolvedValue(undefined),
   gracefulKillProcessTree: vi.fn().mockResolvedValue(undefined),
+  spawnPty: vi.fn(),
 }));
+
+vi.mock("node:module", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:module")>();
+  return {
+    ...actual,
+    createRequire: () => () => ({ spawn: spawnPty }),
+  };
+});
 
 vi.mock("./process-kill.js", () => ({
   killProcessTree,
@@ -87,6 +96,12 @@ describe("TerminalService Windows teardown", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    spawnPty.mockImplementation(() => ({
+      pid: 10_000 + spawnPty.mock.calls.length,
+      onData: () => ({ dispose: vi.fn() }),
+      onExit: () => ({ dispose: vi.fn() }),
+      kill: vi.fn(),
+    }));
     Object.defineProperty(process, "platform", {
       value: "win32",
       configurable: true,
@@ -100,7 +115,7 @@ describe("TerminalService Windows teardown", () => {
     });
   });
 
-  it("uses the ConPTY DLL session as the single Windows process-tree owner", async () => {
+  it("terminates the process tree before closing the Windows PTY", async () => {
     const pty = {
       pid: 12_345,
       kill: vi.fn(),
@@ -142,8 +157,40 @@ describe("TerminalService Windows teardown", () => {
     await service.kill(session.id);
 
     expect(pty.kill).toHaveBeenCalledOnce();
-    expect(killProcessTree).not.toHaveBeenCalled();
+    expect(killProcessTree).toHaveBeenCalledOnce();
+    expect(killProcessTree).toHaveBeenCalledWith(session.pty.pid);
+    const ptyKill = vi.mocked(pty.kill);
+    expect(killProcessTree.mock.invocationCallOrder[0]).toBeLessThan(
+      ptyKill.mock.invocationCallOrder[0]!,
+    );
     expect(gracefulKillProcessTree).not.toHaveBeenCalled();
     expect(pidRegistry.deregister).toHaveBeenCalledWith(session.id);
+  });
+
+  it("rejects a fifth shell without evicting the existing four", () => {
+    const cwd = process.cwd();
+    const service = new TerminalService(
+      { findById: () => ({ workspace_id: "workspace-1", mode: "direct", worktree_path: null }) } as never,
+      { findById: () => ({ path: cwd }) } as never,
+      { resolveWorkingDir: () => cwd } as never,
+      {
+        get: () => ({
+          terminal: {
+            scrollback: 1_000,
+            flowControl: { serverHighBytes: 1_024, serverLowBytes: 512 },
+          },
+        }),
+        on: () => vi.fn(),
+      } as never,
+      { getEnv: () => ({}) } as never,
+      { register: vi.fn(), deregister: vi.fn(), clear: vi.fn() } as never,
+      { assign: vi.fn(), setDescription: vi.fn() } as never,
+    );
+
+    for (let index = 0; index < 4; index += 1) service.create("thread-1");
+
+    expect(() => service.create("thread-1")).toThrow("Maximum PTY limit (4)");
+    expect(service.listActiveSessions()).toHaveLength(4);
+    expect(spawnPty).toHaveBeenCalledTimes(4);
   });
 });

--- a/apps/server/src/services/terminal-service.test.ts
+++ b/apps/server/src/services/terminal-service.test.ts
@@ -30,6 +30,7 @@ vi.mock("@mcode/shared", () => ({
   },
 }));
 
+import { logger } from "@mcode/shared";
 import { TerminalService } from "./terminal-service";
 import { TerminalReplayBuffer } from "./terminal-replay-buffer";
 
@@ -261,6 +262,15 @@ describe("TerminalService Windows teardown", () => {
 
     expect(sender.json).toHaveBeenCalledOnce();
     expect(sender.json).toHaveBeenCalledWith("terminal.exit", { ptyId, code: 11 });
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+      "PTY exited",
+      expect.objectContaining({
+        id: ptyId,
+        exitCode: 11,
+        signal: 0,
+        reason: "natural-exit",
+      }),
+    );
     expect(service.listActiveSessions()).toEqual([]);
     expect(dataDispose).toHaveBeenCalledOnce();
     expect(exitDispose).toHaveBeenCalledOnce();

--- a/apps/server/src/services/terminal-service.test.ts
+++ b/apps/server/src/services/terminal-service.test.ts
@@ -163,6 +163,7 @@ describe("TerminalService Windows teardown", () => {
         ownsProcessTree: false,
         close: vi.fn(),
       },
+      processScopeReady: Promise.resolve(false),
     };
     const internals = service as unknown as {
       sessions: Map<string, typeof session>;
@@ -293,6 +294,7 @@ describe("TerminalService Windows teardown", () => {
     const first = service.kill(ptyId);
     const second = service.kill(ptyId);
 
+    await vi.waitFor(() => expect(killProcessTree).toHaveBeenCalledOnce());
     expect(killProcessTree).toHaveBeenCalledOnce();
     resolveTermination();
     await Promise.all([first, second]);
@@ -307,6 +309,7 @@ describe("TerminalService Windows teardown", () => {
       ready: true,
       ownsProcessTree: true,
       assign: vi.fn(() => ({ ok: true })),
+      reconcile: vi.fn().mockResolvedValue({ ok: true }),
       terminate,
       waitForEmpty,
       close,
@@ -334,6 +337,7 @@ describe("TerminalService Windows teardown", () => {
           ready: true,
           ownsProcessTree: true,
           assign: vi.fn(() => { calls.push("child"); return { ok: true }; }),
+          reconcile: vi.fn().mockResolvedValue({ ok: true }),
           terminate: vi.fn(),
           waitForEmpty: vi.fn(),
           close: vi.fn(),
@@ -355,6 +359,7 @@ describe("TerminalService Windows teardown", () => {
           ready: true,
           ownsProcessTree: true,
           assign: vi.fn(() => ({ ok: true })),
+          reconcile: vi.fn().mockResolvedValue({ ok: true }),
           terminate: vi.fn(),
           waitForEmpty: vi.fn(),
           close,
@@ -381,6 +386,7 @@ describe("TerminalService Windows teardown", () => {
           ready: true,
           ownsProcessTree: true,
           assign: vi.fn(() => ({ ok: true })),
+          reconcile: vi.fn().mockResolvedValue({ ok: true }),
           queryProcessIds,
           terminate: vi.fn(),
           waitForEmpty: vi.fn(),
@@ -403,6 +409,7 @@ describe("TerminalService Windows teardown", () => {
           ready: true,
           ownsProcessTree: true,
           assign: vi.fn(() => ({ ok: true })),
+          reconcile: vi.fn().mockResolvedValue({ ok: true }),
           terminate: vi.fn(() => ({ ok: false, error: "native termination failed" })),
           waitForEmpty: vi.fn(),
           close,
@@ -417,6 +424,28 @@ describe("TerminalService Windows teardown", () => {
     expect(dataDispose).not.toHaveBeenCalled();
     expect(exitDispose).not.toHaveBeenCalled();
     expect(close).not.toHaveBeenCalled();
+  });
+
+  it("falls back when descendant reconciliation cannot establish authority", async () => {
+    const processScope = {
+      ready: true,
+      ownsProcessTree: false,
+      assign: vi.fn(() => ({ ok: true })),
+      reconcile: vi.fn().mockResolvedValue({ ok: false, error: "identity changed" }),
+      terminate: vi.fn(),
+      waitForEmpty: vi.fn(),
+      close: vi.fn(),
+    };
+    const service = createService(
+      { assign: vi.fn(() => true), setDescription: vi.fn() },
+      { create: () => processScope },
+    );
+    const { ptyId } = service.create("thread-1");
+
+    await service.kill(ptyId);
+
+    expect(killProcessTree).toHaveBeenCalledOnce();
+    expect(processScope.terminate).not.toHaveBeenCalled();
   });
 
   function createService(

--- a/apps/server/src/services/terminal-service.test.ts
+++ b/apps/server/src/services/terminal-service.test.ts
@@ -451,6 +451,51 @@ describe("TerminalService Windows teardown", () => {
     expect(processScope.terminate).not.toHaveBeenCalled();
   });
 
+  it("falls back when descendant reconciliation rejects its promise", async () => {
+    const processScope = {
+      ready: true,
+      ownsProcessTree: false,
+      assign: vi.fn(() => ({ ok: true })),
+      reconcile: vi.fn().mockRejectedValue(new Error("snapshot failed")),
+      terminate: vi.fn(),
+      waitForEmpty: vi.fn(),
+      close: vi.fn(),
+    };
+    const service = createService(
+      { assign: vi.fn(() => true), setDescription: vi.fn() },
+      { create: () => processScope },
+    );
+    const { ptyId } = service.create("thread-1");
+
+    await service.kill(ptyId);
+
+    expect(killProcessTree).toHaveBeenCalledOnce();
+    expect(processScope.terminate).not.toHaveBeenCalled();
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "PTY process scope reconciliation failed; close will use process-tree fallback",
+      expect.objectContaining({ error: "snapshot failed" }),
+    );
+  });
+
+  it("clears the authority timeout when reconciliation settles first", async () => {
+    const service = createService();
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const awaitAuthority = (
+      service as unknown as {
+        awaitProcessScopeAuthority: (
+          session: { processScopeReady: Promise<boolean> },
+          timeoutMs: number,
+        ) => Promise<boolean>;
+      }
+    ).awaitProcessScopeAuthority.bind(service);
+
+    await expect(awaitAuthority({ processScopeReady: Promise.resolve(true) }, 500))
+      .resolves.toBe(true);
+
+    expect(clearTimeoutSpy).toHaveBeenCalledOnce();
+    clearTimeoutSpy.mockRestore();
+  });
+
   function createService(
     jobObject: object = { assign: vi.fn(), setDescription: vi.fn() },
     processScopeFactory?: object,

--- a/apps/server/src/services/terminal-service.test.ts
+++ b/apps/server/src/services/terminal-service.test.ts
@@ -93,13 +93,25 @@ describe("TerminalService replay authority", () => {
 
 describe("TerminalService Windows teardown", () => {
   const originalPlatform = process.platform;
+  let onData: ((data: string) => void) | undefined;
+  let onExit: ((event: { exitCode: number; signal: number }) => void) | undefined;
+  let dataDispose: ReturnType<typeof vi.fn>;
+  let exitDispose: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    dataDispose = vi.fn();
+    exitDispose = vi.fn();
     spawnPty.mockImplementation(() => ({
       pid: 10_000 + spawnPty.mock.calls.length,
-      onData: () => ({ dispose: vi.fn() }),
-      onExit: () => ({ dispose: vi.fn() }),
+      onData: (callback: (data: string) => void) => {
+        onData = callback;
+        return { dispose: dataDispose };
+      },
+      onExit: (callback: (event: { exitCode: number; signal: number }) => void) => {
+        onExit = callback;
+        return { dispose: exitDispose };
+      },
       kill: vi.fn(),
     }));
     Object.defineProperty(process, "platform", {
@@ -193,4 +205,104 @@ describe("TerminalService Windows teardown", () => {
     expect(service.listActiveSessions()).toHaveLength(4);
     expect(spawnPty).toHaveBeenCalledTimes(4);
   });
+
+  it("keeps a session connected when termination rejects, then publishes one natural exit", async () => {
+    const service = createService();
+    const sender = { json: vi.fn(), data: vi.fn() };
+    service.setSender(sender);
+    const { ptyId } = service.create("thread-1");
+    service.resume(ptyId);
+    killProcessTree.mockRejectedValueOnce(new Error("verification failed"));
+
+    await expect(service.kill(ptyId)).rejects.toThrow("verification failed");
+    onData?.("still connected");
+
+    expect(sender.data).toHaveBeenCalledOnce();
+    expect(service.listActiveSessions()).toEqual([{ ptyId, threadId: "thread-1" }]);
+    expect(dataDispose).not.toHaveBeenCalled();
+    expect(exitDispose).not.toHaveBeenCalled();
+
+    onExit?.({ exitCode: 7, signal: 0 });
+    onExit?.({ exitCode: 7, signal: 0 });
+
+    expect(sender.json).toHaveBeenCalledOnce();
+    expect(sender.json).toHaveBeenCalledWith("terminal.exit", { ptyId, code: 7 });
+    expect(service.listActiveSessions()).toEqual([]);
+  });
+
+  it("commits a requested close once when exit races successful termination", async () => {
+    const service = createService();
+    const sender = { json: vi.fn(), data: vi.fn() };
+    service.setSender(sender);
+    const { ptyId } = service.create("thread-1");
+    killProcessTree.mockImplementationOnce(async () => {
+      onExit?.({ exitCode: 9, signal: 0 });
+    });
+
+    await service.kill(ptyId);
+
+    expect(sender.json).not.toHaveBeenCalled();
+    expect(service.listActiveSessions()).toEqual([]);
+    expect(dataDispose).toHaveBeenCalledOnce();
+    expect(exitDispose).toHaveBeenCalledOnce();
+  });
+
+  it("publishes a raced natural exit once when termination fails", async () => {
+    const service = createService();
+    const sender = { json: vi.fn(), data: vi.fn() };
+    service.setSender(sender);
+    const { ptyId } = service.create("thread-1");
+    killProcessTree.mockImplementationOnce(async () => {
+      onExit?.({ exitCode: 11, signal: 0 });
+      throw new Error("verification failed");
+    });
+
+    await expect(service.kill(ptyId)).rejects.toThrow("verification failed");
+
+    expect(sender.json).toHaveBeenCalledOnce();
+    expect(sender.json).toHaveBeenCalledWith("terminal.exit", { ptyId, code: 11 });
+    expect(service.listActiveSessions()).toEqual([]);
+    expect(dataDispose).toHaveBeenCalledOnce();
+    expect(exitDispose).toHaveBeenCalledOnce();
+  });
+
+  it("shares one termination attempt across concurrent close requests", async () => {
+    const service = createService();
+    const { ptyId } = service.create("thread-1");
+    let resolveTermination!: () => void;
+    killProcessTree.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveTermination = resolve;
+      }),
+    );
+
+    const first = service.kill(ptyId);
+    const second = service.kill(ptyId);
+
+    expect(killProcessTree).toHaveBeenCalledOnce();
+    resolveTermination();
+    await Promise.all([first, second]);
+    expect(service.listActiveSessions()).toEqual([]);
+  });
+
+  function createService(): TerminalService {
+    const cwd = process.cwd();
+    return new TerminalService(
+      { findById: () => ({ workspace_id: "workspace-1", mode: "direct", worktree_path: null }) } as never,
+      { findById: () => ({ path: cwd }) } as never,
+      { resolveWorkingDir: () => cwd } as never,
+      {
+        get: () => ({
+          terminal: {
+            scrollback: 1_000,
+            flowControl: { serverHighBytes: 1_024, serverLowBytes: 512 },
+          },
+        }),
+        on: () => vi.fn(),
+      } as never,
+      { getEnv: () => ({}) } as never,
+      { register: vi.fn(), deregister: vi.fn(), clear: vi.fn() } as never,
+      { assign: vi.fn(), setDescription: vi.fn() } as never,
+    );
+  }
 });

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -20,6 +20,10 @@ import type { WorkspaceRepo } from "../repositories/workspace-repo";
 import type { GitService } from "./git-service";
 import type { SettingsService } from "./settings-service";
 import { EnvService } from "./env-service.js";
+import {
+  WindowsProcessScopeFactory,
+  type WindowsProcessScope,
+} from "./windows-process-scope.js";
 
 // createRequire lets us load native CJS modules (node-pty) from both ESM
 // (Bun running `src/index.ts`) and the CJS production / dev bundle.
@@ -68,6 +72,7 @@ interface PtySession {
   status: "running" | "closing";
   pendingExit: { readonly exitCode: number; readonly signal?: number } | null;
   closePromise: Promise<void> | null;
+  readonly processScope: WindowsProcessScope;
 }
 
 /** Callbacks for streaming PTY output and exit events to connected clients. */
@@ -118,6 +123,7 @@ export class TerminalService {
     @inject(EnvService) private readonly envService: EnvService,
     @inject("PtyPidRegistry") private readonly pidRegistry: PtyPidRegistry,
     @inject("JobObject") private readonly jobObject: import("./job-object.js").JobObject,
+    private readonly processScopeFactory: WindowsProcessScopeFactory = new WindowsProcessScopeFactory(),
   ) {
     // Keep server-side scrollback retention in sync with the terminal.scrollback
     // setting: when the user changes it, resize all live replay buffers so
@@ -257,7 +263,26 @@ export class TerminalService {
     // on Windows, which can spawn processes with CREATE_BREAKAWAY_FROM_JOB,
     // so explicit assignment is needed — inheritance alone is not sufficient.
     // Best-effort: no-op on non-Windows or if JobObject failed to init.
-    this.jobObject.assign(pty.pid);
+    const processScope = this.processScopeFactory.create();
+    const globalAssigned = this.jobObject.assign(pty.pid);
+    if (process.platform === "win32" && (!globalAssigned || !processScope.ready)) {
+      logger.warn("PTY process scope unavailable; close will use process-tree fallback", {
+        id,
+        pid: pty.pid,
+        reason: !globalAssigned ? "global-job-assignment-failed" : "child-job-init-failed",
+      });
+      processScope.close();
+    } else if (process.platform === "win32") {
+      const assignment = processScope.assign(pty.pid);
+      if (!assignment.ok) {
+        logger.warn("PTY process scope assignment failed; close will use process-tree fallback", {
+          id,
+          pid: pty.pid,
+          error: assignment.error,
+        });
+        processScope.close();
+      }
+    }
     this.jobObject.setDescription(pty.pid, `Mcode Terminal: ${shellBasename(shell)}`);
 
     const dataDisposable = pty.onData((data: string) => {
@@ -294,6 +319,7 @@ export class TerminalService {
       status: "running",
       pendingExit: null,
       closePromise: null,
+      processScope,
     };
     this.sessions = new Map([...this.sessions, [id, session]]);
 
@@ -507,6 +533,15 @@ export class TerminalService {
     const session = this.sessions.get(ptyId);
     if (!session) throw new Error(`PTY not found: ${ptyId}`);
 
+    if (process.platform === "win32" && session.processScope.ownsProcessTree) {
+      const snapshot = session.processScope.queryProcessIds();
+      if (snapshot.ok && !snapshot.overflow) {
+        return {
+          hasChildren: snapshot.processIds.some((pid) => pid !== session.pty.pid),
+        };
+      }
+    }
+
     const pending = [session.pty.pid];
     const visited = new Set<number>();
     try {
@@ -539,6 +574,17 @@ export class TerminalService {
     // identifies its descendants. Closing ConPTY first can orphan children.
     if (this.useGracefulKill) {
       await gracefulKillProcessTree(session.pty.pid);
+    } else if (process.platform === "win32" && session.processScope.ownsProcessTree) {
+      const terminated = session.processScope.terminate(1);
+      const emptied = terminated.ok
+        ? await session.processScope.waitForEmpty(1_900)
+        : terminated;
+      if (!terminated.ok || !emptied.ok) {
+        session.status = "running";
+        session.closePromise = null;
+        if (session.pendingExit) this.handleNaturalExit(session, session.pendingExit);
+        throw new Error(terminated.error ?? emptied.error ?? "Windows process scope termination failed");
+      }
     } else {
       try {
         await killProcessTree(session.pty.pid);
@@ -603,6 +649,7 @@ export class TerminalService {
       this.sender?.json("terminal.exit", { ptyId: session.id, code: exitCode });
     }
     this.removePty(session.id);
+    session.processScope.close();
   }
 
   private removePty(ptyId: string): void {

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -73,6 +73,7 @@ interface PtySession {
   pendingExit: { readonly exitCode: number; readonly signal?: number } | null;
   closePromise: Promise<void> | null;
   readonly processScope: WindowsProcessScope;
+  readonly processScopeReady: Promise<boolean>;
 }
 
 /** Callbacks for streaming PTY output and exit events to connected clients. */
@@ -264,6 +265,7 @@ export class TerminalService {
     // so explicit assignment is needed — inheritance alone is not sufficient.
     // Best-effort: no-op on non-Windows or if JobObject failed to init.
     const processScope = this.processScopeFactory.create();
+    let processScopeReady = Promise.resolve(false);
     const globalAssigned = this.jobObject.assign(pty.pid);
     if (process.platform === "win32" && (!globalAssigned || !processScope.ready)) {
       logger.warn("PTY process scope unavailable; close will use process-tree fallback", {
@@ -281,6 +283,17 @@ export class TerminalService {
           error: assignment.error,
         });
         processScope.close();
+      } else {
+        processScopeReady = processScope.reconcile(pty.pid).then((result) => {
+          if (!result.ok) {
+            logger.warn("PTY process scope reconciliation failed; close will use process-tree fallback", {
+              id,
+              pid: pty.pid,
+              error: result.error,
+            });
+          }
+          return result.ok;
+        });
       }
     }
     this.jobObject.setDescription(pty.pid, `Mcode Terminal: ${shellBasename(shell)}`);
@@ -320,6 +333,7 @@ export class TerminalService {
       pendingExit: null,
       closePromise: null,
       processScope,
+      processScopeReady,
     };
     this.sessions = new Map([...this.sessions, [id, session]]);
 
@@ -533,6 +547,7 @@ export class TerminalService {
     const session = this.sessions.get(ptyId);
     if (!session) throw new Error(`PTY not found: ${ptyId}`);
 
+    await this.awaitProcessScopeAuthority(session, 500);
     if (process.platform === "win32" && session.processScope.ownsProcessTree) {
       const snapshot = session.processScope.queryProcessIds();
       if (snapshot.ok && !snapshot.overflow) {
@@ -574,7 +589,11 @@ export class TerminalService {
     // identifies its descendants. Closing ConPTY first can orphan children.
     if (this.useGracefulKill) {
       await gracefulKillProcessTree(session.pty.pid);
-    } else if (process.platform === "win32" && session.processScope.ownsProcessTree) {
+    } else if (
+      process.platform === "win32" &&
+      await this.awaitProcessScopeAuthority(session, 500) &&
+      session.processScope.ownsProcessTree
+    ) {
       const terminated = session.processScope.terminate(1);
       const emptied = terminated.ok
         ? await session.processScope.waitForEmpty(1_900)
@@ -610,6 +629,17 @@ export class TerminalService {
       });
     }
     this.finalizePty(session);
+  }
+
+  private async awaitProcessScopeAuthority(
+    session: PtySession,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    if (process.platform !== "win32") return false;
+    return Promise.race([
+      session.processScopeReady,
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+    ]);
   }
 
   private handleNaturalExit(

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -284,16 +284,26 @@ export class TerminalService {
         });
         processScope.close();
       } else {
-        processScopeReady = processScope.reconcile(pty.pid).then((result) => {
-          if (!result.ok) {
+        processScopeReady = processScope.reconcile(pty.pid).then(
+          (result) => {
+            if (!result.ok) {
+              logger.warn("PTY process scope reconciliation failed; close will use process-tree fallback", {
+                id,
+                pid: pty.pid,
+                error: result.error,
+              });
+            }
+            return result.ok;
+          },
+          (error: unknown) => {
             logger.warn("PTY process scope reconciliation failed; close will use process-tree fallback", {
               id,
               pid: pty.pid,
-              error: result.error,
+              error: describeError(error),
             });
-          }
-          return result.ok;
-        });
+            return false;
+          },
+        );
       }
     }
     this.jobObject.setDescription(pty.pid, `Mcode Terminal: ${shellBasename(shell)}`);
@@ -636,10 +646,17 @@ export class TerminalService {
     timeoutMs: number,
   ): Promise<boolean> {
     if (process.platform !== "win32") return false;
-    return Promise.race([
-      session.processScopeReady,
-      new Promise<false>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
-    ]);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        session.processScopeReady,
+        new Promise<false>((resolve) => {
+          timeout = setTimeout(() => resolve(false), timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+    }
   }
 
   private handleNaturalExit(

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -276,9 +276,9 @@ export class TerminalService {
         pid: pty.pid,
         scopeId,
         shell,
-        cwd,
         exitCode,
         signal,
+        reason: "natural-exit",
       });
       this.sender?.json("terminal.exit", { ptyId: id, code: exitCode });
       this.removePty(id);
@@ -381,7 +381,11 @@ export class TerminalService {
   }
 
   /** Kill a single PTY session. No-op if the ID is unknown. */
-  async kill(ptyId: string): Promise<void> {
+  async kill(
+    ptyId: string,
+    reason: "user-requested-process-tree-close" | "app-shutdown" =
+      "user-requested-process-tree-close",
+  ): Promise<void> {
     const session = this.sessions.get(ptyId);
     if (!session) return;
     logger.info("PTY kill requested", {
@@ -389,7 +393,7 @@ export class TerminalService {
       pid: session.pty.pid,
       threadId: session.threadId,
       shell: session.shell,
-      cwd: session.cwd,
+      reason,
     });
     await this.destroyPty(session);
     this.removePty(ptyId);
@@ -407,7 +411,9 @@ export class TerminalService {
   /** Kill all PTY sessions across all threads. */
   async shutdown(): Promise<void> {
     this.unsubscribeSettings();
-    await Promise.all([...this.sessions.keys()].map((ptyId) => this.kill(ptyId)));
+    await Promise.all(
+      [...this.sessions.keys()].map((ptyId) => this.kill(ptyId, "app-shutdown")),
+    );
     this.pidRegistry.clear();
   }
 
@@ -494,19 +500,31 @@ export class TerminalService {
     const session = this.sessions.get(ptyId);
     if (!session) throw new Error(`PTY not found: ${ptyId}`);
 
-    let children: Array<{ name: string; pid: number }>;
+    const pending = [session.pty.pid];
+    const visited = new Set<number>();
     try {
-      children = await listDirectChildren(session.pty.pid);
-    } catch {
-      return { hasChildren: false };
+      while (pending.length > 0 && visited.size < 128) {
+        const parentPid = pending.shift()!;
+        if (visited.has(parentPid)) continue;
+        visited.add(parentPid);
+        const children = await listDirectChildren(parentPid);
+        for (const child of children) {
+          const basename =
+            child.name.toLowerCase().split(/[\\/]/).pop() ?? child.name.toLowerCase();
+          if (!SHELL_BASENAMES.has(basename)) return { hasChildren: true };
+          pending.push(child.pid);
+        }
+      }
+      return { hasChildren: pending.length > 0 };
+    } catch (err) {
+      logger.warn("Failed to inspect PTY process tree", {
+        id: session.id,
+        pid: session.pty.pid,
+        threadId: session.threadId,
+        error: describeError(err),
+      });
+      return { hasChildren: true };
     }
-
-    const nonShellChildren = children.filter((child) => {
-      const basename = child.name.toLowerCase().split(/[\\/]/).pop() ?? child.name.toLowerCase();
-      return !SHELL_BASENAMES.has(basename);
-    });
-
-    return { hasChildren: nonShellChildren.length > 0 };
   }
 
   private async destroyPty(session: PtySession): Promise<void> {
@@ -530,31 +548,24 @@ export class TerminalService {
         error: describeError(err),
       });
     }
-    // node-pty owns the ConPTY process-tree shutdown on Windows. Windows PTYs
-    // are spawned with useConptyDll so this call closes the pseudo console
-    // directly without launching node-pty's fragile console-list helper.
-    let ptyKillSucceeded = false;
+    // Terminate the operating-system process tree while the root PID still
+    // identifies its descendants. Closing ConPTY first can orphan children.
+    if (this.useGracefulKill) {
+      await gracefulKillProcessTree(session.pty.pid);
+    } else {
+      await killProcessTree(session.pty.pid);
+    }
+
     try {
       session.pty.kill();
-      ptyKillSucceeded = true;
     } catch (err) {
       logger.warn("Failed to kill PTY process", {
         id: session.id,
         pid: session.pty.pid,
         threadId: session.threadId,
         shell: session.shell,
-        cwd: session.cwd,
         error: describeError(err),
       });
-    }
-    if (process.platform === "win32" && ptyKillSucceeded) return;
-
-    // Unix uses the existing process-tree fallback. Windows reaches this path
-    // only when node-pty could not begin its own process-tree shutdown.
-    if (this.useGracefulKill) {
-      await gracefulKillProcessTree(session.pty.pid);
-    } else {
-      await killProcessTree(session.pty.pid);
     }
   }
 

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -65,6 +65,9 @@ interface PtySession {
   readonly pty: IPty;
   readonly dataDisposable: IDisposable;
   readonly exitDisposable: IDisposable;
+  status: "running" | "closing";
+  pendingExit: { readonly exitCode: number; readonly signal?: number } | null;
+  closePromise: Promise<void> | null;
 }
 
 /** Callbacks for streaming PTY output and exit events to connected clients. */
@@ -271,6 +274,12 @@ export class TerminalService {
     });
 
     const exitDisposable = pty.onExit(({ exitCode, signal }) => {
+      const current = this.sessions.get(id);
+      if (!current) return;
+      if (current.status === "closing") {
+        current.pendingExit = { exitCode, signal };
+        return;
+      }
       logger.info("PTY exited", {
         id,
         pid: pty.pid,
@@ -280,8 +289,7 @@ export class TerminalService {
         signal,
         reason: "natural-exit",
       });
-      this.sender?.json("terminal.exit", { ptyId: id, code: exitCode });
-      this.removePty(id);
+      this.finalizePty(current, exitCode);
     });
 
     const session: PtySession = {
@@ -292,6 +300,9 @@ export class TerminalService {
       pty,
       dataDisposable,
       exitDisposable,
+      status: "running",
+      pendingExit: null,
+      closePromise: null,
     };
     this.sessions = new Map([...this.sessions, [id, session]]);
 
@@ -388,6 +399,9 @@ export class TerminalService {
   ): Promise<void> {
     const session = this.sessions.get(ptyId);
     if (!session) return;
+    if (session.status === "closing" && session.closePromise) {
+      return session.closePromise;
+    }
     logger.info("PTY kill requested", {
       id: session.id,
       pid: session.pty.pid,
@@ -395,8 +409,10 @@ export class TerminalService {
       shell: session.shell,
       reason,
     });
-    await this.destroyPty(session);
-    this.removePty(ptyId);
+    session.status = "closing";
+    const closePromise = this.closePty(session);
+    session.closePromise = closePromise;
+    return closePromise;
   }
 
   /** Kill all PTY sessions for a given thread, concurrently. */
@@ -527,33 +543,22 @@ export class TerminalService {
     }
   }
 
-  private async destroyPty(session: PtySession): Promise<void> {
-    try {
-      session.dataDisposable.dispose();
-    } catch (err) {
-      logger.warn("Failed to dispose data listener", {
-        id: session.id,
-        pid: session.pty.pid,
-        threadId: session.threadId,
-        error: describeError(err),
-      });
-    }
-    try {
-      session.exitDisposable.dispose();
-    } catch (err) {
-      logger.warn("Failed to dispose exit listener", {
-        id: session.id,
-        pid: session.pty.pid,
-        threadId: session.threadId,
-        error: describeError(err),
-      });
-    }
+  private async closePty(session: PtySession): Promise<void> {
     // Terminate the operating-system process tree while the root PID still
     // identifies its descendants. Closing ConPTY first can orphan children.
     if (this.useGracefulKill) {
       await gracefulKillProcessTree(session.pty.pid);
     } else {
-      await killProcessTree(session.pty.pid);
+      try {
+        await killProcessTree(session.pty.pid);
+      } catch (err) {
+        session.status = "running";
+        session.closePromise = null;
+        if (session.pendingExit) {
+          this.finalizePty(session, session.pendingExit.exitCode);
+        }
+        throw err;
+      }
     }
 
     try {
@@ -567,6 +572,30 @@ export class TerminalService {
         error: describeError(err),
       });
     }
+    this.finalizePty(session);
+  }
+
+  private finalizePty(session: PtySession, exitCode?: number): void {
+    if (!this.sessions.has(session.id)) return;
+    for (const [label, disposable] of [
+      ["data", session.dataDisposable],
+      ["exit", session.exitDisposable],
+    ] as const) {
+      try {
+        disposable.dispose();
+      } catch (err) {
+        logger.warn(`Failed to dispose ${label} listener`, {
+          id: session.id,
+          pid: session.pty.pid,
+          threadId: session.threadId,
+          error: describeError(err),
+        });
+      }
+    }
+    if (exitCode !== undefined) {
+      this.sender?.json("terminal.exit", { ptyId: session.id, code: exitCode });
+    }
+    this.removePty(session.id);
   }
 
   private removePty(ptyId: string): void {

--- a/apps/server/src/services/terminal-service.ts
+++ b/apps/server/src/services/terminal-service.ts
@@ -280,16 +280,7 @@ export class TerminalService {
         current.pendingExit = { exitCode, signal };
         return;
       }
-      logger.info("PTY exited", {
-        id,
-        pid: pty.pid,
-        scopeId,
-        shell,
-        exitCode,
-        signal,
-        reason: "natural-exit",
-      });
-      this.finalizePty(current, exitCode);
+      this.handleNaturalExit(current, { exitCode, signal });
     });
 
     const session: PtySession = {
@@ -555,7 +546,7 @@ export class TerminalService {
         session.status = "running";
         session.closePromise = null;
         if (session.pendingExit) {
-          this.finalizePty(session, session.pendingExit.exitCode);
+          this.handleNaturalExit(session, session.pendingExit);
         }
         throw err;
       }
@@ -573,6 +564,22 @@ export class TerminalService {
       });
     }
     this.finalizePty(session);
+  }
+
+  private handleNaturalExit(
+    session: PtySession,
+    exit: { readonly exitCode: number; readonly signal?: number },
+  ): void {
+    logger.info("PTY exited", {
+      id: session.id,
+      pid: session.pty.pid,
+      scopeId: session.threadId,
+      shell: session.shell,
+      exitCode: exit.exitCode,
+      signal: exit.signal,
+      reason: "natural-exit",
+    });
+    this.finalizePty(session, exit.exitCode);
   }
 
   private finalizePty(session: PtySession, exitCode?: number): void {

--- a/apps/server/src/services/windows-process-scope.integration.test.ts
+++ b/apps/server/src/services/windows-process-scope.integration.test.ts
@@ -1,0 +1,73 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import { JobObject } from "./job-object.js";
+import { WindowsProcessScopeFactory } from "./windows-process-scope.js";
+
+describe.runIf(process.platform === "win32")("WindowsProcessScope integration", () => {
+  it("terminates one nested process tree without affecting another", async () => {
+    const globalJob = new JobObject();
+    const factory = new WindowsProcessScopeFactory();
+    const scopeA = factory.create();
+    const scopeB = factory.create();
+    const processA = spawnTree();
+    const processB = spawnTree();
+
+    try {
+      expect(globalJob.assign(processA.pid!)).toBe(true);
+      expect(scopeA.assign(processA.pid!).ok).toBe(true);
+      expect(globalJob.assign(processB.pid!)).toBe(true);
+      expect(scopeB.assign(processB.pid!).ok).toBe(true);
+
+      await waitForMembership(scopeA, 2);
+      await waitForMembership(scopeB, 2);
+      expect(scopeA.terminate(1).ok).toBe(true);
+      await expect(scopeA.waitForEmpty(1_900)).resolves.toEqual({ ok: true });
+      expect(await hasExited(processA, 100)).toBe(true);
+      expect(await hasExited(processB, 100)).toBe(false);
+    } finally {
+      scopeA.close();
+      scopeB.terminate(1);
+      await scopeB.waitForEmpty(1_900);
+      scopeB.close();
+      globalJob.close();
+      processA.kill();
+      processB.kill();
+    }
+  }, 15_000);
+});
+
+function spawnTree(): ChildProcess {
+  return spawn(
+    "powershell.exe",
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "Start-Process ping.exe -ArgumentList '-n','30','127.0.0.1' -WindowStyle Hidden; Start-Sleep -Seconds 30",
+    ],
+    { stdio: "ignore", windowsHide: true },
+  );
+}
+
+async function waitForMembership(
+  scope: ReturnType<WindowsProcessScopeFactory["create"]>,
+  expected: number,
+): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const snapshot = scope.queryProcessIds();
+    if (snapshot.ok && snapshot.processIds.length >= expected) return;
+    await delay(20);
+  }
+  expect(scope.queryProcessIds().processIds.length).toBeGreaterThanOrEqual(expected);
+}
+
+async function hasExited(process: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (process.exitCode !== null || process.signalCode !== null) return true;
+  return Promise.race([
+    new Promise<true>((resolve) => process.once("exit", () => resolve(true))),
+    delay(timeoutMs).then(() => false),
+  ]);
+}

--- a/apps/server/src/services/windows-process-scope.integration.test.ts
+++ b/apps/server/src/services/windows-process-scope.integration.test.ts
@@ -16,8 +16,10 @@ describe.runIf(process.platform === "win32")("WindowsProcessScope integration", 
     try {
       expect(globalJob.assign(processA.pid!)).toBe(true);
       expect(scopeA.assign(processA.pid!).ok).toBe(true);
+      expect((await scopeA.reconcile(processA.pid!)).ok).toBe(true);
       expect(globalJob.assign(processB.pid!)).toBe(true);
       expect(scopeB.assign(processB.pid!).ok).toBe(true);
+      expect((await scopeB.reconcile(processB.pid!)).ok).toBe(true);
 
       await waitForMembership(scopeA, 2);
       await waitForMembership(scopeB, 2);
@@ -33,6 +35,42 @@ describe.runIf(process.platform === "win32")("WindowsProcessScope integration", 
       globalJob.close();
       processA.kill();
       processB.kill();
+    }
+  }, 15_000);
+
+  it("reconciles and terminates a descendant created before root assignment", async () => {
+    const globalJob = new JobObject();
+    const scope = new WindowsProcessScopeFactory().create();
+    const root = spawn(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "$p=Start-Process ping.exe -ArgumentList '-n','30','127.0.0.1' -WindowStyle Hidden -PassThru; Write-Output $p.Id; Start-Sleep -Seconds 30",
+      ],
+      { stdio: ["ignore", "pipe", "ignore"], windowsHide: true },
+    );
+    const childPid = await readFirstPid(root);
+
+    try {
+      expect(globalJob.assign(root.pid!)).toBe(true);
+      expect(scope.assign(root.pid!).ok).toBe(true);
+      expect((await scope.reconcile(root.pid!)).ok).toBe(true);
+      expect(scope.queryProcessIds().processIds).toEqual(
+        expect.arrayContaining([root.pid!, childPid]),
+      );
+
+      expect(scope.terminate(1).ok).toBe(true);
+      await expect(scope.waitForEmpty(1_900)).resolves.toEqual({ ok: true });
+      expect(await hasExited(root, 100)).toBe(true);
+      expect(processIsAlive(childPid)).toBe(false);
+    } finally {
+      scope.close();
+      globalJob.close();
+      root.kill();
+      try { process.kill(childPid); } catch { /* already gone */ }
     }
   }, 15_000);
 });
@@ -70,4 +108,28 @@ async function hasExited(process: ChildProcess, timeoutMs: number): Promise<bool
     new Promise<true>((resolve) => process.once("exit", () => resolve(true))),
     delay(timeoutMs).then(() => false),
   ]);
+}
+
+async function readFirstPid(process: ChildProcess): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let output = "";
+    const timeout = setTimeout(() => reject(new Error("child PID output timed out")), 3_000);
+    process.stdout!.on("data", (chunk) => {
+      output += String(chunk);
+      const match = output.match(/\d+/);
+      if (!match) return;
+      clearTimeout(timeout);
+      resolve(Number(match[0]));
+    });
+    process.once("error", reject);
+  });
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/apps/server/src/services/windows-process-scope.test.ts
+++ b/apps/server/src/services/windows-process-scope.test.ts
@@ -156,6 +156,37 @@ describe("WindowsProcessScope", () => {
     expect(scope.ownsProcessTree).toBe(false);
   });
 
+  it("retries a transient capture failure and then grants authority", async () => {
+    const native = createNative([101]);
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+    const capture = vi.fn()
+      .mockRejectedValueOnce(new Error("snapshot busy"))
+      .mockResolvedValueOnce([
+        { pid: 101, parentPid: null, startMarker: "root", depth: 0 },
+      ]);
+
+    await expect(scope.reconcile(101, capture)).resolves.toEqual({ ok: true });
+
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(scope.ownsProcessTree).toBe(true);
+  });
+
+  it("fails closed after every capture pass fails", async () => {
+    const native = createNative([101]);
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+    const capture = vi.fn().mockRejectedValue(new Error("snapshot unavailable"));
+
+    await expect(scope.reconcile(101, capture)).resolves.toEqual({
+      ok: false,
+      error: "snapshot unavailable",
+    });
+
+    expect(capture).toHaveBeenCalledTimes(5);
+    expect(scope.ownsProcessTree).toBe(false);
+  });
+
   it("rejects Process32FirstW failure with a non-exhaustion error", async () => {
     const snapshotHandle = { kind: "snapshot" };
     const native = createNative([101]);
@@ -173,7 +204,7 @@ describe("WindowsProcessScope", () => {
     expect(result).toEqual({ ok: false, error: "Process32FirstW failed (5)" });
     expect(scope.ownsProcessTree).toBe(false);
     expect(native.closeHandle).toHaveBeenCalledWith(snapshotHandle);
-    expect(vi.mocked(native.closeHandle).mock.calls.filter(([handle]) => handle === snapshotHandle)).toHaveLength(1);
+    expect(vi.mocked(native.closeHandle).mock.calls.filter(([handle]) => handle === snapshotHandle)).toHaveLength(5);
   });
 
   it("rejects a partial snapshot when Process32NextW fails unexpectedly", async () => {
@@ -198,7 +229,7 @@ describe("WindowsProcessScope", () => {
 
     expect(result).toEqual({ ok: false, error: "Process32NextW failed (5)" });
     expect(scope.ownsProcessTree).toBe(false);
-    expect(vi.mocked(native.closeHandle).mock.calls.filter(([handle]) => handle === snapshotHandle)).toHaveLength(1);
+    expect(vi.mocked(native.closeHandle).mock.calls.filter(([handle]) => handle === snapshotHandle)).toHaveLength(5);
   });
 
   it("accepts ERROR_NO_MORE_FILES as complete Process32NextW exhaustion", async () => {

--- a/apps/server/src/services/windows-process-scope.test.ts
+++ b/apps/server/src/services/windows-process-scope.test.ts
@@ -155,4 +155,126 @@ describe("WindowsProcessScope", () => {
     expect(result.ok).toBe(false);
     expect(scope.ownsProcessTree).toBe(false);
   });
+
+  it("rejects Process32FirstW failure with a non-exhaustion error", async () => {
+    const snapshotHandle = { kind: "snapshot" };
+    const native = createNative([101]);
+    Object.assign(native, {
+      createToolhelp32Snapshot: vi.fn(() => snapshotHandle),
+      process32First: vi.fn(() => 0),
+      process32Next: vi.fn(() => 0),
+      getProcessTimes: vi.fn(() => 1),
+    });
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+
+    const result = await scope.reconcile(101);
+
+    expect(result).toEqual({ ok: false, error: "Process32FirstW failed (5)" });
+    expect(scope.ownsProcessTree).toBe(false);
+    expect(native.closeHandle).toHaveBeenCalledWith(snapshotHandle);
+    expect(vi.mocked(native.closeHandle).mock.calls.filter(([handle]) => handle === snapshotHandle)).toHaveLength(1);
+  });
+
+  it("rejects a partial snapshot when Process32NextW fails unexpectedly", async () => {
+    const snapshotHandle = { kind: "snapshot" };
+    const native = createNative([101]);
+    Object.assign(native, {
+      createToolhelp32Snapshot: vi.fn(() => snapshotHandle),
+      process32First: vi.fn((_snapshot: unknown, entry: Buffer) => {
+        writeProcessEntry(entry, 101, 1);
+        return 1;
+      }),
+      process32Next: vi.fn(() => 0),
+      getProcessTimes: vi.fn((_process: unknown, creation: Buffer) => {
+        creation.writeBigUInt64LE(1n);
+        return 1;
+      }),
+    });
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+
+    const result = await scope.reconcile(101);
+
+    expect(result).toEqual({ ok: false, error: "Process32NextW failed (5)" });
+    expect(scope.ownsProcessTree).toBe(false);
+    expect(vi.mocked(native.closeHandle).mock.calls.filter(([handle]) => handle === snapshotHandle)).toHaveLength(1);
+  });
+
+  it("accepts ERROR_NO_MORE_FILES as complete Process32NextW exhaustion", async () => {
+    const snapshotHandle = { kind: "snapshot" };
+    const native = createNative([101]);
+    vi.mocked(native.getLastError).mockReturnValue(18);
+    Object.assign(native, {
+      createToolhelp32Snapshot: vi.fn(() => snapshotHandle),
+      process32First: vi.fn((_snapshot: unknown, entry: Buffer) => {
+        writeProcessEntry(entry, 101, 1);
+        return 1;
+      }),
+      process32Next: vi.fn(() => 0),
+      getProcessTimes: vi.fn((_process: unknown, creation: Buffer) => {
+        creation.writeBigUInt64LE(1n);
+        return 1;
+      }),
+    });
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+
+    await expect(scope.reconcile(101)).resolves.toEqual({ ok: true });
+
+    expect(scope.ownsProcessTree).toBe(true);
+    expect(vi.mocked(native.closeHandle).mock.calls.filter(([handle]) => handle === snapshotHandle)).toHaveLength(1);
+  });
+
+  it("fails closed when GetLastError returns an invalid value", async () => {
+    const native = createNative([101]);
+    vi.mocked(native.getLastError).mockReturnValue(Number.NaN);
+    Object.assign(native, {
+      createToolhelp32Snapshot: vi.fn(() => ({ kind: "snapshot" })),
+      process32First: vi.fn((_snapshot: unknown, entry: Buffer) => {
+        writeProcessEntry(entry, 101, 1);
+        return 1;
+      }),
+      process32Next: vi.fn(() => 0),
+      getProcessTimes: vi.fn(() => 1),
+    });
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+
+    const result = await scope.reconcile(101);
+
+    expect(result).toEqual({ ok: false, error: "GetLastError returned invalid value" });
+    expect(scope.ownsProcessTree).toBe(false);
+  });
+
+  it("fails closed when GetLastError binding throws", async () => {
+    const native = createNative([101]);
+    vi.mocked(native.getLastError).mockImplementation(() => {
+      throw new Error("binding unavailable");
+    });
+    Object.assign(native, {
+      createToolhelp32Snapshot: vi.fn(() => ({ kind: "snapshot" })),
+      process32First: vi.fn((_snapshot: unknown, entry: Buffer) => {
+        writeProcessEntry(entry, 101, 1);
+        return 1;
+      }),
+      process32Next: vi.fn(() => 0),
+      getProcessTimes: vi.fn(() => 1),
+    });
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+
+    const result = await scope.reconcile(101);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "GetLastError failed: binding unavailable",
+    });
+    expect(scope.ownsProcessTree).toBe(false);
+  });
 });
+
+function writeProcessEntry(entry: Buffer, pid: number, parentPid: number): void {
+  entry.writeUInt32LE(pid, 8);
+  entry.writeUInt32LE(parentPid, process.arch === "ia32" ? 24 : 32);
+}

--- a/apps/server/src/services/windows-process-scope.test.ts
+++ b/apps/server/src/services/windows-process-scope.test.ts
@@ -31,6 +31,10 @@ describe("WindowsProcessScope", () => {
     const scope = new WindowsProcessScope(native);
 
     expect(scope.assign(101)).toEqual({ ok: true });
+    await expect(scope.reconcile(101, async () => [
+      { pid: 101, parentPid: null, startMarker: "root", depth: 0 },
+      { pid: 102, parentPid: 101, startMarker: "child", depth: 1 },
+    ])).resolves.toEqual({ ok: true });
     expect(scope.ownsProcessTree).toBe(true);
     expect(scope.queryProcessIds()).toEqual({
       ok: true,
@@ -79,5 +83,76 @@ describe("WindowsProcessScope", () => {
     expect(scope.terminate().ok).toBe(false);
     await expect(scope.waitForEmpty(1)).resolves.toMatchObject({ ok: false });
     expect(() => scope.close()).not.toThrow();
+  });
+
+  it("assigns pre-existing descendants shallowest-first and converges", async () => {
+    const members: number[] = [];
+    const native = createNative(members);
+    vi.mocked(native.assignProcessToJobObject).mockImplementation((_job, process) => {
+      const pid = (process as { pid?: number }).pid;
+      if (pid) members.push(pid);
+      return 1;
+    });
+    vi.mocked(native.openProcess).mockImplementation((_access, _inherit, pid) => ({ pid }));
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+    const tree = [
+      { pid: 101, parentPid: null, startMarker: "root", depth: 0 },
+      { pid: 102, parentPid: 101, startMarker: "child", depth: 1 },
+      { pid: 103, parentPid: 102, startMarker: "grandchild", depth: 2 },
+    ] as const;
+
+    await expect(scope.reconcile(101, async () => tree)).resolves.toEqual({ ok: true });
+
+    expect(scope.ownsProcessTree).toBe(true);
+    expect(members).toEqual([101, 102, 103]);
+  });
+
+  it("captures a child spawned during reconciliation on the next pass", async () => {
+    const members: number[] = [];
+    const native = createNative(members);
+    vi.mocked(native.assignProcessToJobObject).mockImplementation((_job, process) => {
+      const pid = (process as { pid?: number }).pid;
+      if (pid) members.push(pid);
+      return 1;
+    });
+    vi.mocked(native.openProcess).mockImplementation((_access, _inherit, pid) => ({ pid }));
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+    let captures = 0;
+
+    await expect(scope.reconcile(101, async () => {
+      captures += 1;
+      return captures < 3
+        ? [
+            { pid: 101, parentPid: null, startMarker: "root", depth: 0 },
+            { pid: 102, parentPid: 101, startMarker: "child", depth: 1 },
+          ]
+        : [
+            { pid: 101, parentPid: null, startMarker: "root", depth: 0 },
+            { pid: 102, parentPid: 101, startMarker: "child", depth: 1 },
+            { pid: 103, parentPid: 102, startMarker: "grandchild", depth: 2 },
+          ];
+    })).resolves.toEqual({ ok: true });
+
+    expect(members).toContain(103);
+    expect(scope.ownsProcessTree).toBe(true);
+  });
+
+  it("fails closed when reconciliation never converges", async () => {
+    const members: number[] = [];
+    const native = createNative(members);
+    vi.mocked(native.openProcess).mockImplementation((_access, _inherit, pid) => ({ pid }));
+    const scope = new WindowsProcessScope(native);
+    expect(scope.assign(101).ok).toBe(true);
+    let nextPid = 102;
+
+    const result = await scope.reconcile(101, async () => [
+      { pid: 101, parentPid: null, startMarker: "root", depth: 0 },
+      { pid: nextPid++, parentPid: 101, startMarker: `child-${nextPid}`, depth: 1 },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(scope.ownsProcessTree).toBe(false);
   });
 });

--- a/apps/server/src/services/windows-process-scope.test.ts
+++ b/apps/server/src/services/windows-process-scope.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WindowsProcessScope,
+  type WindowsProcessScopeNative,
+} from "./windows-process-scope.js";
+
+function createNative(processIds: number[] = []): WindowsProcessScopeNative {
+  return {
+    jobHandle: { kind: "job" },
+    closeHandle: vi.fn(() => 1),
+    assignProcessToJobObject: vi.fn(() => 1),
+    openProcess: vi.fn(() => ({ kind: "process" })),
+    terminateJobObject: vi.fn(() => 1),
+    queryInformationJobObject: vi.fn((_job, _infoClass, buffer) => {
+      buffer.writeUInt32LE(processIds.length, 0);
+      buffer.writeUInt32LE(Math.min(processIds.length, 128), 4);
+      processIds.slice(0, 128).forEach((pid, index) => {
+        if (process.arch === "ia32") buffer.writeUInt32LE(pid, 8 + index * 4);
+        else buffer.writeBigUInt64LE(BigInt(pid), 8 + index * 8);
+      });
+      return 1;
+    }),
+    getLastError: vi.fn(() => 5),
+  };
+}
+
+describe("WindowsProcessScope", () => {
+  it("owns, enumerates, terminates, waits, and closes one process tree", async () => {
+    const processIds = [101, 102];
+    const native = createNative(processIds);
+    const scope = new WindowsProcessScope(native);
+
+    expect(scope.assign(101)).toEqual({ ok: true });
+    expect(scope.ownsProcessTree).toBe(true);
+    expect(scope.queryProcessIds()).toEqual({
+      ok: true,
+      processIds: [101, 102],
+      overflow: false,
+    });
+    expect(scope.terminate(7)).toEqual({ ok: true });
+    processIds.length = 0;
+    await expect(scope.waitForEmpty(50)).resolves.toEqual({ ok: true });
+
+    scope.close();
+    scope.close();
+    expect(native.closeHandle).toHaveBeenCalledTimes(2);
+    expect(native.terminateJobObject).toHaveBeenCalledWith(native.jobHandle, 7);
+  });
+
+  it("reports assignment failure and closes the process handle", () => {
+    const native = createNative();
+    vi.mocked(native.assignProcessToJobObject).mockReturnValue(0);
+    const scope = new WindowsProcessScope(native);
+
+    expect(scope.assign(101)).toEqual({
+      ok: false,
+      error: "AssignProcessToJobObject failed (5)",
+    });
+    expect(scope.ownsProcessTree).toBe(false);
+    expect(native.closeHandle).toHaveBeenCalledOnce();
+  });
+
+  it("bounds process enumeration and reports overflow", () => {
+    const native = createNative(Array.from({ length: 129 }, (_, index) => index + 1));
+    const scope = new WindowsProcessScope(native);
+
+    const result = scope.queryProcessIds();
+
+    expect(result.ok).toBe(true);
+    expect(result.processIds).toHaveLength(128);
+    expect(result.overflow).toBe(true);
+  });
+
+  it("is safely unavailable without native bindings", async () => {
+    const scope = new WindowsProcessScope(null);
+
+    expect(scope.ready).toBe(false);
+    expect(scope.assign(1).ok).toBe(false);
+    expect(scope.terminate().ok).toBe(false);
+    await expect(scope.waitForEmpty(1)).resolves.toMatchObject({ ok: false });
+    expect(() => scope.close()).not.toThrow();
+  });
+});

--- a/apps/server/src/services/windows-process-scope.ts
+++ b/apps/server/src/services/windows-process-scope.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 const nativeRequire = createRequire(import.meta.url);
 const PROCESS_SET_QUOTA = 0x0100;
 const PROCESS_TERMINATE = 0x0001;
+const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 const JOB_OBJECT_BASIC_PROCESS_ID_LIST = 3;
 const ERROR_MORE_DATA = 234;
 const MAX_PROCESS_IDS = 128;
@@ -10,6 +11,11 @@ const POINTER_BYTES = process.arch === "ia32" ? 4 : 8;
 const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
 const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
 const EXTENDED_LIMIT_SIZE = process.arch === "ia32" ? 112 : 144;
+const TH32CS_SNAPPROCESS = 0x00000002;
+const PROCESS_ENTRY_SIZE = process.arch === "ia32" ? 556 : 568;
+const PROCESS_ENTRY_PARENT_OFFSET = process.arch === "ia32" ? 24 : 32;
+const PROCESS_ENUMERATION_LIMIT = 16_384;
+const RECONCILIATION_PASS_LIMIT = 5;
 
 /** Result returned by a Windows process-scope operation. */
 export interface WindowsProcessScopeResult {
@@ -38,12 +44,31 @@ export interface WindowsProcessScopeNative {
     returnLength: Buffer,
   ) => number;
   readonly getLastError: () => number;
+  readonly createToolhelp32Snapshot?: (flags: number, processId: number) => unknown;
+  readonly process32First?: (snapshot: unknown, entry: Buffer) => number;
+  readonly process32Next?: (snapshot: unknown, entry: Buffer) => number;
+  readonly getProcessTimes?: (
+    process: unknown,
+    creation: Buffer,
+    exit: Buffer,
+    kernel: Buffer,
+    user: Buffer,
+  ) => number;
+}
+
+/** Creation-identity record used while reconciling a terminal process tree. */
+export interface WindowsProcessScopeIdentity {
+  readonly pid: number;
+  readonly parentPid: number | null;
+  readonly startMarker: string;
+  readonly depth: number;
 }
 
 /** Owns one terminal process tree with a nested Windows Job Object. */
 export class WindowsProcessScope {
   private native: WindowsProcessScopeNative | null;
   private assigned = false;
+  private authoritative = false;
 
   constructor(native: WindowsProcessScopeNative | null) {
     this.native = native;
@@ -56,7 +81,7 @@ export class WindowsProcessScope {
 
   /** Whether the terminal root was successfully assigned to this scope. */
   get ownsProcessTree(): boolean {
-    return this.assigned && this.native !== null;
+    return this.authoritative && this.native !== null;
   }
 
   /** Assign a terminal root process to this child Job Object. */
@@ -79,6 +104,89 @@ export class WindowsProcessScope {
         try { native.closeHandle(processHandle); } catch { /* best effort */ }
       }
     }
+  }
+
+  /**
+   * Reconcile descendants that existed before the root entered this Job Object.
+   * Authority is granted only after a complete pass observes no missing members.
+   */
+  async reconcile(
+    rootPid: number,
+    capture: () => Promise<readonly WindowsProcessScopeIdentity[]> =
+      async () => this.captureProcessTree(rootPid),
+  ): Promise<WindowsProcessScopeResult> {
+    if (!this.assigned || !this.native) {
+      return { ok: false, error: "scope root is not assigned" };
+    }
+    this.authoritative = false;
+    for (let pass = 0; pass < RECONCILIATION_PASS_LIMIT; pass += 1) {
+      let descendants: readonly WindowsProcessScopeIdentity[];
+      try {
+        descendants = await capture();
+      } catch (error) {
+        return { ok: false, error: describeError(error) };
+      }
+      if (descendants.length === 0 || descendants[0]?.pid !== rootPid) {
+        return { ok: false, error: "root creation identity unavailable" };
+      }
+      if (descendants.length > MAX_PROCESS_IDS) {
+        return { ok: false, error: `process tree exceeds ${MAX_PROCESS_IDS}-process limit` };
+      }
+      const membership = this.queryProcessIds();
+      if (!membership.ok || membership.overflow) {
+        return { ok: false, error: membership.error ?? "job membership overflow" };
+      }
+      const memberIds = new Set(membership.processIds);
+      const missing = descendants
+        .filter((identity) => !memberIds.has(identity.pid))
+        .sort((left, right) => left.depth - right.depth);
+      if (missing.length === 0) {
+        this.authoritative = true;
+        return { ok: true };
+      }
+
+      let validation: readonly WindowsProcessScopeIdentity[];
+      try {
+        validation = await capture();
+      } catch (error) {
+        return { ok: false, error: describeError(error) };
+      }
+      const validationByPid = new Map(validation.map((identity) => [identity.pid, identity]));
+      for (const identity of missing) {
+        const current = validationByPid.get(identity.pid);
+        if (!current || current.startMarker !== identity.startMarker) {
+          return { ok: false, error: `process identity changed for PID ${identity.pid}` };
+        }
+        const currentMembership = this.queryProcessIds();
+        if (!currentMembership.ok || currentMembership.overflow) {
+          return { ok: false, error: currentMembership.error ?? "job membership overflow" };
+        }
+        if (currentMembership.processIds.includes(identity.pid)) continue;
+        const assignment = this.assignProcess(identity.pid);
+        if (!assignment.ok) {
+          const racedMembership = this.queryProcessIds();
+          let racedIdentity: WindowsProcessScopeIdentity | undefined;
+          try {
+            racedIdentity = (await capture()).find((candidate) => candidate.pid === identity.pid);
+          } catch {
+            // Preserve the original assignment failure when race validation is unavailable.
+          }
+          if (
+            racedMembership.ok &&
+            !racedMembership.overflow &&
+            racedMembership.processIds.includes(identity.pid) &&
+            racedIdentity?.startMarker === identity.startMarker
+          ) {
+            continue;
+          }
+          return {
+            ok: false,
+            error: `${assignment.error ?? "process assignment failed"} for PID ${identity.pid}`,
+          };
+        }
+      }
+    }
+    return { ok: false, error: `process scope did not converge after ${RECONCILIATION_PASS_LIMIT} passes` };
   }
 
   /** Atomically terminate every process owned by this scope. */
@@ -146,11 +254,102 @@ export class WindowsProcessScope {
     if (!native) return;
     this.native = null;
     this.assigned = false;
+    this.authoritative = false;
     try { native.closeHandle(native.jobHandle); } catch { /* best effort */ }
   }
 
   private nativeFailure(native: WindowsProcessScopeNative, operation: string): WindowsProcessScopeResult {
     return { ok: false, error: `${operation} failed (${native.getLastError()})` };
+  }
+
+  private assignProcess(pid: number): WindowsProcessScopeResult {
+    const native = this.native;
+    if (!native) return { ok: false, error: "scope unavailable" };
+    let processHandle: unknown = null;
+    try {
+      processHandle = native.openProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
+      if (!processHandle) return this.nativeFailure(native, "OpenProcess");
+      return native.assignProcessToJobObject(native.jobHandle, processHandle)
+        ? { ok: true }
+        : this.nativeFailure(native, "AssignProcessToJobObject");
+    } catch (error) {
+      return { ok: false, error: describeError(error) };
+    } finally {
+      if (processHandle) {
+        try { native.closeHandle(processHandle); } catch { /* best effort */ }
+      }
+    }
+  }
+
+  private captureProcessTree(rootPid: number): WindowsProcessScopeIdentity[] {
+    const native = this.native;
+    if (
+      !native ||
+      !native.createToolhelp32Snapshot ||
+      !native.process32First ||
+      !native.process32Next ||
+      !native.getProcessTimes
+    ) {
+      throw new Error("native process snapshot unavailable");
+    }
+    const snapshot = native.createToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (!snapshot) throw new Error(`CreateToolhelp32Snapshot failed (${native.getLastError()})`);
+    const parentByPid = new Map<number, number>();
+    try {
+      const entry = Buffer.alloc(PROCESS_ENTRY_SIZE);
+      entry.writeUInt32LE(PROCESS_ENTRY_SIZE, 0);
+      let hasEntry = native.process32First(snapshot, entry);
+      let count = 0;
+      while (hasEntry && count < PROCESS_ENUMERATION_LIMIT) {
+        parentByPid.set(entry.readUInt32LE(8), entry.readUInt32LE(PROCESS_ENTRY_PARENT_OFFSET));
+        entry.fill(0);
+        entry.writeUInt32LE(PROCESS_ENTRY_SIZE, 0);
+        hasEntry = native.process32Next(snapshot, entry);
+        count += 1;
+      }
+      if (hasEntry) throw new Error(`process enumeration exceeds ${PROCESS_ENUMERATION_LIMIT}-entry limit`);
+    } finally {
+      native.closeHandle(snapshot);
+    }
+
+    const childrenByParent = new Map<number, number[]>();
+    for (const [pid, parentPid] of parentByPid) {
+      const children = childrenByParent.get(parentPid) ?? [];
+      children.push(pid);
+      childrenByParent.set(parentPid, children);
+    }
+    const pending = [{ pid: rootPid, parentPid: null as number | null, depth: 0 }];
+    const identities: WindowsProcessScopeIdentity[] = [];
+    const visited = new Set<number>();
+    while (pending.length > 0 && identities.length < MAX_PROCESS_IDS) {
+      const identity = pending.shift()!;
+      if (visited.has(identity.pid) || !parentByPid.has(identity.pid)) continue;
+      visited.add(identity.pid);
+      const startMarker = this.readStartMarker(identity.pid);
+      if (!startMarker) throw new Error(`creation identity unavailable for PID ${identity.pid}`);
+      identities.push({ ...identity, startMarker });
+      pending.push(...(childrenByParent.get(identity.pid) ?? []).map((pid) => ({
+        pid,
+        parentPid: identity.pid,
+        depth: identity.depth + 1,
+      })));
+    }
+    if (pending.length > 0) throw new Error(`process tree exceeds ${MAX_PROCESS_IDS}-process limit`);
+    return identities;
+  }
+
+  private readStartMarker(pid: number): string | null {
+    const native = this.native;
+    if (!native?.getProcessTimes) return null;
+    const processHandle = native.openProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+    if (!processHandle) return null;
+    try {
+      const times = [Buffer.alloc(8), Buffer.alloc(8), Buffer.alloc(8), Buffer.alloc(8)] as const;
+      if (!native.getProcessTimes(processHandle, ...times)) return null;
+      return times[0].toString("hex");
+    } finally {
+      native.closeHandle(processHandle);
+    }
   }
 }
 
@@ -189,6 +388,14 @@ export class WindowsProcessScopeFactory {
         terminateJobObject: kernel32.func("int __stdcall TerminateJobObject(void*, uint32)"),
         queryInformationJobObject: kernel32.func("int __stdcall QueryInformationJobObject(void*, int, void*, uint32, void*)"),
         getLastError: kernel32.func("uint32 __stdcall GetLastError()"),
+        createToolhelp32Snapshot: kernel32.func(
+          "void* __stdcall CreateToolhelp32Snapshot(uint32, uint32)",
+        ),
+        process32First: kernel32.func("int __stdcall Process32FirstW(void*, void*)"),
+        process32Next: kernel32.func("int __stdcall Process32NextW(void*, void*)"),
+        getProcessTimes: kernel32.func(
+          "int __stdcall GetProcessTimes(void*, void*, void*, void*, void*)",
+        ),
       });
     } catch {
       return new WindowsProcessScope(null);

--- a/apps/server/src/services/windows-process-scope.ts
+++ b/apps/server/src/services/windows-process-scope.ts
@@ -6,6 +6,7 @@ const PROCESS_TERMINATE = 0x0001;
 const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
 const JOB_OBJECT_BASIC_PROCESS_ID_LIST = 3;
 const ERROR_MORE_DATA = 234;
+const ERROR_NO_MORE_FILES = 18;
 const MAX_PROCESS_IDS = 128;
 const POINTER_BYTES = process.arch === "ia32" ? 4 : 8;
 const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
@@ -299,6 +300,13 @@ export class WindowsProcessScope {
       const entry = Buffer.alloc(PROCESS_ENTRY_SIZE);
       entry.writeUInt32LE(PROCESS_ENTRY_SIZE, 0);
       let hasEntry = native.process32First(snapshot, entry);
+      if (!hasEntry) {
+        const errorCode = readLastError(native);
+        if (errorCode !== ERROR_NO_MORE_FILES) {
+          throw new Error(`Process32FirstW failed (${errorCode})`);
+        }
+        return [];
+      }
       let count = 0;
       while (hasEntry && count < PROCESS_ENUMERATION_LIMIT) {
         parentByPid.set(entry.readUInt32LE(8), entry.readUInt32LE(PROCESS_ENTRY_PARENT_OFFSET));
@@ -308,6 +316,10 @@ export class WindowsProcessScope {
         count += 1;
       }
       if (hasEntry) throw new Error(`process enumeration exceeds ${PROCESS_ENUMERATION_LIMIT}-entry limit`);
+      const errorCode = readLastError(native);
+      if (errorCode !== ERROR_NO_MORE_FILES) {
+        throw new Error(`Process32NextW failed (${errorCode})`);
+      }
     } finally {
       native.closeHandle(snapshot);
     }
@@ -405,4 +417,17 @@ export class WindowsProcessScopeFactory {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function readLastError(native: WindowsProcessScopeNative): number {
+  let errorCode: number;
+  try {
+    errorCode = native.getLastError();
+  } catch (error) {
+    throw new Error(`GetLastError failed: ${describeError(error)}`);
+  }
+  if (!Number.isInteger(errorCode) || errorCode < 0 || errorCode > 0xffff_ffff) {
+    throw new Error("GetLastError returned invalid value");
+  }
+  return errorCode;
 }

--- a/apps/server/src/services/windows-process-scope.ts
+++ b/apps/server/src/services/windows-process-scope.ts
@@ -1,0 +1,201 @@
+import { createRequire } from "node:module";
+
+const nativeRequire = createRequire(import.meta.url);
+const PROCESS_SET_QUOTA = 0x0100;
+const PROCESS_TERMINATE = 0x0001;
+const JOB_OBJECT_BASIC_PROCESS_ID_LIST = 3;
+const ERROR_MORE_DATA = 234;
+const MAX_PROCESS_IDS = 128;
+const POINTER_BYTES = process.arch === "ia32" ? 4 : 8;
+const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+const EXTENDED_LIMIT_SIZE = process.arch === "ia32" ? 112 : 144;
+
+/** Result returned by a Windows process-scope operation. */
+export interface WindowsProcessScopeResult {
+  readonly ok: boolean;
+  readonly error?: string;
+}
+
+/** Bounded snapshot of processes currently owned by a Windows process scope. */
+export interface WindowsProcessScopeProcessIds extends WindowsProcessScopeResult {
+  readonly processIds: readonly number[];
+  readonly overflow: boolean;
+}
+
+/** Native calls used by a per-terminal Windows Job Object. */
+export interface WindowsProcessScopeNative {
+  readonly jobHandle: unknown;
+  readonly closeHandle: (handle: unknown) => number;
+  readonly assignProcessToJobObject: (job: unknown, process: unknown) => number;
+  readonly openProcess: (access: number, inherit: number, pid: number) => unknown;
+  readonly terminateJobObject: (job: unknown, exitCode: number) => number;
+  readonly queryInformationJobObject: (
+    job: unknown,
+    infoClass: number,
+    buffer: Buffer,
+    bufferLength: number,
+    returnLength: Buffer,
+  ) => number;
+  readonly getLastError: () => number;
+}
+
+/** Owns one terminal process tree with a nested Windows Job Object. */
+export class WindowsProcessScope {
+  private native: WindowsProcessScopeNative | null;
+  private assigned = false;
+
+  constructor(native: WindowsProcessScopeNative | null) {
+    this.native = native;
+  }
+
+  /** Whether the native child Job Object was initialized successfully. */
+  get ready(): boolean {
+    return this.native !== null;
+  }
+
+  /** Whether the terminal root was successfully assigned to this scope. */
+  get ownsProcessTree(): boolean {
+    return this.assigned && this.native !== null;
+  }
+
+  /** Assign a terminal root process to this child Job Object. */
+  assign(pid: number): WindowsProcessScopeResult {
+    const native = this.native;
+    if (!native) return { ok: false, error: "scope unavailable" };
+    let processHandle: unknown = null;
+    try {
+      processHandle = native.openProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
+      if (!processHandle) return this.nativeFailure(native, "OpenProcess");
+      if (!native.assignProcessToJobObject(native.jobHandle, processHandle)) {
+        return this.nativeFailure(native, "AssignProcessToJobObject");
+      }
+      this.assigned = true;
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: describeError(error) };
+    } finally {
+      if (processHandle) {
+        try { native.closeHandle(processHandle); } catch { /* best effort */ }
+      }
+    }
+  }
+
+  /** Atomically terminate every process owned by this scope. */
+  terminate(exitCode = 1): WindowsProcessScopeResult {
+    const native = this.native;
+    if (!native || !this.assigned) return { ok: false, error: "scope does not own a process tree" };
+    try {
+      return native.terminateJobObject(native.jobHandle, exitCode)
+        ? { ok: true }
+        : this.nativeFailure(native, "TerminateJobObject");
+    } catch (error) {
+      return { ok: false, error: describeError(error) };
+    }
+  }
+
+  /** Query at most 128 process IDs currently owned by this scope. */
+  queryProcessIds(): WindowsProcessScopeProcessIds {
+    const native = this.native;
+    if (!native) return { ok: false, processIds: [], overflow: false, error: "scope unavailable" };
+    const buffer = Buffer.alloc(8 + MAX_PROCESS_IDS * POINTER_BYTES);
+    const returnLength = Buffer.alloc(4);
+    try {
+      const ok = native.queryInformationJobObject(
+        native.jobHandle,
+        JOB_OBJECT_BASIC_PROCESS_ID_LIST,
+        buffer,
+        buffer.length,
+        returnLength,
+      );
+      const errorCode = ok ? 0 : native.getLastError();
+      if (!ok && errorCode !== ERROR_MORE_DATA) {
+        return { ok: false, processIds: [], overflow: false, error: `QueryInformationJobObject failed (${errorCode})` };
+      }
+      const assignedCount = buffer.readUInt32LE(0);
+      const listedCount = Math.min(buffer.readUInt32LE(4), MAX_PROCESS_IDS);
+      const processIds: number[] = [];
+      for (let index = 0; index < listedCount; index += 1) {
+        const offset = 8 + index * POINTER_BYTES;
+        const pid = POINTER_BYTES === 4
+          ? buffer.readUInt32LE(offset)
+          : Number(buffer.readBigUInt64LE(offset));
+        if (pid > 0) processIds.push(pid);
+      }
+      return { ok: true, processIds, overflow: assignedCount > MAX_PROCESS_IDS || errorCode === ERROR_MORE_DATA };
+    } catch (error) {
+      return { ok: false, processIds: [], overflow: false, error: describeError(error) };
+    }
+  }
+
+  /** Wait asynchronously until the scope is empty or the timeout expires. */
+  async waitForEmpty(timeoutMs: number): Promise<WindowsProcessScopeResult> {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    do {
+      const snapshot = this.queryProcessIds();
+      if (!snapshot.ok) return snapshot;
+      if (!snapshot.overflow && snapshot.processIds.length === 0) return { ok: true };
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    } while (Date.now() < deadline);
+    return { ok: false, error: `process scope remained non-empty after ${timeoutMs}ms` };
+  }
+
+  /** Close the child Job Object handle exactly once. */
+  close(): void {
+    const native = this.native;
+    if (!native) return;
+    this.native = null;
+    this.assigned = false;
+    try { native.closeHandle(native.jobHandle); } catch { /* best effort */ }
+  }
+
+  private nativeFailure(native: WindowsProcessScopeNative, operation: string): WindowsProcessScopeResult {
+    return { ok: false, error: `${operation} failed (${native.getLastError()})` };
+  }
+}
+
+/** Creates per-terminal Windows process scopes, or unavailable scopes off Windows. */
+export class WindowsProcessScopeFactory {
+  /** Create one isolated terminal process scope. */
+  create(): WindowsProcessScope {
+    if (process.platform !== "win32") return new WindowsProcessScope(null);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const koffi = nativeRequire("koffi") as any;
+      const kernel32 = koffi.load("kernel32.dll");
+      const createJobObject = kernel32.func("void* __stdcall CreateJobObjectW(void*, str16)");
+      const closeHandle = kernel32.func("int __stdcall CloseHandle(void*)");
+      const setInformationJobObject = kernel32.func(
+        "int __stdcall SetInformationJobObject(void*, int, void*, uint32)",
+      );
+      const jobHandle = createJobObject(null, null);
+      if (!jobHandle) return new WindowsProcessScope(null);
+      const limits = Buffer.alloc(EXTENDED_LIMIT_SIZE);
+      limits.writeUInt32LE(JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, 16);
+      if (!setInformationJobObject(
+        jobHandle,
+        JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+        limits,
+        limits.length,
+      )) {
+        closeHandle(jobHandle);
+        return new WindowsProcessScope(null);
+      }
+      return new WindowsProcessScope({
+        jobHandle,
+        closeHandle,
+        assignProcessToJobObject: kernel32.func("int __stdcall AssignProcessToJobObject(void*, void*)"),
+        openProcess: kernel32.func("void* __stdcall OpenProcess(uint32, int, uint32)"),
+        terminateJobObject: kernel32.func("int __stdcall TerminateJobObject(void*, uint32)"),
+        queryInformationJobObject: kernel32.func("int __stdcall QueryInformationJobObject(void*, int, void*, uint32, void*)"),
+        getLastError: kernel32.func("uint32 __stdcall GetLastError()"),
+      });
+    } catch {
+      return new WindowsProcessScope(null);
+    }
+  }
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/server/src/services/windows-process-scope.ts
+++ b/apps/server/src/services/windows-process-scope.ts
@@ -125,6 +125,7 @@ export class WindowsProcessScope {
       try {
         descendants = await capture();
       } catch (error) {
+        if (pass + 1 < RECONCILIATION_PASS_LIMIT) continue;
         return { ok: false, error: describeError(error) };
       }
       if (descendants.length === 0 || descendants[0]?.pid !== rootPid) {
@@ -150,6 +151,7 @@ export class WindowsProcessScope {
       try {
         validation = await capture();
       } catch (error) {
+        if (pass + 1 < RECONCILIATION_PASS_LIMIT) continue;
         return { ok: false, error: describeError(error) };
       }
       const validationByPid = new Map(validation.map((identity) => [identity.pid, identity]));

--- a/apps/web/src/__tests__/TerminalTabContent.test.tsx
+++ b/apps/web/src/__tests__/TerminalTabContent.test.tsx
@@ -107,6 +107,43 @@ describe("TerminalTabContent process-tree close", () => {
     expect(useTerminalStore.getState().terminals["thread-1"]).toBeUndefined();
   });
 
+  it("blocks Escape and outside dismissal while termination is pending", async () => {
+    terminalHasChildren.mockResolvedValue({ hasChildren: true });
+    let resolveKill!: () => void;
+    terminalKill.mockReturnValue(new Promise<void>((resolve) => { resolveKill = resolve; }));
+    render(<TerminalTabContent threadId="thread-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close PowerShell" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Close process tree" }));
+    const dialog = screen.getByRole("dialog");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    const backdrop = document.querySelector('[data-slot="dialog-overlay"]');
+    expect(backdrop).not.toBeNull();
+    fireEvent.pointerDown(backdrop!);
+    fireEvent.click(backdrop!);
+
+    expect(dialog).toBeInTheDocument();
+    expect(terminalKill).toHaveBeenCalledOnce();
+
+    await act(async () => resolveKill());
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("restores focus to the kill-all control after cancellation", async () => {
+    seedTwoTerminals();
+    terminalHasChildren.mockResolvedValue({ hasChildren: true });
+    render(<TerminalTabContent threadId="thread-1" />);
+    const killAll = screen.getByRole("button", { name: "Kill all terminals" });
+
+    fireEvent.click(killAll);
+    expect(await screen.findByText("Close 2 terminals?")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(killAll).toHaveFocus());
+    expect(terminalKillByThread).not.toHaveBeenCalled();
+  });
+
   it("confirms sequential active-child terminal closes", async () => {
     seedTwoTerminals();
     terminalHasChildren.mockResolvedValue({ hasChildren: true });

--- a/apps/web/src/__tests__/TerminalTabContent.test.tsx
+++ b/apps/web/src/__tests__/TerminalTabContent.test.tsx
@@ -1,0 +1,103 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const terminalKill = vi.fn();
+const terminalKillByThread = vi.fn();
+const terminalHasChildren = vi.fn();
+const terminalCreate = vi.fn();
+
+vi.mock("@/transport", () => ({
+  getTransport: () => ({
+    terminalKill,
+    terminalKillByThread,
+    terminalHasChildren,
+    terminalCreate,
+  }),
+}));
+
+import { TerminalTabContent } from "@/components/terminal/TerminalTabContent";
+import { useTerminalStore } from "@/stores/terminalStore";
+
+function seedTerminal(): void {
+  useTerminalStore.setState({
+    terminals: {
+      "thread-1": [{ id: "pty-1", threadId: "thread-1", label: "PowerShell" }],
+    },
+    terminalPanelByThread: {
+      "thread-1": { visible: true, height: 300, activeTerminalId: "pty-1" },
+    },
+    ptyToThread: { "pty-1": "thread-1" },
+    splitMode: true,
+  });
+}
+
+describe("TerminalTabContent process-tree close", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    terminalKill.mockResolvedValue(undefined);
+    terminalKillByThread.mockResolvedValue(undefined);
+    terminalCreate.mockResolvedValue({ ptyId: "new", shell: "pwsh" });
+    useTerminalStore.setState({
+      terminals: {},
+      terminalPanelByThread: {},
+      ptyToThread: {},
+      splitMode: true,
+    });
+    seedTerminal();
+  });
+
+  it("closes an idle terminal without showing confirmation", async () => {
+    terminalHasChildren.mockResolvedValue({ hasChildren: false });
+    render(<TerminalTabContent threadId="thread-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close PowerShell" }));
+
+    await waitFor(() => expect(terminalKill).toHaveBeenCalledOnce());
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(useTerminalStore.getState().terminals["thread-1"]).toBeUndefined();
+  });
+
+  it("cancels an active-tree close and restores focus to its close control", async () => {
+    terminalHasChildren.mockResolvedValue({ hasChildren: true });
+    render(<TerminalTabContent threadId="thread-1" />);
+    const close = screen.getByRole("button", { name: "Close PowerShell" });
+
+    fireEvent.click(close);
+    expect(await screen.findByText("Close PowerShell?")).toBeInTheDocument();
+    expect(screen.getByText(/entire process tree/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(close).toHaveFocus());
+    expect(terminalKill).not.toHaveBeenCalled();
+    expect(screen.getByText("PowerShell")).toBeInTheDocument();
+  });
+
+  it("guards duplicate confirmation and removes the terminal once", async () => {
+    terminalHasChildren.mockResolvedValue({ hasChildren: true });
+    let resolveKill!: () => void;
+    terminalKill.mockReturnValue(new Promise<void>((resolve) => { resolveKill = resolve; }));
+    render(<TerminalTabContent threadId="thread-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close PowerShell" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Close process tree" }));
+    const pending = screen.getByRole("button", { name: "Closing..." });
+    expect(pending).toBeDisabled();
+    fireEvent.click(pending);
+    expect(terminalKill).toHaveBeenCalledOnce();
+
+    await act(async () => resolveKill());
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(terminalKill).toHaveBeenCalledOnce();
+    expect(useTerminalStore.getState().terminals["thread-1"]).toBeUndefined();
+  });
+
+  it("fails closed to confirmation when descendant inspection fails", async () => {
+    terminalHasChildren.mockRejectedValue(new Error("inspection unavailable"));
+    render(<TerminalTabContent threadId="thread-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close PowerShell" }));
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(terminalKill).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/TerminalTabContent.test.tsx
+++ b/apps/web/src/__tests__/TerminalTabContent.test.tsx
@@ -31,6 +31,22 @@ function seedTerminal(): void {
   });
 }
 
+function seedTwoTerminals(): void {
+  useTerminalStore.setState({
+    terminals: {
+      "thread-1": [
+        { id: "pty-1", threadId: "thread-1", label: "PowerShell" },
+        { id: "pty-2", threadId: "thread-1", label: "Command Prompt" },
+      ],
+    },
+    terminalPanelByThread: {
+      "thread-1": { visible: true, height: 300, activeTerminalId: "pty-1" },
+    },
+    ptyToThread: { "pty-1": "thread-1", "pty-2": "thread-1" },
+    splitMode: true,
+  });
+}
+
 describe("TerminalTabContent process-tree close", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -88,6 +104,28 @@ describe("TerminalTabContent process-tree close", () => {
     await act(async () => resolveKill());
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     expect(terminalKill).toHaveBeenCalledOnce();
+    expect(useTerminalStore.getState().terminals["thread-1"]).toBeUndefined();
+  });
+
+  it("confirms sequential active-child terminal closes", async () => {
+    seedTwoTerminals();
+    terminalHasChildren.mockResolvedValue({ hasChildren: true });
+    render(<TerminalTabContent threadId="thread-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close PowerShell" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Close process tree" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+    const secondClose = screen.getByRole("button", { name: "Close Command Prompt" });
+    expect(secondClose).toBeEnabled();
+    fireEvent.click(secondClose);
+    const secondConfirm = await screen.findByRole("button", { name: "Close process tree" });
+    expect(secondConfirm).toBeEnabled();
+    fireEvent.click(secondConfirm);
+
+    await waitFor(() => expect(terminalKill).toHaveBeenCalledTimes(2));
+    expect(terminalKill).toHaveBeenNthCalledWith(1, "pty-1");
+    expect(terminalKill).toHaveBeenNthCalledWith(2, "pty-2");
     expect(useTerminalStore.getState().terminals["thread-1"]).toBeUndefined();
   });
 

--- a/apps/web/src/components/terminal/TerminalKillConfirmDialog.tsx
+++ b/apps/web/src/components/terminal/TerminalKillConfirmDialog.tsx
@@ -11,6 +11,10 @@ import { Button } from "@/components/ui/button";
 export interface TerminalKillConfirmDialogProps {
   /** Whether the dialog is open. */
   readonly open: boolean;
+  /** Shell or terminal group being closed. */
+  readonly targetName?: string;
+  /** Whether process-tree termination is in progress. */
+  readonly pending?: boolean;
   /** Called when the user confirms the kill. */
   readonly onConfirm: () => void;
   /** Called when the user cancels or the dialog is dismissed. */
@@ -24,6 +28,8 @@ export interface TerminalKillConfirmDialogProps {
  */
 export const TerminalKillConfirmDialog = memo(function TerminalKillConfirmDialog({
   open,
+  targetName = "terminal",
+  pending = false,
   onConfirm,
   onCancel,
 }: TerminalKillConfirmDialogProps) {
@@ -37,17 +43,17 @@ export const TerminalKillConfirmDialog = memo(function TerminalKillConfirmDialog
       <DialogContent className="max-w-sm">
         <div className="space-y-3">
           <DialogTitle className="text-sm font-medium">
-            Kill terminal?
+            Close {targetName}?
           </DialogTitle>
           <DialogDescription className="text-xs text-muted-foreground">
-            This terminal has running processes. Closing it will forcibly terminate them.
+            This will terminate the entire process tree, including every running child process.
           </DialogDescription>
           <div className="flex justify-end gap-2 pt-1">
-            <Button variant="outline" size="sm" onClick={onCancel}>
+            <Button variant="outline" size="sm" onClick={onCancel} disabled={pending}>
               Cancel
             </Button>
-            <Button variant="destructive" size="sm" onClick={onConfirm}>
-              Kill anyway
+            <Button variant="destructive" size="sm" onClick={onConfirm} disabled={pending}>
+              {pending ? "Closing..." : "Close process tree"}
             </Button>
           </div>
         </div>

--- a/apps/web/src/components/terminal/TerminalKillConfirmDialog.tsx
+++ b/apps/web/src/components/terminal/TerminalKillConfirmDialog.tsx
@@ -34,13 +34,20 @@ export const TerminalKillConfirmDialog = memo(function TerminalKillConfirmDialog
   onCancel,
 }: TerminalKillConfirmDialogProps) {
   const handleOpenChange = useCallback(
-    (isOpen: boolean) => { if (!isOpen) onCancel(); },
-    [onCancel],
+    (isOpen: boolean, eventDetails: { cancel: () => void }) => {
+      if (isOpen) return;
+      if (pending) {
+        eventDetails.cancel();
+        return;
+      }
+      onCancel();
+    },
+    [onCancel, pending],
   );
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-sm">
+      <DialogContent className="max-w-sm" showCloseButton={!pending}>
         <div className="space-y-3">
           <DialogTitle className="text-sm font-medium">
             Close {targetName}?

--- a/apps/web/src/components/terminal/TerminalList.tsx
+++ b/apps/web/src/components/terminal/TerminalList.tsx
@@ -12,7 +12,7 @@ interface TerminalListProps {
   readonly threadId: string;
   readonly onClose: (ptyId: string, trigger: HTMLButtonElement) => void;
   readonly onAdd: () => void;
-  readonly onDeleteAll: () => void;
+  readonly onDeleteAll: (trigger: HTMLButtonElement) => void;
 }
 
 // Stable action refs.
@@ -149,7 +149,7 @@ export const TerminalList = memo(function TerminalList({
               <Button
                 variant="ghost"
                 size="icon-xs"
-                onClick={onDeleteAll}
+                onClick={(event) => onDeleteAll(event.currentTarget)}
                 className="text-muted-foreground hover:text-foreground"
                 aria-label="Kill all terminals"
               />

--- a/apps/web/src/components/terminal/TerminalList.tsx
+++ b/apps/web/src/components/terminal/TerminalList.tsx
@@ -10,7 +10,7 @@ const EMPTY_TERMINALS: readonly TerminalInstance[] = [];
 /** Props for the terminal sidebar. */
 interface TerminalListProps {
   readonly threadId: string;
-  readonly onClose: (ptyId: string) => void;
+  readonly onClose: (ptyId: string, trigger: HTMLButtonElement) => void;
   readonly onAdd: () => void;
   readonly onDeleteAll: () => void;
 }
@@ -196,7 +196,7 @@ export const TerminalList = memo(function TerminalList({
                 variant="ghost"
                 size="icon-xs"
                 className="shrink-0 bg-transparent opacity-0 transition-opacity hover:bg-transparent active:translate-y-0 active:bg-transparent focus-visible:opacity-100 group-hover:opacity-60"
-                onClick={() => onClose(terminal.id)}
+                onClick={(event) => onClose(terminal.id, event.currentTarget)}
                 aria-label={`Close ${terminal.label}`}
               >
                 <X />

--- a/apps/web/src/components/terminal/TerminalTabContent.tsx
+++ b/apps/web/src/components/terminal/TerminalTabContent.tsx
@@ -11,7 +11,7 @@ const EMPTY_TERMINALS: readonly TerminalInstance[] = [];
 
 type PendingClose =
   | { readonly kind: "one"; readonly ptyId: string; readonly name: string; readonly trigger: HTMLButtonElement }
-  | { readonly kind: "all"; readonly name: string };
+  | { readonly kind: "all"; readonly name: string; readonly trigger: HTMLButtonElement };
 
 const {
   addTerminal: storeAddTerminal,
@@ -110,7 +110,7 @@ export function TerminalTabContent({ threadId }: TerminalTabContentProps) {
   }, [threadId]);
 
   /** Kill-all with optional confirmation. */
-  const closeAllTerminals = useCallback(() => {
+  const closeAllTerminals = useCallback((trigger: HTMLButtonElement) => {
     if (terminals.length === 0) {
       void doCloseAllTerminals();
       return;
@@ -130,7 +130,7 @@ export function TerminalTabContent({ threadId }: TerminalTabContentProps) {
         void doCloseAllTerminals();
         return;
       }
-      setPendingKill({ kind: "all", name: `${terminals.length} terminals` });
+      setPendingKill({ kind: "all", name: `${terminals.length} terminals`, trigger });
     });
   }, [terminals, doCloseAllTerminals]);
 
@@ -151,7 +151,7 @@ export function TerminalTabContent({ threadId }: TerminalTabContentProps) {
   }, [pendingKill, isClosing, doCloseTerminal, doCloseAllTerminals]);
 
   const cancelKill = useCallback(() => {
-    const trigger = pendingKill?.kind === "one" ? pendingKill.trigger : null;
+    const trigger = pendingKill?.trigger ?? null;
     setPendingKill(null);
     window.setTimeout(() => trigger?.focus(), 0);
   }, [pendingKill]);

--- a/apps/web/src/components/terminal/TerminalTabContent.tsx
+++ b/apps/web/src/components/terminal/TerminalTabContent.tsx
@@ -136,13 +136,16 @@ export function TerminalTabContent({ threadId }: TerminalTabContentProps) {
 
   const confirmKill = useCallback(async () => {
     if (!pendingKill || isClosing) return;
+    const operation = pendingKill;
     setIsClosing(true);
-    const closed = pendingKill.kind === "one"
-      ? await doCloseTerminal(pendingKill.ptyId)
-      : await doCloseAllTerminals();
-    if (closed) {
-      setPendingKill(null);
-    } else {
+    try {
+      const closed = operation.kind === "one"
+        ? await doCloseTerminal(operation.ptyId)
+        : await doCloseAllTerminals();
+      if (closed) {
+        setPendingKill((current) => current === operation ? null : current);
+      }
+    } finally {
       setIsClosing(false);
     }
   }, [pendingKill, isClosing, doCloseTerminal, doCloseAllTerminals]);

--- a/apps/web/src/components/terminal/TerminalTabContent.tsx
+++ b/apps/web/src/components/terminal/TerminalTabContent.tsx
@@ -2,13 +2,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useToastStore } from "@/stores/toastStore";
 import { Terminal } from "lucide-react";
 import { useTerminalStore, type TerminalInstance } from "@/stores/terminalStore";
-import { useSettingsStore } from "@/stores/settingsStore";
 import { getTransport } from "@/transport";
 import { Button } from "@/components/ui/button";
 import { TerminalList } from "./TerminalList";
 import { TerminalKillConfirmDialog } from "./TerminalKillConfirmDialog";
 
 const EMPTY_TERMINALS: readonly TerminalInstance[] = [];
+
+type PendingClose =
+  | { readonly kind: "one"; readonly ptyId: string; readonly name: string; readonly trigger: HTMLButtonElement }
+  | { readonly kind: "all"; readonly name: string };
 
 const {
   addTerminal: storeAddTerminal,
@@ -33,15 +36,15 @@ export function TerminalTabContent({ threadId }: TerminalTabContentProps) {
   );
   const hasTerminals = terminals.length > 0;
 
-  const confirmOnKill = useSettingsStore((s) => s.settings.terminal.confirmOnKill);
-
-  const [pendingKill, setPendingKill] = useState<(() => void) | null>(null);
+  const [pendingKill, setPendingKill] = useState<PendingClose | null>(null);
+  const [isClosing, setIsClosing] = useState(false);
   /** Bumped on thread change so stale async kill confirmations are ignored. */
   const opGenRef = useRef(0);
 
   useEffect(() => {
     opGenRef.current += 1;
     setPendingKill(null);
+    setIsClosing(false);
   }, [threadId]);
 
   /** Creates a new terminal for the thread. */
@@ -59,22 +62,22 @@ export function TerminalTabContent({ threadId }: TerminalTabContentProps) {
   }, [threadId]);
 
   /** Immediate kill without guard. Waits for server RPC before evicting local state. */
-  const doCloseTerminal = useCallback(async (ptyId: string) => {
+  const doCloseTerminal = useCallback(async (ptyId: string): Promise<boolean> => {
     try {
       await getTransport().terminalKill(ptyId);
       storeRemoveTerminal(ptyId);
+      return true;
     } catch (err) {
       console.error("[terminal] Failed to kill terminal", ptyId, err);
+      return false;
     }
   }, [threadId]);
 
   /** Kill with optional confirmation. */
   const closeTerminal = useCallback(
-    (ptyId: string) => {
-      if (confirmOnKill === "never") {
-        void doCloseTerminal(ptyId);
-        return;
-      }
+    (ptyId: string, trigger: HTMLButtonElement) => {
+      const terminal = terminals.find((candidate) => candidate.id === ptyId);
+      if (!terminal) return;
       const opGen = opGenRef.current;
       getTransport()
         .terminalHasChildren(ptyId)
@@ -84,31 +87,31 @@ export function TerminalTabContent({ threadId }: TerminalTabContentProps) {
             void doCloseTerminal(ptyId);
             return;
           }
-          setPendingKill(() => () => {
-            void doCloseTerminal(ptyId);
-          });
+          setPendingKill({ kind: "one", ptyId, name: terminal.label, trigger });
         })
         .catch(() => {
           if (opGen !== opGenRef.current) return;
-          void doCloseTerminal(ptyId);
+          setPendingKill({ kind: "one", ptyId, name: terminal.label, trigger });
         });
     },
-    [confirmOnKill, doCloseTerminal],
+    [terminals, doCloseTerminal],
   );
 
   /** Immediate kill-all without guard. Waits for server RPC before evicting local state. */
-  const doCloseAllTerminals = useCallback(async () => {
+  const doCloseAllTerminals = useCallback(async (): Promise<boolean> => {
     try {
       await getTransport().terminalKillByThread(threadId);
       removeAllTerminals(threadId);
+      return true;
     } catch (err) {
       console.error("[terminal] Failed to kill terminals for thread", threadId, err);
+      return false;
     }
   }, [threadId]);
 
   /** Kill-all with optional confirmation. */
   const closeAllTerminals = useCallback(() => {
-    if (confirmOnKill === "never" || terminals.length === 0) {
+    if (terminals.length === 0) {
       void doCloseAllTerminals();
       return;
     }
@@ -127,25 +130,35 @@ export function TerminalTabContent({ threadId }: TerminalTabContentProps) {
         void doCloseAllTerminals();
         return;
       }
-      setPendingKill(() => () => {
-        void doCloseAllTerminals();
-      });
+      setPendingKill({ kind: "all", name: `${terminals.length} terminals` });
     });
-  }, [confirmOnKill, terminals, doCloseAllTerminals]);
+  }, [terminals, doCloseAllTerminals]);
 
-  const confirmKill = useCallback(() => {
-    pendingKill?.();
-    setPendingKill(null);
-  }, [pendingKill]);
+  const confirmKill = useCallback(async () => {
+    if (!pendingKill || isClosing) return;
+    setIsClosing(true);
+    const closed = pendingKill.kind === "one"
+      ? await doCloseTerminal(pendingKill.ptyId)
+      : await doCloseAllTerminals();
+    if (closed) {
+      setPendingKill(null);
+    } else {
+      setIsClosing(false);
+    }
+  }, [pendingKill, isClosing, doCloseTerminal, doCloseAllTerminals]);
 
   const cancelKill = useCallback(() => {
+    const trigger = pendingKill?.kind === "one" ? pendingKill.trigger : null;
     setPendingKill(null);
-  }, []);
+    window.setTimeout(() => trigger?.focus(), 0);
+  }, [pendingKill]);
 
   return (
     <>
       <TerminalKillConfirmDialog
         open={pendingKill !== null}
+        targetName={pendingKill?.name ?? "terminal"}
+        pending={isClosing}
         onConfirm={confirmKill}
         onCancel={cancelKill}
       />

--- a/apps/web/src/transport/ws-events.test.ts
+++ b/apps/web/src/transport/ws-events.test.ts
@@ -12,6 +12,8 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useProviderCatalogStore } from "@/stores/providerCatalogStore";
 import { useDiffStore } from "@/stores/diffStore";
 import { useThreadStore } from "@/stores/threadStore";
+import { useTerminalStore } from "@/stores/terminalStore";
+import { onPtyExit } from "@/components/terminal/ptyDataRegistry";
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {
@@ -191,5 +193,35 @@ describe("ws-events turn.persisted Review invalidation", () => {
       filesChanged: ["src/changed.ts"],
     });
     expect(useDiffStore.getState().diffRevisionByScope["thread-1"]).toBe(1);
+  });
+});
+
+describe("ws-events terminal.exit", () => {
+  afterEach(() => {
+    stopPushListeners();
+    vi.useRealTimers();
+  });
+
+  it("reports a natural exit before removing its terminal after two seconds", () => {
+    vi.useFakeTimers();
+    useTerminalStore.setState({
+      terminals: {
+        "thread-1": [{ id: "pty-1", threadId: "thread-1", label: "PowerShell" }],
+      },
+      ptyToThread: { "pty-1": "thread-1" },
+    });
+    const onExit = vi.fn();
+    const unsubscribe = onPtyExit("pty-1", onExit);
+    startPushListeners();
+
+    pushEmitter.emit("terminal.exit", { ptyId: "pty-1", code: 7 });
+
+    expect(onExit).toHaveBeenCalledWith({ ptyId: "pty-1", code: 7 });
+    expect(useTerminalStore.getState().terminals["thread-1"]).toHaveLength(1);
+    vi.advanceTimersByTime(1_999);
+    expect(useTerminalStore.getState().terminals["thread-1"]).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(useTerminalStore.getState().terminals["thread-1"]).toBeUndefined();
+    unsubscribe();
   });
 });


### PR DESCRIPTION
## What

Harden Terminal-tab process lifecycle handling and make shell exits diagnosable.

## Why

Closing a terminal must stop its complete process tree without freezing the tab, losing output, or leaving descendants behind. Windows also needs an interactive close path that preserves PID-reuse protection without blocking on repeated process-table queries.

## Key Changes

- Terminate and verify complete process trees on supported platforms.
- Add per-terminal nested Windows Job Objects with bounded, fail-closed descendant reconciliation.
- Preserve the server-wide Job Object for crash cleanup and retain the PID-safe fallback.
- Add the designed confirmation flow for active child processes, including cancellation, focus restoration, and duplicate-action protection.
- Preserve natural-exit status and exactly-once terminal removal.
- Add focused server, native Windows integration, UI, benchmark, and live Playwright coverage.

## Verification

- High-risk independent review: finding-free, `RECOMMEND_RELEASE`
- Focused Windows and TerminalService tests: 32 passed
- Typecheck: passed
- Lint: passed
- Live idle close: 86 ms
- Live confirmed root-plus-child close: 397 ms
- Idle close benchmark p95: 0.311 ms
- Pre-existing-child close benchmark p95: 1.050 ms
- Full repository gate: typecheck and lint passed; unit phase remained load-sensitive on Windows, while changed integration tests passed independently

Closes #946

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787543116&installation_model_id=20477&pr_number=955&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F955&signature=aebad82515a98f3932d7fe1288b7d64c1af151950f360f8f91b2d8e54ff2fc70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safer process-tree termination for terminal sessions, including verification that processes have fully stopped.
  - Added Windows-specific process management to improve cleanup of terminal processes and descendants.
  - Terminal close confirmations now identify the target and show a disabled “Closing...” state while processing.
  - Improved handling for concurrent close requests and terminal shutdowns.

- **Bug Fixes**
  - Prevented incomplete or failed termination from prematurely removing terminal sessions.
  - Improved terminal exit event handling and cleanup timing.
  - Added fallback behavior when Windows process management is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->