### PR TITLE
feat(web): redesign skills command rows

### DIFF
--- a/apps/web/e2e/slash-command-popup.spec.ts
+++ b/apps/web/e2e/slash-command-popup.spec.ts
@@ -181,11 +181,24 @@ test.describe("Slash command popup", () => {
     expect(
       Math.abs((popupBox?.y ?? 0) + (popupBox?.height ?? 0) - (composerBox?.y ?? 0)),
     ).toBeLessThanOrEqual(2);
-    await expect(popup.getByText("/compact")).toBeVisible();
-    await expect(popup.getByText("brainstorming")).toBeVisible();
-    await expect(popup.getByText("hookify", { exact: true })).toBeVisible();
-    await expect(popup.getByTestId("slash-command-group-mcode")).toContainText("Mcode");
-    await expect(popup.getByTestId("slash-command-group-plugin")).toContainText("Plugins");
+    await expect(popup.locator('[data-testid^="slash-command-group-"]')).toHaveCount(0);
+    await expect(popup.getByText(/^(Mcode|Commands|Skills|Plugins)$/)).toHaveCount(0);
+    await expect(popup.getByRole("option", {
+      name: "/goal Attach Goal to the composer",
+      exact: true,
+    })).toBeVisible();
+    await expect(popup.getByRole("option", {
+      name: "/review-pr Review a pull request end-to-end",
+      exact: true,
+    })).toBeVisible();
+    await expect(popup.getByRole("option", {
+      name: "brainstorming Generate ideas creatively",
+      exact: true,
+    })).toBeVisible();
+    await expect(popup.getByRole("option", {
+      name: "hookify Configure hookify rules",
+      exact: true,
+    })).toBeVisible();
 
     await page.screenshot({
       path: "e2e/screenshots/slash-command/01-popup-open.png",

--- a/apps/web/src/components/chat/Composer.tsx
+++ b/apps/web/src/components/chat/Composer.tsx
@@ -1532,7 +1532,6 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
       }
     },
   });
-
   const worktrees = useWorkspaceStore((s) => s.worktrees);
   const worktreesLoading = useWorkspaceStore((s) => s.worktreesLoading);
   const selectedWorktree = useWorkspaceStore((s) => s.selectedWorktree);
@@ -3741,6 +3740,7 @@ export function Composer({ threadId, isNewThread, workspaceId, branchFromMessage
         state={slashCommand.state}
         selectedIndex={slashCommand.selectedIndex}
         anchorRect={slashCommand.anchorRect}
+        workspacePath={activeWorkspace?.path}
         onSelect={handleSlashSelect}
         onDismiss={slashCommand.onDismiss}
         onRetry={slashCommand.onRetry}

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -20,7 +20,6 @@ const STATUS_ROW_HEIGHT = ITEM_HEIGHT;
 const LIST_SURFACE_PADDING = 8;
 const LIST_BOTTOM_FADE_HEIGHT = 20;
 const NAMED_MCODE_CAPABILITIES = new Set(["goal", "plan", "ultra", "compact"]);
-type SkillOrigin = "Project" | "Shared" | "Local" | "Provider";
 
 function commandDisplayLabel(command: Command): string {
   if (command.capabilityKind === "plugin") return `@${command.name}`;
@@ -49,7 +48,7 @@ interface SlashCommandPopupProps {
   tone?: "default" | "dark";
   /** Extra class names for border/positioning overrides that don't belong in tone. */
   className?: string;
-  /** Active workspace root used to distinguish project skills from local skills. */
+  /** Active workspace root used to identify local workspace skills. */
   workspacePath?: string;
 }
 
@@ -201,7 +200,7 @@ function CommandRow({
   selected: boolean;
   onSelect: (cmd: Command) => void;
   tone?: "default" | "dark";
-  origin?: Exclude<SkillOrigin, "Shared">;
+  origin?: "Local";
 }) {
   return (
     <Button
@@ -212,15 +211,18 @@ function CommandRow({
       role="option"
       aria-selected={selected}
       data-index={index}
-      aria-label={cmd.capabilityKind === "plugin"
-        ? `${commandDisplayLabel(cmd)} Plugin ${cmd.description}`
-        : `${commandDisplayLabel(cmd)} ${cmd.description}`}
+      aria-label={[
+        commandDisplayLabel(cmd),
+        cmd.capabilityKind === "plugin" ? "Plugin" : undefined,
+        cmd.description,
+        origin,
+      ].filter(Boolean).join(" ")}
       onMouseDown={(e) => {
         e.preventDefault(); // prevent textarea blur
         onSelect(cmd);
       }}
       className={cn(
-        "h-10 w-full justify-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
+        "h-10 min-w-0 w-full justify-start gap-2 overflow-hidden rounded-md px-2 py-1.5 text-left transition-colors",
         tone === "dark"
           ? selected
             ? "bg-white/[0.12]"
@@ -231,15 +233,15 @@ function CommandRow({
       )}
     >
       <CommandIdentityMark command={cmd} tone={tone} />
-      <span className="flex min-w-0 flex-1 items-baseline gap-2">
+      <span className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
         <span className={cn(
-          "shrink-0 text-sm font-medium",
+          "min-w-0 shrink truncate text-sm font-medium",
           tone === "dark" ? "text-neutral-50" : "text-foreground",
         )}>
           {commandDisplayLabel(cmd)}
         </span>
         <span className={cn(
-          "min-w-0 flex-1 overflow-hidden whitespace-nowrap text-xs font-normal",
+          "min-w-12 flex-1 overflow-hidden whitespace-nowrap text-xs font-normal",
           tone === "dark" ? "text-neutral-400" : "text-muted-foreground",
         )} style={{
           maskImage: "linear-gradient(to right, black calc(100% - 2.5rem), transparent)",
@@ -321,7 +323,7 @@ function duplicateSkillOriginTag(
   command: Command,
   commands: Command[],
   workspacePath?: string,
-): Exclude<SkillOrigin, "Shared"> | undefined {
+): "Local" | undefined {
   if (
     command.capabilityKind !== "skill" ||
     !commands.some(
@@ -334,29 +336,17 @@ function duplicateSkillOriginTag(
     return undefined;
   }
 
-  const origin = inferOrigin(command, workspacePath);
-  return origin === "Shared" ? undefined : origin;
-}
-
-function inferOrigin(command: Command, workspacePath?: string): SkillOrigin {
   const nativePath = normalizePath(command.identity?.nativeId ?? command.nativeId);
-  const projectPath = workspacePath
+  const localSkillPath = workspacePath
     ? `${normalizePath(workspacePath).replace(/\/+$/, "")}/.codex/skills/`
-    : null;
-  if (projectPath && nativePath.startsWith(projectPath)) return "Project";
-  if (
-    nativePath.startsWith(".agents/skills/") ||
-    nativePath.includes("/.agents/skills/")
-  ) {
-    return "Shared";
-  }
-  if (
+    : undefined;
+  const isCodexSkillPath =
     nativePath.startsWith(".codex/skills/") ||
-    nativePath.includes("/.codex/skills/")
-  ) {
-    return "Local";
-  }
-  return "Provider";
+    nativePath.includes("/.codex/skills/");
+  return (localSkillPath !== undefined && nativePath.startsWith(localSkillPath)) ||
+    isCodexSkillPath
+    ? "Local"
+    : undefined;
 }
 
 function normalizePath(path: string): string {

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -284,7 +284,7 @@ function CommandIdentityMark({
       : command.capabilityKind === "plugin"
         ? Plug
         : null;
-  const Icon = semanticIcon ?? CapabilityIcon;
+  const Icon = CapabilityIcon ?? semanticIcon;
 
   return (
     <span

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -1,58 +1,32 @@
 import { useEffect, useRef } from "react";
+import {
+  BadgeCheck,
+  Gauge,
+  ListTodo,
+  Minimize2,
+  Plug,
+  Target,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { Command, PopupState } from "./useSlashCommand";
 import { ComposerOverlaySurface } from "./ComposerOverlaySurface";
 import { EntityIcon } from "./EntityToken";
-import { Button } from "@/components/ui/button";
 
-const ITEM_HEIGHT = 44; // px per row
+const ITEM_HEIGHT = 40;
 const VISIBLE_ITEMS = 8;
-const GROUP_HEADER_HEIGHT = 28;
 const STATUS_ROW_HEIGHT = ITEM_HEIGHT;
 const LIST_SURFACE_PADDING = 8;
 const LIST_BOTTOM_FADE_HEIGHT = 20;
-
-const NAMESPACE_LABELS: Record<Command["namespace"], string> = {
-  mcode: "Mcode",
-  command: "Commands",
-  skill: "Skills",
-  plugin: "Plugins",
-};
+const NAMED_MCODE_CAPABILITIES = new Set(["goal", "plan", "ultra", "compact"]);
+type SkillOrigin = "Project" | "Shared" | "Local" | "Provider";
 
 function commandDisplayLabel(command: Command): string {
   if (command.capabilityKind === "plugin") return `@${command.name}`;
   if (command.namespace === "skill") return command.name;
   if (command.namespace === "plugin") return command.name.split(":").at(-1) ?? command.name;
   return `/${command.name}`;
-}
-
-function commandKindLabel(command: Command): string {
-  switch (command.capabilityKind) {
-    case "customPrompt": return "Prompt";
-    case "providerCommand": return "Command";
-    case "plugin": return "Plugin";
-    case "skill": return "Skill";
-    case "mcode": return "Mcode";
-  }
-}
-
-/** Preserve command ordering while exposing the source context of each command. */
-function groupCommands(
-  items: Command[],
-): Array<{ namespace: Command["namespace"]; items: Array<{ command: Command; index: number }> }> {
-  const groups: Array<{
-    namespace: Command["namespace"];
-    items: Array<{ command: Command; index: number }>;
-  }> = [];
-  for (const [index, command] of items.entries()) {
-    const current = groups.at(-1);
-    if (current?.namespace === command.namespace) {
-      current.items.push({ command, index });
-      continue;
-    }
-    groups.push({ namespace: command.namespace, items: [{ command, index }] });
-  }
-  return groups;
 }
 
 /** Props for the {@link SlashCommandPopup} component. */
@@ -75,6 +49,8 @@ interface SlashCommandPopupProps {
   tone?: "default" | "dark";
   /** Extra class names for border/positioning overrides that don't belong in tone. */
   className?: string;
+  /** Active workspace root used to distinguish project skills from local skills. */
+  workspacePath?: string;
 }
 
 /**
@@ -94,13 +70,13 @@ export function SlashCommandPopup({
   onRetry,
   tone = "default",
   className,
+  workspacePath,
 }: SlashCommandPopupProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // The list-bearing states carry the items; all others render no list.
   const items: Command[] =
     state.kind === "ready" || state.kind === "staleRevalidating" ? state.items : [];
-  const commandGroups = groupCommands(items);
   const isOpen = state.kind !== "closed";
 
   // Scroll selected item into view
@@ -124,16 +100,13 @@ export function SlashCommandPopup({
 
   if (state.kind === "closed" || !anchorRect) return null;
 
-  const listMaxHeight =
-    VISIBLE_ITEMS * ITEM_HEIGHT +
-    Math.min(commandGroups.length, VISIBLE_ITEMS) * GROUP_HEADER_HEIGHT +
-    LIST_BOTTOM_FADE_HEIGHT;
+  const listMaxHeight = VISIBLE_ITEMS * ITEM_HEIGHT + LIST_BOTTOM_FADE_HEIGHT;
 
   // Estimate the rendered popup height before positioning. The scrollport is
   // inset from the surface so its native scrollbar clears the rounded corner.
   const willRenderList = state.kind === "ready" || state.kind === "staleRevalidating";
   const renderedListHeight = Math.min(
-    items.length * ITEM_HEIGHT + commandGroups.length * GROUP_HEADER_HEIGHT + LIST_BOTTOM_FADE_HEIGHT,
+    items.length * ITEM_HEIGHT + LIST_BOTTOM_FADE_HEIGHT,
     listMaxHeight,
   );
   const estimatedHeight =
@@ -181,37 +154,16 @@ export function SlashCommandPopup({
                     style={{ maxHeight: listMaxHeight, scrollbarGutter: "stable" }}
                   >
                     <div className="pb-5">
-                      {commandGroups.map(({ namespace, items: groupItems }) => (
-                        <div
-                          key={namespace}
-                          role="group"
-                          aria-label={NAMESPACE_LABELS[namespace]}
-                          data-testid={`slash-command-group-${namespace}`}
-                        >
-                          <div
-                            data-slash-group-heading
-                            role="presentation"
-                            className={cn(
-                              "bg-popover px-2 py-1.5 text-xs font-medium text-foreground",
-                              tone === "dark" && "bg-[#1e1e1e] text-neutral-100",
-                            )}
-                          >
-                            {NAMESPACE_LABELS[namespace]}
-                          </div>
-                          {groupItems.map(({ command: cmd, index }) => {
-                            return (
-                              <div key={cmd.id} role="presentation" data-index={index}>
-                                <CommandRow
-                                  cmd={cmd}
-                                  index={index}
-                                  selected={index === selectedIndex}
-                                  onSelect={onSelect}
-                                  tone={tone}
-                                />
-                              </div>
-                            );
-                          })}
-                        </div>
+                      {items.map((cmd, index) => (
+                        <CommandRow
+                          key={cmd.id}
+                          cmd={cmd}
+                          index={index}
+                          selected={index === selectedIndex}
+                          onSelect={onSelect}
+                          tone={tone}
+                          origin={duplicateSkillOriginTag(cmd, items, workspacePath)}
+                        />
                       ))}
                     </div>
                   </div>
@@ -242,12 +194,14 @@ function CommandRow({
   selected,
   onSelect,
   tone = "default",
+  origin,
 }: {
   cmd: Command;
   index: number;
   selected: boolean;
   onSelect: (cmd: Command) => void;
   tone?: "default" | "dark";
+  origin?: Exclude<SkillOrigin, "Shared">;
 }) {
   return (
     <Button
@@ -257,6 +211,7 @@ function CommandRow({
       id={`slash-cmd-${index}`}
       role="option"
       aria-selected={selected}
+      data-index={index}
       aria-label={cmd.capabilityKind === "plugin"
         ? `${commandDisplayLabel(cmd)} Plugin ${cmd.description}`
         : `${commandDisplayLabel(cmd)} ${cmd.description}`}
@@ -265,7 +220,7 @@ function CommandRow({
         onSelect(cmd);
       }}
       className={cn(
-        "h-auto w-full justify-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
+        "h-10 w-full justify-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
         tone === "dark"
           ? selected
             ? "bg-white/[0.12]"
@@ -275,45 +230,137 @@ function CommandRow({
             : "hover:bg-accent/50",
       )}
     >
-      {/* Icon column */}
-      <span className={cn(
-        "flex size-6 shrink-0 items-center justify-center rounded-md ring-1 ring-inset",
-        tone === "dark"
-          ? "bg-white/[0.06] text-neutral-400 ring-white/10"
-          : "bg-muted/65 text-muted-foreground ring-border/60",
-      )}>
-        <EntityIcon
-          kind={cmd.capabilityKind === "mcode" ? "mcode" : cmd.capabilityKind === "customPrompt" || cmd.capabilityKind === "providerCommand" ? "command" : cmd.capabilityKind}
-          size={14}
-          className="flex items-center justify-center"
-        />
-      </span>
-
-      {/* Name + description */}
-      <span className="flex min-w-0 flex-1 flex-col">
+      <CommandIdentityMark command={cmd} tone={tone} />
+      <span className="flex min-w-0 flex-1 items-baseline gap-2">
         <span className={cn(
-          "truncate text-sm font-medium leading-4",
+          "shrink-0 text-sm font-medium",
           tone === "dark" ? "text-neutral-50" : "text-foreground",
         )}>
-          <span>{commandDisplayLabel(cmd)}</span>
-          <span className={cn(
-            "ml-2 text-xs font-medium uppercase tracking-wide",
-            tone === "dark" ? "text-neutral-500" : "text-muted-foreground",
-          )}>
-            {commandKindLabel(cmd)}
-          </span>
+          {commandDisplayLabel(cmd)}
         </span>
         <span className={cn(
-          "overflow-hidden whitespace-nowrap text-xs font-normal leading-4",
+          "min-w-0 flex-1 overflow-hidden whitespace-nowrap text-xs font-normal",
           tone === "dark" ? "text-neutral-400" : "text-muted-foreground",
         )} style={{
-          maskImage: "linear-gradient(to right, black calc(100% - 1.5rem), transparent)",
+          maskImage: "linear-gradient(to right, black calc(100% - 2.5rem), transparent)",
+          WebkitMaskImage: "linear-gradient(to right, black calc(100% - 2.5rem), transparent)",
         }}>
           {cmd.description}
         </span>
       </span>
+      {origin && (
+        <Badge
+          variant="outline"
+          size="sm"
+          className={cn(tone === "dark" && "border-white/10 text-neutral-300")}
+        >
+          {origin}
+        </Badge>
+      )}
     </Button>
   );
+}
+
+function CommandIdentityMark({
+  command,
+  tone,
+}: {
+  command: Command;
+  tone: "default" | "dark";
+}) {
+  const semanticIcon =
+    command.name === "goal"
+      ? Target
+      : command.name === "plan"
+        ? ListTodo
+        : command.name === "ultra"
+          ? Gauge
+          : command.name === "compact"
+            ? Minimize2
+            : null;
+  const CapabilityIcon =
+    command.capabilityKind === "skill"
+      ? BadgeCheck
+      : command.capabilityKind === "plugin"
+        ? Plug
+        : null;
+  const Icon = semanticIcon ?? CapabilityIcon;
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "flex size-8 shrink-0 items-center justify-center rounded-md ring-1 ring-inset",
+        tone === "dark"
+          ? "bg-white/[0.06] text-neutral-400 ring-white/10"
+          : "bg-muted/65 text-muted-foreground ring-border/60",
+      )}
+    >
+      {Icon ? (
+        <Icon className="size-4" strokeWidth={2.2} />
+      ) : (
+        <EntityIcon
+          kind={
+            command.capabilityKind === "mcode" ||
+            NAMED_MCODE_CAPABILITIES.has(command.name)
+              ? "mcode"
+              : command.capabilityKind === "customPrompt" ||
+                  command.capabilityKind === "providerCommand"
+                ? "command"
+                : command.capabilityKind
+          }
+          size={14}
+          className="flex items-center justify-center"
+        />
+      )}
+    </span>
+  );
+}
+
+function duplicateSkillOriginTag(
+  command: Command,
+  commands: Command[],
+  workspacePath?: string,
+): Exclude<SkillOrigin, "Shared"> | undefined {
+  if (
+    command.capabilityKind !== "skill" ||
+    !commands.some(
+      (candidate) =>
+        candidate.capabilityKind === "skill" &&
+        candidate.name === command.name &&
+        candidate.id !== command.id,
+    )
+  ) {
+    return undefined;
+  }
+
+  const origin = inferOrigin(command, workspacePath);
+  return origin === "Shared" ? undefined : origin;
+}
+
+function inferOrigin(command: Command, workspacePath?: string): SkillOrigin {
+  const nativePath = normalizePath(command.identity?.nativeId ?? command.nativeId);
+  const projectPath = workspacePath
+    ? `${normalizePath(workspacePath).replace(/\/+$/, "")}/.codex/skills/`
+    : null;
+  if (projectPath && nativePath.startsWith(projectPath)) return "Project";
+  if (
+    nativePath.startsWith(".agents/skills/") ||
+    nativePath.includes("/.agents/skills/")
+  ) {
+    return "Shared";
+  }
+  if (
+    nativePath.startsWith(".codex/skills/") ||
+    nativePath.includes("/.codex/skills/")
+  ) {
+    return "Local";
+  }
+  return "Provider";
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").toLowerCase();
 }
 
 /**

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
@@ -61,7 +61,7 @@ function renderDuplicateSkillPopup() {
     {
       id: "skill:shared:grill-with-docs",
       name: "grill-with-docs",
-      description: "Shared interviewing workflow",
+      description: "Interviewing workflow",
       namespace: "skill",
       capabilityKind: "skill",
       nativeId: "C:/Users/test/.agents/skills/grill-with-docs/SKILL.md",
@@ -69,7 +69,7 @@ function renderDuplicateSkillPopup() {
     {
       id: "skill:project:grill-with-docs",
       name: "grill-with-docs",
-      description: "Project interviewing workflow",
+      description: "Interviewing workflow",
       namespace: "skill",
       capabilityKind: "skill",
       nativeId: "C:/workspace/project/.codex/skills/grill-with-docs/SKILL.md",
@@ -80,6 +80,40 @@ function renderDuplicateSkillPopup() {
     <SlashCommandPopup
       state={{ kind: "ready", items: commands }}
       selectedIndex={0}
+      anchorRect={makeAnchorRect()}
+      workspacePath="C:/workspace/project"
+      onSelect={() => {}}
+      onDismiss={() => {}}
+      onRetry={() => {}}
+    />,
+  );
+}
+
+function renderLongDuplicateSkillPopup() {
+  const name = "a-very-long-capability-title-that-must-not-collide-with-its-source";
+  const commands: Command[] = [
+    {
+      id: `skill:shared:${name}`,
+      name,
+      description: "Runs the capability",
+      namespace: "skill",
+      capabilityKind: "skill",
+      nativeId: `C:/Users/test/.agents/skills/${name}/SKILL.md`,
+    },
+    {
+      id: `skill:local:${name}`,
+      name,
+      description: "Runs the capability",
+      namespace: "skill",
+      capabilityKind: "skill",
+      nativeId: `C:/workspace/project/.codex/skills/${name}/SKILL.md`,
+    },
+  ];
+
+  return render(
+    <SlashCommandPopup
+      state={{ kind: "ready", items: commands }}
+      selectedIndex={1}
       anchorRect={makeAnchorRect()}
       workspacePath="C:/workspace/project"
       onSelect={() => {}}
@@ -125,21 +159,48 @@ function renderReservedNameCapabilities() {
 }
 
 describe("SlashCommandPopup row presentation", () => {
-  it("renders duplicate skill rows directly and tags only the project copy", () => {
+  it("labels only the local duplicate and gives identical copies distinct accessible names", () => {
     renderDuplicateSkillPopup();
 
     expect(screen.queryByTestId(/slash-command-group/)).not.toBeInTheDocument();
     expect(screen.queryByText("Skills")).not.toBeInTheDocument();
 
-    const rows = screen.getAllByRole("option", { name: /grill-with-docs/ });
-    expect(within(rows[0]).queryByText("Shared")).not.toBeInTheDocument();
-    expect(within(rows[1]).getByText("Project")).toBeInTheDocument();
-    expect(rows[0]).toHaveClass("h-10");
-    expect(rows[0].querySelector(".lucide-badge-check")).not.toBeNull();
+    const sharedRow = screen.getByRole("option", {
+      name: "grill-with-docs Interviewing workflow",
+    });
+    const localRow = screen.getByRole("option", {
+      name: "grill-with-docs Interviewing workflow Local",
+    });
+    expect(within(sharedRow).queryByText("Local")).not.toBeInTheDocument();
+    expect(within(localRow).getByText("Local")).toBeInTheDocument();
+    expect(screen.queryByText("Project")).not.toBeInTheDocument();
+    expect(screen.queryByText("Provider")).not.toBeInTheDocument();
+    expect(sharedRow).toHaveClass("h-10");
+    expect(sharedRow.querySelector(".lucide-badge-check")).not.toBeNull();
 
-    const content = within(rows[0]).getByText("grill-with-docs").parentElement;
+    const content = within(sharedRow).getByText("grill-with-docs").parentElement;
     expect(content).toHaveClass("items-baseline");
-    expect(content).toContainElement(within(rows[0]).getByText("Shared interviewing workflow"));
+    expect(content).toContainElement(within(sharedRow).getByText("Interviewing workflow"));
+  });
+
+  it("keeps a long local title bounded before its source badge", () => {
+    renderLongDuplicateSkillPopup();
+
+    const localRow = screen.getByRole("option", {
+      name: /Local$/,
+    });
+    const title = within(localRow).getByText(
+      "a-very-long-capability-title-that-must-not-collide-with-its-source",
+    );
+    const description = within(localRow).getByText("Runs the capability");
+    const badge = within(localRow).getByText("Local");
+
+    expect(localRow).toHaveClass("min-w-0", "overflow-hidden");
+    expect(title).toHaveClass("min-w-0", "truncate");
+    expect(description).toHaveClass("min-w-12", "overflow-hidden");
+    expect(description).not.toHaveClass("truncate");
+    expect(title.parentElement).toHaveClass("min-w-0", "overflow-hidden", "items-baseline");
+    expect(badge).toHaveClass("shrink-0");
   });
 
   it("renders rows without namespace headings", () => {

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
@@ -1,4 +1,4 @@
-/** Tests for source grouping and icon correctness in SlashCommandPopup. */
+/** Tests for row presentation and icon correctness in SlashCommandPopup. */
 import { render, screen, within } from "@testing-library/react";
 import { describe, it, expect, beforeAll } from "vitest";
 import { SlashCommandPopup } from "../SlashCommandPopup";
@@ -37,6 +37,10 @@ const COMMANDS: Command[] = [
   { id: "skill:my-skill", name: "my-skill", description: "A skill", namespace: "skill", capabilityKind: "skill", nativeId: "my-skill" },
   { id: "skill:figma:use", name: "figma:use", description: "A plugin skill", namespace: "plugin", capabilityKind: "skill", nativeId: "figma:use" },
   { id: "plugin:browser", name: "Browser", description: "A native plugin", namespace: "plugin", capabilityKind: "plugin", nativeId: "browser@openai-bundled", mentionPath: "plugin://browser@openai-bundled" },
+  { id: "mcode:goal", name: "goal", description: "Manage the active goal", namespace: "mcode", capabilityKind: "mcode", nativeId: "goal" },
+  { id: "mcode:plan", name: "plan", description: "Manage the plan", namespace: "mcode", capabilityKind: "mcode", nativeId: "plan" },
+  { id: "mcode:ultra", name: "ultra", description: "Use ultra reasoning", namespace: "mcode", capabilityKind: "mcode", nativeId: "ultra" },
+  { id: "mcode:compact", name: "compact", description: "Compact context", namespace: "mcode", capabilityKind: "mcode", nativeId: "compact" },
 ];
 
 function renderPopup() {
@@ -52,19 +56,64 @@ function renderPopup() {
   );
 }
 
-describe("SlashCommandPopup source groups", () => {
-  it("places commands under the Commands heading", () => {
-    renderPopup();
-    const group = screen.getByTestId("slash-command-group-command");
-    expect(group).toHaveTextContent("Commands");
-    expect(group).toContainElement(screen.getByRole("option", { name: /deploy/ }));
+function renderDuplicateSkillPopup() {
+  const commands: Command[] = [
+    {
+      id: "skill:shared:grill-with-docs",
+      name: "grill-with-docs",
+      description: "Shared interviewing workflow",
+      namespace: "skill",
+      capabilityKind: "skill",
+      nativeId: "C:/Users/test/.agents/skills/grill-with-docs/SKILL.md",
+    },
+    {
+      id: "skill:project:grill-with-docs",
+      name: "grill-with-docs",
+      description: "Project interviewing workflow",
+      namespace: "skill",
+      capabilityKind: "skill",
+      nativeId: "C:/workspace/project/.codex/skills/grill-with-docs/SKILL.md",
+    },
+  ];
+
+  return render(
+    <SlashCommandPopup
+      state={{ kind: "ready", items: commands }}
+      selectedIndex={0}
+      anchorRect={makeAnchorRect()}
+      workspacePath="C:/workspace/project"
+      onSelect={() => {}}
+      onDismiss={() => {}}
+      onRetry={() => {}}
+    />,
+  );
+}
+
+describe("SlashCommandPopup row presentation", () => {
+  it("renders duplicate skill rows directly and tags only the project copy", () => {
+    renderDuplicateSkillPopup();
+
+    expect(screen.queryByTestId(/slash-command-group/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Skills")).not.toBeInTheDocument();
+
+    const rows = screen.getAllByRole("option", { name: /grill-with-docs/ });
+    expect(within(rows[0]).queryByText("Shared")).not.toBeInTheDocument();
+    expect(within(rows[1]).getByText("Project")).toBeInTheDocument();
+    expect(rows[0]).toHaveClass("h-10");
+    expect(rows[0].querySelector(".lucide-badge-check")).not.toBeNull();
+
+    const content = within(rows[0]).getByText("grill-with-docs").parentElement;
+    expect(content).toHaveClass("items-baseline");
+    expect(content).toContainElement(within(rows[0]).getByText("Shared interviewing workflow"));
   });
 
-  it("places skills under the Skills heading", () => {
+  it("renders rows without namespace headings", () => {
     renderPopup();
-    const group = screen.getByTestId("slash-command-group-skill");
-    expect(group).toHaveTextContent("Skills");
-    expect(group).toContainElement(screen.getByRole("option", { name: /my-skill/ }));
+    expect(screen.queryByTestId(/slash-command-group/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Commands")).not.toBeInTheDocument();
+    expect(screen.queryByText("Skills")).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /deploy/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /my-skill/ })).toBeInTheDocument();
   });
 
   it("shows capability titles without slash or plugin prefixes", () => {
@@ -79,14 +128,15 @@ describe("SlashCommandPopup source groups", () => {
     expect(within(pluginRow).queryByText("/figma:use")).not.toBeInTheDocument();
   });
 
-  it("stacks capability titles above their descriptions", () => {
+  it("places capability titles and descriptions on one row", () => {
     renderPopup();
 
     const pluginRow = screen.getByRole("option", { name: /A plugin skill/ });
     const title = within(pluginRow).getByText("use");
     const description = within(pluginRow).getByText("A plugin skill");
-    const content = title.closest(".flex-col");
+    const content = title.parentElement;
     expect(content).toBe(description.parentElement);
+    expect(content).toHaveClass("items-baseline");
   });
 
   it("fades overflowing descriptions instead of showing an ellipsis", () => {
@@ -96,7 +146,7 @@ describe("SlashCommandPopup source groups", () => {
     expect(description).toHaveClass("overflow-hidden", "whitespace-nowrap");
     expect(description).not.toHaveClass("truncate");
     expect(description).toHaveStyle({
-      maskImage: "linear-gradient(to right, black calc(100% - 1.5rem), transparent)",
+      maskImage: "linear-gradient(to right, black calc(100% - 2.5rem), transparent)",
     });
   });
 
@@ -108,12 +158,11 @@ describe("SlashCommandPopup source groups", () => {
   });
 });
 
-describe("SlashCommandPopup namespace icons", () => {
-  it("skill namespace renders a lucide-sparkles SVG", () => {
+describe("SlashCommandPopup capability icons", () => {
+  it("skills render a fixed neutral BadgeCheck icon", () => {
     renderPopup();
     const skillRow = screen.getByRole("option", { name: /my-skill/ });
-    const sparklesIcon = skillRow.querySelector(".lucide-sparkles");
-    expect(sparklesIcon).not.toBeNull();
+    expect(skillRow.querySelector(".lucide-badge-check")).not.toBeNull();
   });
 
   it("command namespace renders a square-terminal SVG", () => {
@@ -123,30 +172,40 @@ describe("SlashCommandPopup namespace icons", () => {
     expect(terminalIcon).not.toBeNull();
   });
 
-  it("native plugin entries render a blocks SVG", () => {
+  it("native plugin entries render a Plug icon", () => {
     renderPopup();
     const pluginRow = screen.getByRole("option", { name: /A native plugin/ });
-    expect(pluginRow.querySelector(".lucide-blocks")).not.toBeNull();
+    expect(pluginRow.querySelector(".lucide-plug")).not.toBeNull();
   });
 
   it("plugin-provided skills remain skill entries", () => {
     renderPopup();
     const pluginSkillRow = screen.getByRole("option", { name: /A plugin skill/ });
-    expect(pluginSkillRow.querySelector(".lucide-sparkles")).not.toBeNull();
-    expect(pluginSkillRow.querySelector(".lucide-blocks")).toBeNull();
+    expect(pluginSkillRow.querySelector(".lucide-badge-check")).not.toBeNull();
+    expect(pluginSkillRow.querySelector(".lucide-plug")).toBeNull();
   });
 
-  it("command namespace does NOT render a lucide-sparkles SVG", () => {
+  it("command namespace does not render a skill icon", () => {
     renderPopup();
     const commandRow = screen.getByRole("option", { name: /deploy/ });
-    const sparklesIcon = commandRow.querySelector(".lucide-sparkles");
-    expect(sparklesIcon).toBeNull();
+    expect(commandRow.querySelector(".lucide-badge-check")).toBeNull();
   });
 
-  it("skill namespace does NOT render a lucide-terminal SVG", () => {
+  it("skill namespace does not render a command icon", () => {
     renderPopup();
     const skillRow = screen.getByRole("option", { name: /my-skill/ });
     const terminalIcon = skillRow.querySelector(".lucide-square-terminal");
     expect(terminalIcon).toBeNull();
+  });
+
+  it.each([
+    ["goal", "lucide-target"],
+    ["plan", "lucide-list-todo"],
+    ["ultra", "lucide-gauge"],
+    ["compact", "lucide-minimize-2"],
+  ])("renders the accepted semantic icon for %s", (name, iconClass) => {
+    renderPopup();
+    const row = screen.getByRole("option", { name: new RegExp(name) });
+    expect(row.querySelector(`.${iconClass}`)).not.toBeNull();
   });
 });

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
@@ -89,6 +89,41 @@ function renderDuplicateSkillPopup() {
   );
 }
 
+function renderReservedNameCapabilities() {
+  const commands: Command[] = ["goal", "plan", "ultra", "compact"].flatMap(
+    (name): Command[] => [
+      {
+        id: `skill:reserved:${name}`,
+        name,
+        description: `${name} reserved-name skill`,
+        namespace: "skill",
+        capabilityKind: "skill",
+        nativeId: `C:/skills/${name}/SKILL.md`,
+      },
+      {
+        id: `plugin:reserved:${name}`,
+        name,
+        description: `${name} reserved-name plugin`,
+        namespace: "plugin",
+        capabilityKind: "plugin",
+        nativeId: `${name}@test`,
+        mentionPath: `plugin://${name}@test`,
+      },
+    ],
+  );
+
+  return render(
+    <SlashCommandPopup
+      state={{ kind: "ready", items: commands }}
+      selectedIndex={0}
+      anchorRect={makeAnchorRect()}
+      onSelect={() => {}}
+      onDismiss={() => {}}
+      onRetry={() => {}}
+    />,
+  );
+}
+
 describe("SlashCommandPopup row presentation", () => {
   it("renders duplicate skill rows directly and tags only the project copy", () => {
     renderDuplicateSkillPopup();
@@ -177,6 +212,22 @@ describe("SlashCommandPopup capability icons", () => {
     const pluginRow = screen.getByRole("option", { name: /A native plugin/ });
     expect(pluginRow.querySelector(".lucide-plug")).not.toBeNull();
   });
+
+  it.each(["goal", "plan", "ultra", "compact"])(
+    "keeps capability-kind icons for reserved name %s",
+    (name) => {
+      renderReservedNameCapabilities();
+
+      const skillRow = screen.getByRole("option", {
+        name: new RegExp(`${name} reserved-name skill`),
+      });
+      const pluginRow = screen.getByRole("option", {
+        name: new RegExp(`${name} reserved-name plugin`),
+      });
+      expect(skillRow.querySelector(".lucide-badge-check")).not.toBeNull();
+      expect(pluginRow.querySelector(".lucide-plug")).not.toBeNull();
+    },
+  );
 
   it("plugin-provided skills remain skill entries", () => {
     renderPopup();


### PR DESCRIPTION
## What
Redesign the skills and plugin rows in the composer capability picker using the selected Variant A direction.

## Why
The previous rows used generic capability presentation and did not distinguish duplicate local skills clearly. The picker also carried prototype-only chrome that was not needed in the production surface.

## Key Changes
- Use distinct neutral skill and plugin icons while preserving design-system colors.
- Keep titles and descriptions on one row, with bounded title truncation and a gradient fade for long descriptions.
- Show `Local` only on duplicate local skills while leaving the shared copy unlabeled.
- Give duplicate rows distinct accessible names and preserve listbox keyboard behavior.
- Remove the Browse capabilities heading, legends, and prototype controls.

## Verification
- Focused popup tests: 31 passed.
- Web typecheck: passed.
- Live production picker: no navigation or refresh, no removed chrome, duplicate-only Local label, single-row fade, and no console errors.
- Narrow 320px stress check: title truncated, description and badge remained inside the row, and the accessible name included Local.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787543812&installation_model_id=20477&pr_number=956&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F956&signature=b2b985c65a89b49a993662785029ec83cb17075e5b978833a42f66a34efb6d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->