### PR TITLE
fix(ui): respect right panel layout for subagents

### DIFF
--- a/apps/web/src/lib/__tests__/open-subagent-detail.test.ts
+++ b/apps/web/src/lib/__tests__/open-subagent-detail.test.ts
@@ -36,7 +36,7 @@ describe("openSubagentDetail", () => {
     });
     expect(mocks.showRightPanelAdaptive).toHaveBeenCalledWith("workspace-1", "thread-1");
     expect(useUiStore.getState()).toMatchObject({
-      rightPanelMaximized: true,
+      rightPanelMaximized: false,
       rightPanelMaximizedByLayout: false,
     });
   });
@@ -55,7 +55,7 @@ describe("openSubagentDetail", () => {
       openTabs: ["subagents"],
     });
     expect(useUiStore.getState()).toMatchObject({
-      rightPanelMaximized: true,
+      rightPanelMaximized: false,
       rightPanelMaximizedByLayout: false,
     });
   });

--- a/apps/web/src/lib/open-subagent-detail.ts
+++ b/apps/web/src/lib/open-subagent-detail.ts
@@ -1,7 +1,6 @@
 import { showRightPanelAdaptive } from "@/lib/right-panel-layout";
 import { useDiffStore, type SubagentRosterTab } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { useUiStore } from "@/stores/uiStore";
 
 /** Opens the active thread's Subagents panel. */
 export function openSubagentsPanel(): boolean {
@@ -11,7 +10,6 @@ export function openSubagentsPanel(): boolean {
   const diff = useDiffStore.getState();
   diff.setRightPanelTab(activeWorkspaceId, activeThreadId, "subagents");
   showRightPanelAdaptive(activeWorkspaceId, activeThreadId);
-  useUiStore.getState().setRightPanelMaximized(true, "user");
   return true;
 }
 


### PR DESCRIPTION
## What

Make Subagents use the shared adaptive right-panel layout instead of forcing a maximized view.

## Why

Opening Subagents always marked the panel as user-maximized after applying the normal layout policy. This ignored saved panel widths and opened full-screen on wide displays.

## Key Changes

- Remove the unconditional Subagents maximize override.
- Update regression coverage to preserve the adaptive panel state.
- Verify inline layout at 1920px and 1280px, layout-owned full view at 900px, and user-resized width across close and reopen.

## Verification

- Focused frontend tests: 26 passed.
- Live Playwright matrix: 3 passed.
- Typecheck: passed.
- Lint: passed.
- Full unit run: 5 unrelated Windows timing failures across 3 server files; all 35 tests in those files passed on an isolated rerun.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787592513&installation_model_id=20477&pr_number=966&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F966&signature=d8a88ff46e1ee01656108394b7472d7343d90a9abe980d035133d9c63f75c536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Opening the subagents panel no longer automatically maximizes the right panel.
  * The panel continues to display the selected subagent details and adapts to the available layout.

* **Tests**
  * Updated UI state expectations to reflect the panel’s non-maximized default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->