### PR TITLE
feat: add internal thread-control foundation

### DIFF
--- a/apps/server/drizzle/0027_same_epoch.sql
+++ b/apps/server/drizzle/0027_same_epoch.sql
@@ -1,0 +1,28 @@
+CREATE TABLE `workspace_worktrees` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workspace_id` text NOT NULL,
+	`canonical_path` text NOT NULL,
+	`label` text NOT NULL,
+	`branch` text,
+	`base_ref` text,
+	`managed` integer DEFAULT 0 NOT NULL,
+	`last_seen_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`stale` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_workspace_worktrees_path` ON `workspace_worktrees` (`workspace_id`,`canonical_path`);--> statement-breakpoint
+CREATE INDEX `idx_workspace_worktrees_workspace` ON `workspace_worktrees` (`workspace_id`,`stale`);
+--> statement-breakpoint
+ALTER TABLE `threads` ADD `delegation_coordinator_thread_id` text REFERENCES `threads`(`id`) ON DELETE set null;--> statement-breakpoint
+ALTER TABLE `threads` ADD `delegation_creator_turn_id` text;--> statement-breakpoint
+ALTER TABLE `threads` ADD `delegation_creator_tool_call_id` text;--> statement-breakpoint
+ALTER TABLE `threads` ADD `delegation_creation_kind` text;--> statement-breakpoint
+ALTER TABLE `threads` ADD `created_by_integration_id` text;--> statement-breakpoint
+CREATE INDEX `idx_threads_delegation_coordinator` ON `threads` (`delegation_coordinator_thread_id`);--> statement-breakpoint
+CREATE INDEX `idx_threads_created_by_integration` ON `threads` (`created_by_integration_id`);--> statement-breakpoint
+ALTER TABLE `messages` ADD `provider` text;--> statement-breakpoint
+ALTER TABLE `messages` ADD `origin_type` text DEFAULT 'legacy' NOT NULL;--> statement-breakpoint
+ALTER TABLE `messages` ADD `source_thread_id` text;--> statement-breakpoint
+ALTER TABLE `messages` ADD `source_turn_id` text;--> statement-breakpoint
+ALTER TABLE `messages` ADD `source_provider_id` text;

--- a/apps/server/drizzle/meta/0027_snapshot.json
+++ b/apps/server/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,2092 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d18f2ad6-bff6-4479-a748-bf46544828e8",
+  "prevId": "4d751ce0-b6e0-47a5-97c6-ac00f59484e3",
+  "tables": {
+    "cleanup_jobs": {
+      "name": "cleanup_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cleanup_jobs_thread_id_unique": {
+          "name": "cleanup_jobs_thread_id_unique",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cleanup_jobs_retry": {
+          "name": "idx_cleanup_jobs_retry",
+          "columns": [
+            "next_retry_at",
+            "attempts",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diff_summaries": {
+      "name": "diff_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_turn_id": {
+          "name": "last_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_diff_summaries_thread": {
+          "name": "idx_diff_summaries_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "diff_summaries_thread_id_threads_id_fk": {
+          "name": "diff_summaries_thread_id_threads_id_fk",
+          "tableFrom": "diff_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_executions": {
+      "name": "hook_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hook_name": {
+          "name": "hook_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "did_block": {
+          "name": "did_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_hook_executions_message": {
+          "name": "idx_hook_executions_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hook_executions_message_id_messages_id_fk": {
+          "name": "hook_executions_message_id_messages_id_fk",
+          "tableFrom": "hook_executions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_annotations": {
+          "name": "preview_annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quoted_text": {
+          "name": "quoted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_provider_id": {
+          "name": "source_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_messages_thread": {
+          "name": "idx_messages_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_sequence": {
+          "name": "idx_messages_sequence",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_reply_to_message_id_messages_id_fk": {
+          "name": "messages_reply_to_message_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "reply_to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_question_answers": {
+      "name": "plan_question_answers",
+      "columns": {
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_question_answers_thread": {
+          "name": "idx_plan_question_answers_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_question_answers_assistant_message_id_messages_id_fk": {
+          "name": "plan_question_answers_assistant_message_id_messages_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_question_answers_thread_id_threads_id_fk": {
+          "name": "plan_question_answers_thread_id_threads_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plans_thread": {
+          "name": "idx_plans_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plans_thread_version": {
+          "name": "idx_plans_thread_version",
+          "columns": [
+            "thread_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plans_thread_id_threads_id_fk": {
+          "name": "plans_thread_id_threads_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_message_id_messages_id_fk": {
+          "name": "plans_message_id_messages_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_catalog_snapshots": {
+      "name": "provider_catalog_snapshots",
+      "columns": {
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_provider_catalog_snapshots_workspace": {
+          "name": "idx_provider_catalog_snapshots_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_provider_catalog_snapshots_provider": {
+          "name": "idx_provider_catalog_snapshots_provider",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "provider_catalog_snapshots_workspace_id_workspaces_id_fk": {
+          "name": "provider_catalog_snapshots_workspace_id_workspaces_id_fk",
+          "tableFrom": "provider_catalog_snapshots",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_cache": {
+      "name": "provider_model_cache",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_request_review_links": {
+      "name": "pull_request_review_links",
+      "columns": {
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_node_id": {
+          "name": "repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_state": {
+          "name": "pr_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "head_repository_node_id": {
+          "name": "head_repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_owner": {
+          "name": "head_repository_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_name": {
+          "name": "head_repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_oid": {
+          "name": "head_oid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_branch": {
+          "name": "local_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_remote": {
+          "name": "push_remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_ref": {
+          "name": "push_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "managed_remote_name": {
+          "name": "managed_remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_thread_id": {
+          "name": "primary_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_pull_request_review_links_identity": {
+          "name": "idx_pull_request_review_links_identity",
+          "columns": [
+            "provider",
+            "repository_node_id",
+            "pull_request_number"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_primary_thread": {
+          "name": "idx_pull_request_review_links_primary_thread",
+          "columns": [
+            "primary_thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_workspace": {
+          "name": "idx_pull_request_review_links_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pull_request_review_links_worktree_path": {
+          "name": "idx_pull_request_review_links_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_request_review_links_workspace_id_workspaces_id_fk": {
+          "name": "pull_request_review_links_workspace_id_workspaces_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pull_request_review_links_primary_thread_id_threads_id_fk": {
+          "name": "pull_request_review_links_primary_thread_id_threads_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "primary_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thought_segments": {
+      "name": "thought_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_final_response": {
+          "name": "is_final_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_thought_segments_message": {
+          "name": "idx_thought_segments_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thought_segments_message_id_messages_id_fk": {
+          "name": "thought_segments_message_id_messages_id_fk",
+          "tableFrom": "thought_segments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tasks": {
+      "name": "thread_tasks",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_json": {
+          "name": "tasks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tasks_thread_id_threads_id_fk": {
+          "name": "thread_tasks_thread_id_threads_id_fk",
+          "tableFrom": "thread_tasks",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkout_state": {
+          "name": "checkout_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'named'"
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_tokens": {
+          "name": "last_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interaction_mode": {
+          "name": "interaction_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "orchestration_mode": {
+          "name": "orchestration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_message_id": {
+          "name": "forked_from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_coordinator_thread_id": {
+          "name": "delegation_coordinator_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creator_turn_id": {
+          "name": "delegation_creator_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creator_tool_call_id": {
+          "name": "delegation_creator_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creation_kind": {
+          "name": "delegation_creation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_integration_id": {
+          "name": "created_by_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_compact_summary": {
+          "name": "last_compact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "copilot_agent": {
+          "name": "copilot_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window_mode": {
+          "name": "context_window_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codex_fast_mode": {
+          "name": "codex_fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_open_in_app": {
+          "name": "default_open_in_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file_changes": {
+          "name": "has_file_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_threads_workspace": {
+          "name": "idx_threads_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_deleted": {
+          "name": "idx_threads_workspace_deleted",
+          "columns": [
+            "workspace_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_recency": {
+          "name": "idx_threads_workspace_recency",
+          "columns": [
+            "workspace_id",
+            "\"updated_at\" desc"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_status": {
+          "name": "idx_threads_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_parent_thread_id": {
+          "name": "idx_threads_parent_thread_id",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_forked_from_message_id": {
+          "name": "idx_threads_forked_from_message_id",
+          "columns": [
+            "forked_from_message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_delegation_coordinator": {
+          "name": "idx_threads_delegation_coordinator",
+          "columns": [
+            "delegation_coordinator_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_created_by_integration": {
+          "name": "idx_threads_created_by_integration",
+          "columns": [
+            "created_by_integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_workspace_id_workspaces_id_fk": {
+          "name": "threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_delegation_coordinator_thread_id_threads_id_fk": {
+          "name": "threads_delegation_coordinator_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "delegation_coordinator_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_call_records": {
+      "name": "tool_call_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_agent_key": {
+          "name": "provider_agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_truncated": {
+          "name": "output_truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_total_bytes": {
+          "name": "output_total_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_artifact_path": {
+          "name": "output_artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tool_call_records_message": {
+          "name": "idx_tool_call_records_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tool_call_records_parent": {
+          "name": "idx_tool_call_records_parent",
+          "columns": [
+            "parent_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_call_records_message_id_messages_id_fk": {
+          "name": "tool_call_records_message_id_messages_id_fk",
+          "tableFrom": "tool_call_records",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turn_snapshots": {
+      "name": "turn_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_before": {
+          "name": "ref_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_after": {
+          "name": "ref_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "file_effects": {
+          "name": "file_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"revision\":0,\"fileCount\":0,\"additions\":0,\"deletions\":0,\"effects\":[]}'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_turn_snapshots_message": {
+          "name": "idx_turn_snapshots_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_turn_snapshots_thread": {
+          "name": "idx_turn_snapshots_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "turn_snapshots_message_id_messages_id_fk": {
+          "name": "turn_snapshots_message_id_messages_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_snapshots_thread_id_threads_id_fk": {
+          "name": "turn_snapshots_thread_id_threads_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_worktrees": {
+      "name": "workspace_worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "stale": {
+          "name": "stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_workspace_worktrees_path": {
+          "name": "idx_workspace_worktrees_path",
+          "columns": [
+            "workspace_id",
+            "canonical_path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspace_worktrees_workspace": {
+          "name": "idx_workspace_worktrees_workspace",
+          "columns": [
+            "workspace_id",
+            "stale"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_worktrees_workspace_id_workspaces_id_fk": {
+          "name": "workspace_worktrees_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_worktrees",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_path_unique": {
+          "name": "workspaces_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspaces_sort_order": {
+          "name": "idx_workspaces_sort_order",
+          "columns": [
+            "\"sort_order\" asc"
+          ],
+          "isUnique": false
+        },
+        "idx_workspaces_pinned_last_opened": {
+          "name": "idx_workspaces_pinned_last_opened",
+          "columns": [
+            "\"pinned\" desc",
+            "\"last_opened_at\" desc"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_threads_workspace_recency": {
+        "columns": {
+          "\"updated_at\" desc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_sort_order": {
+        "columns": {
+          "\"sort_order\" asc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_pinned_last_opened": {
+        "columns": {
+          "\"pinned\" desc": {
+            "isExpression": true
+          },
+          "\"last_opened_at\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1784821020555,
       "tag": "0026_furry_red_hulk",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1785006903394,
+      "tag": "0027_same_epoch",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,6 +19,8 @@
     "@github/copilot-sdk": "^0.2.2",
     "@mcode/contracts": "workspace:*",
     "@mcode/shared": "workspace:*",
+    "@mcode/thread-orchestration": "workspace:*",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "better-sqlite3": "^12.0.0",
     "drizzle-orm": "^0.45.2",
     "koffi": "^2.16.1",

--- a/apps/server/src/__tests__/message-repo.test.ts
+++ b/apps/server/src/__tests__/message-repo.test.ts
@@ -23,6 +23,11 @@ function createTestDb(): Database.Database {
       reply_to_message_id TEXT,
       quoted_text TEXT,
       model TEXT,
+      provider TEXT,
+      origin_type TEXT NOT NULL DEFAULT 'legacy',
+      source_thread_id TEXT,
+      source_turn_id TEXT,
+      source_provider_id TEXT,
       is_internal INTEGER NOT NULL DEFAULT 0
     );
     CREATE TABLE tool_call_records (
@@ -203,6 +208,35 @@ ORDER BY page.sequence ASC`,
   });
 
   describe("create with reply fields", () => {
+    it("persists authenticated cross-thread provenance", () => {
+      const message = repo.create(
+        "thread-1",
+        "user",
+        "delegated request",
+        1,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          type: "thread",
+          sourceThreadId: "source-thread",
+          sourceTurnId: "source-turn",
+          sourceProviderId: "codex",
+        },
+      );
+
+      expect(db.prepare("SELECT origin_type, source_thread_id, source_turn_id, source_provider_id FROM messages WHERE id = ?").get(message.id)).toEqual({
+        origin_type: "thread",
+        source_thread_id: "source-thread",
+        source_turn_id: "source-turn",
+        source_provider_id: "codex",
+      });
+    });
+
     it("persists replyToMessageId and quotedText", () => {
       const original = repo.create("thread-1", "assistant", "hello", 1);
       const reply = repo.create("thread-1", "user", "reply text", 2, undefined, original.id, "quoted excerpt");

--- a/apps/server/src/__tests__/thread-repo-lineage.test.ts
+++ b/apps/server/src/__tests__/thread-repo-lineage.test.ts
@@ -75,4 +75,50 @@ describe("ThreadRepo lineage", () => {
     expect(found?.parent_thread_id).toBe("parent-id");
     expect(found?.forked_from_message_id).toBe("msg-999");
   });
+
+  it("clears cross-workspace delegation lineage when the coordinator is deleted", () => {
+    db.prepare("INSERT INTO workspaces (id, name, path) VALUES (?, ?, ?)").run("ws-2", "other", "/tmp/other");
+    const coordinator = repo.create("ws-1", "coordinator", "direct", "main");
+    const child = repo.create("ws-2", "child", "direct", "main");
+
+    expect(repo.updateDelegationLineage(child.id, {
+      coordinatorThreadId: coordinator.id,
+      creatorTurnId: "turn-1",
+      creatorToolCallId: "call-1",
+      creationKind: "thread_delegation",
+    })).toBe(true);
+
+    repo.softDelete(coordinator.id);
+
+    const row = db.prepare("SELECT delegation_coordinator_thread_id, delegation_creator_turn_id, delegation_creator_tool_call_id, delegation_creation_kind FROM threads WHERE id = ?").get(child.id) as {
+      delegation_coordinator_thread_id: string | null;
+      delegation_creator_turn_id: string | null;
+      delegation_creator_tool_call_id: string | null;
+      delegation_creation_kind: string | null;
+    };
+    expect(row).toEqual({
+      delegation_coordinator_thread_id: null,
+      delegation_creator_turn_id: "turn-1",
+      delegation_creator_tool_call_id: "call-1",
+      delegation_creation_kind: "thread_delegation",
+    });
+  });
+
+  it("keeps a cross-workspace child when its coordinator is hard-deleted", () => {
+    db.prepare("INSERT INTO workspaces (id, name, path) VALUES (?, ?, ?)").run("ws-2", "other", "/tmp/other");
+    const coordinator = repo.create("ws-1", "coordinator", "direct", "main");
+    const child = repo.create("ws-2", "child", "direct", "main");
+    repo.updateDelegationLineage(child.id, {
+      coordinatorThreadId: coordinator.id,
+      creatorTurnId: "turn-1",
+      creatorToolCallId: "call-1",
+      creationKind: "thread_delegation",
+    });
+
+    expect(repo.hardDelete(coordinator.id)).toBe(true);
+
+    expect(db.prepare("SELECT delegation_coordinator_thread_id FROM threads WHERE id = ?").get(child.id)).toEqual({
+      delegation_coordinator_thread_id: null,
+    });
+  });
 });

--- a/apps/server/src/__tests__/worktree-repo.test.ts
+++ b/apps/server/src/__tests__/worktree-repo.test.ts
@@ -1,0 +1,30 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { openMemoryDatabase } from "../store/database.js";
+import { WorkspaceRepo } from "../repositories/workspace-repo.js";
+import { WorktreeRepo } from "../repositories/worktree-repo.js";
+
+describe("WorktreeRepo", () => {
+  it("keeps an opaque identity stable and marks absent registrations stale", () => {
+    const db = openMemoryDatabase();
+    const workspaces = new WorkspaceRepo(db);
+    const worktrees = new WorktreeRepo(db);
+    const workspace = workspaces.create("Workspace", "/repo");
+    const first = worktrees.reconcile(workspace.id, [{
+      canonicalPath: "/repo/.worktrees/feature",
+      label: "feature",
+      branch: "feature",
+      managed: true,
+    }]);
+    const second = worktrees.reconcile(workspace.id, [{
+      canonicalPath: "/repo/.worktrees/feature",
+      label: "feature",
+      branch: "feature",
+      managed: true,
+    }]);
+    expect(second[0]?.worktreeId).toBe(first[0]?.worktreeId);
+    expect(Object.keys(second[0] ?? {})).not.toContain("canonicalPath");
+    expect(worktrees.reconcile(workspace.id, [])).toEqual([]);
+    db.close();
+  });
+});

--- a/apps/server/src/__tests__/worktree-repo.test.ts
+++ b/apps/server/src/__tests__/worktree-repo.test.ts
@@ -1,10 +1,14 @@
 import "reflect-metadata";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { openMemoryDatabase } from "../store/database.js";
 import { WorkspaceRepo } from "../repositories/workspace-repo.js";
-import { WorktreeRepo } from "../repositories/worktree-repo.js";
+import { STALE_WORKTREE_RETENTION_DAYS, WorktreeRepo } from "../repositories/worktree-repo.js";
 
 describe("WorktreeRepo", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("keeps an opaque identity stable and marks absent registrations stale", () => {
     const db = openMemoryDatabase();
     const workspaces = new WorkspaceRepo(db);
@@ -25,6 +29,62 @@ describe("WorktreeRepo", () => {
     expect(second[0]?.worktreeId).toBe(first[0]?.worktreeId);
     expect(Object.keys(second[0] ?? {})).not.toContain("canonicalPath");
     expect(worktrees.reconcile(workspace.id, [])).toEqual([]);
+    db.close();
+  });
+
+  it("retains stale registrations through the cutoff and gives a purged path a new identity", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const db = openMemoryDatabase();
+    const workspaces = new WorkspaceRepo(db);
+    const worktrees = new WorktreeRepo(db);
+    const workspace = workspaces.create("Workspace", "/repo");
+    const input = {
+      canonicalPath: "/repo/.worktrees/feature",
+      label: "feature",
+      branch: "feature",
+      managed: true,
+    };
+    const originalId = worktrees.reconcile(workspace.id, [input])[0]?.worktreeId;
+
+    vi.advanceTimersByTime(STALE_WORKTREE_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+    worktrees.reconcile(workspace.id, []);
+    expect(worktrees.reconcile(workspace.id, [input])[0]?.worktreeId).toBe(originalId);
+
+    worktrees.reconcile(workspace.id, []);
+    vi.advanceTimersByTime(STALE_WORKTREE_RETENTION_DAYS * 24 * 60 * 60 * 1000 + 1);
+    worktrees.reconcile(workspace.id, []);
+    expect(worktrees.reconcile(workspace.id, [input])[0]?.worktreeId).not.toBe(originalId);
+    db.close();
+  });
+
+  it("purges only stale registrations from the reconciled workspace", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const db = openMemoryDatabase();
+    const workspaces = new WorkspaceRepo(db);
+    const worktrees = new WorktreeRepo(db);
+    const firstWorkspace = workspaces.create("First", "/first");
+    const secondWorkspace = workspaces.create("Second", "/second");
+    const secondInput = {
+      canonicalPath: "/second/.worktrees/feature",
+      label: "feature",
+      branch: "feature",
+      managed: true,
+    };
+    worktrees.reconcile(firstWorkspace.id, [{
+      canonicalPath: "/first/.worktrees/feature",
+      label: "feature",
+      branch: "feature",
+      managed: true,
+    }]);
+    const secondId = worktrees.reconcile(secondWorkspace.id, [secondInput])[0]?.worktreeId;
+
+    worktrees.reconcile(secondWorkspace.id, []);
+    vi.advanceTimersByTime((STALE_WORKTREE_RETENTION_DAYS + 1) * 24 * 60 * 60 * 1000);
+    worktrees.reconcile(firstWorkspace.id, []);
+
+    expect(worktrees.reconcile(secondWorkspace.id, [secondInput])[0]?.worktreeId).toBe(secondId);
     db.close();
   });
 });

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -10,6 +10,7 @@ import { openDatabase } from "./store/database";
 
 // Repositories
 import { WorkspaceRepo } from "./repositories/workspace-repo";
+import { WorktreeRepo } from "./repositories/worktree-repo";
 import { ThreadRepo } from "./repositories/thread-repo";
 import { MessageRepo } from "./repositories/message-repo";
 import { ToolCallRecordRepo } from "./repositories/tool-call-record-repo";
@@ -329,6 +330,11 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register(
     AgentService,
     { useClass: AgentService },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    WorktreeRepo,
+    { useClass: WorktreeRepo },
     { lifecycle: Lifecycle.Singleton },
   );
   container.register(ThreadControlService, { useClass: ThreadControlService }, { lifecycle: Lifecycle.Singleton });

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -74,6 +74,9 @@ import { ModelCacheService } from "./services/model-cache-service";
 import { ProtectedEnvStore } from "./services/protected-env-store";
 import { ShellEnvResolver } from "./services/shell-env-resolver";
 import { EnvService } from "./services/env-service";
+import { ThreadControlService } from "./services/thread-control-service";
+import { InternalThreadControlMcpAuthority } from "./services/thread-control-mcp-authority";
+import { InternalThreadControlMcpRuntime } from "./services/thread-control-mcp-runtime";
 import { UtilityCompletionService } from "./services/utility-completion-service";
 import { DiffSummaryService } from "./services/diff-summary-service";
 import { RecapService } from "./services/recap-service";
@@ -328,6 +331,9 @@ export function setupContainer(mcodeDir: string): typeof container {
     { useClass: AgentService },
     { lifecycle: Lifecycle.Singleton },
   );
+  container.register(ThreadControlService, { useClass: ThreadControlService }, { lifecycle: Lifecycle.Singleton });
+  container.register(InternalThreadControlMcpAuthority, { useClass: InternalThreadControlMcpAuthority }, { lifecycle: Lifecycle.Singleton });
+  container.register(InternalThreadControlMcpRuntime, { useClass: InternalThreadControlMcpRuntime }, { lifecycle: Lifecycle.Singleton });
   container.register(
     ThreadTeardownService,
     { useClass: ThreadTeardownService },

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -1487,8 +1487,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
   }
 
   /** Provider teardown: close the SDK query handle. */
-  close(state: ClaudeSessionState): void {
-    this.threadControlMcp?.close(state.sessionId);
+  async close(state: ClaudeSessionState): Promise<void> {
+    await this.threadControlMcp?.close(state.sessionId);
     state.query.close();
   }
 

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -44,6 +44,7 @@ import { EnvService } from "../../services/env-service.js";
 import { JobObject } from "../../services/job-object.js";
 import { ScopedPreGrantService } from "../../services/scoped-pre-grant.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
+import { InternalThreadControlMcpRuntime } from "../../services/thread-control-mcp-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import { listDirectChildren } from "../../services/process-kill.js";
 import { CleanForker } from "../../services/handoff/session-forker.js";
@@ -399,6 +400,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     // pipeline-issued handoff grants are visible here.
     @inject(ScopedPreGrantService)
     private readonly scopedPreGrant: ScopedPreGrantService = new ScopedPreGrantService(),
+    @inject(InternalThreadControlMcpRuntime)
+    private readonly threadControlMcp: InternalThreadControlMcpRuntime = undefined as never,
   ) {
     super();
     this.runtime = new SessionRuntime<ClaudeSessionState>(this, {
@@ -1025,6 +1028,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
 
     const autoCompactWindow = resolveAutoCompactWindow(contextWindowMode, resolvedModel);
 
+    const internalMcpServer = this.threadControlMcp?.createClaudeServer(sessionId);
     const baseOptions = {
       cwd: resolvedCwd,
       // sdkModelSlug appends "[1m]" when the user opted into the 1M context window
@@ -1044,6 +1048,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
         type: "preset" as const,
         preset: "claude_code" as const,
       },
+      ...(internalMcpServer && {
+        mcpServers: {
+          mcode_internal_thread_control: { type: "sdk" as const, instance: internalMcpServer },
+        },
+      }),
       // EnterPlanMode is disallowed because Mcode controls plan entry.
       // ExitPlanMode is NOT disallowed: we intercept it in canUseTool.
       // In plan-answer mode we capture the plan; in normal mode we deny
@@ -1479,6 +1488,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
 
   /** Provider teardown: close the SDK query handle. */
   close(state: ClaudeSessionState): void {
+    this.threadControlMcp?.close(state.sessionId);
     state.query.close();
   }
 

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -1186,7 +1186,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
    * Drives every teardown path (stop, shutdown, eviction, stale-discard).
    */
   async close(state: CodexSessionState): Promise<void> {
-    this.threadControlMcp?.close(state.sessionId);
+    await this.threadControlMcp?.close(state.sessionId);
     for (const event of state.mapper.drainPendingAssistantBoundary(false)) {
       this.emit("event", event);
     }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -16,6 +16,7 @@ import { logger } from "@mcode/shared";
 import { SettingsService } from "../../services/settings-service.js";
 import { JobObject } from "../../services/job-object.js";
 import { EnvService } from "../../services/env-service.js";
+import { InternalThreadControlMcpRuntime } from "../../services/thread-control-mcp-runtime.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import { AttachmentService } from "../../services/attachment-service.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
@@ -512,6 +513,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     @inject(EnvService) private readonly envService: EnvService,
     @inject(AttachmentService) private readonly attachmentService: AttachmentService,
     @inject(CodexCatalogService) private readonly codexCatalogService: CodexCatalogService,
+    @inject(InternalThreadControlMcpRuntime)
+    private readonly threadControlMcp: InternalThreadControlMcpRuntime = undefined as never,
   ) {
     super();
     this.runtime = new SessionRuntime<CodexSessionState>(this, {
@@ -982,6 +985,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     // still runs locally), so this guard is defensive and keeps the wiring
     // obvious in logs.
     const supervised = approvalPolicy === "on-request";
+    const internalMcp = await this.threadControlMcp?.createCodexConfiguration(sessionId);
 
     const server = new CodexAppServer({
       cliPath,
@@ -996,7 +1000,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
         ? (req) => this.handleApprovalRequest(sessionId, threadId, req)
         : undefined,
       jobObject: this.jobObject,
-      getSpawnEnv: () => args.env,
+      getSpawnEnv: () => ({ ...args.env, ...internalMcp?.env }),
+      configOverrides: internalMcp?.configOverrides,
     });
 
     const mapper = new CodexEventMapper(threadId, undefined, (event) => {
@@ -1181,6 +1186,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
    * Drives every teardown path (stop, shutdown, eviction, stale-discard).
    */
   async close(state: CodexSessionState): Promise<void> {
+    this.threadControlMcp?.close(state.sessionId);
     for (const event of state.mapper.drainPendingAssistantBoundary(false)) {
       this.emit("event", event);
     }

--- a/apps/server/src/repositories/message-repo.ts
+++ b/apps/server/src/repositories/message-repo.ts
@@ -43,6 +43,15 @@ interface MessageBudgetRow {
   metadata_bytes: number;
 }
 
+type MessageOriginInput =
+  | { type: "composer" }
+  | {
+      type: "thread";
+      sourceThreadId: string;
+      sourceTurnId: string;
+      sourceProviderId: string;
+    };
+
 export interface ThreadHistoryBudget {
   budgetBytes: number;
   retainedBytes: number;
@@ -202,6 +211,7 @@ export class MessageRepo {
     isInternal?: boolean,
     mentions?: MessageMention[],
     previewAnnotations?: PreviewAnnotationBundle,
+    origin: MessageOriginInput = { type: "composer" },
   ): Message {
     const id = randomUUID();
     const now = new Date().toISOString();
@@ -216,14 +226,17 @@ export class MessageRepo {
     const previewAnnotationsJson = serializePreviewAnnotations(previewAnnotations);
     const modelValue = model ?? null;
     const isInternalValue = isInternal ? 1 : 0;
+    const sourceThreadId = origin.type === "thread" ? origin.sourceThreadId : null;
+    const sourceTurnId = origin.type === "thread" ? origin.sourceTurnId : null;
+    const sourceProviderId = origin.type === "thread" ? origin.sourceProviderId : null;
 
     this.db
       .prepare(
-        "INSERT INTO messages (id, thread_id, role, content, timestamp, sequence, attachments, preview_annotations, mentions, reply_to_message_id, quoted_text, model, is_internal) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO messages (id, thread_id, role, content, timestamp, sequence, attachments, preview_annotations, mentions, reply_to_message_id, quoted_text, model, origin_type, source_thread_id, source_turn_id, source_provider_id, is_internal) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
       )
       .run(
         id, threadId, role, content, now, sequence,
-        attachmentsJson, previewAnnotationsJson, mentionsJson, replyToMessageId ?? null, quotedText ?? null, modelValue, isInternalValue,
+        attachmentsJson, previewAnnotationsJson, mentionsJson, replyToMessageId ?? null, quotedText ?? null, modelValue, origin.type, sourceThreadId, sourceTurnId, sourceProviderId, isInternalValue,
       );
 
     return {
@@ -269,11 +282,13 @@ export class MessageRepo {
     content: string;
     sequence: number;
     model?: string | null;
+    provider?: string | null;
     attachments?: StoredAttachment[];
     mentions?: MessageMention[];
   }): Message {
     const now = new Date().toISOString();
     const modelValue = input.model ?? null;
+    const providerValue = input.provider ?? null;
     const attachmentsJson =
       input.attachments && input.attachments.length > 0
         ? JSON.stringify(input.attachments)
@@ -285,9 +300,9 @@ export class MessageRepo {
 
     const result = this.db
       .prepare(
-        "INSERT OR IGNORE INTO messages (id, thread_id, role, content, timestamp, sequence, attachments, mentions, model, is_internal) VALUES (?, ?, 'assistant', ?, ?, ?, ?, ?, ?, 0)",
+        "INSERT OR IGNORE INTO messages (id, thread_id, role, content, timestamp, sequence, attachments, mentions, model, provider, origin_type, is_internal) VALUES (?, ?, 'assistant', ?, ?, ?, ?, ?, ?, ?, 'composer', 0)",
       )
-      .run(input.id, input.threadId, input.content, now, input.sequence, attachmentsJson, mentionsJson, modelValue);
+      .run(input.id, input.threadId, input.content, now, input.sequence, attachmentsJson, mentionsJson, modelValue, providerValue);
 
     const attachments =
       result.changes === 0 && input.attachments && input.attachments.length > 0

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -405,6 +405,9 @@ export class ThreadRepo {
         this.db.prepare(
           "UPDATE pull_request_review_links SET primary_thread_id = NULL, updated_at = ? WHERE primary_thread_id = ?",
         ).run(now, id);
+        this.db.prepare(
+          "UPDATE threads SET delegation_coordinator_thread_id = NULL, updated_at = ? WHERE delegation_coordinator_thread_id = ? AND workspace_id != (SELECT workspace_id FROM threads WHERE id = ?)",
+        ).run(now, id, id);
       }
       return result.changes > 0;
     })();
@@ -608,6 +611,33 @@ export class ThreadRepo {
     return result.changes > 0;
   }
 
+  /** Persist delegation provenance after a delegated thread is created. */
+  updateDelegationLineage(
+    id: string,
+    lineage: {
+      coordinatorThreadId: string;
+      creatorTurnId: string;
+      creatorToolCallId: string;
+      creationKind: "thread_delegation";
+      integrationId?: string;
+    },
+  ): boolean {
+    const result = this.db
+      .prepare(
+        "UPDATE threads SET delegation_coordinator_thread_id = ?, delegation_creator_turn_id = ?, delegation_creator_tool_call_id = ?, delegation_creation_kind = ?, created_by_integration_id = ?, updated_at = ? WHERE id = ?",
+      )
+      .run(
+        lineage.coordinatorThreadId,
+        lineage.creatorTurnId,
+        lineage.creatorToolCallId,
+        lineage.creationKind,
+        lineage.integrationId ?? null,
+        new Date().toISOString(),
+        id,
+      );
+    return result.changes > 0;
+  }
+
   /**
    * Find all threads in a workspace that have a worktree_path set (both active and deleted).
    * Used during workspace deletion to know which threads need filesystem cleanup.
@@ -642,7 +672,7 @@ export class ThreadRepo {
   nullifyExternalLineage(workspaceId: string): number {
     const result = this.db
       .prepare(
-        `UPDATE threads SET parent_thread_id = NULL, forked_from_message_id = NULL, updated_at = ?
+        `UPDATE threads SET parent_thread_id = NULL, forked_from_message_id = NULL, delegation_coordinator_thread_id = NULL, updated_at = ?
          WHERE parent_thread_id IN (SELECT id FROM threads WHERE workspace_id = ?)
          AND workspace_id != ?`,
       )

--- a/apps/server/src/repositories/workspace-repo.ts
+++ b/apps/server/src/repositories/workspace-repo.ts
@@ -176,6 +176,20 @@ export class WorkspaceRepo {
     return rows.map(rowToWorkspace);
   }
 
+  /** Search registered non-deleted workspaces by name or repository path. */
+  search(query: string, limit: number): Workspace[] {
+    const normalized = query.trim();
+    if (!normalized) {
+      return this.db.prepare(
+        "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order, deleted_at FROM workspaces WHERE deleted_at IS NULL ORDER BY last_opened_at DESC NULLS LAST, updated_at DESC, id ASC LIMIT ?",
+      ).all(limit).map((row) => rowToWorkspace(row as WorkspaceRow));
+    }
+    const pattern = `%${normalized.replace(/[\\%_]/g, "\\$&")}%`;
+    return this.db.prepare(
+      "SELECT id, name, path, provider_config, is_git_repo, created_at, updated_at, pinned, last_opened_at, sort_order, deleted_at FROM workspaces WHERE deleted_at IS NULL AND (name LIKE ? ESCAPE '\\' OR path LIKE ? ESCAPE '\\') ORDER BY last_opened_at DESC NULLS LAST, updated_at DESC, id ASC LIMIT ?",
+    ).all(pattern, pattern, limit).map((row) => rowToWorkspace(row as WorkspaceRow));
+  }
+
   /** Rename a non-deleted workspace and return its updated record. */
   rename(id: string, name: string): Workspace | null {
     const result = this.db

--- a/apps/server/src/repositories/worktree-repo.ts
+++ b/apps/server/src/repositories/worktree-repo.ts
@@ -2,6 +2,10 @@ import { randomUUID } from "node:crypto";
 import { injectable, inject } from "tsyringe";
 import type Database from "better-sqlite3";
 
+/** Number of days to retain a stale worktree registration for identity revival. */
+export const STALE_WORKTREE_RETENTION_DAYS = 30;
+const STALE_WORKTREE_RETENTION_MS = STALE_WORKTREE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
 /** Worktree metadata safe to expose outside the server. */
 export interface RegisteredWorktree {
   worktreeId: string;
@@ -26,15 +30,18 @@ export class WorktreeRepo {
 
   /** Reconcile current Git registrations and return opaque display metadata. */
   reconcile(workspaceId: string, worktrees: readonly RegisteredWorktreeInput[]): RegisteredWorktree[] {
-    const now = new Date().toISOString();
+    const now = new Date();
+    const lastSeenAt = now.toISOString();
+    const staleCutoff = new Date(now.getTime() - STALE_WORKTREE_RETENTION_MS).toISOString();
     const run = this.db.transaction(() => {
       this.db.prepare("UPDATE workspace_worktrees SET stale = 1 WHERE workspace_id = ?").run(workspaceId);
       const upsert = this.db.prepare(
         "INSERT INTO workspace_worktrees (id, workspace_id, canonical_path, label, branch, base_ref, managed, last_seen_at, stale) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0) ON CONFLICT(workspace_id, canonical_path) DO UPDATE SET label = excluded.label, branch = excluded.branch, base_ref = excluded.base_ref, managed = excluded.managed, last_seen_at = excluded.last_seen_at, stale = 0",
       );
       for (const worktree of worktrees) {
-        upsert.run(randomUUID(), workspaceId, worktree.canonicalPath, worktree.label, worktree.branch ?? null, worktree.baseRef ?? null, worktree.managed ? 1 : 0, now);
+        upsert.run(randomUUID(), workspaceId, worktree.canonicalPath, worktree.label, worktree.branch ?? null, worktree.baseRef ?? null, worktree.managed ? 1 : 0, lastSeenAt);
       }
+      this.db.prepare("DELETE FROM workspace_worktrees WHERE workspace_id = ? AND stale = 1 AND last_seen_at < ?").run(workspaceId, staleCutoff);
     });
     run();
     return this.list(workspaceId);

--- a/apps/server/src/repositories/worktree-repo.ts
+++ b/apps/server/src/repositories/worktree-repo.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from "node:crypto";
+import { injectable, inject } from "tsyringe";
+import type Database from "better-sqlite3";
+
+/** Worktree metadata safe to expose outside the server. */
+export interface RegisteredWorktree {
+  worktreeId: string;
+  label: string;
+  branch?: string;
+  baseRef?: string;
+}
+
+/** Server-side worktree registration input. */
+export interface RegisteredWorktreeInput {
+  canonicalPath: string;
+  label: string;
+  branch?: string;
+  baseRef?: string;
+  managed: boolean;
+}
+
+/** Repository for stable workspace-scoped worktree identities. */
+@injectable()
+export class WorktreeRepo {
+  constructor(@inject("Database") private readonly db: Database.Database) {}
+
+  /** Reconcile current Git registrations and return opaque display metadata. */
+  reconcile(workspaceId: string, worktrees: readonly RegisteredWorktreeInput[]): RegisteredWorktree[] {
+    const now = new Date().toISOString();
+    const run = this.db.transaction(() => {
+      this.db.prepare("UPDATE workspace_worktrees SET stale = 1 WHERE workspace_id = ?").run(workspaceId);
+      const upsert = this.db.prepare(
+        "INSERT INTO workspace_worktrees (id, workspace_id, canonical_path, label, branch, base_ref, managed, last_seen_at, stale) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0) ON CONFLICT(workspace_id, canonical_path) DO UPDATE SET label = excluded.label, branch = excluded.branch, base_ref = excluded.base_ref, managed = excluded.managed, last_seen_at = excluded.last_seen_at, stale = 0",
+      );
+      for (const worktree of worktrees) {
+        upsert.run(randomUUID(), workspaceId, worktree.canonicalPath, worktree.label, worktree.branch ?? null, worktree.baseRef ?? null, worktree.managed ? 1 : 0, now);
+      }
+    });
+    run();
+    return this.list(workspaceId);
+  }
+
+  /** List only current worktrees, never their canonical filesystem paths. */
+  list(workspaceId: string): RegisteredWorktree[] {
+    return this.db.prepare(
+      "SELECT id AS worktreeId, label, branch, base_ref AS baseRef FROM workspace_worktrees WHERE workspace_id = ? AND stale = 0 ORDER BY label COLLATE NOCASE, id",
+    ).all(workspaceId).map((row) => {
+      const value = row as { worktreeId: string; label: string; branch: string | null; baseRef: string | null };
+      return {
+        worktreeId: value.worktreeId,
+        label: value.label,
+        ...(value.branch ? { branch: value.branch } : {}),
+        ...(value.baseRef ? { baseRef: value.baseRef } : {}),
+      };
+    });
+  }
+}

--- a/apps/server/src/services/__tests__/agent-service-transient-retry.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-transient-retry.test.ts
@@ -68,6 +68,7 @@ function buildService(): {
   sendTurn: ReturnType<typeof vi.fn>;
   discardSession: ReturnType<typeof vi.fn>;
   waitForSessionExit: ReturnType<typeof vi.fn>;
+  threadControlMcp: { activate: ReturnType<typeof vi.fn> };
   providerEmitter: EventEmitter;
   threadRepo: ThreadRepo & { clearSdkSessionId: ReturnType<typeof vi.fn>; updateStatus: ReturnType<typeof vi.fn> };
 } {
@@ -157,6 +158,7 @@ function buildService(): {
     isAnswered: vi.fn(() => false),
     listAnsweredForThread: vi.fn(() => []),
   } as unknown as PlanQuestionAnswersRepo;
+  const threadControlMcp = { activate: vi.fn(), revoke: vi.fn(), close: vi.fn() };
   const db = {
     transaction: vi.fn((fn: (...args: unknown[]) => unknown) => fn),
     prepare: vi.fn(() => ({ run: vi.fn() })),
@@ -189,9 +191,11 @@ function buildService(): {
       { bulkCreate: () => {}, create: () => ({}), listByMessage: () => [], countByMessage: () => 0 } as unknown as import("../../repositories/hook-execution-repo.js").HookExecutionRepo,
     ),
     new PlanQuestionService(messageRepo, planQuestionAnswersRepo),
+    undefined,
+    threadControlMcp as never,
   );
 
-  return { service, sendTurn, discardSession, waitForSessionExit, providerEmitter, threadRepo };
+  return { service, sendTurn, discardSession, waitForSessionExit, providerEmitter, threadRepo, threadControlMcp };
 }
 
 describe("AgentService transient-failure auto-retry", () => {
@@ -224,6 +228,29 @@ describe("AgentService transient-failure auto-retry", () => {
     expect(discardSession).toHaveBeenCalledWith(`mcode-${THREAD_ID}`);
     expect(threadRepo.clearSdkSessionId).toHaveBeenCalledWith(THREAD_ID);
     expect(threadRepo.updateStatus).not.toHaveBeenCalledWith(THREAD_ID, "errored");
+  });
+
+  it("reactivates the same turn authority after retry discards its provider session", async () => {
+    const { service, sendTurn, threadControlMcp } = buildService();
+    service.init();
+    sendTurn.mockRejectedValueOnce(new Error("read ECONNRESET")).mockResolvedValueOnce(undefined);
+
+    await service.sendMessage({
+      threadId: THREAD_ID,
+      content: "hello",
+      permissionMode: "full",
+      model: "claude-sonnet-4-6",
+      attachments: [],
+      provider: "claude",
+    });
+
+    expect(threadControlMcp.activate).toHaveBeenCalledTimes(2);
+    expect(threadControlMcp.activate.mock.calls[1][0]).toMatchObject({
+      sourceThreadId: THREAD_ID,
+      sourceTurnId: threadControlMcp.activate.mock.calls[0][0].sourceTurnId,
+      sourceProviderId: "claude",
+      permissionMode: "full",
+    });
   });
 
   it("does not retry a fatal send failure", async () => {

--- a/apps/server/src/services/__tests__/thread-control-container.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-container.test.ts
@@ -1,0 +1,19 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { container } from "tsyringe";
+import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
+import { WorktreeRepo } from "../../repositories/worktree-repo.js";
+import { GitService } from "../git-service.js";
+import { ThreadControlService } from "../thread-control-service.js";
+
+describe("thread-control DI", () => {
+  it("resolves explicit repository and Git dependencies", () => {
+    const child = container.createChildContainer();
+    child.registerInstance(WorkspaceRepo, {} as WorkspaceRepo);
+    child.registerInstance(WorktreeRepo, {} as WorktreeRepo);
+    child.registerInstance(GitService, {} as GitService);
+    child.register(ThreadControlService, { useClass: ThreadControlService });
+
+    expect(() => child.resolve(ThreadControlService)).not.toThrow();
+  });
+});

--- a/apps/server/src/services/__tests__/thread-control-mcp-authority.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-authority.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
+import { constantTimeCredentialEqual, InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
 
 describe("InternalThreadControlMcpAuthority", () => {
   it("keeps one opaque credential per pooled session while rotating its active turn lease", () => {
@@ -30,6 +30,7 @@ describe("InternalThreadControlMcpAuthority", () => {
     expect(retry.credential).toBe(first.credential);
     expect(nextTurn.credential).toBe(first.credential);
     expect(authority.authorize(first.credential, "call-1")).toMatchObject({
+      type: "internal",
       userId: "local-user",
       sourceTurnId: "turn-two",
       sourceToolCallId: "call-1",
@@ -50,5 +51,10 @@ describe("InternalThreadControlMcpAuthority", () => {
     authority.revoke("mcode-source");
 
     expect(authority.authorize(lease.credential, "call-1")).toBeUndefined();
+  });
+
+  it("rejects unequal credential lengths before constant-time comparison", () => {
+    expect(constantTimeCredentialEqual("credential", "credential")).toBe(true);
+    expect(constantTimeCredentialEqual("credential", "credential-extra")).toBe(false);
   });
 });

--- a/apps/server/src/services/__tests__/thread-control-mcp-authority.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-authority.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
+
+describe("InternalThreadControlMcpAuthority", () => {
+  it("keeps one opaque credential per pooled session while rotating its active turn lease", () => {
+    const authority = new InternalThreadControlMcpAuthority();
+
+    const first = authority.activate({
+      sessionId: "mcode-source",
+      sourceThreadId: "source",
+      sourceTurnId: "turn-one",
+      sourceProviderId: "claude",
+      permissionMode: "supervised",
+    });
+    const retry = authority.activate({
+      sessionId: "mcode-source",
+      sourceThreadId: "source",
+      sourceTurnId: "turn-one",
+      sourceProviderId: "claude",
+      permissionMode: "supervised",
+    });
+    const nextTurn = authority.activate({
+      sessionId: "mcode-source",
+      sourceThreadId: "source",
+      sourceTurnId: "turn-two",
+      sourceProviderId: "claude",
+      permissionMode: "full",
+    });
+
+    expect(retry.credential).toBe(first.credential);
+    expect(nextTurn.credential).toBe(first.credential);
+    expect(authority.authorize(first.credential, "call-1")).toMatchObject({
+      userId: "local-user",
+      sourceTurnId: "turn-two",
+      sourceToolCallId: "call-1",
+      permissionMode: "full",
+    });
+  });
+
+  it("fails closed after revocation", () => {
+    const authority = new InternalThreadControlMcpAuthority();
+    const lease = authority.activate({
+      sessionId: "mcode-source",
+      sourceThreadId: "source",
+      sourceTurnId: "turn-one",
+      sourceProviderId: "codex",
+      permissionMode: "supervised",
+    });
+
+    authority.revoke("mcode-source");
+
+    expect(authority.authorize(lease.credential, "call-1")).toBeUndefined();
+  });
+});

--- a/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
@@ -1,0 +1,62 @@
+import "reflect-metadata";
+import { request } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
+import { InternalThreadControlMcpRuntime } from "../thread-control-mcp-runtime.js";
+
+function status(url: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const outgoing = request(url, { method: "POST" }, (response) => {
+      response.resume();
+      response.once("end", () => resolve(response.statusCode ?? 0));
+    });
+    outgoing.once("error", reject);
+    outgoing.end();
+  });
+}
+
+function runtime(): { runtime: InternalThreadControlMcpRuntime; authority: InternalThreadControlMcpAuthority } {
+  const authority = new InternalThreadControlMcpAuthority();
+  const instance = new InternalThreadControlMcpRuntime({} as never, authority);
+  return { runtime: instance, authority };
+}
+
+describe("InternalThreadControlMcpRuntime", () => {
+  it("shares one startup listener and rejects malformed session encoding", async () => {
+    const { runtime: instance, authority } = runtime();
+    const lease = authority.activate({
+      sessionId: "session",
+      sourceThreadId: "thread",
+      sourceTurnId: "turn",
+      sourceProviderId: "codex",
+      permissionMode: "full",
+    });
+
+    const [first, second] = await Promise.all([
+      instance.createCodexConfiguration("session"),
+      instance.createCodexConfiguration("session"),
+    ]);
+
+    expect(first?.configOverrides).toEqual(second?.configOverrides);
+    const port = first?.configOverrides[0].match(/127\.0\.0\.1:(\d+)/)?.[1];
+    expect(port).toBeDefined();
+    expect(await status(`http://127.0.0.1:${port}/%`)).toBe(401);
+
+    const sessions = (instance as unknown as {
+      httpSessions: Map<string, { transport: { close: () => Promise<void> } }>;
+    }).httpSessions;
+    vi.spyOn(sessions.get("session")!.transport, "close").mockRejectedValueOnce(new Error("transport close failed"));
+    await expect(instance.close("session")).resolves.toBeUndefined();
+    expect(authority.authorize(lease.credential, "call")).toBeUndefined();
+
+    authority.activate({
+      sessionId: "session",
+      sourceThreadId: "thread",
+      sourceTurnId: "turn",
+      sourceProviderId: "codex",
+      permissionMode: "full",
+    });
+    await expect(instance.createCodexConfiguration("session")).resolves.toBeDefined();
+    await instance.close("session");
+  });
+});

--- a/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { request } from "node:http";
+import { request, type Server } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import { InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
 import { InternalThreadControlMcpRuntime } from "../thread-control-mcp-runtime.js";
@@ -58,5 +58,38 @@ describe("InternalThreadControlMcpRuntime", () => {
     });
     await expect(instance.createCodexConfiguration("session")).resolves.toBeDefined();
     await instance.close("session");
+  });
+
+  it("does not retain a loopback listener when close wins during startup", async () => {
+    const { runtime: instance, authority } = runtime();
+    authority.activate({
+      sessionId: "session",
+      sourceThreadId: "thread",
+      sourceTurnId: "turn",
+      sourceProviderId: "codex",
+      permissionMode: "full",
+    });
+    let finishStartup!: () => void;
+    const startup = new Promise<void>((resolve) => {
+      finishStartup = resolve;
+    });
+    const server = { close: vi.fn((callback: () => void) => callback()) };
+    vi.spyOn(instance as unknown as { startHttpServer: () => Promise<void> }, "startHttpServer").mockImplementation(async () => {
+      await startup;
+      const state = instance as unknown as { httpServer: typeof server; httpPort: number };
+      state.httpServer = server;
+      state.httpPort = 1234;
+    });
+
+    const config = instance.createCodexConfiguration("session");
+    const close = instance.close("session");
+    finishStartup();
+
+    await expect(config).resolves.toBeUndefined();
+    await expect(close).resolves.toBeUndefined();
+    const state = instance as unknown as { httpServer: Server | undefined; httpSessions: Map<string, unknown> };
+    expect(server.close).toHaveBeenCalledOnce();
+    expect(state.httpServer).toBeUndefined();
+    expect(state.httpSessions).toHaveLength(0);
   });
 });

--- a/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
+import { createInternalThreadControlMcpSession } from "../thread-control-mcp-transport.js";
+import type { ThreadControlService } from "../thread-control-service.js";
+
+describe("internal thread-control MCP transport", () => {
+  it("dispatches workspace_search through an active bearer lease", async () => {
+    const authority = new InternalThreadControlMcpAuthority();
+    const lease = authority.activate({
+      sessionId: "pooled-provider-session",
+      sourceThreadId: "source-thread",
+      sourceTurnId: "source-turn",
+      sourceProviderId: "claude",
+      permissionMode: "supervised",
+    });
+    const service = {
+      workspaceSearch: vi.fn().mockReturnValue({ workspaces: [] }),
+      worktreeList: vi.fn(),
+    } as unknown as ThreadControlService;
+    const session = createInternalThreadControlMcpSession({ authority, service });
+
+    await expect(session.dispatch({
+      bearerCredential: lease.credential,
+      requestId: "call-1",
+      toolName: "workspace_search",
+      arguments: { query: "mcode" },
+    })).resolves.toEqual({ workspaces: [] });
+    expect(service.workspaceSearch).toHaveBeenCalledWith(expect.objectContaining({
+      sourceThreadId: "source-thread",
+      sourceToolCallId: "call-1",
+    }), { query: "mcode", limit: 20 });
+  });
+
+  it("fails closed for revoked leases and unsupported tools", async () => {
+    const authority = new InternalThreadControlMcpAuthority();
+    const lease = authority.activate({
+      sessionId: "pooled-provider-session",
+      sourceThreadId: "source-thread",
+      sourceTurnId: "source-turn",
+      sourceProviderId: "codex",
+      permissionMode: "full",
+    });
+    const service = {
+      workspaceSearch: vi.fn(),
+      worktreeList: vi.fn(),
+    } as unknown as ThreadControlService;
+    const session = createInternalThreadControlMcpSession({ authority, service });
+
+    await expect(session.dispatch({
+      bearerCredential: lease.credential,
+      requestId: "call-2",
+      toolName: "thread_create" as never,
+      arguments: {},
+    })).rejects.toThrow("Internal thread-control MCP request denied");
+
+    await expect(session.dispatch({
+      bearerCredential: "invalid",
+      requestId: "call-2a",
+      toolName: "workspace_search",
+      arguments: {},
+    })).rejects.toThrow("Internal thread-control MCP request denied");
+
+    authority.revoke(lease.sessionId);
+    await expect(session.dispatch({
+      bearerCredential: lease.credential,
+      requestId: "call-3",
+      toolName: "workspace_search",
+      arguments: {},
+    })).rejects.toThrow("Internal thread-control MCP request denied");
+    expect(service.workspaceSearch).not.toHaveBeenCalled();
+  });
+
+  it("registers only discovery tools and rejects forged tool authority", async () => {
+    const authority = new InternalThreadControlMcpAuthority();
+    const lease = authority.activate({
+      sessionId: "pooled-provider-session",
+      sourceThreadId: "source-thread",
+      sourceTurnId: "source-turn",
+      sourceProviderId: "claude",
+      permissionMode: "supervised",
+    });
+    const service = {
+      workspaceSearch: vi.fn().mockReturnValue({ workspaces: [] }),
+      worktreeList: vi.fn(),
+    } as unknown as ThreadControlService;
+    const session = createInternalThreadControlMcpSession({ authority, service });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = session.createServer(lease.credential);
+    const client = new Client({ name: "thread-control-test", version: "0.1.0" });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    await expect(client.listTools()).resolves.toMatchObject({
+      tools: [{ name: "workspace_search" }, { name: "worktree_list" }],
+    });
+    await expect(session.dispatch({
+      bearerCredential: lease.credential,
+      requestId: "call-4",
+      toolName: "workspace_search",
+      arguments: { sourceThreadId: "forged" },
+    })).rejects.toBeDefined();
+    await client.close();
+    await server.close();
+  });
+});

--- a/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
@@ -104,4 +104,43 @@ describe("internal thread-control MCP transport", () => {
     await client.close();
     await server.close();
   });
+
+  it("serves worktree_list through the MCP protocol and fails closed after revocation", async () => {
+    const authority = new InternalThreadControlMcpAuthority();
+    const lease = authority.activate({
+      sessionId: "pooled-provider-session",
+      sourceThreadId: "source-thread",
+      sourceTurnId: "source-turn",
+      sourceProviderId: "codex",
+      permissionMode: "full",
+    });
+    const service = {
+      workspaceSearch: vi.fn().mockReturnValue({ workspaces: [] }),
+      worktreeList: vi.fn().mockResolvedValue({
+        status: "found",
+        workspaceId: "workspace-1",
+        worktrees: [{ worktreeId: "worktree-1", label: "main", branch: "main" }],
+      }),
+    } as unknown as ThreadControlService;
+    const session = createInternalThreadControlMcpSession({ authority, service });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = session.createServer(lease.credential);
+    const client = new Client({ name: "thread-control-test", version: "0.1.0" });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    await expect(client.listTools()).resolves.toMatchObject({
+      tools: [{ name: "workspace_search" }, { name: "worktree_list" }],
+    });
+    await expect(client.callTool({ name: "worktree_list", arguments: { workspaceId: "workspace-1" } }))
+      .resolves.toMatchObject({
+        structuredContent: { status: "found", workspaceId: "workspace-1" },
+      });
+
+    authority.revoke(lease.sessionId);
+    await expect(client.callTool({ name: "worktree_list", arguments: { workspaceId: "workspace-1" } }))
+      .resolves.toMatchObject({ isError: true });
+    await client.close();
+    await server.close();
+  });
 });

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { ThreadControlService, type InternalThreadControlAuthority } from "../thread-control-service.js";
 
 const authority: InternalThreadControlAuthority = {
+  type: "internal",
   userId: "local-user",
   sourceThreadId: "thread-1",
   sourceTurnId: "turn-1",

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -1,0 +1,28 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { ThreadControlService, type InternalThreadControlAuthority } from "../thread-control-service.js";
+
+const authority: InternalThreadControlAuthority = {
+  userId: "local-user",
+  sourceThreadId: "thread-1",
+  sourceTurnId: "turn-1",
+  sourceToolCallId: "call-1",
+  sourceProviderId: "claude",
+  permissionMode: "supervised",
+};
+
+describe("ThreadControlService", () => {
+  it("never returns a registered workspace filesystem path from workspace_search", () => {
+    const workspacePath = "C:/private/workspace";
+    const service = new ThreadControlService(
+      { search: () => [{ id: "workspace-1", name: "Workspace", path: workspacePath, last_opened_at: null }] } as never,
+      {} as never,
+      {} as never,
+    );
+
+    const result = service.workspaceSearch(authority, { limit: 20 });
+
+    expect(JSON.stringify(result)).not.toContain(workspacePath);
+    expect(result.workspaces).toEqual([{ workspaceId: "workspace-1", name: "Workspace" }]);
+  });
+});

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -305,6 +305,7 @@ export class AgentService {
       /** False once the in-flight `sendTurn` promise has settled (success or throw). */
       sendTurnInFlight: boolean;
       sessionName: string;
+      sourceTurnId: string;
       resolvedProvider: import("@mcode/contracts").IAgentProvider;
       effectiveProvider: ProviderId;
       turnRequest: TurnRequest;
@@ -893,6 +894,7 @@ export class AgentService {
       retryInFlight: false,
       sendTurnInFlight: false,
       sessionName,
+      sourceTurnId,
       resolvedProvider,
       effectiveProvider,
       turnRequest: baseTurnRequest,
@@ -2043,6 +2045,15 @@ export class AgentService {
         logger.warn("Failed to discard pooled session before retry", {
           threadId,
           error: evictErr instanceof Error ? evictErr.message : String(evictErr),
+        });
+      }
+      if (dispatch.effectiveProvider === "claude" || dispatch.effectiveProvider === "codex") {
+        this.threadControlMcp?.activate({
+          sessionId: dispatch.sessionName,
+          sourceThreadId: threadId,
+          sourceTurnId: dispatch.sourceTurnId,
+          sourceProviderId: dispatch.effectiveProvider,
+          permissionMode: dispatch.turnRequest.permissionMode === "full" ? "full" : "supervised",
         });
       }
       try {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -8,6 +8,7 @@
 import { injectable, inject, delay } from "tsyringe";
 import { existsSync, statSync } from "fs";
 import { isAbsolute } from "path";
+import { randomUUID } from "node:crypto";
 import { logger, validateBranchName } from "@mcode/shared";
 import {
   AgentEventType,
@@ -77,6 +78,7 @@ import { HandoffCoordinator } from "./handoff/handoff-coordinator.js";
 import { ScopedPreGrantService } from "./scoped-pre-grant.js";
 import { normalizeAgentProviderError } from "./provider-agent-error-normalize.js";
 import { TurnErrorPolicy } from "./turn-error-policy.js";
+import { InternalThreadControlMcpRuntime } from "./thread-control-mcp-runtime.js";
 import type { TurnOutcome } from "./turn-outcome.js";
 
 /**
@@ -377,6 +379,8 @@ export class AgentService {
     @inject(PlanQuestionService)
     private readonly planQuestionService: PlanQuestionService,
     @inject(FileService) private readonly fileService?: FileService,
+    @inject(InternalThreadControlMcpRuntime)
+    private readonly threadControlMcp?: InternalThreadControlMcpRuntime,
   ) {
     this.turnFileTracker = new TurnFileTracker(
       (cwd, ref, path) => this.snapshotService.getFileAtRef(cwd, ref, path),
@@ -797,6 +801,7 @@ export class AgentService {
     });
 
     const sessionName = `mcode-${threadId}`;
+    const sourceTurnId = randomUUID();
     // A branched child has a system handoff at seq 1 but no sdk_session_id.
     // Only treat as resume if there is actually a session to resume.
     const isResume = nextSeq > 1 && !!thread.sdk_session_id;
@@ -874,6 +879,15 @@ export class AgentService {
       resumeFrom: attemptResumeFrom,
       providerOptions,
     } as TurnRequest;
+    if (effectiveProvider === "claude" || effectiveProvider === "codex") {
+      this.threadControlMcp?.activate({
+        sessionId: sessionName,
+        sourceThreadId: threadId,
+        sourceTurnId,
+        sourceProviderId: effectiveProvider,
+        permissionMode: permissionMode === "full" ? "full" : "supervised",
+      });
+    }
     this.turnRetryDispatchByThread.set(threadId, {
       attempt: 1,
       retryInFlight: false,
@@ -2574,6 +2588,7 @@ export class AgentService {
           // before the compaction API call, but the session continues
           // automatically.
           if (!this.compactionInProgressByThread.has(event.threadId)) {
+            this.threadControlMcp?.revoke(`mcode-${event.threadId}`);
             this.trackSessionEnded(event.threadId);
             this.disarmTurnRetryWindow(event.threadId);
             void this.refreshNativeClaudeGoalAfterTurn(event.threadId);
@@ -2735,6 +2750,7 @@ export class AgentService {
             void this.finalizeTerminalTurn(event.threadId, outcome, "ended");
           }
           this.trackSessionEnded(event.threadId);
+          this.threadControlMcp?.revoke(`mcode-${event.threadId}`);
           // Turn-scoped cleanup of any one-shot handoff Read grant. No-op on
           // later turns since the grant is already gone (consumed or cleared).
           this.scopedPreGrant.clear(event.threadId);

--- a/apps/server/src/services/thread-control-mcp-authority.ts
+++ b/apps/server/src/services/thread-control-mcp-authority.ts
@@ -1,5 +1,5 @@
-import { randomBytes } from "node:crypto";
-import type { InternalThreadControlAuthority } from "./thread-control-service.js";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { InternalThreadControlAuthority } from "@mcode/thread-orchestration";
 
 /** Mutable server-owned lease for an internal provider-session MCP credential. */
 interface ActiveLease {
@@ -25,6 +25,13 @@ export interface InternalThreadControlMcpLease {
   sessionId: string;
 }
 
+/** Compares two bearer values without exposing equal-length match timing. */
+export function constantTimeCredentialEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
 /** Owns opaque credentials and revocable authority for internal MCP sessions. */
 export class InternalThreadControlMcpAuthority {
   private readonly leases = new Map<string, { credential: string; active?: ActiveLease }>();
@@ -47,8 +54,9 @@ export class InternalThreadControlMcpAuthority {
   authorize(credential: string, sourceToolCallId: string): InternalThreadControlAuthority | undefined {
     if (sourceToolCallId.length < 1 || sourceToolCallId.length > 128) return undefined;
     for (const entry of this.leases.values()) {
-      if (entry.credential !== credential || !entry.active?.active) continue;
+      if (!constantTimeCredentialEqual(entry.credential, credential) || !entry.active?.active) continue;
       return {
+        type: "internal",
         userId: "local-user",
         sourceThreadId: entry.active.sourceThreadId,
         sourceTurnId: entry.active.sourceTurnId,

--- a/apps/server/src/services/thread-control-mcp-authority.ts
+++ b/apps/server/src/services/thread-control-mcp-authority.ts
@@ -1,0 +1,78 @@
+import { randomBytes } from "node:crypto";
+import type { InternalThreadControlAuthority } from "./thread-control-service.js";
+
+/** Mutable server-owned lease for an internal provider-session MCP credential. */
+interface ActiveLease {
+  sourceThreadId: string;
+  sourceTurnId: string;
+  sourceProviderId: string;
+  permissionMode: "supervised" | "full";
+  active: boolean;
+}
+
+/** Provider turn fields used to activate the internal MCP authority. */
+export interface ActivateInternalThreadControlMcpLease {
+  sessionId: string;
+  sourceThreadId: string;
+  sourceTurnId: string;
+  sourceProviderId: string;
+  permissionMode: "supervised" | "full";
+}
+
+/** Opaque credential and stable session binding supplied to a provider transport. */
+export interface InternalThreadControlMcpLease {
+  credential: string;
+  sessionId: string;
+}
+
+/** Owns opaque credentials and revocable authority for internal MCP sessions. */
+export class InternalThreadControlMcpAuthority {
+  private readonly leases = new Map<string, { credential: string; active?: ActiveLease }>();
+
+  /** Activates a turn lease without rotating its pooled session credential. */
+  activate(input: ActivateInternalThreadControlMcpLease): InternalThreadControlMcpLease {
+    const entry = this.leases.get(input.sessionId) ?? { credential: randomBytes(32).toString("base64url") };
+    entry.active = {
+      sourceThreadId: input.sourceThreadId,
+      sourceTurnId: input.sourceTurnId,
+      sourceProviderId: input.sourceProviderId,
+      permissionMode: input.permissionMode,
+      active: true,
+    };
+    this.leases.set(input.sessionId, entry);
+    return { credential: entry.credential, sessionId: input.sessionId };
+  }
+
+  /** Resolves the active lease only when its bearer credential remains valid. */
+  authorize(credential: string, sourceToolCallId: string): InternalThreadControlAuthority | undefined {
+    if (sourceToolCallId.length < 1 || sourceToolCallId.length > 128) return undefined;
+    for (const entry of this.leases.values()) {
+      if (entry.credential !== credential || !entry.active?.active) continue;
+      return {
+        userId: "local-user",
+        sourceThreadId: entry.active.sourceThreadId,
+        sourceTurnId: entry.active.sourceTurnId,
+        sourceToolCallId,
+        sourceProviderId: entry.active.sourceProviderId,
+        permissionMode: entry.active.permissionMode,
+      };
+    }
+    return undefined;
+  }
+
+  /** Returns the stable credential only while a provider session remains active. */
+  credential(sessionId: string): string | undefined {
+    return this.leases.get(sessionId)?.credential;
+  }
+
+  /** Revokes the active turn lease while retaining the credential for pooled reuse. */
+  revoke(sessionId: string): void {
+    const entry = this.leases.get(sessionId);
+    if (entry?.active) entry.active.active = false;
+  }
+
+  /** Removes a closed transport and its credential permanently. */
+  close(sessionId: string): void {
+    this.leases.delete(sessionId);
+  }
+}

--- a/apps/server/src/services/thread-control-mcp-runtime.ts
+++ b/apps/server/src/services/thread-control-mcp-runtime.ts
@@ -21,6 +21,7 @@ export class InternalThreadControlMcpRuntime {
   private httpServer: Server | undefined;
   private httpPort: number | undefined;
   private httpServerStartup: Promise<void> | undefined;
+  private lifecycleTail: Promise<void> = Promise.resolve();
 
   constructor(
     @inject(ThreadControlService) service: ThreadControlService,
@@ -42,19 +43,14 @@ export class InternalThreadControlMcpRuntime {
   /** Closes all MCP state owned by a provider session. */
   async close(sessionId: string): Promise<void> {
     this.authority.close(sessionId);
-    const entry = this.httpSessions.get(sessionId);
-    this.httpSessions.delete(sessionId);
-    if (entry) {
-      await entry.transport.close().catch(() => undefined);
-    }
-    const server = this.httpSessions.size === 0 ? this.httpServer : undefined;
-    if (server) {
-      this.httpServer = undefined;
-      this.httpPort = undefined;
-      await new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      });
-    }
+    await this.inLifecycle(async () => {
+      const entry = this.httpSessions.get(sessionId);
+      this.httpSessions.delete(sessionId);
+      if (entry) {
+        await entry.transport.close().catch(() => undefined);
+      }
+      await this.closeHttpServerWhenIdle();
+    });
   }
 
   /** Creates the Claude SDK in-process MCP server for an active provider session. */
@@ -67,22 +63,57 @@ export class InternalThreadControlMcpRuntime {
   async createCodexConfiguration(sessionId: string): Promise<{ configOverrides: string[]; env: Record<string, string> } | undefined> {
     const credential = this.authority.credential(sessionId);
     if (!credential) return undefined;
-    await this.ensureHttpServer();
-    if (!this.httpPort) return undefined;
-    if (!this.httpSessions.has(sessionId)) {
-      const server = this.transport.createServer(credential);
-      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-      await server.connect(transport);
-      this.httpSessions.set(sessionId, { server, transport });
+    return this.inLifecycle(async () => {
+      await this.ensureHttpServer();
+      if (credential !== this.authority.credential(sessionId) || !this.httpPort) {
+        await this.closeHttpServerWhenIdle();
+        return undefined;
+      }
+      if (!this.httpSessions.has(sessionId)) {
+        const server = this.transport.createServer(credential);
+        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+        await server.connect(transport);
+        if (credential !== this.authority.credential(sessionId)) {
+          await transport.close().catch(() => undefined);
+          await this.closeHttpServerWhenIdle();
+          return undefined;
+        }
+        this.httpSessions.set(sessionId, { server, transport });
+      }
+      const url = `http://127.0.0.1:${this.httpPort}/${encodeURIComponent(sessionId)}`;
+      return {
+        configOverrides: [
+          `mcp_servers.${CODEX_MCP_NAME}.url=\"${url}\"`,
+          `mcp_servers.${CODEX_MCP_NAME}.bearer_token_env_var=\"${CODEX_MCP_TOKEN_ENV}\"`,
+        ],
+        env: { [CODEX_MCP_TOKEN_ENV]: credential },
+      };
+    });
+  }
+
+  private async inLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const previous = this.lifecycleTail;
+    this.lifecycleTail = next;
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
     }
-    const url = `http://127.0.0.1:${this.httpPort}/${encodeURIComponent(sessionId)}`;
-    return {
-      configOverrides: [
-        `mcp_servers.${CODEX_MCP_NAME}.url=\"${url}\"`,
-        `mcp_servers.${CODEX_MCP_NAME}.bearer_token_env_var=\"${CODEX_MCP_TOKEN_ENV}\"`,
-      ],
-      env: { [CODEX_MCP_TOKEN_ENV]: credential },
-    };
+  }
+
+  private async closeHttpServerWhenIdle(): Promise<void> {
+    if (this.httpSessions.size > 0 || !this.httpServer) return;
+    const server = this.httpServer;
+    this.httpServer = undefined;
+    this.httpPort = undefined;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
   }
 
   private async ensureHttpServer(): Promise<void> {

--- a/apps/server/src/services/thread-control-mcp-runtime.ts
+++ b/apps/server/src/services/thread-control-mcp-runtime.ts
@@ -2,7 +2,11 @@ import { createServer, type Server } from "node:http";
 import { inject, injectable } from "tsyringe";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { InternalThreadControlMcpAuthority, type ActivateInternalThreadControlMcpLease } from "./thread-control-mcp-authority.js";
+import {
+  constantTimeCredentialEqual,
+  InternalThreadControlMcpAuthority,
+  type ActivateInternalThreadControlMcpLease,
+} from "./thread-control-mcp-authority.js";
 import { createInternalThreadControlMcpSession } from "./thread-control-mcp-transport.js";
 import { ThreadControlService } from "./thread-control-service.js";
 
@@ -16,6 +20,7 @@ export class InternalThreadControlMcpRuntime {
   private readonly httpSessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
   private httpServer: Server | undefined;
   private httpPort: number | undefined;
+  private httpServerStartup: Promise<void> | undefined;
 
   constructor(
     @inject(ThreadControlService) service: ThreadControlService,
@@ -35,15 +40,20 @@ export class InternalThreadControlMcpRuntime {
   }
 
   /** Closes all MCP state owned by a provider session. */
-  close(sessionId: string): void {
+  async close(sessionId: string): Promise<void> {
     this.authority.close(sessionId);
     const entry = this.httpSessions.get(sessionId);
     this.httpSessions.delete(sessionId);
-    void entry?.transport.close();
-    if (this.httpSessions.size === 0 && this.httpServer) {
-      void new Promise<void>((resolve) => this.httpServer?.close(() => resolve()));
+    if (entry) {
+      await entry.transport.close().catch(() => undefined);
+    }
+    const server = this.httpSessions.size === 0 ? this.httpServer : undefined;
+    if (server) {
       this.httpServer = undefined;
       this.httpPort = undefined;
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
     }
   }
 
@@ -77,15 +87,33 @@ export class InternalThreadControlMcpRuntime {
 
   private async ensureHttpServer(): Promise<void> {
     if (this.httpServer) return;
+    if (this.httpServerStartup) return this.httpServerStartup;
+    const startup = this.startHttpServer();
+    this.httpServerStartup = startup;
+    try {
+      await startup;
+    } finally {
+      if (this.httpServerStartup === startup) this.httpServerStartup = undefined;
+    }
+  }
+
+  private async startHttpServer(): Promise<void> {
     const server = createServer((request, response) => {
-      const sessionId = request.url?.slice(1);
-      if (!sessionId || request.method !== "POST") {
+      const encodedSessionId = request.url?.slice(1);
+      if (!encodedSessionId || request.method !== "POST") {
         response.writeHead(404).end();
         return;
       }
-      const entry = this.httpSessions.get(decodeURIComponent(sessionId));
-      const credential = entry && this.authority.credential(decodeURIComponent(sessionId));
-      if (!entry || !credential || request.headers.authorization !== `Bearer ${credential}`) {
+      let sessionId: string;
+      try {
+        sessionId = decodeURIComponent(encodedSessionId);
+      } catch {
+        response.writeHead(401).end();
+        return;
+      }
+      const entry = this.httpSessions.get(sessionId);
+      const credential = entry && this.authority.credential(sessionId);
+      if (!entry || !credential || !constantTimeCredentialEqual(request.headers.authorization ?? "", `Bearer ${credential}`)) {
         response.writeHead(401).end();
         return;
       }

--- a/apps/server/src/services/thread-control-mcp-runtime.ts
+++ b/apps/server/src/services/thread-control-mcp-runtime.ts
@@ -1,0 +1,112 @@
+import { createServer, type Server } from "node:http";
+import { inject, injectable } from "tsyringe";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InternalThreadControlMcpAuthority, type ActivateInternalThreadControlMcpLease } from "./thread-control-mcp-authority.js";
+import { createInternalThreadControlMcpSession } from "./thread-control-mcp-transport.js";
+import { ThreadControlService } from "./thread-control-service.js";
+
+const CODEX_MCP_TOKEN_ENV = "MCODE_INTERNAL_THREAD_CONTROL_TOKEN";
+const CODEX_MCP_NAME = "mcode_internal_thread_control";
+
+/** Server-only lifecycle bridge for provider-injected thread-control MCP sessions. */
+@injectable()
+export class InternalThreadControlMcpRuntime {
+  private readonly transport;
+  private readonly httpSessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
+  private httpServer: Server | undefined;
+  private httpPort: number | undefined;
+
+  constructor(
+    @inject(ThreadControlService) service: ThreadControlService,
+    @inject(InternalThreadControlMcpAuthority) private readonly authority: InternalThreadControlMcpAuthority,
+  ) {
+    this.transport = createInternalThreadControlMcpSession({ authority, service });
+  }
+
+  /** Activates the current intentional turn while preserving the pooled-session credential. */
+  activate(input: ActivateInternalThreadControlMcpLease): void {
+    this.authority.activate(input);
+  }
+
+  /** Revokes the active turn lease without destroying a reusable provider session. */
+  revoke(sessionId: string): void {
+    this.authority.revoke(sessionId);
+  }
+
+  /** Closes all MCP state owned by a provider session. */
+  close(sessionId: string): void {
+    this.authority.close(sessionId);
+    const entry = this.httpSessions.get(sessionId);
+    this.httpSessions.delete(sessionId);
+    void entry?.transport.close();
+    if (this.httpSessions.size === 0 && this.httpServer) {
+      void new Promise<void>((resolve) => this.httpServer?.close(() => resolve()));
+      this.httpServer = undefined;
+      this.httpPort = undefined;
+    }
+  }
+
+  /** Creates the Claude SDK in-process MCP server for an active provider session. */
+  createClaudeServer(sessionId: string): McpServer | undefined {
+    const credential = this.authority.credential(sessionId);
+    return credential ? this.transport.createServer(credential) : undefined;
+  }
+
+  /** Creates bounded loopback configuration for one Codex app-server session. */
+  async createCodexConfiguration(sessionId: string): Promise<{ configOverrides: string[]; env: Record<string, string> } | undefined> {
+    const credential = this.authority.credential(sessionId);
+    if (!credential) return undefined;
+    await this.ensureHttpServer();
+    if (!this.httpPort) return undefined;
+    if (!this.httpSessions.has(sessionId)) {
+      const server = this.transport.createServer(credential);
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      await server.connect(transport);
+      this.httpSessions.set(sessionId, { server, transport });
+    }
+    const url = `http://127.0.0.1:${this.httpPort}/${encodeURIComponent(sessionId)}`;
+    return {
+      configOverrides: [
+        `mcp_servers.${CODEX_MCP_NAME}.url=\"${url}\"`,
+        `mcp_servers.${CODEX_MCP_NAME}.bearer_token_env_var=\"${CODEX_MCP_TOKEN_ENV}\"`,
+      ],
+      env: { [CODEX_MCP_TOKEN_ENV]: credential },
+    };
+  }
+
+  private async ensureHttpServer(): Promise<void> {
+    if (this.httpServer) return;
+    const server = createServer((request, response) => {
+      const sessionId = request.url?.slice(1);
+      if (!sessionId || request.method !== "POST") {
+        response.writeHead(404).end();
+        return;
+      }
+      const entry = this.httpSessions.get(decodeURIComponent(sessionId));
+      const credential = entry && this.authority.credential(decodeURIComponent(sessionId));
+      if (!entry || !credential || request.headers.authorization !== `Bearer ${credential}`) {
+        response.writeHead(401).end();
+        return;
+      }
+      void entry.transport.handleRequest(request, response).catch(() => {
+        if (!response.headersSent) response.writeHead(500);
+        response.end();
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Internal MCP loopback listener did not expose a TCP port");
+    }
+    this.httpServer = server;
+    this.httpPort = address.port;
+  }
+}

--- a/apps/server/src/services/thread-control-mcp-transport.ts
+++ b/apps/server/src/services/thread-control-mcp-transport.ts
@@ -79,7 +79,6 @@ export function createInternalThreadControlMcpSession(
       server.registerTool("worktree_list", {
         description: "List tracked worktrees for one registered Mcode workspace.",
         inputSchema: WorktreeListInputSchema(),
-        outputSchema: WorktreeListResultSchema(),
       }, async (arguments_, extra) => createToolResult(await dispatch({
         bearerCredential,
         requestId: extra.requestId,

--- a/apps/server/src/services/thread-control-mcp-transport.ts
+++ b/apps/server/src/services/thread-control-mcp-transport.ts
@@ -1,0 +1,106 @@
+import {
+  WorkspaceSearchInputSchema,
+  WorkspaceSearchResultSchema,
+  WorktreeListInputSchema,
+  WorktreeListResultSchema,
+} from "@mcode/contracts";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { InternalThreadControlMcpAuthority } from "./thread-control-mcp-authority.js";
+import type { ThreadControlService } from "./thread-control-service.js";
+
+/** Incoming request context for the server-internal MCP transport. */
+export interface InternalThreadControlMcpRequest {
+  bearerCredential: string;
+  requestId: string | number;
+  toolName: string;
+  arguments: unknown;
+}
+
+/** Creates MCP servers and direct dispatchers for one server-owned thread-control authority. */
+export interface InternalThreadControlMcpSession {
+  /** Dispatches one authenticated internal MCP tool request without exposing authority in tool arguments. */
+  dispatch(request: InternalThreadControlMcpRequest): Promise<Record<string, unknown>>;
+  /** Creates an in-process MCP server for later Claude or Codex transport injection. */
+  createServer(bearerCredential: string): McpServer;
+}
+
+/** Dependencies required by the server-internal MCP transport. */
+export interface CreateInternalThreadControlMcpSessionOptions {
+  authority: InternalThreadControlMcpAuthority;
+  service: ThreadControlService;
+}
+
+/** Rejects a request whose transport context cannot establish active internal authority. */
+export class InternalThreadControlMcpAuthorizationError extends Error {
+  constructor() {
+    super("Internal thread-control MCP request denied");
+  }
+}
+
+/** Creates an in-process MCP session with only the internal discovery tool allowlist. */
+export function createInternalThreadControlMcpSession(
+  options: CreateInternalThreadControlMcpSessionOptions,
+): InternalThreadControlMcpSession {
+  const dispatch = async (request: InternalThreadControlMcpRequest): Promise<Record<string, unknown>> => {
+    const sourceToolCallId = normalizeRequestId(request.requestId);
+    const authority = sourceToolCallId === undefined
+      ? undefined
+      : options.authority.authorize(request.bearerCredential, sourceToolCallId);
+    if (!authority) throw new InternalThreadControlMcpAuthorizationError();
+
+    switch (request.toolName) {
+      case "workspace_search": {
+        const input = WorkspaceSearchInputSchema().parse(request.arguments);
+        return WorkspaceSearchResultSchema().parse(options.service.workspaceSearch(authority, input));
+      }
+      case "worktree_list": {
+        const input = WorktreeListInputSchema().parse(request.arguments);
+        return WorktreeListResultSchema().parse(await options.service.worktreeList(authority, input));
+      }
+      default:
+        throw new InternalThreadControlMcpAuthorizationError();
+    }
+  };
+
+  return {
+    dispatch,
+    createServer(bearerCredential) {
+      const server = new McpServer({ name: "mcode-internal-thread-control", version: "0.1.0" });
+      server.registerTool("workspace_search", {
+        description: "Search registered Mcode workspaces.",
+        inputSchema: WorkspaceSearchInputSchema(),
+        outputSchema: WorkspaceSearchResultSchema(),
+      }, async (arguments_, extra) => createToolResult(await dispatch({
+        bearerCredential,
+        requestId: extra.requestId,
+        toolName: "workspace_search",
+        arguments: arguments_,
+      })));
+      server.registerTool("worktree_list", {
+        description: "List tracked worktrees for one registered Mcode workspace.",
+        inputSchema: WorktreeListInputSchema(),
+        outputSchema: WorktreeListResultSchema(),
+      }, async (arguments_, extra) => createToolResult(await dispatch({
+        bearerCredential,
+        requestId: extra.requestId,
+        toolName: "worktree_list",
+        arguments: arguments_,
+      })));
+      return server;
+    },
+  };
+}
+
+function normalizeRequestId(requestId: string | number): string | undefined {
+  if (typeof requestId === "number") {
+    return Number.isSafeInteger(requestId) ? String(requestId) : undefined;
+  }
+  return requestId.length > 0 && requestId.length <= 128 ? requestId : undefined;
+}
+
+function createToolResult(structuredContent: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(structuredContent) }],
+    structuredContent,
+  };
+}

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -4,8 +4,10 @@ import type {
   WorktreeListInput,
   WorktreeListResult,
 } from "@mcode/contracts";
+import { inject, injectable } from "tsyringe";
 import { WorkspaceRepo } from "../repositories/workspace-repo.js";
 import { WorktreeRepo } from "../repositories/worktree-repo.js";
+import { GitService } from "./git-service.js";
 
 /** Server-derived authority for one active internal provider turn. */
 export interface InternalThreadControlAuthority {
@@ -23,11 +25,12 @@ export interface ThreadControlGitDiscovery {
 }
 
 /** Sole server authority boundary for internal thread-control discovery. */
+@injectable()
 export class ThreadControlService {
   constructor(
-    private readonly workspaces: WorkspaceRepo,
-    private readonly worktrees: WorktreeRepo,
-    private readonly git: ThreadControlGitDiscovery,
+    @inject(WorkspaceRepo) private readonly workspaces: WorkspaceRepo,
+    @inject(WorktreeRepo) private readonly worktrees: WorktreeRepo,
+    @inject(GitService) private readonly git: ThreadControlGitDiscovery,
   ) {}
 
   /** Search only registered workspaces; authority is intentionally not tool input. */
@@ -37,7 +40,6 @@ export class ThreadControlService {
       workspaces: this.workspaces.search(query, input.limit).map((workspace) => ({
         workspaceId: workspace.id,
         name: workspace.name,
-        repositoryIdentity: workspace.path,
         ...(workspace.last_opened_at ? { lastUsedAt: new Date(workspace.last_opened_at).toISOString() } : {}),
       })),
     };

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -4,20 +4,12 @@ import type {
   WorktreeListInput,
   WorktreeListResult,
 } from "@mcode/contracts";
+import type { InternalThreadControlAuthority } from "@mcode/thread-orchestration";
+export type { InternalThreadControlAuthority } from "@mcode/thread-orchestration";
 import { inject, injectable } from "tsyringe";
 import { WorkspaceRepo } from "../repositories/workspace-repo.js";
 import { WorktreeRepo } from "../repositories/worktree-repo.js";
 import { GitService } from "./git-service.js";
-
-/** Server-derived authority for one active internal provider turn. */
-export interface InternalThreadControlAuthority {
-  userId: string;
-  sourceThreadId: string;
-  sourceTurnId: string;
-  sourceToolCallId: string;
-  sourceProviderId: string;
-  permissionMode: "supervised" | "full";
-}
 
 /** Git worktree discovery restricted to a registered workspace. */
 export interface ThreadControlGitDiscovery {

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -1,0 +1,61 @@
+import type {
+  WorkspaceSearchInput,
+  WorkspaceSearchResult,
+  WorktreeListInput,
+  WorktreeListResult,
+} from "@mcode/contracts";
+import { WorkspaceRepo } from "../repositories/workspace-repo.js";
+import { WorktreeRepo } from "../repositories/worktree-repo.js";
+
+/** Server-derived authority for one active internal provider turn. */
+export interface InternalThreadControlAuthority {
+  userId: string;
+  sourceThreadId: string;
+  sourceTurnId: string;
+  sourceToolCallId: string;
+  sourceProviderId: string;
+  permissionMode: "supervised" | "full";
+}
+
+/** Git worktree discovery restricted to a registered workspace. */
+export interface ThreadControlGitDiscovery {
+  listWorktrees(workspaceId: string): Promise<Array<{ name: string; path: string; branch: string; managed: boolean }>>;
+}
+
+/** Sole server authority boundary for internal thread-control discovery. */
+export class ThreadControlService {
+  constructor(
+    private readonly workspaces: WorkspaceRepo,
+    private readonly worktrees: WorktreeRepo,
+    private readonly git: ThreadControlGitDiscovery,
+  ) {}
+
+  /** Search only registered workspaces; authority is intentionally not tool input. */
+  workspaceSearch(_authority: InternalThreadControlAuthority, input: WorkspaceSearchInput): WorkspaceSearchResult {
+    const query = input.query?.trim() ?? "";
+    return {
+      workspaces: this.workspaces.search(query, input.limit).map((workspace) => ({
+        workspaceId: workspace.id,
+        name: workspace.name,
+        repositoryIdentity: workspace.path,
+        ...(workspace.last_opened_at ? { lastUsedAt: new Date(workspace.last_opened_at).toISOString() } : {}),
+      })),
+    };
+  }
+
+  /** Revalidate workspace registration and return only opaque worktree identities. */
+  async worktreeList(authority: InternalThreadControlAuthority, input: WorktreeListInput): Promise<WorktreeListResult> {
+    void authority;
+    if (!this.workspaces.findById(input.workspaceId)) {
+      return { status: "rejected", error: { code: "not_found", message: "Workspace not found", retryable: false } };
+    }
+    const discovered = await this.git.listWorktrees(input.workspaceId);
+    const worktrees = this.worktrees.reconcile(input.workspaceId, discovered.map((worktree) => ({
+      canonicalPath: worktree.path,
+      label: worktree.name,
+      branch: worktree.branch || undefined,
+      managed: worktree.managed,
+    })));
+    return { status: "found", workspaceId: input.workspaceId, worktrees };
+  }
+}

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -33,6 +33,26 @@ export const workspaces = sqliteTable(
   ],
 );
 
+/** Server-only stable identities for registered worktrees in each workspace. */
+export const workspaceWorktrees = sqliteTable(
+  "workspace_worktrees",
+  {
+    id: text("id").primaryKey().notNull(),
+    workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+    canonicalPath: text("canonical_path").notNull(),
+    label: text("label").notNull(),
+    branch: text("branch"),
+    baseRef: text("base_ref"),
+    managed: integer("managed").notNull().default(0),
+    lastSeenAt: text("last_seen_at").notNull().default(timestampDefault),
+    stale: integer("stale").notNull().default(0),
+  },
+  (table) => [
+    uniqueIndex("idx_workspace_worktrees_path").on(table.workspaceId, table.canonicalPath),
+    index("idx_workspace_worktrees_workspace").on(table.workspaceId, table.stale),
+  ],
+);
+
 export const threads = sqliteTable(
   "threads",
   {
@@ -65,6 +85,11 @@ export const threads = sqliteTable(
     permissionMode: text("permission_mode"),
     parentThreadId: text("parent_thread_id"),
     forkedFromMessageId: text("forked_from_message_id"),
+    delegationCoordinatorThreadId: text("delegation_coordinator_thread_id").references((): AnySQLiteColumn => threads.id, { onDelete: "set null" }),
+    delegationCreatorTurnId: text("delegation_creator_turn_id"),
+    delegationCreatorToolCallId: text("delegation_creator_tool_call_id"),
+    delegationCreationKind: text("delegation_creation_kind"),
+    createdByIntegrationId: text("created_by_integration_id"),
     lastCompactSummary: text("last_compact_summary"),
     copilotAgent: text("copilot_agent"),
     contextWindowMode: text("context_window_mode"),
@@ -85,6 +110,8 @@ export const threads = sqliteTable(
     index("idx_threads_status").on(table.status),
     index("idx_threads_parent_thread_id").on(table.parentThreadId),
     index("idx_threads_forked_from_message_id").on(table.forkedFromMessageId),
+    index("idx_threads_delegation_coordinator").on(table.delegationCoordinatorThreadId),
+    index("idx_threads_created_by_integration").on(table.createdByIntegrationId),
   ],
 );
 
@@ -158,6 +185,11 @@ export const messages = sqliteTable(
      * existed — the UI falls back gracefully when absent.
      */
     model: text("model"),
+    provider: text("provider"),
+    originType: text("origin_type").notNull().default("legacy"),
+    sourceThreadId: text("source_thread_id"),
+    sourceTurnId: text("source_turn_id"),
+    sourceProviderId: text("source_provider_id"),
     /**
      * When 1, this message is internal to mcode (e.g. a hidden handoff request
      * on a Cursor parent thread) and must not render in the chat UI. The

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,8 @@
         "@github/copilot-sdk": "^0.2.2",
         "@mcode/contracts": "workspace:*",
         "@mcode/shared": "workspace:*",
+        "@mcode/thread-orchestration": "workspace:*",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "better-sqlite3": "^12.0.0",
         "drizzle-orm": "^0.45.2",
         "koffi": "^2.16.1",
@@ -167,6 +169,14 @@
         "winston": "^3.17.0",
         "winston-daily-rotate-file": "^5.0.0",
       },
+      "devDependencies": {
+        "typescript": "^5.8.0",
+        "vitest": "^4.1.0",
+      },
+    },
+    "packages/thread-orchestration": {
+      "name": "@mcode/thread-orchestration",
+      "version": "0.0.1",
       "devDependencies": {
         "typescript": "^5.8.0",
         "vitest": "^4.1.0",
@@ -547,6 +557,8 @@
     "@mcode/server": ["@mcode/server@workspace:apps/server"],
 
     "@mcode/shared": ["@mcode/shared@workspace:packages/shared"],
+
+    "@mcode/thread-orchestration": ["@mcode/thread-orchestration@workspace:packages/thread-orchestration"],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
 
@@ -1086,7 +1098,7 @@
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
-    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
@@ -1286,7 +1298,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
@@ -1750,7 +1762,7 @@
 
     "iconv-corefoundation": ["iconv-corefoundation@1.1.7", "", { "dependencies": { "cli-truncate": "^2.1.0", "node-addon-api": "^1.6.3" }, "os": "darwin" }, "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ=="],
 
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -1866,7 +1878,7 @@
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
@@ -2142,7 +2154,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 
@@ -2826,6 +2838,8 @@
 
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@develar/schema-utils/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
     "@dnd-kit/accessibility/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@dnd-kit/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -2886,8 +2900,6 @@
 
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
-    "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
     "@npmcli/move-file/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
@@ -2930,9 +2942,7 @@
 
     "@xhmikosr/downloader/got": ["got@14.6.6", "", { "dependencies": { "@sindresorhus/is": "^7.0.1", "byte-counter": "^0.1.0", "cacheable-lookup": "^7.0.0", "cacheable-request": "^13.0.12", "decompress-response": "^10.0.0", "form-data-encoder": "^4.0.2", "http2-wrapper": "^2.2.1", "keyv": "^5.5.3", "lowercase-keys": "^3.0.0", "p-cancelable": "^4.0.1", "responselike": "^4.0.2", "type-fest": "^4.26.1" } }, "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg=="],
 
-    "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+    "ajv-keywords/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "app-builder-lib/@electron/rebuild": ["@electron/rebuild@3.6.1", "", { "dependencies": { "@malept/cross-spawn-promise": "^2.0.0", "chalk": "^4.0.0", "debug": "^4.1.1", "detect-libc": "^2.0.1", "fs-extra": "^10.0.0", "got": "^11.7.0", "node-abi": "^3.45.0", "node-api-version": "^0.2.0", "node-gyp": "^9.0.0", "ora": "^5.1.0", "read-binary-file-arch": "^1.0.6", "semver": "^7.3.5", "tar": "^6.0.5", "yargs": "^17.0.1" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w=="],
 
@@ -2949,8 +2959,6 @@
     "ast-types/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "binary-version/execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
-
-    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "cacache/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
@@ -2974,11 +2982,17 @@
 
     "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
+    "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
     "dir-compare/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "dmg-builder/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "dmg-license/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -2986,13 +3000,15 @@
 
     "electron-updater/builder-util-runtime": ["builder-util-runtime@9.5.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ=="],
 
+    "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
     "eslint/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "execa/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "execa/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
-
-    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -3024,6 +3040,8 @@
 
     "make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -3039,6 +3057,8 @@
     "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "msw/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "node-gyp/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -3059,8 +3079,6 @@
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
-
-    "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "react-remove-scroll/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -3115,6 +3133,8 @@
     "zip-stream/archiver-utils": ["archiver-utils@3.0.4", "", { "dependencies": { "glob": "^7.2.3", "graceful-fs": "^4.2.0", "lazystream": "^1.0.0", "lodash.defaults": "^4.2.0", "lodash.difference": "^4.5.0", "lodash.flatten": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.union": "^4.6.0", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@develar/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
@@ -3186,8 +3206,6 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "@npmcli/move-file/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
@@ -3214,7 +3232,7 @@
 
     "@xhmikosr/downloader/got/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+    "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "app-builder-lib/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
@@ -3255,6 +3273,8 @@
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "dir-compare/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "dmg-license/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -3311,6 +3331,8 @@
     "electron-mksnapshot/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "electron-mksnapshot/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
+
+    "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "eslint/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 

--- a/packages/contracts/src/__tests__/thread-control.test.ts
+++ b/packages/contracts/src/__tests__/thread-control.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  WORKSPACE_SEARCH_LIMIT_DEFAULT,
+  WorkspaceSearchInputSchema,
+  WorktreeListInputSchema,
+  WorktreeListResultSchema,
+} from "../thread-control.js";
+
+describe("thread control discovery schemas", () => {
+  it("bounds and defaults workspace search without accepting authority fields", () => {
+    expect(WorkspaceSearchInputSchema().parse({})).toEqual({ limit: WORKSPACE_SEARCH_LIMIT_DEFAULT });
+    expect(WorkspaceSearchInputSchema().safeParse({ limit: 51 }).success).toBe(false);
+    expect(WorkspaceSearchInputSchema().safeParse({ sourceThreadId: "forged" }).success).toBe(false);
+  });
+
+  it("rejects forged fields and raw paths in worktree discovery payloads", () => {
+    expect(WorktreeListInputSchema().safeParse({ workspaceId: "workspace", path: "C:/secret" }).success).toBe(false);
+    expect(WorktreeListResultSchema().safeParse({
+      status: "found", workspaceId: "workspace", worktrees: [{ worktreeId: "worktree", label: "main", path: "C:/secret" }],
+    }).success).toBe(false);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -36,6 +36,25 @@ export { WorkspaceSchema, WorkspaceEnrichmentSchema } from "./models/workspace.j
 export type { Workspace, WorkspaceEnrichment } from "./models/workspace.js";
 
 export {
+  THREAD_CONTROL_OPAQUE_ID_MAX_LENGTH,
+  WORKSPACE_SEARCH_QUERY_MAX_LENGTH,
+  WORKSPACE_SEARCH_LIMIT_MAX,
+  WORKSPACE_SEARCH_LIMIT_DEFAULT,
+  WorkspaceSearchInputSchema,
+  WorkspaceSearchResultSchema,
+  WorktreeListInputSchema,
+  WorktreeListResultSchema,
+  ThreadControlErrorSchema,
+} from "./thread-control.js";
+export type {
+  WorkspaceSearchInput,
+  WorkspaceSearchResult,
+  WorktreeListInput,
+  WorktreeListResult,
+  ThreadControlError,
+} from "./thread-control.js";
+
+export {
   MCODE_WORKSPACE_PREVIEW_PROTOCOL,
   isMcodeWorkspacePreviewUrl,
   mcodeWorkspacePreviewHref,

--- a/packages/contracts/src/thread-control.ts
+++ b/packages/contracts/src/thread-control.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import { lazySchema } from "./utils/lazySchema.js";
+
+/** Maximum characters accepted for an opaque thread-control identifier. */
+export const THREAD_CONTROL_OPAQUE_ID_MAX_LENGTH = 128;
+/** Maximum trimmed characters accepted for a workspace search query. */
+export const WORKSPACE_SEARCH_QUERY_MAX_LENGTH = 256;
+/** Maximum workspace search results returned by one request. */
+export const WORKSPACE_SEARCH_LIMIT_MAX = 50;
+/** Default workspace search result limit. */
+export const WORKSPACE_SEARCH_LIMIT_DEFAULT = 20;
+
+const opaqueId = z.string().trim().min(1).max(THREAD_CONTROL_OPAQUE_ID_MAX_LENGTH);
+
+/** Input accepted by the internal workspace_search tool. */
+export const WorkspaceSearchInputSchema = lazySchema(() =>
+  z.object({
+    query: z.string().trim().max(WORKSPACE_SEARCH_QUERY_MAX_LENGTH).optional(),
+    limit: z.number().int().min(1).max(WORKSPACE_SEARCH_LIMIT_MAX).default(WORKSPACE_SEARCH_LIMIT_DEFAULT),
+  }).strict(),
+);
+/** Internal workspace_search input. */
+export type WorkspaceSearchInput = z.infer<ReturnType<typeof WorkspaceSearchInputSchema>>;
+
+/** Result emitted by the internal workspace_search tool. */
+export const WorkspaceSearchResultSchema = lazySchema(() =>
+  z.object({
+    workspaces: z.array(z.object({
+      workspaceId: opaqueId,
+      name: z.string(),
+      repositoryIdentity: z.string().optional(),
+      lastUsedAt: z.string().optional(),
+    }).strict()),
+  }).strict(),
+);
+/** Internal workspace_search result. */
+export type WorkspaceSearchResult = z.infer<ReturnType<typeof WorkspaceSearchResultSchema>>;
+
+/** Input accepted by the internal worktree_list tool. */
+export const WorktreeListInputSchema = lazySchema(() =>
+  z.object({ workspaceId: opaqueId }).strict(),
+);
+/** Internal worktree_list input. */
+export type WorktreeListInput = z.infer<ReturnType<typeof WorktreeListInputSchema>>;
+
+/** Public error payload for thread-control discovery operations. */
+export const ThreadControlErrorSchema = lazySchema(() =>
+  z.object({
+    code: z.enum(["forbidden", "not_found", "invalid_request", "internal_error"]),
+    message: z.string().min(1).max(512),
+    retryable: z.boolean(),
+    retryAfterSeconds: z.number().int().positive().optional(),
+  }).strict(),
+);
+/** Thread-control discovery error. */
+export type ThreadControlError = z.infer<ReturnType<typeof ThreadControlErrorSchema>>;
+
+/** Result emitted by the internal worktree_list tool. */
+export const WorktreeListResultSchema = lazySchema(() =>
+  z.discriminatedUnion("status", [
+    z.object({
+      status: z.literal("found"),
+      workspaceId: opaqueId,
+      worktrees: z.array(z.object({
+        worktreeId: opaqueId,
+        label: z.string(),
+        branch: z.string().optional(),
+        baseRef: z.string().optional(),
+      }).strict()),
+    }).strict(),
+    z.object({
+      status: z.literal("rejected"),
+      workspaceId: opaqueId.optional(),
+      error: ThreadControlErrorSchema(),
+    }).strict(),
+  ]),
+);
+/** Internal worktree_list result. */
+export type WorktreeListResult = z.infer<ReturnType<typeof WorktreeListResultSchema>>;

--- a/packages/thread-orchestration/package.json
+++ b/packages/thread-orchestration/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@mcode/thread-orchestration",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/thread-orchestration/package.json
+++ b/packages/thread-orchestration/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/thread-orchestration/src/__tests__/index.test.ts
+++ b/packages/thread-orchestration/src/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isInternalThreadTargetAllowed } from "../index.js";
+
+describe("internal thread authority", () => {
+  it("excludes its source thread", () => {
+    const authority = {
+      type: "internal" as const,
+      userId: "local-user" as const,
+      sourceThreadId: "source",
+      sourceTurnId: "turn",
+      sourceToolCallId: "call",
+      sourceProviderId: "codex",
+      permissionMode: "full" as const,
+    };
+    expect(isInternalThreadTargetAllowed(authority, "source")).toBe(false);
+    expect(isInternalThreadTargetAllowed(authority, "other")).toBe(true);
+  });
+});

--- a/packages/thread-orchestration/src/index.ts
+++ b/packages/thread-orchestration/src/index.ts
@@ -1,0 +1,26 @@
+/** Provider-neutral authority for an active internal thread-control lease. */
+export interface InternalThreadControlAuthority {
+  type: "internal";
+  userId: "local-user";
+  sourceThreadId: string;
+  sourceTurnId: string;
+  sourceToolCallId: string;
+  sourceProviderId: string;
+  permissionMode: "supervised" | "full";
+}
+
+/** Lineage written when a thread is created through delegation. */
+export interface ThreadDelegationLineage {
+  coordinatorThreadId: string;
+  creatorTurnId: string;
+  creatorToolCallId: string;
+  creationKind: "thread_delegation";
+}
+
+/** Return whether an internal caller may discover or target a thread. */
+export function isInternalThreadTargetAllowed(
+  authority: InternalThreadControlAuthority,
+  targetThreadId: string,
+): boolean {
+  return authority.sourceThreadId !== targetThreadId;
+}

--- a/packages/thread-orchestration/tsconfig.json
+++ b/packages/thread-orchestration/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}


### PR DESCRIPTION
## What

Adds the internal thread-control foundation and project discovery surface for agent-driven orchestration.

## Why

Agents need a secure, provider-neutral way to discover projects and worktrees before later issues add thread creation and interaction operations. This change establishes that boundary without exposing the broader control surface.

## Key Changes

- Adds strict shared contracts for `workspace_search` and `worktree_list`.
- Adds durable worktree identities, delegation lineage, and message provenance.
- Adds a provider-neutral authority lease and internal MCP transport for Claude and Codex.
- Enforces source-thread exclusion, bounded request identities, credential revocation, and no-path responses.
- Adds focused contract, persistence, lifecycle, DI, and real MCP protocol coverage.

## Verification

- Reviewer/QA high-risk review: `RECOMMEND_RELEASE`.
- Server focused tests: 17 passed.
- Contracts focused tests: 2 passed.
- Thread orchestration focused tests: 1 passed.
- Server, contracts, and thread orchestration typechecks passed.
- Real MCP client calls to both discovery tools passed; invalid and revoked credentials failed closed.
- Runtime started successfully, `/health` returned 200, and shutdown completed cleanly.

The full verification run still reports three pre-existing Windows process-test failures outside this change. Typecheck and lint passed.

Closes #959

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787603055&installation_model_id=20477&pr_number=968&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F968&signature=a10f0a59ab50f7a09b5e99fa2826761a9bf4a99320e5f5a6d4d0ecb8832a6d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace search and worktree discovery capabilities.
  * Added stable worktree registration and status tracking.
  * Added thread delegation lineage and message provenance tracking.
  * Added secure provider integrations for thread-control operations.
* **Bug Fixes**
  * Improved cleanup of delegation references when threads are deleted.
  * Prevented sensitive filesystem paths from appearing in discovery results.
* **Tests**
  * Added coverage for workspace search, worktree reconciliation, delegation cleanup, provenance persistence, authorization, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->