### PR TITLE
fix(web): prevent blank screen after render crashes

### DIFF
--- a/apps/web/src/app/AppErrorBoundary.tsx
+++ b/apps/web/src/app/AppErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+/** Props for the application-wide crash recovery boundary. */
+interface AppErrorBoundaryProps {
+  children: ReactNode;
+  onReload?: () => void;
+}
+
+/** Prevents descendant render failures from unmounting the application root. */
+export class AppErrorBoundary extends Component<
+  AppErrorBoundaryProps,
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(): { hasError: true } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[AppErrorBoundary] Caught application render error", error, info);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-6 text-center text-foreground">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold">Mcode ran into a problem</h1>
+            <p className="text-sm text-muted-foreground">
+              Reload the app to continue.
+            </p>
+          </div>
+          <Button onClick={this.props.onReload ?? (() => window.location.reload())}>
+            Reload Mcode
+          </Button>
+        </main>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/web/src/app/__tests__/AppErrorBoundary.test.tsx
+++ b/apps/web/src/app/__tests__/AppErrorBoundary.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AppErrorBoundary } from "../AppErrorBoundary";
+
+/** Throws during rendering to exercise the boundary's recovery path. */
+function ThrowingChild(): never {
+  throw new Error("render failed");
+}
+
+describe("AppErrorBoundary", () => {
+  it("leaves healthy application content unchanged", () => {
+    render(
+      <AppErrorBoundary>
+        <div>Application content</div>
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByText("Application content")).toBeInTheDocument();
+  });
+
+  it("renders recovery UI and reports a descendant render failure", () => {
+    const diagnostic = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <AppErrorBoundary>
+        <ThrowingChild />
+      </AppErrorBoundary>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Mcode ran into a problem" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Reload the app to continue.")).toBeInTheDocument();
+    expect(diagnostic).toHaveBeenCalledWith(
+      "[AppErrorBoundary] Caught application render error",
+      expect.any(Error),
+      expect.objectContaining({ componentStack: expect.any(String) }),
+    );
+
+    diagnostic.mockRestore();
+  });
+
+  it("reloads after the user activates recovery", () => {
+    const reload = vi.fn();
+    const diagnostic = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <AppErrorBoundary onReload={reload}>
+        <ThrowingChild />
+      </AppErrorBoundary>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Reload Mcode" }));
+
+    expect(reload).toHaveBeenCalledOnce();
+    diagnostic.mockRestore();
+  });
+});

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app/App";
+import { AppErrorBoundary } from "./app/AppErrorBoundary";
 import { initTransport } from "./transport";
 import { initDesktopPowerReporting } from "./lib/desktop-power";
 import "./index.css";
@@ -71,7 +72,9 @@ initTransport()
     root.innerHTML = "";
     createRoot(root).render(
       <StrictMode>
-        <App />
+        <AppErrorBoundary>
+          <App />
+        </AppErrorBoundary>
       </StrictMode>
     );
   })


### PR DESCRIPTION
## What

Prevent uncaught frontend render and lazy-import errors from leaving Mcode with a blank window. A root error boundary now shows a recovery screen with a reload action.

## Why

Rejecting the lazy Settings module reproduced the reported failure: React unmounted the application root and left `#root` empty. The app had no root error boundary to contain the failure or offer recovery.

## Key Changes

- Wrap the application root in `AppErrorBoundary`.
- Show an accessible recovery screen without exposing raw error details.
- Log caught errors and component stacks with a stable diagnostic prefix.
- Test healthy rendering, failure recovery, diagnostics, and reload behavior.

## Verification

- Focused Vitest: 3 tests passed.
- Web typecheck: passed.
- Live Playwright repro: rejected Settings module kept `#root` nonempty and displayed the recovery screen.
- Independent high-risk review: no findings, `RECOMMEND_RELEASE`.
- Full repository verification reached unchanged server tests; six tests failed under the restricted Windows environment because of home-directory `EPERM`, denied process inspection, and integration timeouts. No frontend test failed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606142&installation_model_id=20477&pr_number=969&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F969&signature=facea50601e215d6587d167d42832fb80fb812601cc3799ec3fef4d570ef7cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->