### PR TITLE
fix(sidebar): preserve expanded projects during drag

### DIFF
--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -274,9 +274,14 @@ describe("ProjectTree thread interactions", () => {
   });
 
   it("keeps expanded threads mounted when a project drag starts", () => {
+    localStorage.setItem(
+      "mcode-expanded-projects",
+      JSON.stringify({ "ws-1": true }),
+    );
     setupStoreMocks();
 
     render(<ProjectTree />);
+    expect(screen.getByRole("button", { name: /My Thread/i })).toBeVisible();
     const projectRow = screen.getByTestId("project-row-ws-1");
     projectRow.focus();
     fireEvent.keyDown(projectRow, { key: " " });

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -273,6 +273,22 @@ describe("ProjectTree thread interactions", () => {
     expect(state.loadThreads).toHaveBeenCalledWith("ws-1");
   });
 
+  it("keeps expanded threads mounted when a project drag starts", () => {
+    setupStoreMocks();
+
+    render(<ProjectTree />);
+    const projectRow = screen.getByTestId("project-row-ws-1");
+    projectRow.focus();
+    fireEvent.keyDown(projectRow, { key: " " });
+
+    expect(screen.getByRole("button", { name: /My Thread/i })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Toggle threads for Test Project" }),
+    ).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.keyDown(projectRow, { key: " " });
+  });
+
   it("reveals project actions when the project row is hovered or focused", () => {
     setupStoreMocks();
 

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -627,7 +627,6 @@ export function ProjectTree() {
                   <SortableProjectShell
                     key={ws.id}
                     sortableId={ws.id}
-                    activeDragId={activeDragId}
                     workspace={ws}
                     isExpanded={expanded[ws.id] ?? false}
                     isActive={activeWorkspaceId === ws.id}
@@ -1805,14 +1804,12 @@ const ProjectNode = memo(function ProjectNode({
 });
 
 /**
- * Wraps {@link ProjectNode} with `@dnd-kit/sortable` transforms and collapses
- * thread children while the user is dragging this project.
+ * Wraps {@link ProjectNode} with `@dnd-kit/sortable` transforms.
  */
 const SortableProjectShell = memo(function SortableProjectShell(
-  props: ProjectNodeProps & { sortableId: string; activeDragId: string | null },
+  props: ProjectNodeProps & { sortableId: string },
 ) {
-  const { sortableId, activeDragId, ...nodeProps } = props;
-  const collapseForDrag = activeDragId !== null;
+  const { sortableId, ...nodeProps } = props;
   const {
     attributes,
     listeners,
@@ -1843,7 +1840,6 @@ const SortableProjectShell = memo(function SortableProjectShell(
     >
       <ProjectNode
         {...nodeProps}
-        isExpanded={nodeProps.isExpanded && !collapseForDrag}
         isProjectDragging={isDragging}
         sortableListeners={listeners}
       />

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -1804,7 +1804,7 @@ const ProjectNode = memo(function ProjectNode({
 });
 
 /**
- * Wraps {@link ProjectNode} with `@dnd-kit/sortable` transforms.
+ * Preserves project and thread rendering while applying sortable positioning.
  */
 const SortableProjectShell = memo(function SortableProjectShell(
   props: ProjectNodeProps & { sortableId: string },


### PR DESCRIPTION
## What

Keep expanded project threads mounted while their project is being reordered.

## Why

Dragging an expanded project collapsed its thread list after dnd-kit measured the layout. The project then reappeared at its new position, which made the drag and later expansion animations look detached from the project row.

## Key Changes

- Preserve each project's expanded state throughout drag start, movement, and drop.
- Keep the measured project subtree height stable while sortable transforms run.
- Add a regression test that starts a keyboard drag and verifies the thread row and expanded state remain visible.

## Verification

- `ProjectTree.test.tsx`: 29 tests passed.
- Changed-file gate: typecheck, lint, and web unit tests passed.
- In-app browser: expanded thread remained visible 50 ms after pointer drag activation, stayed expanded after drop, and reopened beneath the correct project row.
- Full monorepo run reached 2,615 of 2,616 passing web tests; one unrelated 5-second performance test timed out and passed when rerun alone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606457&installation_model_id=20477&pr_number=970&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F970&signature=bd6c04a5a89a728ab6a776894cbaeaa8a65af8ce4300d58aa01bb7424c0f662c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented project thread lists from collapsing when a project is dragged.
  * Preserved expanded project state during drag-and-drop interactions.

* **Tests**
  * Added coverage verifying that expanded threads remain visible and accessible after initiating a drag interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->