### PR TITLE
feat: add batched delegated thread creation

### DIFF
--- a/apps/server/drizzle/0028_rare_network.sql
+++ b/apps/server/drizzle/0028_rare_network.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `thread_control_approvals` (
+	`id` text PRIMARY KEY NOT NULL,
+	`thread_id` text NOT NULL,
+	`workspace_id` text NOT NULL,
+	`prompt` text NOT NULL,
+	`execution_json` text NOT NULL,
+	`placement_json` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`resolved_at` text,
+	FOREIGN KEY (`thread_id`) REFERENCES `threads`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_thread_control_approvals_thread` ON `thread_control_approvals` (`thread_id`,`status`);

--- a/apps/server/drizzle/0029_cuddly_sally_floyd.sql
+++ b/apps/server/drizzle/0029_cuddly_sally_floyd.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `thread_control_audit` (
+	`id` text PRIMARY KEY NOT NULL,
+	`caller_id` text NOT NULL,
+	`source_thread_id` text,
+	`workspace_id` text,
+	`thread_id` text,
+	`operation` text NOT NULL,
+	`outcome` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_thread_control_audit_thread` ON `thread_control_audit` (`thread_id`,`created_at`);--> statement-breakpoint
+ALTER TABLE `thread_control_approvals` ADD `turn_id` text;--> statement-breakpoint
+UPDATE `thread_control_approvals` SET `turn_id` = lower(hex(randomblob(16))) WHERE `turn_id` IS NULL;--> statement-breakpoint
+ALTER TABLE `thread_control_approvals` ADD `operation_phase` text DEFAULT 'pre_provision' NOT NULL;--> statement-breakpoint
+ALTER TABLE `thread_control_approvals` ADD `processing_started_at` text;

--- a/apps/server/drizzle/0030_chemical_harrier.sql
+++ b/apps/server/drizzle/0030_chemical_harrier.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `thread_control_approvals` ADD `caller_id` text;--> statement-breakpoint
+ALTER TABLE `thread_control_approvals` ADD `source_thread_id` text;

--- a/apps/server/drizzle/meta/0028_snapshot.json
+++ b/apps/server/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,2203 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "75d3b697-fef7-4bb4-b401-841c03a526d4",
+  "prevId": "d18f2ad6-bff6-4479-a748-bf46544828e8",
+  "tables": {
+    "cleanup_jobs": {
+      "name": "cleanup_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cleanup_jobs_thread_id_unique": {
+          "name": "cleanup_jobs_thread_id_unique",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cleanup_jobs_retry": {
+          "name": "idx_cleanup_jobs_retry",
+          "columns": [
+            "next_retry_at",
+            "attempts",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diff_summaries": {
+      "name": "diff_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_turn_id": {
+          "name": "last_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_diff_summaries_thread": {
+          "name": "idx_diff_summaries_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "diff_summaries_thread_id_threads_id_fk": {
+          "name": "diff_summaries_thread_id_threads_id_fk",
+          "tableFrom": "diff_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_executions": {
+      "name": "hook_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hook_name": {
+          "name": "hook_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "did_block": {
+          "name": "did_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_hook_executions_message": {
+          "name": "idx_hook_executions_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hook_executions_message_id_messages_id_fk": {
+          "name": "hook_executions_message_id_messages_id_fk",
+          "tableFrom": "hook_executions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_annotations": {
+          "name": "preview_annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quoted_text": {
+          "name": "quoted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_provider_id": {
+          "name": "source_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_messages_thread": {
+          "name": "idx_messages_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_sequence": {
+          "name": "idx_messages_sequence",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_reply_to_message_id_messages_id_fk": {
+          "name": "messages_reply_to_message_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "reply_to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_question_answers": {
+      "name": "plan_question_answers",
+      "columns": {
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_question_answers_thread": {
+          "name": "idx_plan_question_answers_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_question_answers_assistant_message_id_messages_id_fk": {
+          "name": "plan_question_answers_assistant_message_id_messages_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_question_answers_thread_id_threads_id_fk": {
+          "name": "plan_question_answers_thread_id_threads_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plans_thread": {
+          "name": "idx_plans_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plans_thread_version": {
+          "name": "idx_plans_thread_version",
+          "columns": [
+            "thread_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plans_thread_id_threads_id_fk": {
+          "name": "plans_thread_id_threads_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_message_id_messages_id_fk": {
+          "name": "plans_message_id_messages_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_catalog_snapshots": {
+      "name": "provider_catalog_snapshots",
+      "columns": {
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_provider_catalog_snapshots_workspace": {
+          "name": "idx_provider_catalog_snapshots_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_provider_catalog_snapshots_provider": {
+          "name": "idx_provider_catalog_snapshots_provider",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "provider_catalog_snapshots_workspace_id_workspaces_id_fk": {
+          "name": "provider_catalog_snapshots_workspace_id_workspaces_id_fk",
+          "tableFrom": "provider_catalog_snapshots",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_cache": {
+      "name": "provider_model_cache",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_request_review_links": {
+      "name": "pull_request_review_links",
+      "columns": {
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_node_id": {
+          "name": "repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_state": {
+          "name": "pr_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "head_repository_node_id": {
+          "name": "head_repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_owner": {
+          "name": "head_repository_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_name": {
+          "name": "head_repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_oid": {
+          "name": "head_oid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_branch": {
+          "name": "local_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_remote": {
+          "name": "push_remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_ref": {
+          "name": "push_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "managed_remote_name": {
+          "name": "managed_remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_thread_id": {
+          "name": "primary_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_pull_request_review_links_identity": {
+          "name": "idx_pull_request_review_links_identity",
+          "columns": [
+            "provider",
+            "repository_node_id",
+            "pull_request_number"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_primary_thread": {
+          "name": "idx_pull_request_review_links_primary_thread",
+          "columns": [
+            "primary_thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_workspace": {
+          "name": "idx_pull_request_review_links_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pull_request_review_links_worktree_path": {
+          "name": "idx_pull_request_review_links_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_request_review_links_workspace_id_workspaces_id_fk": {
+          "name": "pull_request_review_links_workspace_id_workspaces_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pull_request_review_links_primary_thread_id_threads_id_fk": {
+          "name": "pull_request_review_links_primary_thread_id_threads_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "primary_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thought_segments": {
+      "name": "thought_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_final_response": {
+          "name": "is_final_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_thought_segments_message": {
+          "name": "idx_thought_segments_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thought_segments_message_id_messages_id_fk": {
+          "name": "thought_segments_message_id_messages_id_fk",
+          "tableFrom": "thought_segments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_control_approvals": {
+      "name": "thread_control_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_json": {
+          "name": "execution_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placement_json": {
+          "name": "placement_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thread_control_approvals_thread": {
+          "name": "idx_thread_control_approvals_thread",
+          "columns": [
+            "thread_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_control_approvals_thread_id_threads_id_fk": {
+          "name": "thread_control_approvals_thread_id_threads_id_fk",
+          "tableFrom": "thread_control_approvals",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_control_approvals_workspace_id_workspaces_id_fk": {
+          "name": "thread_control_approvals_workspace_id_workspaces_id_fk",
+          "tableFrom": "thread_control_approvals",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tasks": {
+      "name": "thread_tasks",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_json": {
+          "name": "tasks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tasks_thread_id_threads_id_fk": {
+          "name": "thread_tasks_thread_id_threads_id_fk",
+          "tableFrom": "thread_tasks",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkout_state": {
+          "name": "checkout_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'named'"
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_tokens": {
+          "name": "last_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interaction_mode": {
+          "name": "interaction_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "orchestration_mode": {
+          "name": "orchestration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_message_id": {
+          "name": "forked_from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_coordinator_thread_id": {
+          "name": "delegation_coordinator_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creator_turn_id": {
+          "name": "delegation_creator_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creator_tool_call_id": {
+          "name": "delegation_creator_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creation_kind": {
+          "name": "delegation_creation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_integration_id": {
+          "name": "created_by_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_compact_summary": {
+          "name": "last_compact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "copilot_agent": {
+          "name": "copilot_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window_mode": {
+          "name": "context_window_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codex_fast_mode": {
+          "name": "codex_fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_open_in_app": {
+          "name": "default_open_in_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file_changes": {
+          "name": "has_file_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_threads_workspace": {
+          "name": "idx_threads_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_deleted": {
+          "name": "idx_threads_workspace_deleted",
+          "columns": [
+            "workspace_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_recency": {
+          "name": "idx_threads_workspace_recency",
+          "columns": [
+            "workspace_id",
+            "\"updated_at\" desc"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_status": {
+          "name": "idx_threads_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_parent_thread_id": {
+          "name": "idx_threads_parent_thread_id",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_forked_from_message_id": {
+          "name": "idx_threads_forked_from_message_id",
+          "columns": [
+            "forked_from_message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_delegation_coordinator": {
+          "name": "idx_threads_delegation_coordinator",
+          "columns": [
+            "delegation_coordinator_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_created_by_integration": {
+          "name": "idx_threads_created_by_integration",
+          "columns": [
+            "created_by_integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_workspace_id_workspaces_id_fk": {
+          "name": "threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_delegation_coordinator_thread_id_threads_id_fk": {
+          "name": "threads_delegation_coordinator_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "delegation_coordinator_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_call_records": {
+      "name": "tool_call_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_agent_key": {
+          "name": "provider_agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_truncated": {
+          "name": "output_truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_total_bytes": {
+          "name": "output_total_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_artifact_path": {
+          "name": "output_artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tool_call_records_message": {
+          "name": "idx_tool_call_records_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tool_call_records_parent": {
+          "name": "idx_tool_call_records_parent",
+          "columns": [
+            "parent_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_call_records_message_id_messages_id_fk": {
+          "name": "tool_call_records_message_id_messages_id_fk",
+          "tableFrom": "tool_call_records",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turn_snapshots": {
+      "name": "turn_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_before": {
+          "name": "ref_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_after": {
+          "name": "ref_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "file_effects": {
+          "name": "file_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"revision\":0,\"fileCount\":0,\"additions\":0,\"deletions\":0,\"effects\":[]}'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_turn_snapshots_message": {
+          "name": "idx_turn_snapshots_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_turn_snapshots_thread": {
+          "name": "idx_turn_snapshots_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "turn_snapshots_message_id_messages_id_fk": {
+          "name": "turn_snapshots_message_id_messages_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_snapshots_thread_id_threads_id_fk": {
+          "name": "turn_snapshots_thread_id_threads_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_worktrees": {
+      "name": "workspace_worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "stale": {
+          "name": "stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_workspace_worktrees_path": {
+          "name": "idx_workspace_worktrees_path",
+          "columns": [
+            "workspace_id",
+            "canonical_path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspace_worktrees_workspace": {
+          "name": "idx_workspace_worktrees_workspace",
+          "columns": [
+            "workspace_id",
+            "stale"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_worktrees_workspace_id_workspaces_id_fk": {
+          "name": "workspace_worktrees_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_worktrees",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_path_unique": {
+          "name": "workspaces_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspaces_sort_order": {
+          "name": "idx_workspaces_sort_order",
+          "columns": [
+            "\"sort_order\" asc"
+          ],
+          "isUnique": false
+        },
+        "idx_workspaces_pinned_last_opened": {
+          "name": "idx_workspaces_pinned_last_opened",
+          "columns": [
+            "\"pinned\" desc",
+            "\"last_opened_at\" desc"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_threads_workspace_recency": {
+        "columns": {
+          "\"updated_at\" desc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_sort_order": {
+        "columns": {
+          "\"sort_order\" asc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_pinned_last_opened": {
+        "columns": {
+          "\"pinned\" desc": {
+            "isExpression": true
+          },
+          "\"last_opened_at\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/meta/0029_snapshot.json
+++ b/apps/server/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,2301 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9a0dfeb5-394f-4e40-9cb7-0a9af0836c7e",
+  "prevId": "75d3b697-fef7-4bb4-b401-841c03a526d4",
+  "tables": {
+    "cleanup_jobs": {
+      "name": "cleanup_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cleanup_jobs_thread_id_unique": {
+          "name": "cleanup_jobs_thread_id_unique",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cleanup_jobs_retry": {
+          "name": "idx_cleanup_jobs_retry",
+          "columns": [
+            "next_retry_at",
+            "attempts",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diff_summaries": {
+      "name": "diff_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_turn_id": {
+          "name": "last_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_diff_summaries_thread": {
+          "name": "idx_diff_summaries_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "diff_summaries_thread_id_threads_id_fk": {
+          "name": "diff_summaries_thread_id_threads_id_fk",
+          "tableFrom": "diff_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_executions": {
+      "name": "hook_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hook_name": {
+          "name": "hook_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "did_block": {
+          "name": "did_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_hook_executions_message": {
+          "name": "idx_hook_executions_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hook_executions_message_id_messages_id_fk": {
+          "name": "hook_executions_message_id_messages_id_fk",
+          "tableFrom": "hook_executions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_annotations": {
+          "name": "preview_annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quoted_text": {
+          "name": "quoted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_provider_id": {
+          "name": "source_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_messages_thread": {
+          "name": "idx_messages_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_sequence": {
+          "name": "idx_messages_sequence",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_reply_to_message_id_messages_id_fk": {
+          "name": "messages_reply_to_message_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "reply_to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_question_answers": {
+      "name": "plan_question_answers",
+      "columns": {
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_question_answers_thread": {
+          "name": "idx_plan_question_answers_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_question_answers_assistant_message_id_messages_id_fk": {
+          "name": "plan_question_answers_assistant_message_id_messages_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_question_answers_thread_id_threads_id_fk": {
+          "name": "plan_question_answers_thread_id_threads_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plans_thread": {
+          "name": "idx_plans_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plans_thread_version": {
+          "name": "idx_plans_thread_version",
+          "columns": [
+            "thread_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plans_thread_id_threads_id_fk": {
+          "name": "plans_thread_id_threads_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_message_id_messages_id_fk": {
+          "name": "plans_message_id_messages_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_catalog_snapshots": {
+      "name": "provider_catalog_snapshots",
+      "columns": {
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_provider_catalog_snapshots_workspace": {
+          "name": "idx_provider_catalog_snapshots_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_provider_catalog_snapshots_provider": {
+          "name": "idx_provider_catalog_snapshots_provider",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "provider_catalog_snapshots_workspace_id_workspaces_id_fk": {
+          "name": "provider_catalog_snapshots_workspace_id_workspaces_id_fk",
+          "tableFrom": "provider_catalog_snapshots",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_cache": {
+      "name": "provider_model_cache",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_request_review_links": {
+      "name": "pull_request_review_links",
+      "columns": {
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_node_id": {
+          "name": "repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_state": {
+          "name": "pr_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "head_repository_node_id": {
+          "name": "head_repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_owner": {
+          "name": "head_repository_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_name": {
+          "name": "head_repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_oid": {
+          "name": "head_oid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_branch": {
+          "name": "local_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_remote": {
+          "name": "push_remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_ref": {
+          "name": "push_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "managed_remote_name": {
+          "name": "managed_remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_thread_id": {
+          "name": "primary_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_pull_request_review_links_identity": {
+          "name": "idx_pull_request_review_links_identity",
+          "columns": [
+            "provider",
+            "repository_node_id",
+            "pull_request_number"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_primary_thread": {
+          "name": "idx_pull_request_review_links_primary_thread",
+          "columns": [
+            "primary_thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_workspace": {
+          "name": "idx_pull_request_review_links_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pull_request_review_links_worktree_path": {
+          "name": "idx_pull_request_review_links_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_request_review_links_workspace_id_workspaces_id_fk": {
+          "name": "pull_request_review_links_workspace_id_workspaces_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pull_request_review_links_primary_thread_id_threads_id_fk": {
+          "name": "pull_request_review_links_primary_thread_id_threads_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "primary_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thought_segments": {
+      "name": "thought_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_final_response": {
+          "name": "is_final_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_thought_segments_message": {
+          "name": "idx_thought_segments_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thought_segments_message_id_messages_id_fk": {
+          "name": "thought_segments_message_id_messages_id_fk",
+          "tableFrom": "thought_segments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_control_approvals": {
+      "name": "thread_control_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_json": {
+          "name": "execution_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placement_json": {
+          "name": "placement_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation_phase": {
+          "name": "operation_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pre_provision'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thread_control_approvals_thread": {
+          "name": "idx_thread_control_approvals_thread",
+          "columns": [
+            "thread_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_control_approvals_thread_id_threads_id_fk": {
+          "name": "thread_control_approvals_thread_id_threads_id_fk",
+          "tableFrom": "thread_control_approvals",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_control_approvals_workspace_id_workspaces_id_fk": {
+          "name": "thread_control_approvals_workspace_id_workspaces_id_fk",
+          "tableFrom": "thread_control_approvals",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_control_audit": {
+      "name": "thread_control_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_id": {
+          "name": "caller_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_thread_control_audit_thread": {
+          "name": "idx_thread_control_audit_thread",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tasks": {
+      "name": "thread_tasks",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_json": {
+          "name": "tasks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tasks_thread_id_threads_id_fk": {
+          "name": "thread_tasks_thread_id_threads_id_fk",
+          "tableFrom": "thread_tasks",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkout_state": {
+          "name": "checkout_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'named'"
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_tokens": {
+          "name": "last_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interaction_mode": {
+          "name": "interaction_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "orchestration_mode": {
+          "name": "orchestration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_message_id": {
+          "name": "forked_from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_coordinator_thread_id": {
+          "name": "delegation_coordinator_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creator_turn_id": {
+          "name": "delegation_creator_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creator_tool_call_id": {
+          "name": "delegation_creator_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creation_kind": {
+          "name": "delegation_creation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_integration_id": {
+          "name": "created_by_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_compact_summary": {
+          "name": "last_compact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "copilot_agent": {
+          "name": "copilot_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window_mode": {
+          "name": "context_window_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codex_fast_mode": {
+          "name": "codex_fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_open_in_app": {
+          "name": "default_open_in_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file_changes": {
+          "name": "has_file_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_threads_workspace": {
+          "name": "idx_threads_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_deleted": {
+          "name": "idx_threads_workspace_deleted",
+          "columns": [
+            "workspace_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_recency": {
+          "name": "idx_threads_workspace_recency",
+          "columns": [
+            "workspace_id",
+            "\"updated_at\" desc"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_status": {
+          "name": "idx_threads_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_parent_thread_id": {
+          "name": "idx_threads_parent_thread_id",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_forked_from_message_id": {
+          "name": "idx_threads_forked_from_message_id",
+          "columns": [
+            "forked_from_message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_delegation_coordinator": {
+          "name": "idx_threads_delegation_coordinator",
+          "columns": [
+            "delegation_coordinator_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_created_by_integration": {
+          "name": "idx_threads_created_by_integration",
+          "columns": [
+            "created_by_integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_workspace_id_workspaces_id_fk": {
+          "name": "threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_delegation_coordinator_thread_id_threads_id_fk": {
+          "name": "threads_delegation_coordinator_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "delegation_coordinator_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_call_records": {
+      "name": "tool_call_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_agent_key": {
+          "name": "provider_agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_truncated": {
+          "name": "output_truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_total_bytes": {
+          "name": "output_total_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_artifact_path": {
+          "name": "output_artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tool_call_records_message": {
+          "name": "idx_tool_call_records_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tool_call_records_parent": {
+          "name": "idx_tool_call_records_parent",
+          "columns": [
+            "parent_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_call_records_message_id_messages_id_fk": {
+          "name": "tool_call_records_message_id_messages_id_fk",
+          "tableFrom": "tool_call_records",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turn_snapshots": {
+      "name": "turn_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_before": {
+          "name": "ref_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_after": {
+          "name": "ref_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "file_effects": {
+          "name": "file_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"revision\":0,\"fileCount\":0,\"additions\":0,\"deletions\":0,\"effects\":[]}'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_turn_snapshots_message": {
+          "name": "idx_turn_snapshots_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_turn_snapshots_thread": {
+          "name": "idx_turn_snapshots_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "turn_snapshots_message_id_messages_id_fk": {
+          "name": "turn_snapshots_message_id_messages_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_snapshots_thread_id_threads_id_fk": {
+          "name": "turn_snapshots_thread_id_threads_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_worktrees": {
+      "name": "workspace_worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "stale": {
+          "name": "stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_workspace_worktrees_path": {
+          "name": "idx_workspace_worktrees_path",
+          "columns": [
+            "workspace_id",
+            "canonical_path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspace_worktrees_workspace": {
+          "name": "idx_workspace_worktrees_workspace",
+          "columns": [
+            "workspace_id",
+            "stale"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_worktrees_workspace_id_workspaces_id_fk": {
+          "name": "workspace_worktrees_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_worktrees",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_path_unique": {
+          "name": "workspaces_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspaces_sort_order": {
+          "name": "idx_workspaces_sort_order",
+          "columns": [
+            "\"sort_order\" asc"
+          ],
+          "isUnique": false
+        },
+        "idx_workspaces_pinned_last_opened": {
+          "name": "idx_workspaces_pinned_last_opened",
+          "columns": [
+            "\"pinned\" desc",
+            "\"last_opened_at\" desc"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_threads_workspace_recency": {
+        "columns": {
+          "\"updated_at\" desc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_sort_order": {
+        "columns": {
+          "\"sort_order\" asc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_pinned_last_opened": {
+        "columns": {
+          "\"pinned\" desc": {
+            "isExpression": true
+          },
+          "\"last_opened_at\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/meta/0030_snapshot.json
+++ b/apps/server/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,2315 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "75c56949-79fd-4bc1-a67c-121095c1ca6a",
+  "prevId": "9a0dfeb5-394f-4e40-9cb7-0a9af0836c7e",
+  "tables": {
+    "cleanup_jobs": {
+      "name": "cleanup_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cleanup_jobs_thread_id_unique": {
+          "name": "cleanup_jobs_thread_id_unique",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cleanup_jobs_retry": {
+          "name": "idx_cleanup_jobs_retry",
+          "columns": [
+            "next_retry_at",
+            "attempts",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diff_summaries": {
+      "name": "diff_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_count": {
+          "name": "turn_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_turn_id": {
+          "name": "last_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_diff_summaries_thread": {
+          "name": "idx_diff_summaries_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "diff_summaries_thread_id_threads_id_fk": {
+          "name": "diff_summaries_thread_id_threads_id_fk",
+          "tableFrom": "diff_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_executions": {
+      "name": "hook_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hook_name": {
+          "name": "hook_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "did_block": {
+          "name": "did_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_hook_executions_message": {
+          "name": "idx_hook_executions_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hook_executions_message_id_messages_id_fk": {
+          "name": "hook_executions_message_id_messages_id_fk",
+          "tableFrom": "hook_executions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_annotations": {
+          "name": "preview_annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quoted_text": {
+          "name": "quoted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_provider_id": {
+          "name": "source_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_messages_thread": {
+          "name": "idx_messages_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_sequence": {
+          "name": "idx_messages_sequence",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_reply_to_message_id_messages_id_fk": {
+          "name": "messages_reply_to_message_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "reply_to_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan_question_answers": {
+      "name": "plan_question_answers",
+      "columns": {
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plan_question_answers_thread": {
+          "name": "idx_plan_question_answers_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plan_question_answers_assistant_message_id_messages_id_fk": {
+          "name": "plan_question_answers_assistant_message_id_messages_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_question_answers_thread_id_threads_id_fk": {
+          "name": "plan_question_answers_thread_id_threads_id_fk",
+          "tableFrom": "plan_question_answers",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_plans_thread": {
+          "name": "idx_plans_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plans_thread_version": {
+          "name": "idx_plans_thread_version",
+          "columns": [
+            "thread_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "plans_thread_id_threads_id_fk": {
+          "name": "plans_thread_id_threads_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_message_id_messages_id_fk": {
+          "name": "plans_message_id_messages_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_catalog_snapshots": {
+      "name": "provider_catalog_snapshots",
+      "columns": {
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_provider_catalog_snapshots_workspace": {
+          "name": "idx_provider_catalog_snapshots_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_provider_catalog_snapshots_provider": {
+          "name": "idx_provider_catalog_snapshots_provider",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "provider_catalog_snapshots_workspace_id_workspaces_id_fk": {
+          "name": "provider_catalog_snapshots_workspace_id_workspaces_id_fk",
+          "tableFrom": "provider_catalog_snapshots",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_cache": {
+      "name": "provider_model_cache",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "model_count": {
+          "name": "model_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_request_review_links": {
+      "name": "pull_request_review_links",
+      "columns": {
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_node_id": {
+          "name": "repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_state": {
+          "name": "pr_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "head_repository_node_id": {
+          "name": "head_repository_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_owner": {
+          "name": "head_repository_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_name": {
+          "name": "head_repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_oid": {
+          "name": "head_oid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_branch": {
+          "name": "local_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_remote": {
+          "name": "push_remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "push_ref": {
+          "name": "push_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "managed_remote_name": {
+          "name": "managed_remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_thread_id": {
+          "name": "primary_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_pull_request_review_links_identity": {
+          "name": "idx_pull_request_review_links_identity",
+          "columns": [
+            "provider",
+            "repository_node_id",
+            "pull_request_number"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_primary_thread": {
+          "name": "idx_pull_request_review_links_primary_thread",
+          "columns": [
+            "primary_thread_id"
+          ],
+          "isUnique": true
+        },
+        "idx_pull_request_review_links_workspace": {
+          "name": "idx_pull_request_review_links_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pull_request_review_links_worktree_path": {
+          "name": "idx_pull_request_review_links_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_request_review_links_workspace_id_workspaces_id_fk": {
+          "name": "pull_request_review_links_workspace_id_workspaces_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pull_request_review_links_primary_thread_id_threads_id_fk": {
+          "name": "pull_request_review_links_primary_thread_id_threads_id_fk",
+          "tableFrom": "pull_request_review_links",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "primary_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thought_segments": {
+      "name": "thought_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_final_response": {
+          "name": "is_final_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_thought_segments_message": {
+          "name": "idx_thought_segments_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thought_segments_message_id_messages_id_fk": {
+          "name": "thought_segments_message_id_messages_id_fk",
+          "tableFrom": "thought_segments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_control_approvals": {
+      "name": "thread_control_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_json": {
+          "name": "execution_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placement_json": {
+          "name": "placement_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_id": {
+          "name": "caller_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation_phase": {
+          "name": "operation_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pre_provision'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thread_control_approvals_thread": {
+          "name": "idx_thread_control_approvals_thread",
+          "columns": [
+            "thread_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_control_approvals_thread_id_threads_id_fk": {
+          "name": "thread_control_approvals_thread_id_threads_id_fk",
+          "tableFrom": "thread_control_approvals",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_control_approvals_workspace_id_workspaces_id_fk": {
+          "name": "thread_control_approvals_workspace_id_workspaces_id_fk",
+          "tableFrom": "thread_control_approvals",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_control_audit": {
+      "name": "thread_control_audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_id": {
+          "name": "caller_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_thread_control_audit_thread": {
+          "name": "idx_thread_control_audit_thread",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tasks": {
+      "name": "thread_tasks",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_json": {
+          "name": "tasks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tasks_thread_id_threads_id_fk": {
+          "name": "thread_tasks_thread_id_threads_id_fk",
+          "tableFrom": "thread_tasks",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkout_state": {
+          "name": "checkout_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'named'"
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_status": {
+          "name": "pr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_managed": {
+          "name": "worktree_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_context_tokens": {
+          "name": "last_context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interaction_mode": {
+          "name": "interaction_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "orchestration_mode": {
+          "name": "orchestration_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_from_message_id": {
+          "name": "forked_from_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_coordinator_thread_id": {
+          "name": "delegation_coordinator_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creator_turn_id": {
+          "name": "delegation_creator_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creator_tool_call_id": {
+          "name": "delegation_creator_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delegation_creation_kind": {
+          "name": "delegation_creation_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_integration_id": {
+          "name": "created_by_integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_compact_summary": {
+          "name": "last_compact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "copilot_agent": {
+          "name": "copilot_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window_mode": {
+          "name": "context_window_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codex_fast_mode": {
+          "name": "codex_fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_open_in_app": {
+          "name": "default_open_in_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_file_changes": {
+          "name": "has_file_changes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_threads_workspace": {
+          "name": "idx_threads_workspace",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_deleted": {
+          "name": "idx_threads_workspace_deleted",
+          "columns": [
+            "workspace_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_workspace_recency": {
+          "name": "idx_threads_workspace_recency",
+          "columns": [
+            "workspace_id",
+            "\"updated_at\" desc"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_status": {
+          "name": "idx_threads_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_parent_thread_id": {
+          "name": "idx_threads_parent_thread_id",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_forked_from_message_id": {
+          "name": "idx_threads_forked_from_message_id",
+          "columns": [
+            "forked_from_message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_delegation_coordinator": {
+          "name": "idx_threads_delegation_coordinator",
+          "columns": [
+            "delegation_coordinator_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_threads_created_by_integration": {
+          "name": "idx_threads_created_by_integration",
+          "columns": [
+            "created_by_integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "threads_workspace_id_workspaces_id_fk": {
+          "name": "threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_delegation_coordinator_thread_id_threads_id_fk": {
+          "name": "threads_delegation_coordinator_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "delegation_coordinator_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_call_records": {
+      "name": "tool_call_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_agent_key": {
+          "name": "provider_agent_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "output_truncated": {
+          "name": "output_truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_total_bytes": {
+          "name": "output_total_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_artifact_path": {
+          "name": "output_artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tool_call_records_message": {
+          "name": "idx_tool_call_records_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tool_call_records_parent": {
+          "name": "idx_tool_call_records_parent",
+          "columns": [
+            "parent_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_call_records_message_id_messages_id_fk": {
+          "name": "tool_call_records_message_id_messages_id_fk",
+          "tableFrom": "tool_call_records",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turn_snapshots": {
+      "name": "turn_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_before": {
+          "name": "ref_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_after": {
+          "name": "ref_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_changed": {
+          "name": "files_changed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "file_effects": {
+          "name": "file_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"revision\":0,\"fileCount\":0,\"additions\":0,\"deletions\":0,\"effects\":[]}'"
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "idx_turn_snapshots_message": {
+          "name": "idx_turn_snapshots_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_turn_snapshots_thread": {
+          "name": "idx_turn_snapshots_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "turn_snapshots_message_id_messages_id_fk": {
+          "name": "turn_snapshots_message_id_messages_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turn_snapshots_thread_id_threads_id_fk": {
+          "name": "turn_snapshots_thread_id_threads_id_fk",
+          "tableFrom": "turn_snapshots",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_worktrees": {
+      "name": "workspace_worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "stale": {
+          "name": "stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_workspace_worktrees_path": {
+          "name": "idx_workspace_worktrees_path",
+          "columns": [
+            "workspace_id",
+            "canonical_path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspace_worktrees_workspace": {
+          "name": "idx_workspace_worktrees_workspace",
+          "columns": [
+            "workspace_id",
+            "stale"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_worktrees_workspace_id_workspaces_id_fk": {
+          "name": "workspace_worktrees_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_worktrees",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_path_unique": {
+          "name": "workspaces_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_workspaces_sort_order": {
+          "name": "idx_workspaces_sort_order",
+          "columns": [
+            "\"sort_order\" asc"
+          ],
+          "isUnique": false
+        },
+        "idx_workspaces_pinned_last_opened": {
+          "name": "idx_workspaces_pinned_last_opened",
+          "columns": [
+            "\"pinned\" desc",
+            "\"last_opened_at\" desc"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_threads_workspace_recency": {
+        "columns": {
+          "\"updated_at\" desc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_sort_order": {
+        "columns": {
+          "\"sort_order\" asc": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workspaces_pinned_last_opened": {
+        "columns": {
+          "\"pinned\" desc": {
+            "isExpression": true
+          },
+          "\"last_opened_at\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1785006903394,
       "tag": "0027_same_epoch",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1785093938855,
+      "tag": "0028_rare_network",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1785093938855,
       "tag": "0028_rare_network",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1785102082352,
+      "tag": "0029_cuddly_sally_floyd",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1785102082352,
       "tag": "0029_cuddly_sally_floyd",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "6",
+      "when": 1785102643273,
+      "tag": "0030_chemical_harrier",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/__tests__/git-service-push.test.ts
+++ b/apps/server/src/__tests__/git-service-push.test.ts
@@ -120,6 +120,37 @@ describe("GitService.createBranch", () => {
     ]);
   });
 
+  it("creates a named worktree branch from the exact requested base ref", async () => {
+    execFn.mockImplementation(async (args) => {
+      if (args[2] === "rev-parse") throw new Error("missing branch");
+      return { stdout: "", stderr: "" };
+    });
+    vi.mocked(existsSync).mockImplementation((path) => path === "/repo");
+
+    await expect(
+      gitService.createWorktree(
+        "/repo",
+        "issue-960",
+        "codex/issue-960",
+        { baseRef: "origin/main" },
+      ),
+    ).resolves.toMatchObject({
+      branch: "codex/issue-960",
+      createdBranch: true,
+    });
+
+    expect(execFn).toHaveBeenLastCalledWith([
+      "-C",
+      "/repo",
+      "worktree",
+      "add",
+      path.join("/mock/mcode", "worktrees", "repo", "issue-960"),
+      "-b",
+      "codex/issue-960",
+      "origin/main",
+    ]);
+  });
+
   it.each([
     "",
     "--force",

--- a/apps/server/src/__tests__/git-service.test.ts
+++ b/apps/server/src/__tests__/git-service.test.ts
@@ -258,6 +258,24 @@ describe("GitService.removeWorktree", () => {
     );
   });
 
+  it("treats an already-absent managed worktree as successful cleanup", async () => {
+    execFn
+      .mockRejectedValueOnce(new Error("not a working tree"))
+      .mockResolvedValueOnce({ stdout: "", stderr: "" });
+    mockExistsSync.mockReturnValue(false);
+    mockRmdir.mockRejectedValue(Object.assign(new Error("missing"), { code: "ENOENT" }));
+
+    await expect(
+      gitService.removeWorktree("/repo", "my-worktree", { deleteBranch: false }),
+    ).resolves.toBe(true);
+
+    expect(mockRm).not.toHaveBeenCalled();
+    expect(execFn).toHaveBeenCalledWith(
+      ["-C", "/repo", "worktree", "prune"],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
   it("leaves a worktree in place for retry when another application locks it", async () => {
     execFn.mockRejectedValueOnce(new Error("git failed")); // worktree remove
     mockRm.mockRejectedValueOnce(Object.assign(new Error("EBUSY"), { code: "EBUSY" }));

--- a/apps/server/src/__tests__/thread-control-approval-repo.test.ts
+++ b/apps/server/src/__tests__/thread-control-approval-repo.test.ts
@@ -43,6 +43,7 @@ describe("ThreadControlApprovalRepo", () => {
         interactionMode: "build",
       },
       placement: { type: "new_worktree", baseRef: "main" },
+      turnId: "turn-960",
     });
 
     expect(approvals.listPendingByThread(threadId)).toEqual([{
@@ -57,10 +58,28 @@ describe("ThreadControlApprovalRepo", () => {
         interactionMode: "build",
       },
       placement: { type: "new_worktree", baseRef: "main" },
+      turnId: "turn-960",
+      operationPhase: "pre_provision",
     }]);
     expect(approvals.claim(approvalId)?.approvalId).toBe(approvalId);
     expect(approvals.claim(approvalId)).toBeNull();
     expect(approvals.settle(approvalId, "approved")).toBe(true);
     expect(approvals.listPendingByThread(threadId)).toEqual([]);
+  });
+
+  it("returns only pre-side-effect processing approvals to pending after restart", () => {
+    const approvalId = approvals.create({
+      threadId,
+      workspaceId,
+      prompt: "Recover safely.",
+      execution: { providerId: "codex", modelId: "gpt-5.6-sol", permissionMode: "full", interactionMode: "build" },
+      placement: { type: "new_worktree", baseRef: "main" },
+      turnId: "turn-recovery",
+    });
+
+    expect(approvals.claim(approvalId)?.operationPhase).toBe("pre_provision");
+    expect(approvals.listProcessing()).toHaveLength(1);
+    expect(approvals.requeue(approvalId)).toBe(true);
+    expect(approvals.listPendingByThread(threadId)).toHaveLength(1);
   });
 });

--- a/apps/server/src/__tests__/thread-control-approval-repo.test.ts
+++ b/apps/server/src/__tests__/thread-control-approval-repo.test.ts
@@ -44,6 +44,8 @@ describe("ThreadControlApprovalRepo", () => {
       },
       placement: { type: "new_worktree", baseRef: "main" },
       turnId: "turn-960",
+      callerId: "local-user",
+      sourceThreadId: "thread-source",
     });
 
     expect(approvals.listPendingByThread(threadId)).toEqual([{
@@ -60,6 +62,8 @@ describe("ThreadControlApprovalRepo", () => {
       placement: { type: "new_worktree", baseRef: "main" },
       turnId: "turn-960",
       operationPhase: "pre_provision",
+      callerId: "local-user",
+      sourceThreadId: "thread-source",
     }]);
     expect(approvals.claim(approvalId)?.approvalId).toBe(approvalId);
     expect(approvals.claim(approvalId)).toBeNull();
@@ -75,6 +79,7 @@ describe("ThreadControlApprovalRepo", () => {
       execution: { providerId: "codex", modelId: "gpt-5.6-sol", permissionMode: "full", interactionMode: "build" },
       placement: { type: "new_worktree", baseRef: "main" },
       turnId: "turn-recovery",
+      callerId: "local-user",
     });
 
     expect(approvals.claim(approvalId)?.operationPhase).toBe("pre_provision");

--- a/apps/server/src/__tests__/thread-control-approval-repo.test.ts
+++ b/apps/server/src/__tests__/thread-control-approval-repo.test.ts
@@ -87,4 +87,42 @@ describe("ThreadControlApprovalRepo", () => {
     expect(approvals.requeue(approvalId)).toBe(true);
     expect(approvals.listPendingByThread(threadId)).toHaveLength(1);
   });
+
+  it("does not requeue an approval after provisioning has started", () => {
+    const approvalId = approvals.create({
+      threadId,
+      workspaceId,
+      prompt: "Provision once.",
+      execution: { providerId: "codex", modelId: "gpt-5.6-sol", permissionMode: "full", interactionMode: "build" },
+      placement: { type: "new_worktree", baseRef: "main" },
+      turnId: "turn-provisioning",
+      callerId: "local-user",
+    });
+
+    expect(approvals.claim(approvalId)).not.toBeNull();
+    expect(approvals.setOperationPhase(approvalId, "provisioning")).toBe(true);
+    expect(approvals.requeue(approvalId)).toBe(false);
+  });
+
+  it("returns a fail-closed recovery item for malformed persisted payloads", () => {
+    const approvalId = approvals.create({
+      threadId,
+      workspaceId,
+      prompt: "Never expose this prompt.",
+      execution: { providerId: "codex", modelId: "gpt-5.6-sol", permissionMode: "full", interactionMode: "build" },
+      placement: { type: "new_worktree", baseRef: "main" },
+      turnId: "turn-malformed",
+      callerId: "local-user",
+    });
+    expect(approvals.claim(approvalId)).not.toBeNull();
+    db.prepare("UPDATE thread_control_approvals SET execution_json = ? WHERE id = ?").run("{", approvalId);
+
+    expect(approvals.listProcessing()).toEqual([{
+      invalid: true,
+      approvalId,
+      threadId,
+      workspaceId,
+      callerId: "local-user",
+    }]);
+  });
 });

--- a/apps/server/src/__tests__/thread-control-approval-repo.test.ts
+++ b/apps/server/src/__tests__/thread-control-approval-repo.test.ts
@@ -1,0 +1,66 @@
+import "reflect-metadata";
+import { beforeEach, describe, expect, it } from "vitest";
+import type Database from "better-sqlite3";
+import { ThreadControlApprovalRepo } from "../repositories/thread-control-approval-repo.js";
+import { ThreadRepo } from "../repositories/thread-repo.js";
+import { WorkspaceRepo } from "../repositories/workspace-repo.js";
+import { openMemoryDatabase } from "../store/database.js";
+
+describe("ThreadControlApprovalRepo", () => {
+  let db: Database.Database;
+  let approvals: ThreadControlApprovalRepo;
+  let threadId: string;
+  let workspaceId: string;
+
+  beforeEach(() => {
+    db = openMemoryDatabase();
+    approvals = new ThreadControlApprovalRepo(db);
+    const workspace = new WorkspaceRepo(db).create("Workspace", "C:/workspace");
+    const thread = new ThreadRepo(db).create(
+      workspace.id,
+      "Pending delegated thread",
+      "worktree",
+      "main",
+      true,
+      "codex",
+      undefined,
+      "branchless",
+      "main",
+    );
+    workspaceId = workspace.id;
+    threadId = thread.id;
+  });
+
+  it("persists, rehydrates, claims, and settles a pending creation approval", () => {
+    const approvalId = approvals.create({
+      threadId,
+      workspaceId,
+      prompt: "Implement issue #960.",
+      execution: {
+        providerId: "codex",
+        modelId: "gpt-5.6-sol",
+        permissionMode: "full",
+        interactionMode: "build",
+      },
+      placement: { type: "new_worktree", baseRef: "main" },
+    });
+
+    expect(approvals.listPendingByThread(threadId)).toEqual([{
+      approvalId,
+      threadId,
+      workspaceId,
+      prompt: "Implement issue #960.",
+      execution: {
+        providerId: "codex",
+        modelId: "gpt-5.6-sol",
+        permissionMode: "full",
+        interactionMode: "build",
+      },
+      placement: { type: "new_worktree", baseRef: "main" },
+    }]);
+    expect(approvals.claim(approvalId)?.approvalId).toBe(approvalId);
+    expect(approvals.claim(approvalId)).toBeNull();
+    expect(approvals.settle(approvalId, "approved")).toBe(true);
+    expect(approvals.listPendingByThread(threadId)).toEqual([]);
+  });
+});

--- a/apps/server/src/__tests__/thread-control-audit-repo.test.ts
+++ b/apps/server/src/__tests__/thread-control-audit-repo.test.ts
@@ -1,0 +1,30 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { ThreadControlAuditRepo } from "../repositories/thread-control-audit-repo.js";
+import { openMemoryDatabase } from "../store/database.js";
+
+describe("ThreadControlAuditRepo", () => {
+  it("persists bounded identity and outcome fields without prompt or path columns", () => {
+    const db = openMemoryDatabase();
+    const audit = new ThreadControlAuditRepo(db);
+
+    audit.write({
+      callerId: "user-1",
+      sourceThreadId: "source-1",
+      workspaceId: "workspace-1",
+      threadId: "thread-1",
+      operation: "thread_create_batch",
+      outcome: "created",
+    });
+
+    expect(db.prepare("SELECT caller_id, source_thread_id, workspace_id, thread_id, operation, outcome FROM thread_control_audit").get()).toEqual({
+      caller_id: "user-1",
+      source_thread_id: "source-1",
+      workspace_id: "workspace-1",
+      thread_id: "thread-1",
+      operation: "thread_create_batch",
+      outcome: "created",
+    });
+    expect((db.prepare("PRAGMA table_info(thread_control_audit)").all() as Array<{ name: string }>).map((column) => column.name)).not.toEqual(expect.arrayContaining(["prompt", "path", "secret"]));
+  });
+});

--- a/apps/server/src/__tests__/thread-service.test.ts
+++ b/apps/server/src/__tests__/thread-service.test.ts
@@ -337,4 +337,20 @@ describe("ThreadService.delete", () => {
       base_branch: "feat/base",
     });
   });
+
+  it("removes only the deterministic interrupted provisioning worktree without deleting its branch", async () => {
+    const ws = workspaceRepo.create("test", "/tmp/test");
+
+    await expect(threadService.cleanupInterruptedProvisioning(
+      "12345678-thread-id",
+      ws.id,
+      { baseRef: "main", branchName: "codex/issue-960" },
+    )).resolves.toBe(true);
+
+    expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+      "/tmp/test",
+      "codex-issue-960-12345678",
+      { deleteBranch: false },
+    );
+  });
 });

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -77,6 +77,7 @@ import { ShellEnvResolver } from "./services/shell-env-resolver";
 import { EnvService } from "./services/env-service";
 import { ThreadControlService } from "./services/thread-control-service";
 import { ThreadControlApprovalRepo } from "./repositories/thread-control-approval-repo";
+import { ThreadControlAuditRepo } from "./repositories/thread-control-audit-repo";
 import { InternalThreadControlMcpAuthority } from "./services/thread-control-mcp-authority";
 import { InternalThreadControlMcpRuntime } from "./services/thread-control-mcp-runtime";
 import { UtilityCompletionService } from "./services/utility-completion-service";
@@ -343,6 +344,7 @@ export function setupContainer(mcodeDir: string): typeof container {
     { useClass: ThreadControlApprovalRepo },
     { lifecycle: Lifecycle.Singleton },
   );
+  container.register(ThreadControlAuditRepo, { useClass: ThreadControlAuditRepo }, { lifecycle: Lifecycle.Singleton });
   container.register(ThreadControlService, { useClass: ThreadControlService }, { lifecycle: Lifecycle.Singleton });
   container.register(InternalThreadControlMcpAuthority, { useClass: InternalThreadControlMcpAuthority }, { lifecycle: Lifecycle.Singleton });
   container.register(InternalThreadControlMcpRuntime, { useClass: InternalThreadControlMcpRuntime }, { lifecycle: Lifecycle.Singleton });

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -76,6 +76,7 @@ import { ProtectedEnvStore } from "./services/protected-env-store";
 import { ShellEnvResolver } from "./services/shell-env-resolver";
 import { EnvService } from "./services/env-service";
 import { ThreadControlService } from "./services/thread-control-service";
+import { ThreadControlApprovalRepo } from "./repositories/thread-control-approval-repo";
 import { InternalThreadControlMcpAuthority } from "./services/thread-control-mcp-authority";
 import { InternalThreadControlMcpRuntime } from "./services/thread-control-mcp-runtime";
 import { UtilityCompletionService } from "./services/utility-completion-service";
@@ -335,6 +336,11 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register(
     WorktreeRepo,
     { useClass: WorktreeRepo },
+    { lifecycle: Lifecycle.Singleton },
+  );
+  container.register(
+    ThreadControlApprovalRepo,
+    { useClass: ThreadControlApprovalRepo },
     { lifecycle: Lifecycle.Singleton },
   );
   container.register(ThreadControlService, { useClass: ThreadControlService }, { lifecycle: Lifecycle.Singleton });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -21,6 +21,7 @@ import { sanitizePublicToolInput } from "./services/public-tool-input";
 import { WorkspaceService } from "./services/workspace-service";
 import { ThreadService } from "./services/thread-service";
 import { AgentService } from "./services/agent-service";
+import { ThreadControlService } from "./services/thread-control-service";
 import { NarrativeStore } from "./services/narrative-store";
 import { GitService } from "./services/git-service";
 import { GithubService } from "./services/github-service";
@@ -214,6 +215,7 @@ const container = setupContainer(getMcodeDir());
 const workspaceService = container.resolve(WorkspaceService);
 const threadService = container.resolve(ThreadService);
 const agentService = container.resolve(AgentService);
+const threadControlService = container.resolve(ThreadControlService);
 const gitService = container.resolve(GitService);
 const githubService = container.resolve(GithubService);
 const pullRequestService = container.resolve(PullRequestService);
@@ -603,6 +605,7 @@ const { httpServer, wss } = createWsServer({
   workspaceService,
   threadService,
   agentService,
+  threadControlService,
   gitService,
   githubService,
   pullRequestService,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -216,7 +216,6 @@ const workspaceService = container.resolve(WorkspaceService);
 const threadService = container.resolve(ThreadService);
 const agentService = container.resolve(AgentService);
 const threadControlService = container.resolve(ThreadControlService);
-await threadControlService.recoverApprovals();
 const gitService = container.resolve(GitService);
 const githubService = container.resolve(GithubService);
 const pullRequestService = container.resolve(PullRequestService);
@@ -731,14 +730,27 @@ killOrphanedServer({ lockFilePath: LOCK_FILE_PATH, logger });
 const pidRegistry = container.resolve<PtyPidRegistry>("PtyPidRegistry");
 reapOrphanedPtys(pidRegistry, logger);
 
-ipcServer.listen(ipcPath).then(() => {
+async function bootstrapServer(): Promise<void> {
+  try {
+    await threadControlService.recoverApprovals();
+  } catch (err) {
+    logger.error("Thread-control approval recovery failed; refusing to accept work", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    process.exit(1);
+  }
+
+  try {
+    await ipcServer.listen(ipcPath);
+  } catch (err) {
+    logger.error("IPC server failed to start, fell back to WebSocket-only push", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
   startServerAndSubscribe();
-}).catch((err) => {
-  logger.error("IPC server failed to start, fell back to WebSocket-only push", {
-    error: err instanceof Error ? err.message : String(err),
-  });
-  startServerAndSubscribe();
-});
+}
+
+void bootstrapServer();
 
 /**
  * Gracefully shut down all services, close WebSocket connections,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -216,7 +216,7 @@ const workspaceService = container.resolve(WorkspaceService);
 const threadService = container.resolve(ThreadService);
 const agentService = container.resolve(AgentService);
 const threadControlService = container.resolve(ThreadControlService);
-threadControlService.recoverApprovals();
+await threadControlService.recoverApprovals();
 const gitService = container.resolve(GitService);
 const githubService = container.resolve(GithubService);
 const pullRequestService = container.resolve(PullRequestService);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -216,6 +216,7 @@ const workspaceService = container.resolve(WorkspaceService);
 const threadService = container.resolve(ThreadService);
 const agentService = container.resolve(AgentService);
 const threadControlService = container.resolve(ThreadControlService);
+threadControlService.recoverApprovals();
 const gitService = container.resolve(GitService);
 const githubService = container.resolve(GithubService);
 const pullRequestService = container.resolve(PullRequestService);

--- a/apps/server/src/repositories/thread-control-approval-repo.ts
+++ b/apps/server/src/repositories/thread-control-approval-repo.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from "node:crypto";
+import { inject, injectable } from "tsyringe";
+import type Database from "better-sqlite3";
+import {
+  ResolvedExecutionSchema,
+  ThreadPlacementSchema,
+  type ResolvedExecution,
+  type ThreadPlacement,
+} from "@mcode/contracts";
+
+/** Persisted input needed to resume a protected delegated-thread creation. */
+export interface PendingThreadCreateApproval {
+  approvalId: string;
+  threadId: string;
+  workspaceId: string;
+  prompt: string;
+  execution: ResolvedExecution;
+  placement: Extract<ThreadPlacement, { type: "new_worktree" }>;
+}
+
+interface ApprovalRow {
+  id: string;
+  thread_id: string;
+  workspace_id: string;
+  prompt: string;
+  execution_json: string;
+  placement_json: string;
+}
+
+/** Durable repository for protected thread-control creation approvals. */
+@injectable()
+export class ThreadControlApprovalRepo {
+  constructor(@inject("Database") private readonly db: Database.Database) {}
+
+  /** Persist one pending approval and return its opaque identity. */
+  create(input: Omit<PendingThreadCreateApproval, "approvalId">): string {
+    const approvalId = randomUUID();
+    this.db.prepare(
+      "INSERT INTO thread_control_approvals (id, thread_id, workspace_id, prompt, execution_json, placement_json, status) VALUES (?, ?, ?, ?, ?, ?, 'pending')",
+    ).run(
+      approvalId,
+      input.threadId,
+      input.workspaceId,
+      input.prompt,
+      JSON.stringify(input.execution),
+      JSON.stringify(input.placement),
+    );
+    return approvalId;
+  }
+
+  /** Atomically claim one pending approval so repeated decisions cannot resume it twice. */
+  claim(approvalId: string): PendingThreadCreateApproval | null {
+    const claim = this.db.transaction(() => {
+      const row = this.db.prepare(
+        "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json FROM thread_control_approvals WHERE id = ? AND status = 'pending'",
+      ).get(approvalId) as ApprovalRow | undefined;
+      if (!row) return null;
+      const updated = this.db.prepare(
+        "UPDATE thread_control_approvals SET status = 'processing', resolved_at = ? WHERE id = ? AND status = 'pending'",
+      ).run(new Date().toISOString(), approvalId);
+      return updated.changes === 1 ? row : null;
+    });
+    const row = claim();
+    return row ? this.parse(row) : null;
+  }
+
+  /** Mark a claimed approval with its terminal outcome. */
+  settle(approvalId: string, status: "approved" | "rejected" | "failed"): boolean {
+    return this.db.prepare(
+      "UPDATE thread_control_approvals SET status = ?, resolved_at = ? WHERE id = ? AND status = 'processing'",
+    ).run(status, new Date().toISOString(), approvalId).changes === 1;
+  }
+
+  /** Return pending approval cards for one visible thread. */
+  listPendingByThread(threadId: string): PendingThreadCreateApproval[] {
+    const rows = this.db.prepare(
+      "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json FROM thread_control_approvals WHERE thread_id = ? AND status = 'pending' ORDER BY created_at, id",
+    ).all(threadId) as ApprovalRow[];
+    return rows.map((row) => this.parse(row));
+  }
+
+  private parse(row: ApprovalRow): PendingThreadCreateApproval {
+    const placement = ThreadPlacementSchema().parse(JSON.parse(row.placement_json));
+    if (placement.type !== "new_worktree") {
+      throw new Error("Stored thread-control approval has invalid placement");
+    }
+    return {
+      approvalId: row.id,
+      threadId: row.thread_id,
+      workspaceId: row.workspace_id,
+      prompt: row.prompt,
+      execution: ResolvedExecutionSchema().parse(JSON.parse(row.execution_json)),
+      placement,
+    };
+  }
+}

--- a/apps/server/src/repositories/thread-control-approval-repo.ts
+++ b/apps/server/src/repositories/thread-control-approval-repo.ts
@@ -18,6 +18,8 @@ export interface PendingThreadCreateApproval {
   placement: Extract<ThreadPlacement, { type: "new_worktree" }>;
   turnId: string;
   operationPhase: "pre_provision" | "provisioning" | "provisioned" | "dispatching" | "dispatched";
+  callerId: string;
+  sourceThreadId?: string;
 }
 
 interface ApprovalRow {
@@ -29,6 +31,8 @@ interface ApprovalRow {
   placement_json: string;
   turn_id: string;
   operation_phase: PendingThreadCreateApproval["operationPhase"];
+  caller_id: string | null;
+  source_thread_id: string | null;
 }
 
 /** Durable repository for protected thread-control creation approvals. */
@@ -40,7 +44,7 @@ export class ThreadControlApprovalRepo {
   create(input: Omit<PendingThreadCreateApproval, "approvalId" | "operationPhase">): string {
     const approvalId = randomUUID();
     this.db.prepare(
-      "INSERT INTO thread_control_approvals (id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase, status) VALUES (?, ?, ?, ?, ?, ?, ?, 'pre_provision', 'pending')",
+      "INSERT INTO thread_control_approvals (id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, caller_id, source_thread_id, operation_phase, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pre_provision', 'pending')",
     ).run(
       approvalId,
       input.threadId,
@@ -49,6 +53,8 @@ export class ThreadControlApprovalRepo {
       JSON.stringify(input.execution),
       JSON.stringify(input.placement),
       input.turnId,
+      input.callerId,
+      input.sourceThreadId ?? null,
     );
     return approvalId;
   }
@@ -57,7 +63,7 @@ export class ThreadControlApprovalRepo {
   claim(approvalId: string): PendingThreadCreateApproval | null {
     const claim = this.db.transaction(() => {
       const row = this.db.prepare(
-        "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase FROM thread_control_approvals WHERE id = ? AND status = 'pending'",
+        "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase, caller_id, source_thread_id FROM thread_control_approvals WHERE id = ? AND status = 'pending'",
       ).get(approvalId) as ApprovalRow | undefined;
       if (!row) return null;
       const updated = this.db.prepare(
@@ -76,7 +82,7 @@ export class ThreadControlApprovalRepo {
 
   /** Return approvals stranded by a process exit. */
   listProcessing(): PendingThreadCreateApproval[] {
-    const rows = this.db.prepare("SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase FROM thread_control_approvals WHERE status = 'processing' ORDER BY processing_started_at, id").all() as ApprovalRow[];
+    const rows = this.db.prepare("SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase, caller_id, source_thread_id FROM thread_control_approvals WHERE status = 'processing' ORDER BY processing_started_at, id").all() as ApprovalRow[];
     return rows.map((row) => this.parse(row));
   }
 
@@ -95,7 +101,7 @@ export class ThreadControlApprovalRepo {
   /** Return pending approval cards for one visible thread. */
   listPendingByThread(threadId: string): PendingThreadCreateApproval[] {
     const rows = this.db.prepare(
-      "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase FROM thread_control_approvals WHERE thread_id = ? AND status = 'pending' ORDER BY created_at, id",
+      "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase, caller_id, source_thread_id FROM thread_control_approvals WHERE thread_id = ? AND status = 'pending' ORDER BY created_at, id",
     ).all(threadId) as ApprovalRow[];
     return rows.map((row) => this.parse(row));
   }
@@ -114,6 +120,8 @@ export class ThreadControlApprovalRepo {
       placement,
       turnId: row.turn_id,
       operationPhase: row.operation_phase,
+      callerId: row.caller_id ?? "unknown",
+      ...(row.source_thread_id ? { sourceThreadId: row.source_thread_id } : {}),
     };
   }
 }

--- a/apps/server/src/repositories/thread-control-approval-repo.ts
+++ b/apps/server/src/repositories/thread-control-approval-repo.ts
@@ -91,6 +91,11 @@ export class ThreadControlApprovalRepo {
     return this.db.prepare("UPDATE thread_control_approvals SET status = 'pending', processing_started_at = NULL WHERE id = ? AND status = 'processing' AND operation_phase = 'pre_provision'").run(approvalId).changes === 1;
   }
 
+  /** Return a recovered provisioning approval to the pre-provision pending state. */
+  requeueRecoveredProvisioning(approvalId: string): boolean {
+    return this.db.prepare("UPDATE thread_control_approvals SET status = 'pending', processing_started_at = NULL, operation_phase = 'pre_provision' WHERE id = ? AND status = 'processing' AND operation_phase = 'provisioning'").run(approvalId).changes === 1;
+  }
+
   /** Mark a claimed approval with its terminal outcome. */
   settle(approvalId: string, status: "approved" | "rejected" | "failed"): boolean {
     return this.db.prepare(

--- a/apps/server/src/repositories/thread-control-approval-repo.ts
+++ b/apps/server/src/repositories/thread-control-approval-repo.ts
@@ -16,6 +16,8 @@ export interface PendingThreadCreateApproval {
   prompt: string;
   execution: ResolvedExecution;
   placement: Extract<ThreadPlacement, { type: "new_worktree" }>;
+  turnId: string;
+  operationPhase: "pre_provision" | "provisioning" | "provisioned" | "dispatching" | "dispatched";
 }
 
 interface ApprovalRow {
@@ -25,6 +27,8 @@ interface ApprovalRow {
   prompt: string;
   execution_json: string;
   placement_json: string;
+  turn_id: string;
+  operation_phase: PendingThreadCreateApproval["operationPhase"];
 }
 
 /** Durable repository for protected thread-control creation approvals. */
@@ -33,10 +37,10 @@ export class ThreadControlApprovalRepo {
   constructor(@inject("Database") private readonly db: Database.Database) {}
 
   /** Persist one pending approval and return its opaque identity. */
-  create(input: Omit<PendingThreadCreateApproval, "approvalId">): string {
+  create(input: Omit<PendingThreadCreateApproval, "approvalId" | "operationPhase">): string {
     const approvalId = randomUUID();
     this.db.prepare(
-      "INSERT INTO thread_control_approvals (id, thread_id, workspace_id, prompt, execution_json, placement_json, status) VALUES (?, ?, ?, ?, ?, ?, 'pending')",
+      "INSERT INTO thread_control_approvals (id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase, status) VALUES (?, ?, ?, ?, ?, ?, ?, 'pre_provision', 'pending')",
     ).run(
       approvalId,
       input.threadId,
@@ -44,6 +48,7 @@ export class ThreadControlApprovalRepo {
       input.prompt,
       JSON.stringify(input.execution),
       JSON.stringify(input.placement),
+      input.turnId,
     );
     return approvalId;
   }
@@ -52,16 +57,32 @@ export class ThreadControlApprovalRepo {
   claim(approvalId: string): PendingThreadCreateApproval | null {
     const claim = this.db.transaction(() => {
       const row = this.db.prepare(
-        "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json FROM thread_control_approvals WHERE id = ? AND status = 'pending'",
+        "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase FROM thread_control_approvals WHERE id = ? AND status = 'pending'",
       ).get(approvalId) as ApprovalRow | undefined;
       if (!row) return null;
       const updated = this.db.prepare(
-        "UPDATE thread_control_approvals SET status = 'processing', resolved_at = ? WHERE id = ? AND status = 'pending'",
+        "UPDATE thread_control_approvals SET status = 'processing', processing_started_at = ? WHERE id = ? AND status = 'pending'",
       ).run(new Date().toISOString(), approvalId);
       return updated.changes === 1 ? row : null;
     });
     const row = claim();
     return row ? this.parse(row) : null;
+  }
+
+  /** Persist a completed side-effect boundary before the next operation begins. */
+  setOperationPhase(approvalId: string, phase: PendingThreadCreateApproval["operationPhase"]): boolean {
+    return this.db.prepare("UPDATE thread_control_approvals SET operation_phase = ? WHERE id = ? AND status = 'processing'").run(phase, approvalId).changes === 1;
+  }
+
+  /** Return approvals stranded by a process exit. */
+  listProcessing(): PendingThreadCreateApproval[] {
+    const rows = this.db.prepare("SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase FROM thread_control_approvals WHERE status = 'processing' ORDER BY processing_started_at, id").all() as ApprovalRow[];
+    return rows.map((row) => this.parse(row));
+  }
+
+  /** Return a pre-side-effect accepted operation to the visible pending state. */
+  requeue(approvalId: string): boolean {
+    return this.db.prepare("UPDATE thread_control_approvals SET status = 'pending', processing_started_at = NULL WHERE id = ? AND status = 'processing' AND operation_phase = 'pre_provision'").run(approvalId).changes === 1;
   }
 
   /** Mark a claimed approval with its terminal outcome. */
@@ -74,7 +95,7 @@ export class ThreadControlApprovalRepo {
   /** Return pending approval cards for one visible thread. */
   listPendingByThread(threadId: string): PendingThreadCreateApproval[] {
     const rows = this.db.prepare(
-      "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json FROM thread_control_approvals WHERE thread_id = ? AND status = 'pending' ORDER BY created_at, id",
+      "SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase FROM thread_control_approvals WHERE thread_id = ? AND status = 'pending' ORDER BY created_at, id",
     ).all(threadId) as ApprovalRow[];
     return rows.map((row) => this.parse(row));
   }
@@ -91,6 +112,8 @@ export class ThreadControlApprovalRepo {
       prompt: row.prompt,
       execution: ResolvedExecutionSchema().parse(JSON.parse(row.execution_json)),
       placement,
+      turnId: row.turn_id,
+      operationPhase: row.operation_phase,
     };
   }
 }

--- a/apps/server/src/repositories/thread-control-approval-repo.ts
+++ b/apps/server/src/repositories/thread-control-approval-repo.ts
@@ -22,6 +22,19 @@ export interface PendingThreadCreateApproval {
   sourceThreadId?: string;
 }
 
+/** Safe persisted identity for a processing approval whose payload cannot be rehydrated. */
+export interface MalformedThreadCreateApproval {
+  invalid: true;
+  approvalId: string;
+  threadId: string;
+  workspaceId: string;
+  callerId: string;
+  sourceThreadId?: string;
+}
+
+/** Processing approval that can either resume safely or must fail closed. */
+export type RecoverableThreadCreateApproval = PendingThreadCreateApproval | MalformedThreadCreateApproval;
+
 interface ApprovalRow {
   id: string;
   thread_id: string;
@@ -80,10 +93,23 @@ export class ThreadControlApprovalRepo {
     return this.db.prepare("UPDATE thread_control_approvals SET operation_phase = ? WHERE id = ? AND status = 'processing'").run(phase, approvalId).changes === 1;
   }
 
-  /** Return approvals stranded by a process exit. */
-  listProcessing(): PendingThreadCreateApproval[] {
+  /** Return approvals stranded by a process exit without letting one malformed payload block recovery. */
+  listProcessing(): RecoverableThreadCreateApproval[] {
     const rows = this.db.prepare("SELECT id, thread_id, workspace_id, prompt, execution_json, placement_json, turn_id, operation_phase, caller_id, source_thread_id FROM thread_control_approvals WHERE status = 'processing' ORDER BY processing_started_at, id").all() as ApprovalRow[];
-    return rows.map((row) => this.parse(row));
+    return rows.map((row) => {
+      try {
+        return this.parse(row);
+      } catch {
+        return {
+          invalid: true,
+          approvalId: row.id,
+          threadId: row.thread_id,
+          workspaceId: row.workspace_id,
+          callerId: row.caller_id ?? "unknown",
+          ...(row.source_thread_id ? { sourceThreadId: row.source_thread_id } : {}),
+        };
+      }
+    });
   }
 
   /** Return a pre-side-effect accepted operation to the visible pending state. */

--- a/apps/server/src/repositories/thread-control-audit-repo.ts
+++ b/apps/server/src/repositories/thread-control-audit-repo.ts
@@ -1,0 +1,14 @@
+import { randomUUID } from "node:crypto";
+import { inject, injectable } from "tsyringe";
+import type Database from "better-sqlite3";
+
+/** Writes bounded, content-free thread-control audit events. */
+@injectable()
+export class ThreadControlAuditRepo {
+  constructor(@inject("Database") private readonly db: Database.Database) {}
+
+  /** Persist one operation outcome without prompt, credential, or path data. */
+  write(input: { callerId: string; sourceThreadId?: string; workspaceId?: string; threadId?: string; operation: string; outcome: string }): void {
+    this.db.prepare("INSERT INTO thread_control_audit (id, caller_id, source_thread_id, workspace_id, thread_id, operation, outcome) VALUES (?, ?, ?, ?, ?, ?, ?)").run(randomUUID(), input.callerId, input.sourceThreadId ?? null, input.workspaceId ?? null, input.threadId ?? null, input.operation, input.outcome);
+  }
+}

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -638,6 +638,21 @@ export class ThreadRepo {
     return result.changes > 0;
   }
 
+  /** Persist ownership for a thread created by a paired external integration. */
+  updateExternalCreator(id: string, integrationId: string): boolean {
+    return this.db.prepare(
+      "UPDATE threads SET created_by_integration_id = ?, updated_at = ? WHERE id = ?",
+    ).run(integrationId, new Date().toISOString(), id).changes > 0;
+  }
+
+  /** Count active capacity owned by one paired external integration. */
+  countActiveByIntegration(integrationId: string): number {
+    const row = this.db.prepare(
+      "SELECT COUNT(*) AS count FROM threads WHERE created_by_integration_id = ? AND deleted_at IS NULL AND status IN ('active', 'paused')",
+    ).get(integrationId) as { count: number };
+    return row.count;
+  }
+
   /**
    * Find all threads in a workspace that have a worktree_path set (both active and deleted).
    * Used during workspace deletion to know which threads need filesystem cleanup.

--- a/apps/server/src/repositories/thread-repo.ts
+++ b/apps/server/src/repositories/thread-repo.ts
@@ -336,6 +336,16 @@ export class ThreadRepo {
     return result.changes > 0;
   }
 
+  /** Clear a thread's persisted worktree path after its managed checkout is removed. */
+  clearWorktreePath(id: string): boolean {
+    const now = new Date().toISOString();
+    const result = this.db
+      .prepare("UPDATE threads SET worktree_path = NULL, updated_at = ? WHERE id = ?")
+      .run(now, id);
+
+    return result.changes > 0;
+  }
+
   /** Mark a thread as a named-branch checkout after creating a branch in place. */
   updateCheckoutToNamedBranch(id: string, branch: string): Thread | null {
     const now = new Date().toISOString();

--- a/apps/server/src/repositories/worktree-repo.ts
+++ b/apps/server/src/repositories/worktree-repo.ts
@@ -23,6 +23,13 @@ export interface RegisteredWorktreeInput {
   managed: boolean;
 }
 
+/** Server-only worktree registration including its canonical path and ownership. */
+export interface InternalRegisteredWorktree extends RegisteredWorktree {
+  workspaceId: string;
+  canonicalPath: string;
+  managed: boolean;
+}
+
 /** Repository for stable workspace-scoped worktree identities. */
 @injectable()
 export class WorktreeRepo {
@@ -60,5 +67,61 @@ export class WorktreeRepo {
         ...(value.baseRef ? { baseRef: value.baseRef } : {}),
       };
     });
+  }
+
+  /** Resolve one current opaque worktree only within the supplied workspace. */
+  findCurrentById(workspaceId: string, worktreeId: string): InternalRegisteredWorktree | null {
+    const row = this.db.prepare(
+      "SELECT id AS worktreeId, workspace_id AS workspaceId, canonical_path AS canonicalPath, label, branch, base_ref AS baseRef, managed FROM workspace_worktrees WHERE workspace_id = ? AND id = ? AND stale = 0",
+    ).get(workspaceId, worktreeId) as {
+      worktreeId: string;
+      workspaceId: string;
+      canonicalPath: string;
+      label: string;
+      branch: string | null;
+      baseRef: string | null;
+      managed: number;
+    } | undefined;
+    if (!row) return null;
+    return {
+      worktreeId: row.worktreeId,
+      workspaceId: row.workspaceId,
+      canonicalPath: row.canonicalPath,
+      label: row.label,
+      managed: row.managed === 1,
+      ...(row.branch ? { branch: row.branch } : {}),
+      ...(row.baseRef ? { baseRef: row.baseRef } : {}),
+    };
+  }
+
+  /** Register one newly provisioned worktree without invalidating sibling registrations. */
+  register(workspaceId: string, worktree: RegisteredWorktreeInput): RegisteredWorktree {
+    const id = randomUUID();
+    this.db.prepare(
+      "INSERT INTO workspace_worktrees (id, workspace_id, canonical_path, label, branch, base_ref, managed, last_seen_at, stale) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0) ON CONFLICT(workspace_id, canonical_path) DO UPDATE SET label = excluded.label, branch = excluded.branch, base_ref = excluded.base_ref, managed = excluded.managed, last_seen_at = excluded.last_seen_at, stale = 0",
+    ).run(
+      id,
+      workspaceId,
+      worktree.canonicalPath,
+      worktree.label,
+      worktree.branch ?? null,
+      worktree.baseRef ?? null,
+      worktree.managed ? 1 : 0,
+      new Date().toISOString(),
+    );
+    const row = this.db.prepare(
+      "SELECT id AS worktreeId, label, branch, base_ref AS baseRef FROM workspace_worktrees WHERE workspace_id = ? AND canonical_path = ?",
+    ).get(workspaceId, worktree.canonicalPath) as {
+      worktreeId: string;
+      label: string;
+      branch: string | null;
+      baseRef: string | null;
+    };
+    return {
+      worktreeId: row.worktreeId,
+      label: row.label,
+      ...(row.branch ? { branch: row.branch } : {}),
+      ...(row.baseRef ? { baseRef: row.baseRef } : {}),
+    };
   }
 }

--- a/apps/server/src/services/__tests__/thread-control-container.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-container.test.ts
@@ -3,14 +3,22 @@ import { describe, expect, it } from "vitest";
 import { container } from "tsyringe";
 import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import { WorktreeRepo } from "../../repositories/worktree-repo.js";
+import { ThreadRepo } from "../../repositories/thread-repo.js";
+import { ThreadControlApprovalRepo } from "../../repositories/thread-control-approval-repo.js";
 import { GitService } from "../git-service.js";
 import { ThreadControlService } from "../thread-control-service.js";
+import { ThreadService } from "../thread-service.js";
+import { SettingsService } from "../settings-service.js";
 
 describe("thread-control DI", () => {
   it("resolves explicit repository and Git dependencies", () => {
     const child = container.createChildContainer();
     child.registerInstance(WorkspaceRepo, {} as WorkspaceRepo);
     child.registerInstance(WorktreeRepo, {} as WorktreeRepo);
+    child.registerInstance(ThreadRepo, {} as ThreadRepo);
+    child.registerInstance(ThreadService, {} as ThreadService);
+    child.registerInstance(SettingsService, {} as SettingsService);
+    child.registerInstance(ThreadControlApprovalRepo, {} as ThreadControlApprovalRepo);
     child.registerInstance(GitService, {} as GitService);
     child.register(ThreadControlService, { useClass: ThreadControlService });
 

--- a/apps/server/src/services/__tests__/thread-control-container.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-container.test.ts
@@ -5,6 +5,7 @@ import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
 import { WorktreeRepo } from "../../repositories/worktree-repo.js";
 import { ThreadRepo } from "../../repositories/thread-repo.js";
 import { ThreadControlApprovalRepo } from "../../repositories/thread-control-approval-repo.js";
+import { ThreadControlAuditRepo } from "../../repositories/thread-control-audit-repo.js";
 import { GitService } from "../git-service.js";
 import { ThreadControlService } from "../thread-control-service.js";
 import { ThreadService } from "../thread-service.js";
@@ -19,6 +20,7 @@ describe("thread-control DI", () => {
     child.registerInstance(ThreadService, {} as ThreadService);
     child.registerInstance(SettingsService, {} as SettingsService);
     child.registerInstance(ThreadControlApprovalRepo, {} as ThreadControlApprovalRepo);
+    child.registerInstance(ThreadControlAuditRepo, {} as ThreadControlAuditRepo);
     child.registerInstance(GitService, {} as GitService);
     child.register(ThreadControlService, { useClass: ThreadControlService });
 

--- a/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
@@ -18,6 +18,7 @@ describe("internal thread-control MCP transport", () => {
     const service = {
       workspaceSearch: vi.fn().mockReturnValue({ workspaces: [] }),
       worktreeList: vi.fn(),
+      threadCreateBatch: vi.fn(),
     } as unknown as ThreadControlService;
     const session = createInternalThreadControlMcpSession({ authority, service });
 
@@ -45,6 +46,7 @@ describe("internal thread-control MCP transport", () => {
     const service = {
       workspaceSearch: vi.fn(),
       worktreeList: vi.fn(),
+      threadCreateBatch: vi.fn(),
     } as unknown as ThreadControlService;
     const session = createInternalThreadControlMcpSession({ authority, service });
 
@@ -72,7 +74,7 @@ describe("internal thread-control MCP transport", () => {
     expect(service.workspaceSearch).not.toHaveBeenCalled();
   });
 
-  it("registers only discovery tools and rejects forged tool authority", async () => {
+  it("registers the internal thread-control tools and rejects forged tool authority", async () => {
     const authority = new InternalThreadControlMcpAuthority();
     const lease = authority.activate({
       sessionId: "pooled-provider-session",
@@ -84,6 +86,7 @@ describe("internal thread-control MCP transport", () => {
     const service = {
       workspaceSearch: vi.fn().mockReturnValue({ workspaces: [] }),
       worktreeList: vi.fn(),
+      threadCreateBatch: vi.fn().mockResolvedValue({ results: [] }),
     } as unknown as ThreadControlService;
     const session = createInternalThreadControlMcpSession({ authority, service });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -93,7 +96,11 @@ describe("internal thread-control MCP transport", () => {
     await server.connect(serverTransport);
     await client.connect(clientTransport);
     await expect(client.listTools()).resolves.toMatchObject({
-      tools: [{ name: "workspace_search" }, { name: "worktree_list" }],
+      tools: [
+        { name: "workspace_search" },
+        { name: "worktree_list" },
+        { name: "thread_create_batch" },
+      ],
     });
     await expect(session.dispatch({
       bearerCredential: lease.credential,
@@ -121,6 +128,7 @@ describe("internal thread-control MCP transport", () => {
         workspaceId: "workspace-1",
         worktrees: [{ worktreeId: "worktree-1", label: "main", branch: "main" }],
       }),
+      threadCreateBatch: vi.fn(),
     } as unknown as ThreadControlService;
     const session = createInternalThreadControlMcpSession({ authority, service });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -130,7 +138,11 @@ describe("internal thread-control MCP transport", () => {
     await server.connect(serverTransport);
     await client.connect(clientTransport);
     await expect(client.listTools()).resolves.toMatchObject({
-      tools: [{ name: "workspace_search" }, { name: "worktree_list" }],
+      tools: [
+        { name: "workspace_search" },
+        { name: "worktree_list" },
+        { name: "thread_create_batch" },
+      ],
     });
     await expect(client.callTool({ name: "worktree_list", arguments: { workspaceId: "workspace-1" } }))
       .resolves.toMatchObject({
@@ -142,5 +154,58 @@ describe("internal thread-control MCP transport", () => {
       .resolves.toMatchObject({ isError: true });
     await client.close();
     await server.close();
+  });
+
+  it("dispatches thread_create_batch through the authenticated MCP protocol", async () => {
+    const authority = new InternalThreadControlMcpAuthority();
+    const lease = authority.activate({
+      sessionId: "pooled-provider-session",
+      sourceThreadId: "source-thread",
+      sourceTurnId: "source-turn",
+      sourceProviderId: "codex",
+      permissionMode: "full",
+    });
+    const service = {
+      workspaceSearch: vi.fn(),
+      worktreeList: vi.fn(),
+      threadCreateBatch: vi.fn().mockResolvedValue({
+        results: [{
+          index: 0,
+          status: "created",
+          workspaceId: "workspace-1",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          execution: {
+            providerId: "codex",
+            modelId: "gpt-5.6-sol",
+            permissionMode: "full",
+            interactionMode: "build",
+          },
+          placement: { type: "direct" },
+          state: { status: "starting" },
+        }],
+      }),
+    } as unknown as ThreadControlService;
+    const session = createInternalThreadControlMcpSession({ authority, service });
+
+    await expect(session.dispatch({
+      bearerCredential: lease.credential,
+      requestId: "create-call",
+      toolName: "thread_create_batch",
+      arguments: {
+        items: [{
+          workspaceId: "workspace-1",
+          title: "Delegated thread",
+          prompt: "Implement the task.",
+          placement: { type: "direct" },
+        }],
+      },
+    })).resolves.toMatchObject({
+      results: [{ status: "created", threadId: "thread-1" }],
+    });
+    expect(service.threadCreateBatch).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceToolCallId: "create-call" }),
+      expect.objectContaining({ items: [expect.objectContaining({ title: "Delegated thread" })] }),
+    );
   });
 });

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -56,8 +56,12 @@ describe("ThreadControlService", () => {
     create: ReturnType<typeof vi.fn>;
     claim: ReturnType<typeof vi.fn>;
     settle: ReturnType<typeof vi.fn>;
+    setOperationPhase: ReturnType<typeof vi.fn>;
+    listProcessing: ReturnType<typeof vi.fn>;
+    requeue: ReturnType<typeof vi.fn>;
     listPendingByThread: ReturnType<typeof vi.fn>;
   };
+  let audit: { write: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     workspaces = {
@@ -95,8 +99,12 @@ describe("ThreadControlService", () => {
       create: vi.fn().mockReturnValue("approval-1"),
       claim: vi.fn(),
       settle: vi.fn().mockReturnValue(true),
+      setOperationPhase: vi.fn().mockReturnValue(true),
+      listProcessing: vi.fn().mockReturnValue([]),
+      requeue: vi.fn().mockReturnValue(true),
       listPendingByThread: vi.fn().mockReturnValue([]),
     };
+    audit = { write: vi.fn() };
   });
 
   function createService() {
@@ -127,6 +135,7 @@ describe("ThreadControlService", () => {
         )),
       } as never,
       approvals as never,
+      audit as never,
     );
   }
 
@@ -134,6 +143,7 @@ describe("ThreadControlService", () => {
     const workspacePath = "C:/private/workspace";
     const service = new ThreadControlService(
       { search: () => [{ id: "workspace-1", name: "Workspace", path: workspacePath, last_opened_at: null }] } as never,
+      {} as never,
       {} as never,
       {} as never,
       {} as never,
@@ -395,6 +405,8 @@ describe("ThreadControlService", () => {
         interactionMode: "build",
       },
       placement: { type: "new_worktree", baseRef: "main" },
+      turnId: "turn-approval-1",
+      operationPhase: "pre_provision",
     });
 
     await expect(service.respondToApproval("approval-1", "allow")).resolves.toBe(true);
@@ -409,6 +421,20 @@ describe("ThreadControlService", () => {
     approvals.claim.mockReturnValue(null);
     await expect(service.respondToApproval("approval-1", "allow")).resolves.toBe(false);
     expect(threadService.provisionWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("rehydrates only pre-side-effect approvals and fails ambiguous processing rows", () => {
+    const service = createService();
+    approvals.listProcessing.mockReturnValue([
+      { approvalId: "safe", threadId: "thread-safe", operationPhase: "pre_provision" },
+      { approvalId: "ambiguous", threadId: "thread-ambiguous", operationPhase: "provisioning" },
+    ]);
+
+    service.recoverApprovals();
+
+    expect(approvals.requeue).toHaveBeenCalledWith("safe");
+    expect(approvals.settle).toHaveBeenCalledWith("ambiguous", "failed");
+    expect(threads.updateStatus).toHaveBeenCalledWith("thread-ambiguous", "errored");
   });
 
   it("reserves external capacity in input order and preserves earlier success", async () => {

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -225,6 +225,25 @@ describe("ThreadControlService", () => {
     }));
   });
 
+  it("returns a created result when audit storage fails", async () => {
+    const service = createService();
+    audit.write.mockImplementationOnce(() => { throw new Error("audit unavailable"); });
+
+    await expect(service.threadCreateBatch(authority, {
+      items: [{
+        workspaceId: workspace.id,
+        title: "Audit failure",
+        prompt: "Create once.",
+        placement: { type: "direct" },
+      }],
+    })).resolves.toMatchObject({
+      results: [{ status: "created", threadId: createdThread.id }],
+    });
+
+    expect(threads.create).toHaveBeenCalledTimes(1);
+    expect(agentService.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("honors exact provider and model overrides or rejects them without persistence", async () => {
     const service = createService();
 
@@ -437,6 +456,50 @@ describe("ThreadControlService", () => {
     approvals.claim.mockReturnValue(null);
     await expect(service.respondToApproval("approval-1", "allow")).resolves.toBe(false);
     expect(threadService.provisionWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an approved thread active when its post-settlement audit write fails", async () => {
+    const service = createService();
+    approvals.claim.mockReturnValue({
+      approvalId: "approval-audit-failure",
+      threadId: createdThread.id,
+      workspaceId: workspace.id,
+      prompt: "Resume once.",
+      execution: { providerId: "codex", modelId: "gpt-default", permissionMode: "full", interactionMode: "build" },
+      placement: { type: "new_worktree", baseRef: "main" },
+      turnId: "turn-audit-failure",
+      operationPhase: "pre_provision",
+      callerId: "local-user",
+    });
+    audit.write.mockImplementationOnce(() => { throw new Error("audit unavailable"); });
+
+    await expect(service.respondToApproval("approval-audit-failure", "allow")).resolves.toBe(true);
+
+    expect(approvals.settle).toHaveBeenCalledWith("approval-audit-failure", "approved");
+    expect(threads.updateStatus).not.toHaveBeenCalledWith(createdThread.id, "errored");
+    expect(mockBroadcast).toHaveBeenCalledWith("thread.status", {
+      threadId: createdThread.id,
+      status: "active",
+    });
+  });
+
+  it.each(["deny", "failure"])("does not throw when %s auditing fails", async (outcome) => {
+    const service = createService();
+    approvals.claim.mockReturnValue({
+      approvalId: `approval-${outcome}`,
+      threadId: createdThread.id,
+      workspaceId: workspace.id,
+      prompt: "Resume once.",
+      execution: { providerId: "codex", modelId: "gpt-default", permissionMode: "full", interactionMode: "build" },
+      placement: { type: "new_worktree", baseRef: "main" },
+      turnId: `turn-${outcome}`,
+      operationPhase: "pre_provision",
+      callerId: "local-user",
+    });
+    audit.write.mockImplementationOnce(() => { throw new Error("audit unavailable"); });
+    if (outcome === "failure") agentService.sendMessage.mockRejectedValueOnce(new Error("dispatch failed"));
+
+    await expect(service.respondToApproval(`approval-${outcome}`, outcome === "deny" ? "deny" : "allow")).resolves.toBe(true);
   });
 
   it("requeues a recovered provisioning approval only after cleanup clears its persisted checkout", async () => {

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -47,10 +47,11 @@ describe("ThreadControlService", () => {
     updateDelegationLineage: ReturnType<typeof vi.fn>;
     updateStatus: ReturnType<typeof vi.fn>;
     updateWorktreePath: ReturnType<typeof vi.fn>;
+    clearWorktreePath: ReturnType<typeof vi.fn>;
     updateExternalCreator: ReturnType<typeof vi.fn>;
     countActiveByIntegration: ReturnType<typeof vi.fn>;
   };
-  let threadService: { provisionWorktree: ReturnType<typeof vi.fn> };
+  let threadService: { provisionWorktree: ReturnType<typeof vi.fn>; cleanupInterruptedProvisioning: ReturnType<typeof vi.fn> };
   let agentService: { sendMessage: ReturnType<typeof vi.fn> };
   let approvals: {
     create: ReturnType<typeof vi.fn>;
@@ -59,6 +60,7 @@ describe("ThreadControlService", () => {
     setOperationPhase: ReturnType<typeof vi.fn>;
     listProcessing: ReturnType<typeof vi.fn>;
     requeue: ReturnType<typeof vi.fn>;
+    requeueRecoveredProvisioning: ReturnType<typeof vi.fn>;
     listPendingByThread: ReturnType<typeof vi.fn>;
   };
   let audit: { write: ReturnType<typeof vi.fn> };
@@ -84,6 +86,7 @@ describe("ThreadControlService", () => {
       updateDelegationLineage: vi.fn().mockReturnValue(true),
       updateStatus: vi.fn().mockReturnValue(true),
       updateWorktreePath: vi.fn().mockReturnValue(true),
+      clearWorktreePath: vi.fn().mockReturnValue(true),
       updateExternalCreator: vi.fn().mockReturnValue(true),
       countActiveByIntegration: vi.fn().mockReturnValue(0),
     };
@@ -93,6 +96,7 @@ describe("ThreadControlService", () => {
         mode: "worktree",
         worktree_path: "C:/private/workspace/.worktrees/created",
       }),
+      cleanupInterruptedProvisioning: vi.fn().mockResolvedValue(true),
     };
     agentService = { sendMessage: vi.fn().mockResolvedValue(undefined) };
     approvals = {
@@ -102,6 +106,7 @@ describe("ThreadControlService", () => {
       setOperationPhase: vi.fn().mockReturnValue(true),
       listProcessing: vi.fn().mockReturnValue([]),
       requeue: vi.fn().mockReturnValue(true),
+      requeueRecoveredProvisioning: vi.fn().mockReturnValue(true),
       listPendingByThread: vi.fn().mockReturnValue([]),
     };
     audit = { write: vi.fn() };
@@ -425,18 +430,60 @@ describe("ThreadControlService", () => {
     expect(threadService.provisionWorktree).toHaveBeenCalledTimes(1);
   });
 
-  it("rehydrates only pre-side-effect approvals and fails ambiguous processing rows", () => {
+  it("requeues a recovered provisioning approval only after cleanup clears its persisted checkout", async () => {
     const service = createService();
     approvals.listProcessing.mockReturnValue([
       { approvalId: "safe", threadId: "thread-safe", operationPhase: "pre_provision" },
-      { approvalId: "ambiguous", threadId: "thread-ambiguous", operationPhase: "provisioning" },
+      {
+        approvalId: "provisioning",
+        threadId: "thread-provisioning",
+        workspaceId: workspace.id,
+        placement: { type: "new_worktree", baseRef: "main" },
+        callerId: "local-user",
+        sourceThreadId: "thread-1",
+        operationPhase: "provisioning",
+      },
     ]);
 
-    service.recoverApprovals();
+    await service.recoverApprovals();
 
     expect(approvals.requeue).toHaveBeenCalledWith("safe");
-    expect(approvals.settle).toHaveBeenCalledWith("ambiguous", "failed");
-    expect(threads.updateStatus).toHaveBeenCalledWith("thread-ambiguous", "errored");
+    expect(threadService.cleanupInterruptedProvisioning).toHaveBeenCalledWith(
+      "thread-provisioning",
+      workspace.id,
+      { type: "new_worktree", baseRef: "main" },
+    );
+    expect(threads.clearWorktreePath).toHaveBeenCalledWith("thread-provisioning");
+    expect(threads.updateStatus).toHaveBeenCalledWith("thread-provisioning", "paused");
+    expect(approvals.requeueRecoveredProvisioning).toHaveBeenCalledWith("provisioning");
+    expect(agentService.sendMessage).not.toHaveBeenCalled();
+    expect(audit.write).toHaveBeenCalledWith(expect.objectContaining({ outcome: "recovery-requeued" }));
+  });
+
+  it.each([
+    ["returns false", () => threadService.cleanupInterruptedProvisioning.mockResolvedValue(false)],
+    ["throws", () => threadService.cleanupInterruptedProvisioning.mockRejectedValue(new Error("locked"))],
+  ])("fails recovery when managed worktree cleanup %s", async (_case, arrange) => {
+    const service = createService();
+    arrange();
+    approvals.listProcessing.mockReturnValue([{
+      approvalId: "provisioning",
+      threadId: "thread-provisioning",
+      workspaceId: workspace.id,
+      placement: { type: "new_worktree", baseRef: "main" },
+      callerId: "local-user",
+      sourceThreadId: "thread-1",
+      operationPhase: "provisioning",
+    }]);
+
+    await service.recoverApprovals();
+
+    expect(approvals.settle).toHaveBeenCalledWith("provisioning", "failed");
+    expect(threads.updateStatus).toHaveBeenCalledWith("thread-provisioning", "errored");
+    expect(threads.clearWorktreePath).not.toHaveBeenCalled();
+    expect(approvals.requeueRecoveredProvisioning).not.toHaveBeenCalled();
+    expect(agentService.sendMessage).not.toHaveBeenCalled();
+    expect(audit.write).toHaveBeenCalledWith(expect.objectContaining({ outcome: "recovery-failed" }));
   });
 
   it("reserves external capacity in input order and preserves earlier success", async () => {

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -1,5 +1,10 @@
 import "reflect-metadata";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockBroadcast } = vi.hoisted(() => ({ mockBroadcast: vi.fn() }));
+
+vi.mock("../../transport/push.js", () => ({ broadcast: mockBroadcast }));
+
 import { ThreadControlService, type InternalThreadControlAuthority } from "../thread-control-service.js";
 
 const authority: InternalThreadControlAuthority = {
@@ -424,6 +429,10 @@ describe("ThreadControlService", () => {
       content: "Resume this prompt.",
     }));
     expect(approvals.settle).toHaveBeenCalledWith("approval-1", "approved");
+    expect(mockBroadcast).toHaveBeenCalledWith("thread.status", {
+      threadId: createdThread.id,
+      status: "active",
+    });
 
     approvals.claim.mockReturnValue(null);
     await expect(service.respondToApproval("approval-1", "allow")).resolves.toBe(false);
@@ -458,6 +467,59 @@ describe("ThreadControlService", () => {
     expect(approvals.requeueRecoveredProvisioning).toHaveBeenCalledWith("provisioning");
     expect(agentService.sendMessage).not.toHaveBeenCalled();
     expect(audit.write).toHaveBeenCalledWith(expect.objectContaining({ outcome: "recovery-requeued" }));
+  });
+
+  it("fails a malformed recovery item and continues with the next valid approval", async () => {
+    const service = createService();
+    approvals.listProcessing.mockReturnValue([
+      {
+        invalid: true,
+        approvalId: "malformed",
+        threadId: "thread-malformed",
+        workspaceId: workspace.id,
+        callerId: "local-user",
+      },
+      {
+        approvalId: "valid",
+        threadId: "thread-valid",
+        workspaceId: workspace.id,
+        callerId: "local-user",
+        operationPhase: "pre_provision",
+      },
+    ]);
+
+    await expect(service.recoverApprovals()).resolves.toBeUndefined();
+
+    expect(approvals.settle).toHaveBeenCalledWith("malformed", "failed");
+    expect(threads.updateStatus).toHaveBeenCalledWith("thread-malformed", "errored");
+    expect(approvals.requeue).toHaveBeenCalledWith("valid");
+  });
+
+  it("continues recovery when failure persistence or audit logging throws", async () => {
+    const service = createService();
+    approvals.settle.mockImplementationOnce(() => { throw new Error("database unavailable"); });
+    audit.write.mockImplementationOnce(() => { throw new Error("audit unavailable"); });
+    approvals.listProcessing.mockReturnValue([
+      {
+        invalid: true,
+        approvalId: "broken",
+        threadId: "thread-broken",
+        workspaceId: workspace.id,
+        callerId: "local-user",
+      },
+      {
+        approvalId: "valid",
+        threadId: "thread-valid",
+        workspaceId: workspace.id,
+        callerId: "local-user",
+        operationPhase: "pre_provision",
+      },
+    ]);
+
+    await expect(service.recoverApprovals()).resolves.toBeUndefined();
+
+    expect(threads.updateStatus).toHaveBeenCalledWith("thread-broken", "errored");
+    expect(approvals.requeue).toHaveBeenCalledWith("valid");
   });
 
   it.each([

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -407,6 +407,8 @@ describe("ThreadControlService", () => {
       placement: { type: "new_worktree", baseRef: "main" },
       turnId: "turn-approval-1",
       operationPhase: "pre_provision",
+      callerId: "local-user",
+      sourceThreadId: "thread-1",
     });
 
     await expect(service.respondToApproval("approval-1", "allow")).resolves.toBe(true);

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ThreadControlService, type InternalThreadControlAuthority } from "../thread-control-service.js";
 
 const authority: InternalThreadControlAuthority = {
@@ -13,10 +13,134 @@ const authority: InternalThreadControlAuthority = {
 };
 
 describe("ThreadControlService", () => {
+  const workspace = {
+    id: "workspace-1",
+    name: "Workspace",
+    path: "C:/private/workspace",
+    is_git_repo: true,
+  };
+  const createdThread = {
+    id: "thread-created",
+    workspace_id: workspace.id,
+    status: "active",
+    mode: "direct",
+    branch: "main",
+    permission_mode: null,
+    interaction_mode: null,
+    model: null,
+    provider: "claude",
+  };
+  let workspaces: {
+    search: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+  };
+  let worktrees: {
+    reconcile: ReturnType<typeof vi.fn>;
+    findCurrentById: ReturnType<typeof vi.fn>;
+    register: ReturnType<typeof vi.fn>;
+  };
+  let git: { listWorktrees: ReturnType<typeof vi.fn>; getCurrentBranch: ReturnType<typeof vi.fn> };
+  let threads: {
+    create: ReturnType<typeof vi.fn>;
+    updateModel: ReturnType<typeof vi.fn>;
+    updateSettings: ReturnType<typeof vi.fn>;
+    updateDelegationLineage: ReturnType<typeof vi.fn>;
+    updateStatus: ReturnType<typeof vi.fn>;
+    updateWorktreePath: ReturnType<typeof vi.fn>;
+    updateExternalCreator: ReturnType<typeof vi.fn>;
+    countActiveByIntegration: ReturnType<typeof vi.fn>;
+  };
+  let threadService: { provisionWorktree: ReturnType<typeof vi.fn> };
+  let agentService: { sendMessage: ReturnType<typeof vi.fn> };
+  let approvals: {
+    create: ReturnType<typeof vi.fn>;
+    claim: ReturnType<typeof vi.fn>;
+    settle: ReturnType<typeof vi.fn>;
+    listPendingByThread: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    workspaces = {
+      search: vi.fn().mockReturnValue([workspace]),
+      findById: vi.fn().mockReturnValue(workspace),
+    };
+    worktrees = {
+      reconcile: vi.fn().mockReturnValue([]),
+      findCurrentById: vi.fn(),
+      register: vi.fn().mockReturnValue({ worktreeId: "worktree-created", label: "created" }),
+    };
+    git = {
+      listWorktrees: vi.fn().mockResolvedValue([]),
+      getCurrentBranch: vi.fn().mockResolvedValue("main"),
+    };
+    threads = {
+      create: vi.fn().mockReturnValue(createdThread),
+      updateModel: vi.fn().mockReturnValue(true),
+      updateSettings: vi.fn().mockReturnValue(true),
+      updateDelegationLineage: vi.fn().mockReturnValue(true),
+      updateStatus: vi.fn().mockReturnValue(true),
+      updateWorktreePath: vi.fn().mockReturnValue(true),
+      updateExternalCreator: vi.fn().mockReturnValue(true),
+      countActiveByIntegration: vi.fn().mockReturnValue(0),
+    };
+    threadService = {
+      provisionWorktree: vi.fn().mockResolvedValue({
+        ...createdThread,
+        mode: "worktree",
+        worktree_path: "C:/private/workspace/.worktrees/created",
+      }),
+    };
+    agentService = { sendMessage: vi.fn().mockResolvedValue(undefined) };
+    approvals = {
+      create: vi.fn().mockReturnValue("approval-1"),
+      claim: vi.fn(),
+      settle: vi.fn().mockReturnValue(true),
+      listPendingByThread: vi.fn().mockReturnValue([]),
+    };
+  });
+
+  function createService() {
+    return new ThreadControlService(
+      workspaces as never,
+      worktrees as never,
+      git as never,
+      threads as never,
+      threadService as never,
+      agentService as never,
+      {
+        get: () => ({
+          model: { defaults: { provider: "codex", id: "gpt-default" } },
+          agent: { defaults: { permission: "full" } },
+        }),
+      } as never,
+      {
+        resolve: (providerId: string) => {
+          if (providerId !== "codex" && providerId !== "claude") throw new Error("unknown");
+          return { id: providerId };
+        },
+      } as never,
+      {
+        listModels: vi.fn().mockImplementation((providerId: string) => Promise.resolve(
+          providerId === "codex"
+            ? [{ id: "gpt-default" }, { id: "gpt-exact" }]
+            : [{ id: "claude-exact" }],
+        )),
+      } as never,
+      approvals as never,
+    );
+  }
+
   it("never returns a registered workspace filesystem path from workspace_search", () => {
     const workspacePath = "C:/private/workspace";
     const service = new ThreadControlService(
       { search: () => [{ id: "workspace-1", name: "Workspace", path: workspacePath, last_opened_at: null }] } as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
       {} as never,
       {} as never,
     );
@@ -25,5 +149,306 @@ describe("ThreadControlService", () => {
 
     expect(JSON.stringify(result)).not.toContain(workspacePath);
     expect(result.workspaces).toEqual([{ workspaceId: "workspace-1", name: "Workspace" }]);
+  });
+
+  it("creates a direct thread with user defaults, exact title, lineage, and Build mode", async () => {
+    const service = createService();
+
+    const result = await service.threadCreateBatch(authority, {
+      items: [{
+        workspaceId: workspace.id,
+        title: "Exact delegated title",
+        prompt: "Implement the task.",
+        placement: { type: "direct" },
+      }],
+    });
+
+    expect(result.results).toEqual([expect.objectContaining({
+      index: 0,
+      status: "created",
+      workspaceId: workspace.id,
+      threadId: createdThread.id,
+      execution: {
+        providerId: "codex",
+        modelId: "gpt-default",
+        permissionMode: "full",
+        interactionMode: "build",
+      },
+      placement: { type: "direct" },
+      state: { status: "starting" },
+    })]);
+    expect(threads.create).toHaveBeenCalledWith(
+      workspace.id,
+      "Exact delegated title",
+      "direct",
+      "main",
+      true,
+      "codex",
+      undefined,
+      "named",
+      null,
+    );
+    expect(threads.updateDelegationLineage).toHaveBeenCalledWith(createdThread.id, {
+      coordinatorThreadId: authority.sourceThreadId,
+      creatorTurnId: authority.sourceTurnId,
+      creatorToolCallId: authority.sourceToolCallId,
+      creationKind: "thread_delegation",
+    });
+    expect(agentService.sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      threadId: createdThread.id,
+      content: "Implement the task.",
+      provider: "codex",
+      model: "gpt-default",
+      permissionMode: "full",
+      interactionMode: "build",
+      sourceTurnId: expect.any(String),
+    }));
+  });
+
+  it("honors exact provider and model overrides or rejects them without persistence", async () => {
+    const service = createService();
+
+    const result = await service.threadCreateBatch(authority, {
+      items: [
+        {
+          workspaceId: workspace.id,
+          title: "Exact overrides",
+          prompt: "Use Claude.",
+          placement: { type: "direct" },
+          providerId: "claude",
+          modelId: "claude-exact",
+          permissionMode: "supervised",
+          interactionMode: "plan",
+        },
+        {
+          workspaceId: workspace.id,
+          title: "Invalid model",
+          prompt: "Reject this.",
+          placement: { type: "direct" },
+          providerId: "codex",
+          modelId: "missing-model",
+        },
+      ],
+    });
+
+    expect(result.results[0]).toMatchObject({
+      index: 0,
+      status: "created",
+      execution: {
+        providerId: "claude",
+        modelId: "claude-exact",
+        permissionMode: "supervised",
+        interactionMode: "plan",
+      },
+    });
+    expect(result.results[1]).toEqual({
+      index: 1,
+      status: "rejected",
+      workspaceId: workspace.id,
+      error: {
+        code: "invalid_model",
+        message: "Model is not available for the selected provider",
+        retryable: false,
+      },
+    });
+    expect(threads.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves partial success and input order", async () => {
+    const service = createService();
+    workspaces.findById.mockImplementation((workspaceId: string) =>
+      workspaceId === workspace.id ? workspace : null,
+    );
+
+    const result = await service.threadCreateBatch(authority, {
+      items: [
+        {
+          workspaceId: "missing-workspace",
+          title: "Missing",
+          prompt: "Reject this.",
+          placement: { type: "direct" },
+        },
+        {
+          workspaceId: workspace.id,
+          title: "Created",
+          prompt: "Create this.",
+          placement: { type: "direct" },
+        },
+      ],
+    });
+
+    expect(result.results.map((item) => [item.index, item.status])).toEqual([
+      [0, "rejected"],
+      [1, "created"],
+    ]);
+  });
+
+  it("validates existing-worktree ownership without returning its path", async () => {
+    const service = createService();
+    worktrees.findCurrentById.mockReturnValue(null);
+
+    const result = await service.threadCreateBatch(authority, {
+      items: [{
+        workspaceId: workspace.id,
+        title: "Wrong worktree",
+        prompt: "Do not create this.",
+        placement: { type: "existing_worktree", worktreeId: "other-worktree" },
+      }],
+    });
+
+    expect(result.results).toEqual([{
+      index: 0,
+      status: "rejected",
+      workspaceId: workspace.id,
+      error: {
+        code: "invalid_placement",
+        message: "Worktree does not belong to the selected workspace",
+        retryable: false,
+      },
+    }]);
+    expect(JSON.stringify(result)).not.toContain("C:/");
+  });
+
+  it("persists a visible pending thread before supervised new-worktree approval", async () => {
+    const service = createService();
+    const supervisedAuthority = { ...authority, permissionMode: "supervised" as const };
+
+    const result = await service.threadCreateBatch(supervisedAuthority, {
+      items: [{
+        workspaceId: workspace.id,
+        title: "Pending worktree",
+        prompt: "Wait for approval.",
+        placement: { type: "new_worktree", baseRef: "main" },
+      }],
+    });
+
+    expect(result.results).toEqual([{
+      index: 0,
+      status: "pending_approval",
+      workspaceId: workspace.id,
+      threadId: createdThread.id,
+      approvalId: "approval-1",
+      execution: {
+        providerId: "codex",
+        modelId: "gpt-default",
+        permissionMode: "full",
+        interactionMode: "build",
+      },
+      requestedPlacement: { type: "new_worktree", baseRef: "main" },
+      state: { status: "waiting_for_approval", approvalId: "approval-1" },
+    }]);
+    expect(threads.create).toHaveBeenCalled();
+    expect(approvals.create).toHaveBeenCalled();
+    expect(threadService.provisionWorktree).not.toHaveBeenCalled();
+    expect(agentService.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("provisions a full-access new worktree and returns only its opaque identity", async () => {
+    const service = createService();
+    const fullAuthority = { ...authority, permissionMode: "full" as const };
+
+    const result = await service.threadCreateBatch(fullAuthority, {
+      items: [{
+        workspaceId: workspace.id,
+        title: "Provision worktree",
+        prompt: "Start after provisioning.",
+        placement: {
+          type: "new_worktree",
+          baseRef: "main",
+          branchName: "codex/issue-960",
+        },
+      }],
+    });
+
+    expect(result.results[0]).toMatchObject({
+      status: "created",
+      placement: {
+        type: "new_worktree",
+        baseRef: "main",
+        branchName: "codex/issue-960",
+        worktreeId: "worktree-created",
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("C:/private");
+    expect(threadService.provisionWorktree).toHaveBeenCalledWith(
+      createdThread.id,
+      workspace.id,
+      {
+        type: "new_worktree",
+        baseRef: "main",
+        branchName: "codex/issue-960",
+      },
+    );
+  });
+
+  it("resumes the same pending operation exactly once after human approval", async () => {
+    const service = createService();
+    approvals.claim.mockReturnValue({
+      approvalId: "approval-1",
+      threadId: createdThread.id,
+      workspaceId: workspace.id,
+      prompt: "Resume this prompt.",
+      execution: {
+        providerId: "codex",
+        modelId: "gpt-default",
+        permissionMode: "full",
+        interactionMode: "build",
+      },
+      placement: { type: "new_worktree", baseRef: "main" },
+    });
+
+    await expect(service.respondToApproval("approval-1", "allow")).resolves.toBe(true);
+
+    expect(threadService.provisionWorktree).toHaveBeenCalledTimes(1);
+    expect(agentService.sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      threadId: createdThread.id,
+      content: "Resume this prompt.",
+    }));
+    expect(approvals.settle).toHaveBeenCalledWith("approval-1", "approved");
+
+    approvals.claim.mockReturnValue(null);
+    await expect(service.respondToApproval("approval-1", "allow")).resolves.toBe(false);
+    expect(threadService.provisionWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("reserves external capacity in input order and preserves earlier success", async () => {
+    const service = createService();
+    const externalAuthority = {
+      type: "external" as const,
+      integrationId: "integration-1",
+      allowedWorkspaceIds: [workspace.id],
+      scopes: ["threads:create"] as const,
+      limits: { callsPerMinute: 10, maxActiveThreads: 1 },
+    };
+
+    const result = await service.threadCreateBatch(externalAuthority, {
+      items: [
+        {
+          workspaceId: workspace.id,
+          title: "First",
+          prompt: "Create first.",
+          placement: { type: "direct" },
+        },
+        {
+          workspaceId: workspace.id,
+          title: "Second",
+          prompt: "Reject second.",
+          placement: { type: "direct" },
+        },
+      ],
+    });
+
+    expect(result.results.map((item) => [item.index, item.status])).toEqual([
+      [0, "created"],
+      [1, "rejected"],
+    ]);
+    expect(result.results[1]).toMatchObject({
+      error: { code: "limit_exceeded", retryable: true },
+    });
+    expect(threads.updateExternalCreator).toHaveBeenCalledWith(
+      createdThread.id,
+      "integration-1",
+    );
+    expect(agentService.sendMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -99,6 +99,8 @@ export type SendMessageCommand = Omit<SendMessageInput, "permissionMode" | "prov
   markPlanAnswerForMessageId?: string;
   /** Provider payload used instead of the persisted user-facing content. */
   providerWireOverride?: string;
+  /** Server-assigned turn identity used by thread-control creation results. */
+  sourceTurnId?: string;
 };
 
 /** Command accepted by {@link AgentService.createAndSend}, including service defaults for model and permission mode. */
@@ -380,7 +382,7 @@ export class AgentService {
     @inject(PlanQuestionService)
     private readonly planQuestionService: PlanQuestionService,
     @inject(FileService) private readonly fileService?: FileService,
-    @inject(InternalThreadControlMcpRuntime)
+    @inject(delay(() => InternalThreadControlMcpRuntime))
     private readonly threadControlMcp?: InternalThreadControlMcpRuntime,
   ) {
     this.turnFileTracker = new TurnFileTracker(
@@ -504,6 +506,7 @@ export class AgentService {
     previewAnnotations,
     goalObjective,
     orchestrationMode,
+    sourceTurnId: requestedSourceTurnId,
   }: SendMessageCommand): Promise<void> {
     const thread = this.threadRepo.findById(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
@@ -802,7 +805,7 @@ export class AgentService {
     });
 
     const sessionName = `mcode-${threadId}`;
-    const sourceTurnId = randomUUID();
+    const sourceTurnId = requestedSourceTurnId ?? randomUUID();
     // A branched child has a system handoff at seq 1 but no sdk_session_id.
     // Only treat as resume if there is actually a session to resume.
     const isResume = nextSeq > 1 && !!thread.sdk_session_id;

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -816,7 +816,8 @@ export class GitService {
 
   /**
    * Remove a git worktree by name.
-   * Returns true when the worktree is already absent so interrupted cleanup is idempotent.
+   * Returns true only when the target worktree and managed parent directories are clean.
+   * Returns false when a transient lock leaves a managed parent directory for retry.
    * When deleteBranch is true, deletes options.branchName or the default managed branch.
    * When worktreePath is set, removes that exact worktree path instead of deriving
    * one under the managed mcode worktree directory.

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -754,7 +754,7 @@ export class GitService {
     repoPath: string,
     name: string,
     branchName?: string,
-    options: { branchless?: boolean } = {},
+    options: { branchless?: boolean; baseRef?: string } = {},
   ): Promise<WorktreeInfo & { createdBranch: boolean; warnings: string[] }> {
     validateWorktreeName(name);
 
@@ -764,6 +764,7 @@ export class GitService {
 
     const branch = branchName ?? `mcode/${name}`;
     validateBranchName(branch);
+    if (options.baseRef) validateBranchName(options.baseRef);
     const wtPath = join(ensureWorktreeBaseDir(repoPath), name);
 
     if (existsSync(wtPath)) {
@@ -779,7 +780,16 @@ export class GitService {
       } else if (!createdBranch) {
         await this.gitExecutor.exec(["-C", repoPath, "worktree", "add", wtPath, branch]);
       } else {
-        await this.gitExecutor.exec(["-C", repoPath, "worktree", "add", wtPath, "-b", branch]);
+        await this.gitExecutor.exec([
+          "-C",
+          repoPath,
+          "worktree",
+          "add",
+          wtPath,
+          "-b",
+          branch,
+          ...(options.baseRef ? [options.baseRef] : []),
+        ]);
       }
     } catch (err) {
       // If the worktree's .git file exists, git initialized the worktree

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -816,6 +816,7 @@ export class GitService {
 
   /**
    * Remove a git worktree by name.
+   * Returns true when the worktree is already absent so interrupted cleanup is idempotent.
    * When deleteBranch is true, deletes options.branchName or the default managed branch.
    * When worktreePath is set, removes that exact worktree path instead of deriving
    * one under the managed mcode worktree directory.

--- a/apps/server/src/services/thread-control-mcp-transport.ts
+++ b/apps/server/src/services/thread-control-mcp-transport.ts
@@ -1,4 +1,6 @@
 import {
+  ThreadCreateBatchInputSchema,
+  ThreadCreateBatchResultSchema,
   WorkspaceSearchInputSchema,
   WorkspaceSearchResultSchema,
   WorktreeListInputSchema,
@@ -57,6 +59,12 @@ export function createInternalThreadControlMcpSession(
         const input = WorktreeListInputSchema().parse(request.arguments);
         return WorktreeListResultSchema().parse(await options.service.worktreeList(authority, input));
       }
+      case "thread_create_batch": {
+        const input = ThreadCreateBatchInputSchema().parse(request.arguments);
+        return ThreadCreateBatchResultSchema().parse(
+          await options.service.threadCreateBatch(authority, input),
+        );
+      }
       default:
         throw new InternalThreadControlMcpAuthorizationError();
     }
@@ -83,6 +91,16 @@ export function createInternalThreadControlMcpSession(
         bearerCredential,
         requestId: extra.requestId,
         toolName: "worktree_list",
+        arguments: arguments_,
+      })));
+      server.registerTool("thread_create_batch", {
+        description: "Create and start one to twenty normal Mcode threads in registered Projects.",
+        inputSchema: ThreadCreateBatchInputSchema(),
+        outputSchema: ThreadCreateBatchResultSchema(),
+      }, async (arguments_, extra) => createToolResult(await dispatch({
+        bearerCredential,
+        requestId: extra.requestId,
+        toolName: "thread_create_batch",
         arguments: arguments_,
       })));
       return server;

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -33,6 +33,7 @@ import { WorkspaceRepo } from "../repositories/workspace-repo.js";
 import { WorktreeRepo, type InternalRegisteredWorktree } from "../repositories/worktree-repo.js";
 import { ThreadRepo } from "../repositories/thread-repo.js";
 import { ThreadControlApprovalRepo } from "../repositories/thread-control-approval-repo.js";
+import { ThreadControlAuditRepo } from "../repositories/thread-control-audit-repo.js";
 import { ProviderRegistry } from "../providers/provider-registry.js";
 import { AgentService } from "./agent-service.js";
 import { GitService } from "./git-service.js";
@@ -64,6 +65,7 @@ export class ThreadControlService {
     @inject(delay(() => ProviderRegistry)) private readonly providers: IProviderRegistry,
     @inject(delay(() => ModelCacheService)) private readonly models: ModelCacheService,
     @inject(ThreadControlApprovalRepo) private readonly approvals: ThreadControlApprovalRepo,
+    @inject(ThreadControlAuditRepo) private readonly audit: ThreadControlAuditRepo,
   ) {}
 
   /** Search only registered workspaces; authority is intentionally not tool input. */
@@ -110,16 +112,20 @@ export class ThreadControlService {
         && this.externalItemCanCreate(authority, validatedInput.items[index]!)
         && !reservations[index]
       ) {
-        results.push({
+        const result: ThreadCreateItemResult = {
           index,
           status: "rejected",
           workspaceId: validatedInput.items[index]!.workspaceId,
           error: this.error("limit_exceeded", "External active-thread limit reached", true),
-        });
+        };
+        this.auditCreateResult(authority, result);
+        results.push(result);
         continue;
       }
       try {
-        results.push(await this.createOne(authority, validatedInput.items[index]!, index));
+        const result = await this.createOne(authority, validatedInput.items[index]!, index);
+        this.auditCreateResult(authority, result);
+        results.push(result);
       } finally {
         if (authority.type === "external" && reservations[index]) {
           await this.releaseExternalReservation(authority.integrationId);
@@ -143,18 +149,22 @@ export class ThreadControlService {
     }
 
     try {
+      this.approvals.setOperationPhase(requestId, "provisioning");
       const provisioned = await this.threadService.provisionWorktree(
         pending.threadId,
         pending.workspaceId,
         pending.placement,
       );
       this.registerProvisionedWorktree(pending.workspaceId, provisioned, pending.placement);
+      this.approvals.setOperationPhase(requestId, "provisioned");
+      this.approvals.setOperationPhase(requestId, "dispatching");
       await this.startTurn(
         pending.threadId,
         pending.prompt,
         pending.execution,
-        randomUUID(),
+        pending.turnId,
       );
+      this.approvals.setOperationPhase(requestId, "dispatched");
       this.approvals.settle(requestId, "approved");
       broadcast("permission.resolved", { requestId, decision });
       return true;
@@ -169,6 +179,19 @@ export class ThreadControlService {
       broadcast("permission.resolved", { requestId, decision });
       broadcast("thread.status", { threadId: pending.threadId, status: "errored" });
       return true;
+    }
+  }
+
+  /** Restore stranded approvals without replaying an ambiguous external side effect. */
+  recoverApprovals(): void {
+    for (const approval of this.approvals.listProcessing()) {
+      if (approval.operationPhase === "pre_provision") {
+        this.approvals.requeue(approval.approvalId);
+        continue;
+      }
+      this.approvals.settle(approval.approvalId, "failed");
+      this.threads.updateStatus(approval.threadId, "errored");
+      broadcast("thread.status", { threadId: approval.threadId, status: "errored" });
     }
   }
 
@@ -288,6 +311,7 @@ export class ThreadControlService {
           prompt: input.prompt,
           execution: execution.value,
           placement: input.placement,
+          turnId: randomUUID(),
         });
         broadcast("permission.request", {
           requestId: approvalId,
@@ -363,6 +387,17 @@ export class ThreadControlService {
         state: { status: "failed" },
       };
     }
+  }
+
+  private auditCreateResult(authority: ThreadControlAuthority, result: ThreadCreateItemResult): void {
+    this.audit.write({
+      callerId: authority.type === "internal" ? authority.userId : authority.integrationId,
+      ...(authority.type === "internal" ? { sourceThreadId: authority.sourceThreadId } : {}),
+      workspaceId: result.workspaceId,
+      ...("threadId" in result ? { threadId: result.threadId } : {}),
+      operation: "thread_create_batch",
+      outcome: result.status,
+    });
   }
 
   private async resolveExecution(

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -143,6 +143,7 @@ export class ThreadControlService {
     if (decision === "deny" || decision === "cancelled") {
       this.approvals.settle(requestId, "rejected");
       this.threads.updateStatus(pending.threadId, "errored");
+      this.audit.write({ callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "denied" });
       broadcast("permission.resolved", { requestId, decision });
       broadcast("thread.status", { threadId: pending.threadId, status: "errored" });
       return true;
@@ -166,6 +167,7 @@ export class ThreadControlService {
       );
       this.approvals.setOperationPhase(requestId, "dispatched");
       this.approvals.settle(requestId, "approved");
+      this.audit.write({ callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "resumed-approved" });
       broadcast("permission.resolved", { requestId, decision });
       return true;
     } catch (error) {
@@ -175,6 +177,7 @@ export class ThreadControlService {
         error: String(error),
       });
       this.approvals.settle(requestId, "failed");
+      this.audit.write({ callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "resumed-failed" });
       this.threads.updateStatus(pending.threadId, "errored");
       broadcast("permission.resolved", { requestId, decision });
       broadcast("thread.status", { threadId: pending.threadId, status: "errored" });
@@ -312,6 +315,8 @@ export class ThreadControlService {
           execution: execution.value,
           placement: input.placement,
           turnId: randomUUID(),
+          callerId: authority.type === "internal" ? authority.userId : authority.integrationId,
+          ...(authority.type === "internal" ? { sourceThreadId: authority.sourceThreadId } : {}),
         });
         broadcast("permission.request", {
           requestId: approvalId,

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -1,28 +1,69 @@
-import type {
-  WorkspaceSearchInput,
-  WorkspaceSearchResult,
-  WorktreeListInput,
-  WorktreeListResult,
+import { randomUUID } from "node:crypto";
+import { logger } from "@mcode/shared";
+import {
+  type IProviderRegistry,
+  type PermissionDecision,
+  type PermissionRequest,
+  type ProviderId,
+  type ResolvedExecution,
+  type ResolvedPlacement,
+  type ThreadCreateBatchInput,
+  type ThreadCreateBatchResult,
+  type ThreadCreateInput,
+  type ThreadCreateItemResult,
+  type ThreadControlError,
+  type WorkspaceSearchInput,
+  type WorkspaceSearchResult,
+  type WorktreeListInput,
+  type WorktreeListResult,
+  ThreadCreateBatchInputSchema,
 } from "@mcode/contracts";
-import type { InternalThreadControlAuthority } from "@mcode/thread-orchestration";
-export type { InternalThreadControlAuthority } from "@mcode/thread-orchestration";
-import { inject, injectable } from "tsyringe";
+import type {
+  ExternalThreadControlAuthority,
+  InternalThreadControlAuthority,
+  ThreadControlAuthority,
+} from "@mcode/thread-orchestration";
+export type {
+  ExternalThreadControlAuthority,
+  InternalThreadControlAuthority,
+  ThreadControlAuthority,
+} from "@mcode/thread-orchestration";
+import { delay, inject, injectable } from "tsyringe";
 import { WorkspaceRepo } from "../repositories/workspace-repo.js";
-import { WorktreeRepo } from "../repositories/worktree-repo.js";
+import { WorktreeRepo, type InternalRegisteredWorktree } from "../repositories/worktree-repo.js";
+import { ThreadRepo } from "../repositories/thread-repo.js";
+import { ThreadControlApprovalRepo } from "../repositories/thread-control-approval-repo.js";
+import { ProviderRegistry } from "../providers/provider-registry.js";
+import { AgentService } from "./agent-service.js";
 import { GitService } from "./git-service.js";
+import { ModelCacheService } from "./model-cache-service.js";
+import { SettingsService } from "./settings-service.js";
+import { ThreadService } from "./thread-service.js";
+import { broadcast } from "../transport/push.js";
 
-/** Git worktree discovery restricted to a registered workspace. */
+/** Git operations required by thread-control discovery and placement. */
 export interface ThreadControlGitDiscovery {
   listWorktrees(workspaceId: string): Promise<Array<{ name: string; path: string; branch: string; managed: boolean }>>;
+  getCurrentBranch(workspaceId: string): Promise<string | null>;
 }
 
-/** Sole server authority boundary for internal thread-control discovery. */
+/** Sole server authority boundary for internal thread-control operations. */
 @injectable()
 export class ThreadControlService {
+  private capacityTail: Promise<void> = Promise.resolve();
+  private readonly externalReservations = new Map<string, number>();
+
   constructor(
     @inject(WorkspaceRepo) private readonly workspaces: WorkspaceRepo,
     @inject(WorktreeRepo) private readonly worktrees: WorktreeRepo,
     @inject(GitService) private readonly git: ThreadControlGitDiscovery,
+    @inject(ThreadRepo) private readonly threads: ThreadRepo,
+    @inject(ThreadService) private readonly threadService: ThreadService,
+    @inject(delay(() => AgentService)) private readonly agentService: AgentService,
+    @inject(SettingsService) private readonly settings: SettingsService,
+    @inject(delay(() => ProviderRegistry)) private readonly providers: IProviderRegistry,
+    @inject(delay(() => ModelCacheService)) private readonly models: ModelCacheService,
+    @inject(ThreadControlApprovalRepo) private readonly approvals: ThreadControlApprovalRepo,
   ) {}
 
   /** Search only registered workspaces; authority is intentionally not tool input. */
@@ -41,7 +82,7 @@ export class ThreadControlService {
   async worktreeList(authority: InternalThreadControlAuthority, input: WorktreeListInput): Promise<WorktreeListResult> {
     void authority;
     if (!this.workspaces.findById(input.workspaceId)) {
-      return { status: "rejected", error: { code: "not_found", message: "Workspace not found", retryable: false } };
+      return { status: "rejected", error: this.error("not_found", "Workspace not found", false) };
     }
     const discovered = await this.git.listWorktrees(input.workspaceId);
     const worktrees = this.worktrees.reconcile(input.workspaceId, discovered.map((worktree) => ({
@@ -51,5 +92,490 @@ export class ThreadControlService {
       managed: worktree.managed,
     })));
     return { status: "found", workspaceId: input.workspaceId, worktrees };
+  }
+
+  /** Create one to twenty independent delegated threads while preserving input order. */
+  async threadCreateBatch(
+    authority: ThreadControlAuthority,
+    input: ThreadCreateBatchInput,
+  ): Promise<ThreadCreateBatchResult> {
+    const validatedInput = ThreadCreateBatchInputSchema().parse(input);
+    const reservations = authority.type === "external"
+      ? await this.reserveExternalCapacity(authority, validatedInput)
+      : validatedInput.items.map(() => false);
+    const results: ThreadCreateItemResult[] = [];
+    for (let index = 0; index < validatedInput.items.length; index += 1) {
+      if (
+        authority.type === "external"
+        && this.externalItemCanCreate(authority, validatedInput.items[index]!)
+        && !reservations[index]
+      ) {
+        results.push({
+          index,
+          status: "rejected",
+          workspaceId: validatedInput.items[index]!.workspaceId,
+          error: this.error("limit_exceeded", "External active-thread limit reached", true),
+        });
+        continue;
+      }
+      try {
+        results.push(await this.createOne(authority, validatedInput.items[index]!, index));
+      } finally {
+        if (authority.type === "external" && reservations[index]) {
+          await this.releaseExternalReservation(authority.integrationId);
+        }
+      }
+    }
+    return { results };
+  }
+
+  /** Resolve a durable delegated-thread approval before provider permission handlers. */
+  async respondToApproval(requestId: string, decision: PermissionDecision): Promise<boolean> {
+    const pending = this.approvals.claim(requestId);
+    if (!pending) return false;
+
+    if (decision === "deny" || decision === "cancelled") {
+      this.approvals.settle(requestId, "rejected");
+      this.threads.updateStatus(pending.threadId, "errored");
+      broadcast("permission.resolved", { requestId, decision });
+      broadcast("thread.status", { threadId: pending.threadId, status: "errored" });
+      return true;
+    }
+
+    try {
+      const provisioned = await this.threadService.provisionWorktree(
+        pending.threadId,
+        pending.workspaceId,
+        pending.placement,
+      );
+      this.registerProvisionedWorktree(pending.workspaceId, provisioned, pending.placement);
+      await this.startTurn(
+        pending.threadId,
+        pending.prompt,
+        pending.execution,
+        randomUUID(),
+      );
+      this.approvals.settle(requestId, "approved");
+      broadcast("permission.resolved", { requestId, decision });
+      return true;
+    } catch (error) {
+      logger.error("Delegated thread approval failed", {
+        approvalId: requestId,
+        threadId: pending.threadId,
+        error: String(error),
+      });
+      this.approvals.settle(requestId, "failed");
+      this.threads.updateStatus(pending.threadId, "errored");
+      broadcast("permission.resolved", { requestId, decision });
+      broadcast("thread.status", { threadId: pending.threadId, status: "errored" });
+      return true;
+    }
+  }
+
+  /** Return durable thread-control approvals for frontend rehydration. */
+  listPendingApprovals(threadId: string): PermissionRequest[] {
+    return this.approvals.listPendingByThread(threadId).map((approval) => ({
+      requestId: approval.approvalId,
+      threadId: approval.threadId,
+      toolName: "thread_create_batch",
+      title: "Create a new worktree",
+      input: {
+        workspaceId: approval.workspaceId,
+        placement: approval.placement,
+        execution: approval.execution,
+      },
+    }));
+  }
+
+  private async createOne(
+    authority: ThreadControlAuthority,
+    input: ThreadCreateInput,
+    index: number,
+  ): Promise<ThreadCreateItemResult> {
+    if (
+      authority.type === "external"
+      && (
+        !authority.allowedWorkspaceIds.includes(input.workspaceId)
+        || !authority.scopes.includes("threads:create")
+      )
+    ) {
+      return {
+        index,
+        status: "rejected",
+        error: this.error("not_found", "Workspace not found", false),
+      };
+    }
+    const workspace = this.workspaces.findById(input.workspaceId);
+    if (!workspace) {
+      return {
+        index,
+        status: "rejected",
+        error: this.error("not_found", "Workspace not found", false),
+      };
+    }
+
+    if (
+      authority.type === "external"
+      && input.placement.type === "new_worktree"
+      && !authority.scopes.includes("worktrees:create")
+    ) {
+      return {
+        index,
+        status: "rejected",
+        workspaceId: input.workspaceId,
+        error: this.error("forbidden", "New worktree creation is not permitted", false),
+      };
+    }
+
+    const execution = await this.resolveExecution(authority, input);
+    if ("error" in execution) {
+      return { index, status: "rejected", workspaceId: input.workspaceId, error: execution.error };
+    }
+
+    let existingWorktree: InternalRegisteredWorktree | null = null;
+    if (input.placement.type === "existing_worktree") {
+      existingWorktree = this.worktrees.findCurrentById(input.workspaceId, input.placement.worktreeId);
+      if (!existingWorktree) {
+        return {
+          index,
+          status: "rejected",
+          workspaceId: input.workspaceId,
+          error: this.error(
+            "invalid_placement",
+            "Worktree does not belong to the selected workspace",
+            false,
+          ),
+        };
+      }
+      if (!this.existingWorktreeBranch(existingWorktree)) {
+        return {
+          index,
+          status: "rejected",
+          workspaceId: input.workspaceId,
+          error: this.error(
+            "invalid_placement",
+            "Detached worktree does not have a registered base ref",
+            false,
+          ),
+        };
+      }
+    }
+
+    let threadId: string | undefined;
+    try {
+      const persisted = await this.persistThread(input, execution.value, existingWorktree);
+      threadId = persisted.threadId;
+      if (authority.type === "internal") {
+        this.threads.updateDelegationLineage(threadId, {
+          coordinatorThreadId: authority.sourceThreadId,
+          creatorTurnId: authority.sourceTurnId,
+          creatorToolCallId: authority.sourceToolCallId,
+          creationKind: "thread_delegation",
+        });
+      } else {
+        this.threads.updateExternalCreator(threadId, authority.integrationId);
+      }
+
+      const protectedMutationNeedsApproval =
+        authority.type === "internal"
+          ? authority.permissionMode === "supervised"
+          : execution.value.permissionMode === "supervised";
+      if (input.placement.type === "new_worktree" && protectedMutationNeedsApproval) {
+        this.threads.updateStatus(threadId, "paused");
+        const approvalId = this.approvals.create({
+          threadId,
+          workspaceId: input.workspaceId,
+          prompt: input.prompt,
+          execution: execution.value,
+          placement: input.placement,
+        });
+        broadcast("permission.request", {
+          requestId: approvalId,
+          threadId,
+          toolName: "thread_create_batch",
+          title: "Create a new worktree",
+          input: {
+            workspaceId: input.workspaceId,
+            placement: input.placement,
+            execution: execution.value,
+          },
+        });
+        return {
+          index,
+          status: "pending_approval",
+          workspaceId: input.workspaceId,
+          threadId,
+          approvalId,
+          execution: execution.value,
+          requestedPlacement: input.placement,
+          state: { status: "waiting_for_approval", approvalId },
+        };
+      }
+
+      let placement: ResolvedPlacement;
+      if (input.placement.type === "new_worktree") {
+        const provisioned = await this.threadService.provisionWorktree(
+          threadId,
+          input.workspaceId,
+          input.placement,
+        );
+        const registered = this.registerProvisionedWorktree(
+          input.workspaceId,
+          provisioned,
+          input.placement,
+        );
+        placement = {
+          ...input.placement,
+          worktreeId: registered.worktreeId,
+        };
+      } else {
+        placement = input.placement;
+      }
+
+      const turnId = randomUUID();
+      await this.startTurn(threadId, input.prompt, execution.value, turnId);
+      return {
+        index,
+        status: "created",
+        workspaceId: input.workspaceId,
+        threadId,
+        turnId,
+        execution: execution.value,
+        placement,
+        state: { status: "starting" },
+      };
+    } catch {
+      if (!threadId) {
+        return {
+          index,
+          status: "rejected",
+          workspaceId: input.workspaceId,
+          error: this.error("internal_error", "Thread creation failed", true),
+        };
+      }
+      this.threads.updateStatus(threadId, "errored");
+      return {
+        index,
+        status: "failed",
+        workspaceId: input.workspaceId,
+        threadId,
+        error: this.error("internal_error", "Thread creation failed", true),
+        state: { status: "failed" },
+      };
+    }
+  }
+
+  private async resolveExecution(
+    authority: ThreadControlAuthority,
+    input: ThreadCreateInput,
+  ): Promise<{ value: ResolvedExecution } | { error: ThreadControlError }> {
+    const settings = this.settings.get();
+    if (
+      authority.type === "external"
+      && input.permissionMode === "full"
+      && !authority.scopes.includes("execution:full")
+    ) {
+      return {
+        error: this.error("forbidden", "Full execution is not permitted", false),
+      };
+    }
+    const providerId = input.providerId ?? settings.model.defaults.provider;
+    try {
+      this.providers.resolve(providerId as ProviderId);
+    } catch {
+      return { error: this.error("invalid_provider", "Provider is not available", false) };
+    }
+
+    const modelId = input.modelId ?? settings.model.defaults.id;
+    let models;
+    try {
+      models = await this.models.listModels(providerId);
+    } catch {
+      return { error: this.error("internal_error", "Provider model discovery failed", true) };
+    }
+    if (!models.some((model) => model.id === modelId && model.policy?.state !== "disabled")) {
+      return {
+        error: this.error(
+          "invalid_model",
+          "Model is not available for the selected provider",
+          false,
+        ),
+      };
+    }
+
+    const permissionMode = input.permissionMode ?? (
+      authority.type === "external" && !authority.scopes.includes("execution:full")
+        ? "supervised"
+        : settings.agent.defaults.permission
+    );
+
+    return {
+      value: {
+        providerId,
+        modelId,
+        permissionMode,
+        interactionMode: input.interactionMode ?? "build",
+      },
+    };
+  }
+
+  private async persistThread(
+    input: ThreadCreateInput,
+    execution: ResolvedExecution,
+    existingWorktree: InternalRegisteredWorktree | null,
+  ): Promise<{ threadId: string }> {
+    let branch: string;
+    let mode: "direct" | "worktree";
+    let managed = true;
+    let checkoutState: "named" | "branchless" = "named";
+    let baseBranch: string | null = null;
+
+    if (input.placement.type === "direct") {
+      mode = "direct";
+      branch = await this.git.getCurrentBranch(input.workspaceId).catch(() => null) ?? "HEAD";
+    } else if (input.placement.type === "new_worktree") {
+      mode = "worktree";
+      branch = input.placement.branchName ?? input.placement.baseRef;
+      checkoutState = input.placement.branchName ? "named" : "branchless";
+      baseBranch = input.placement.branchName ? null : input.placement.baseRef;
+    } else {
+      mode = "worktree";
+      managed = false;
+      branch = this.existingWorktreeBranch(existingWorktree!)!;
+      checkoutState = existingWorktree!.branch === "(detached)" ? "branchless" : "named";
+      baseBranch = checkoutState === "branchless" ? existingWorktree!.baseRef ?? null : null;
+    }
+
+    const thread = this.threads.create(
+      input.workspaceId,
+      input.title,
+      mode,
+      branch,
+      managed,
+      execution.providerId,
+      undefined,
+      checkoutState,
+      baseBranch,
+    );
+    this.threads.updateModel(thread.id, execution.modelId);
+    this.threads.updateSettings(thread.id, {
+      permission_mode: execution.permissionMode,
+      interaction_mode: execution.interactionMode,
+    });
+    if (existingWorktree) {
+      this.threads.updateWorktreePath(thread.id, existingWorktree.canonicalPath);
+    }
+    return { threadId: thread.id };
+  }
+
+  private existingWorktreeBranch(worktree: InternalRegisteredWorktree): string | undefined {
+    return worktree.branch && worktree.branch !== "(detached)"
+      ? worktree.branch
+      : worktree.baseRef;
+  }
+
+  private registerProvisionedWorktree(
+    workspaceId: string,
+    thread: { id: string; worktree_path?: string | null },
+    placement: Extract<ThreadCreateInput["placement"], { type: "new_worktree" }>,
+  ) {
+    if (!thread.worktree_path) {
+      throw new Error("Provisioned worktree path was not persisted");
+    }
+    return this.worktrees.register(workspaceId, {
+      canonicalPath: thread.worktree_path,
+      label: placement.branchName ?? placement.baseRef,
+      branch: placement.branchName,
+      baseRef: placement.branchName ? undefined : placement.baseRef,
+      managed: true,
+    });
+  }
+
+  private async startTurn(
+    threadId: string,
+    prompt: string,
+    execution: ResolvedExecution,
+    sourceTurnId: string,
+  ): Promise<void> {
+    await this.agentService.sendMessage({
+      threadId,
+      content: prompt,
+      provider: execution.providerId as ProviderId,
+      model: execution.modelId,
+      permissionMode: execution.permissionMode,
+      interactionMode: execution.interactionMode,
+      sourceTurnId,
+    });
+  }
+
+  private error(
+    code: ThreadControlError["code"],
+    message: string,
+    retryable: boolean,
+  ): ThreadControlError {
+    return { code, message, retryable };
+  }
+
+  private externalItemCanCreate(
+    authority: ExternalThreadControlAuthority,
+    input: ThreadCreateInput,
+  ): boolean {
+    return authority.allowedWorkspaceIds.includes(input.workspaceId)
+      && authority.scopes.includes("threads:create")
+      && (
+        input.placement.type !== "new_worktree"
+        || authority.scopes.includes("worktrees:create")
+      );
+  }
+
+  private async reserveExternalCapacity(
+    authority: ExternalThreadControlAuthority,
+    input: ThreadCreateBatchInput,
+  ): Promise<boolean[]> {
+    return this.withCapacityLock(() => {
+      const persisted = this.threads.countActiveByIntegration(authority.integrationId);
+      let available = Math.max(
+        0,
+        authority.limits.maxActiveThreads
+          - persisted
+          - (this.externalReservations.get(authority.integrationId) ?? 0),
+      );
+      const reservations = input.items.map((item) => {
+        if (!this.externalItemCanCreate(authority, item) || available === 0) return false;
+        available -= 1;
+        return true;
+      });
+      const reservedCount = reservations.filter(Boolean).length;
+      if (reservedCount > 0) {
+        this.externalReservations.set(
+          authority.integrationId,
+          (this.externalReservations.get(authority.integrationId) ?? 0) + reservedCount,
+        );
+      }
+      return reservations;
+    });
+  }
+
+  private async releaseExternalReservation(integrationId: string): Promise<void> {
+    await this.withCapacityLock(() => {
+      const remaining = (this.externalReservations.get(integrationId) ?? 1) - 1;
+      if (remaining > 0) this.externalReservations.set(integrationId, remaining);
+      else this.externalReservations.delete(integrationId);
+    });
+  }
+
+  private async withCapacityLock<T>(operation: () => T): Promise<T> {
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const previous = this.capacityTail;
+    this.capacityTail = next;
+    await previous;
+    try {
+      return operation();
+    } finally {
+      release();
+    }
   }
 }

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -150,22 +150,22 @@ export class ThreadControlService {
     }
 
     try {
-      this.approvals.setOperationPhase(requestId, "provisioning");
+      this.requirePhase(requestId, "provisioning");
       const provisioned = await this.threadService.provisionWorktree(
         pending.threadId,
         pending.workspaceId,
         pending.placement,
       );
       this.registerProvisionedWorktree(pending.workspaceId, provisioned, pending.placement);
-      this.approvals.setOperationPhase(requestId, "provisioned");
-      this.approvals.setOperationPhase(requestId, "dispatching");
+      this.requirePhase(requestId, "provisioned");
+      this.requirePhase(requestId, "dispatching");
       await this.startTurn(
         pending.threadId,
         pending.prompt,
         pending.execution,
         pending.turnId,
       );
-      this.approvals.setOperationPhase(requestId, "dispatched");
+      this.requirePhase(requestId, "dispatched");
       this.approvals.settle(requestId, "approved");
       this.audit.write({ callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "resumed-approved" });
       broadcast("permission.resolved", { requestId, decision });
@@ -189,10 +189,13 @@ export class ThreadControlService {
   recoverApprovals(): void {
     for (const approval of this.approvals.listProcessing()) {
       if (approval.operationPhase === "pre_provision") {
-        this.approvals.requeue(approval.approvalId);
+        if (this.approvals.requeue(approval.approvalId)) {
+          this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome: "recovery-requeued" });
+        }
         continue;
       }
       this.approvals.settle(approval.approvalId, "failed");
+      this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome: "recovery-failed" });
       this.threads.updateStatus(approval.threadId, "errored");
       broadcast("thread.status", { threadId: approval.threadId, status: "errored" });
     }
@@ -546,6 +549,12 @@ export class ThreadControlService {
       interactionMode: execution.interactionMode,
       sourceTurnId,
     });
+  }
+
+  private requirePhase(approvalId: string, phase: "pre_provision" | "provisioning" | "provisioned" | "dispatching" | "dispatched"): void {
+    if (!this.approvals.setOperationPhase(approvalId, phase)) {
+      throw new Error(`Could not persist approval phase: ${phase}`);
+    }
   }
 
   private error(

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -146,7 +146,10 @@ export class ThreadControlService {
     if (decision === "deny" || decision === "cancelled") {
       this.approvals.settle(requestId, "rejected");
       this.threads.updateStatus(pending.threadId, "errored");
-      this.audit.write({ callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "denied" });
+      this.writeAudit(
+        { callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "denied" },
+        { approvalId: requestId, threadId: pending.threadId },
+      );
       broadcast("permission.resolved", { requestId, decision });
       broadcast("thread.status", { threadId: pending.threadId, status: "errored" });
       return true;
@@ -170,7 +173,10 @@ export class ThreadControlService {
       );
       this.requirePhase(requestId, "dispatched");
       this.approvals.settle(requestId, "approved");
-      this.audit.write({ callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "resumed-approved" });
+      this.writeAudit(
+        { callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "resumed-approved" },
+        { approvalId: requestId, threadId: pending.threadId },
+      );
       broadcast("permission.resolved", { requestId, decision });
       broadcast("thread.status", { threadId: pending.threadId, status: "active" });
       return true;
@@ -181,7 +187,10 @@ export class ThreadControlService {
         error: String(error),
       });
       this.approvals.settle(requestId, "failed");
-      this.audit.write({ callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "resumed-failed" });
+      this.writeAudit(
+        { callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "resumed-failed" },
+        { approvalId: requestId, threadId: pending.threadId },
+      );
       this.threads.updateStatus(pending.threadId, "errored");
       broadcast("permission.resolved", { requestId, decision });
       broadcast("thread.status", { threadId: pending.threadId, status: "errored" });
@@ -442,14 +451,18 @@ export class ThreadControlService {
   }
 
   private auditCreateResult(authority: ThreadControlAuthority, result: ThreadCreateItemResult): void {
-    this.audit.write({
-      callerId: authority.type === "internal" ? authority.userId : authority.integrationId,
-      ...(authority.type === "internal" ? { sourceThreadId: authority.sourceThreadId } : {}),
-      workspaceId: result.workspaceId,
-      ...("threadId" in result ? { threadId: result.threadId } : {}),
-      operation: "thread_create_batch",
-      outcome: result.status,
-    });
+    const threadId = "threadId" in result ? result.threadId : undefined;
+    this.writeAudit(
+      {
+        callerId: authority.type === "internal" ? authority.userId : authority.integrationId,
+        ...(authority.type === "internal" ? { sourceThreadId: authority.sourceThreadId } : {}),
+        workspaceId: result.workspaceId,
+        ...(threadId ? { threadId } : {}),
+        operation: "thread_create_batch",
+        outcome: result.status,
+      },
+      threadId ? { threadId } : {},
+    );
   }
 
   private async resolveExecution(
@@ -625,13 +638,20 @@ export class ThreadControlService {
     approval: Pick<RecoverableThreadCreateApproval, "approvalId" | "threadId" | "workspaceId" | "callerId" | "sourceThreadId">,
     outcome: "recovery-failed" | "recovery-requeued",
   ): void {
+    this.writeAudit(
+      { callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome },
+      { approvalId: approval.approvalId, threadId: approval.threadId },
+    );
+  }
+
+  private writeAudit(
+    input: { callerId: string; sourceThreadId?: string; workspaceId?: string; threadId?: string; operation: string; outcome: string },
+    identity: { approvalId?: string; threadId?: string },
+  ): void {
     try {
-      this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome });
+      this.audit.write(input);
     } catch {
-      logger.error("Could not audit recovered approval", {
-        approvalId: approval.approvalId,
-        threadId: approval.threadId,
-      });
+      logger.error("Thread-control audit write failed", identity);
     }
   }
 

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -32,7 +32,10 @@ import { delay, inject, injectable } from "tsyringe";
 import { WorkspaceRepo } from "../repositories/workspace-repo.js";
 import { WorktreeRepo, type InternalRegisteredWorktree } from "../repositories/worktree-repo.js";
 import { ThreadRepo } from "../repositories/thread-repo.js";
-import { ThreadControlApprovalRepo, type PendingThreadCreateApproval } from "../repositories/thread-control-approval-repo.js";
+import {
+  ThreadControlApprovalRepo,
+  type RecoverableThreadCreateApproval,
+} from "../repositories/thread-control-approval-repo.js";
 import { ThreadControlAuditRepo } from "../repositories/thread-control-audit-repo.js";
 import { ProviderRegistry } from "../providers/provider-registry.js";
 import { AgentService } from "./agent-service.js";
@@ -169,6 +172,7 @@ export class ThreadControlService {
       this.approvals.settle(requestId, "approved");
       this.audit.write({ callerId: pending.callerId, sourceThreadId: pending.sourceThreadId, workspaceId: pending.workspaceId, threadId: pending.threadId, operation: "thread_create_batch", outcome: "resumed-approved" });
       broadcast("permission.resolved", { requestId, decision });
+      broadcast("thread.status", { threadId: pending.threadId, status: "active" });
       return true;
     } catch (error) {
       logger.error("Delegated thread approval failed", {
@@ -188,40 +192,57 @@ export class ThreadControlService {
   /** Restore stranded approvals without replaying an ambiguous external side effect. */
   async recoverApprovals(): Promise<void> {
     for (const approval of this.approvals.listProcessing()) {
-      if (approval.operationPhase === "pre_provision") {
-        if (this.approvals.requeue(approval.approvalId)) {
-          this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome: "recovery-requeued" });
-        }
-        continue;
+      try {
+        await this.recoverApproval(approval);
+      } catch {
+        logger.error("Thread-control approval recovery item failed", {
+          approvalId: approval.approvalId,
+          threadId: approval.threadId,
+        });
+        this.failRecovery(approval);
       }
-      if (approval.operationPhase === "provisioning") {
-        try {
-          const cleaned = await this.threadService.cleanupInterruptedProvisioning(
-            approval.threadId,
-            approval.workspaceId,
-            approval.placement,
-          );
-          if (!cleaned) {
-            this.failRecovery(approval);
-            continue;
-          }
-        } catch {
-          this.failRecovery(approval);
-          continue;
-        }
-        if (
-          this.threads.clearWorktreePath(approval.threadId)
-          && this.threads.updateStatus(approval.threadId, "paused")
-          && this.approvals.requeueRecoveredProvisioning(approval.approvalId)
-        ) {
-          this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome: "recovery-requeued" });
-        } else {
-          this.failRecovery(approval);
-        }
-        continue;
-      }
-      this.failRecovery(approval);
     }
+  }
+
+  private async recoverApproval(approval: RecoverableThreadCreateApproval): Promise<void> {
+    if ("invalid" in approval) {
+      logger.error("Thread-control approval payload is invalid during recovery", {
+        approvalId: approval.approvalId,
+        threadId: approval.threadId,
+      });
+      this.failRecovery(approval);
+      return;
+    }
+    if (approval.operationPhase === "pre_provision") {
+      if (!this.approvals.requeue(approval.approvalId)) {
+        this.failRecovery(approval);
+        return;
+      }
+      this.writeRecoveryAudit(approval, "recovery-requeued");
+      return;
+    }
+    if (approval.operationPhase === "provisioning") {
+      const cleaned = await this.threadService.cleanupInterruptedProvisioning(
+        approval.threadId,
+        approval.workspaceId,
+        approval.placement,
+      );
+      if (!cleaned) {
+        this.failRecovery(approval);
+        return;
+      }
+      if (
+        this.threads.clearWorktreePath(approval.threadId)
+        && this.threads.updateStatus(approval.threadId, "paused")
+        && this.approvals.requeueRecoveredProvisioning(approval.approvalId)
+      ) {
+        this.writeRecoveryAudit(approval, "recovery-requeued");
+      } else {
+        this.failRecovery(approval);
+      }
+      return;
+    }
+    this.failRecovery(approval);
   }
 
   /** Return durable thread-control approvals for frontend rehydration. */
@@ -580,15 +601,38 @@ export class ThreadControlService {
     }
   }
 
-  private failRecovery(approval: PendingThreadCreateApproval): void {
-    if (!this.approvals.settle(approval.approvalId, "failed")) {
-      throw new Error(`Could not fail recovered approval: ${approval.approvalId}`);
+  private failRecovery(approval: Pick<RecoverableThreadCreateApproval, "approvalId" | "threadId" | "workspaceId" | "callerId" | "sourceThreadId">): void {
+    const identity = { approvalId: approval.approvalId, threadId: approval.threadId };
+    try {
+      if (!this.approvals.settle(approval.approvalId, "failed")) {
+        logger.error("Could not fail recovered approval", identity);
+      }
+    } catch {
+      logger.error("Could not fail recovered approval", identity);
     }
-    if (!this.threads.updateStatus(approval.threadId, "errored")) {
-      throw new Error(`Could not mark recovered thread errored: ${approval.threadId}`);
+    try {
+      if (!this.threads.updateStatus(approval.threadId, "errored")) {
+        logger.error("Could not mark recovered thread errored", identity);
+      }
+    } catch {
+      logger.error("Could not mark recovered thread errored", identity);
     }
-    this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome: "recovery-failed" });
+    this.writeRecoveryAudit(approval, "recovery-failed");
     broadcast("thread.status", { threadId: approval.threadId, status: "errored" });
+  }
+
+  private writeRecoveryAudit(
+    approval: Pick<RecoverableThreadCreateApproval, "approvalId" | "threadId" | "workspaceId" | "callerId" | "sourceThreadId">,
+    outcome: "recovery-failed" | "recovery-requeued",
+  ): void {
+    try {
+      this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome });
+    } catch {
+      logger.error("Could not audit recovered approval", {
+        approvalId: approval.approvalId,
+        threadId: approval.threadId,
+      });
+    }
   }
 
   private error(

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -32,7 +32,7 @@ import { delay, inject, injectable } from "tsyringe";
 import { WorkspaceRepo } from "../repositories/workspace-repo.js";
 import { WorktreeRepo, type InternalRegisteredWorktree } from "../repositories/worktree-repo.js";
 import { ThreadRepo } from "../repositories/thread-repo.js";
-import { ThreadControlApprovalRepo } from "../repositories/thread-control-approval-repo.js";
+import { ThreadControlApprovalRepo, type PendingThreadCreateApproval } from "../repositories/thread-control-approval-repo.js";
 import { ThreadControlAuditRepo } from "../repositories/thread-control-audit-repo.js";
 import { ProviderRegistry } from "../providers/provider-registry.js";
 import { AgentService } from "./agent-service.js";
@@ -186,7 +186,7 @@ export class ThreadControlService {
   }
 
   /** Restore stranded approvals without replaying an ambiguous external side effect. */
-  recoverApprovals(): void {
+  async recoverApprovals(): Promise<void> {
     for (const approval of this.approvals.listProcessing()) {
       if (approval.operationPhase === "pre_provision") {
         if (this.approvals.requeue(approval.approvalId)) {
@@ -194,10 +194,33 @@ export class ThreadControlService {
         }
         continue;
       }
-      this.approvals.settle(approval.approvalId, "failed");
-      this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome: "recovery-failed" });
-      this.threads.updateStatus(approval.threadId, "errored");
-      broadcast("thread.status", { threadId: approval.threadId, status: "errored" });
+      if (approval.operationPhase === "provisioning") {
+        try {
+          const cleaned = await this.threadService.cleanupInterruptedProvisioning(
+            approval.threadId,
+            approval.workspaceId,
+            approval.placement,
+          );
+          if (!cleaned) {
+            this.failRecovery(approval);
+            continue;
+          }
+        } catch {
+          this.failRecovery(approval);
+          continue;
+        }
+        if (
+          this.threads.clearWorktreePath(approval.threadId)
+          && this.threads.updateStatus(approval.threadId, "paused")
+          && this.approvals.requeueRecoveredProvisioning(approval.approvalId)
+        ) {
+          this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome: "recovery-requeued" });
+        } else {
+          this.failRecovery(approval);
+        }
+        continue;
+      }
+      this.failRecovery(approval);
     }
   }
 
@@ -555,6 +578,17 @@ export class ThreadControlService {
     if (!this.approvals.setOperationPhase(approvalId, phase)) {
       throw new Error(`Could not persist approval phase: ${phase}`);
     }
+  }
+
+  private failRecovery(approval: PendingThreadCreateApproval): void {
+    if (!this.approvals.settle(approval.approvalId, "failed")) {
+      throw new Error(`Could not fail recovered approval: ${approval.approvalId}`);
+    }
+    if (!this.threads.updateStatus(approval.threadId, "errored")) {
+      throw new Error(`Could not mark recovered thread errored: ${approval.threadId}`);
+    }
+    this.audit.write({ callerId: approval.callerId, sourceThreadId: approval.sourceThreadId, workspaceId: approval.workspaceId, threadId: approval.threadId, operation: "thread_create_batch", outcome: "recovery-failed" });
+    broadcast("thread.status", { threadId: approval.threadId, status: "errored" });
   }
 
   private error(

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -176,6 +176,19 @@ export class ThreadService {
     };
   }
 
+  /** Remove only the deterministic managed worktree for an interrupted provisioning approval. */
+  async cleanupInterruptedProvisioning(
+    threadId: string,
+    workspaceId: string,
+    placement: { baseRef: string; branchName?: string },
+  ): Promise<boolean> {
+    const workspace = this.workspaceRepo.findById(workspaceId);
+    if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
+    const ref = placement.branchName ?? placement.baseRef;
+    const name = `${sanitizeBranchForFolder(ref).slice(0, 91)}-${threadId.slice(0, 8)}`;
+    return this.gitService.removeWorktree(workspace.path, name, { deleteBranch: false });
+  }
+
   /**
    * Create a named branch in a thread's resolved checkout and persist the named checkout state.
    */

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -130,6 +130,52 @@ export class ThreadService {
     return thread;
   }
 
+  /** Provision a new worktree for an already-persisted delegated thread. */
+  async provisionWorktree(
+    threadId: string,
+    workspaceId: string,
+    placement: { baseRef: string; branchName?: string },
+  ): Promise<Thread & { warnings?: string[] }> {
+    const thread = this.threadRepo.findById(threadId);
+    if (!thread || thread.workspace_id !== workspaceId || thread.mode !== "worktree") {
+      throw new Error("Delegated worktree thread is not available for provisioning");
+    }
+    if (thread.worktree_path) {
+      throw new Error("Delegated worktree thread is already provisioned");
+    }
+    validateBranchName(placement.baseRef);
+    if (placement.branchName) validateBranchName(placement.branchName);
+    const workspace = this.workspaceRepo.findById(workspaceId);
+    if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
+
+    const worktreeRef = placement.branchName ?? placement.baseRef;
+    const shortId = thread.id.slice(0, 8);
+    const sanitized = sanitizeBranchForFolder(worktreeRef).slice(0, 91);
+    const worktreeName = `${sanitized}-${shortId}`;
+    const info = await this.gitService.createWorktree(
+      workspace.path,
+      worktreeName,
+      worktreeRef,
+      {
+        branchless: placement.branchName === undefined,
+        ...(placement.branchName ? { baseRef: placement.baseRef } : {}),
+      },
+    );
+    const updated = this.threadRepo.updateWorktreePath(thread.id, info.path);
+    if (!updated) {
+      await this.gitService.removeWorktree(workspace.path, worktreeName, {
+        ...(info.createdBranch ? { branchName: worktreeRef } : { deleteBranch: false }),
+      });
+      throw new Error(`Failed to persist worktree path for thread ${thread.id}`);
+    }
+    this.threadRepo.updateStatus(thread.id, "active");
+    return {
+      ...thread,
+      worktree_path: info.path,
+      warnings: info.warnings.length > 0 ? info.warnings : undefined,
+    };
+  }
+
   /**
    * Create a named branch in a thread's resolved checkout and persist the named checkout state.
    */

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -14,6 +14,10 @@ import { CleanupJobRepo } from "../repositories/cleanup-job-repo";
 import { AttachmentService } from "./attachment-service";
 import { HandoffStorage } from "./handoff/handoff-storage.js";
 
+function managedWorktreeName(ref: string, threadId: string): string {
+  return `${sanitizeBranchForFolder(ref).slice(0, 91)}-${threadId.slice(0, 8)}`;
+}
+
 /** Handles thread creation, deletion, worktree provisioning, and lifecycle. */
 @injectable()
 export class ThreadService {
@@ -67,11 +71,7 @@ export class ThreadService {
       }
 
       try {
-        const shortId = thread.id.slice(0, 8);
-        // Truncate to 91 chars so the full name (prefix + "-" + 8-char id) stays within
-        // the 100-character limit enforced by validateWorktreeName.
-        const sanitized = sanitizeBranchForFolder(branch).slice(0, 91);
-        const worktreeName = `${sanitized}-${shortId}`;
+        const worktreeName = managedWorktreeName(branch, thread.id);
         const info = await this.gitService.createWorktree(
           workspace.path,
           worktreeName,
@@ -149,9 +149,7 @@ export class ThreadService {
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
 
     const worktreeRef = placement.branchName ?? placement.baseRef;
-    const shortId = thread.id.slice(0, 8);
-    const sanitized = sanitizeBranchForFolder(worktreeRef).slice(0, 91);
-    const worktreeName = `${sanitized}-${shortId}`;
+    const worktreeName = managedWorktreeName(worktreeRef, thread.id);
     const info = await this.gitService.createWorktree(
       workspace.path,
       worktreeName,
@@ -185,7 +183,7 @@ export class ThreadService {
     const workspace = this.workspaceRepo.findById(workspaceId);
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`);
     const ref = placement.branchName ?? placement.baseRef;
-    const name = `${sanitizeBranchForFolder(ref).slice(0, 91)}-${threadId.slice(0, 8)}`;
+    const name = managedWorktreeName(ref, threadId);
     return this.gitService.removeWorktree(workspace.path, name, { deleteBranch: false });
   }
 

--- a/apps/server/src/services/thread-service.ts
+++ b/apps/server/src/services/thread-service.ts
@@ -176,7 +176,7 @@ export class ThreadService {
     };
   }
 
-  /** Remove only the deterministic managed worktree for an interrupted provisioning approval. */
+  /** Idempotently remove only the deterministic managed worktree for interrupted provisioning. */
   async cleanupInterruptedProvisioning(
     threadId: string,
     workspaceId: string,

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -126,6 +126,8 @@ export const threadControlApprovals = sqliteTable(
     executionJson: text("execution_json").notNull(),
     placementJson: text("placement_json").notNull(),
     turnId: text("turn_id").notNull(),
+    callerId: text("caller_id"),
+    sourceThreadId: text("source_thread_id"),
     operationPhase: text("operation_phase").notNull().default("pre_provision"),
     status: text("status").notNull().default("pending"),
     processingStartedAt: text("processing_started_at"),

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -115,6 +115,25 @@ export const threads = sqliteTable(
   ],
 );
 
+/** Durable human approvals for protected delegated-thread creation mutations. */
+export const threadControlApprovals = sqliteTable(
+  "thread_control_approvals",
+  {
+    id: text("id").primaryKey().notNull(),
+    threadId: text("thread_id").notNull().references(() => threads.id, { onDelete: "cascade" }),
+    workspaceId: text("workspace_id").notNull().references(() => workspaces.id, { onDelete: "cascade" }),
+    prompt: text("prompt").notNull(),
+    executionJson: text("execution_json").notNull(),
+    placementJson: text("placement_json").notNull(),
+    status: text("status").notNull().default("pending"),
+    createdAt: text("created_at").notNull().default(timestampDefault),
+    resolvedAt: text("resolved_at"),
+  },
+  (table) => [
+    index("idx_thread_control_approvals_thread").on(table.threadId, table.status),
+  ],
+);
+
 export const pullRequestReviewLinks = sqliteTable(
   "pull_request_review_links",
   {

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -125,13 +125,32 @@ export const threadControlApprovals = sqliteTable(
     prompt: text("prompt").notNull(),
     executionJson: text("execution_json").notNull(),
     placementJson: text("placement_json").notNull(),
+    turnId: text("turn_id").notNull(),
+    operationPhase: text("operation_phase").notNull().default("pre_provision"),
     status: text("status").notNull().default("pending"),
+    processingStartedAt: text("processing_started_at"),
     createdAt: text("created_at").notNull().default(timestampDefault),
     resolvedAt: text("resolved_at"),
   },
   (table) => [
     index("idx_thread_control_approvals_thread").on(table.threadId, table.status),
   ],
+);
+
+/** Bounded lifecycle records for thread-control operations. */
+export const threadControlAudit = sqliteTable(
+  "thread_control_audit",
+  {
+    id: text("id").primaryKey().notNull(),
+    callerId: text("caller_id").notNull(),
+    sourceThreadId: text("source_thread_id"),
+    workspaceId: text("workspace_id"),
+    threadId: text("thread_id"),
+    operation: text("operation").notNull(),
+    outcome: text("outcome").notNull(),
+    createdAt: text("created_at").notNull().default(timestampDefault),
+  },
+  (table) => [index("idx_thread_control_audit_thread").on(table.threadId, table.createdAt)],
 );
 
 export const pullRequestReviewLinks = sqliteTable(

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -28,6 +28,7 @@ import { discoverCopilotAgents } from "../providers/copilot/copilot-agent-discov
 import type { WorkspaceService } from "../services/workspace-service";
 import type { ThreadService } from "../services/thread-service";
 import type { AgentService } from "../services/agent-service";
+import type { ThreadControlService } from "../services/thread-control-service";
 import type { GitService } from "../services/git-service";
 import type { GithubService } from "../services/github-service";
 import type { FileService } from "../services/file-service";
@@ -148,6 +149,8 @@ export interface RouterDeps {
   workspaceService: WorkspaceService;
   threadService: ThreadService;
   agentService: AgentService;
+  /** Owns durable approvals for protected delegated-thread mutations. */
+  threadControlService: ThreadControlService;
   gitService: GitService;
   githubService: GithubService;
   fileService: FileService;
@@ -1399,12 +1402,18 @@ async function dispatch(
 
     // Permission
     case "permission.respond": {
+      if (await deps.threadControlService.respondToApproval(params.requestId, params.decision)) {
+        return;
+      }
       deps.agentService.respondToPermission(params.requestId, params.decision);
       // broadcast is handled by the provider's "permission_resolved" event → index.ts listener
       return;
     }
     case "permission.listPending":
-      return deps.agentService.listPendingPermissions(params.threadId);
+      return [
+        ...deps.threadControlService.listPendingApprovals(params.threadId),
+        ...deps.agentService.listPendingPermissions(params.threadId),
+      ];
 
     case "handoff.regenerate":
       // v1 stub; live regeneration is deferred to a follow-on plan.

--- a/packages/contracts/src/__tests__/thread-control.test.ts
+++ b/packages/contracts/src/__tests__/thread-control.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  THREAD_CREATE_BATCH_MAX_ITEMS,
+  THREAD_CREATE_PROMPT_MAX_LENGTH,
+  ThreadCreateBatchInputSchema,
+  ThreadCreateBatchResultSchema,
   WORKSPACE_SEARCH_LIMIT_DEFAULT,
   WorkspaceSearchInputSchema,
   WorktreeListInputSchema,
@@ -17,6 +21,97 @@ describe("thread control discovery schemas", () => {
     expect(WorktreeListInputSchema().safeParse({ workspaceId: "workspace", path: "C:/secret" }).success).toBe(false);
     expect(WorktreeListResultSchema().safeParse({
       status: "found", workspaceId: "workspace", worktrees: [{ worktreeId: "worktree", label: "main", path: "C:/secret" }],
+    }).success).toBe(false);
+  });
+});
+
+describe("thread_create_batch schemas", () => {
+  const item = {
+    workspaceId: "workspace",
+    title: "Implement issue #960",
+    prompt: "Implement the issue.",
+    placement: { type: "direct" as const },
+  };
+
+  it("accepts one to twenty ordered creation items and rejects authority fields", () => {
+    expect(ThreadCreateBatchInputSchema().parse({ items: [item] })).toEqual({ items: [item] });
+    expect(ThreadCreateBatchInputSchema().safeParse({ items: [] }).success).toBe(false);
+    expect(ThreadCreateBatchInputSchema().safeParse({
+      items: Array.from({ length: THREAD_CREATE_BATCH_MAX_ITEMS + 1 }, () => item),
+    }).success).toBe(false);
+    expect(ThreadCreateBatchInputSchema().safeParse({
+      items: [{ ...item, sourceThreadId: "forged" }],
+    }).success).toBe(false);
+  });
+
+  it("bounds text and accepts every placement and explicit override", () => {
+    expect(ThreadCreateBatchInputSchema().safeParse({
+      items: [{
+        ...item,
+        prompt: "x".repeat(THREAD_CREATE_PROMPT_MAX_LENGTH),
+        placement: { type: "new_worktree", baseRef: "main", branchName: "codex/issue-960" },
+        providerId: "codex",
+        modelId: "gpt-5.6-sol",
+        permissionMode: "supervised",
+        interactionMode: "plan",
+      }],
+    }).success).toBe(true);
+    expect(ThreadCreateBatchInputSchema().safeParse({
+      items: [{ ...item, placement: { type: "existing_worktree", worktreeId: "worktree" } }],
+    }).success).toBe(true);
+    expect(ThreadCreateBatchInputSchema().safeParse({
+      items: [{ ...item, prompt: "x".repeat(THREAD_CREATE_PROMPT_MAX_LENGTH + 1) }],
+    }).success).toBe(false);
+  });
+
+  it("validates all four ordered result variants without exposing paths", () => {
+    const execution = {
+      providerId: "codex",
+      modelId: "gpt-5.6-sol",
+      permissionMode: "full" as const,
+      interactionMode: "build" as const,
+    };
+    const result = {
+      results: [
+        {
+          index: 0,
+          status: "created" as const,
+          workspaceId: "workspace",
+          threadId: "thread-created",
+          turnId: "turn-created",
+          execution,
+          placement: { type: "direct" as const },
+          state: { status: "starting" as const },
+        },
+        {
+          index: 1,
+          status: "pending_approval" as const,
+          workspaceId: "workspace",
+          threadId: "thread-pending",
+          approvalId: "approval",
+          execution: { ...execution, permissionMode: "supervised" as const },
+          requestedPlacement: { type: "new_worktree" as const, baseRef: "main" },
+          state: { status: "waiting_for_approval" as const, approvalId: "approval" },
+        },
+        {
+          index: 2,
+          status: "failed" as const,
+          workspaceId: "workspace",
+          threadId: "thread-failed",
+          error: { code: "internal_error" as const, message: "Dispatch failed", retryable: true },
+          state: { status: "failed" as const },
+        },
+        {
+          index: 3,
+          status: "rejected" as const,
+          error: { code: "invalid_model" as const, message: "Model unavailable", retryable: false },
+        },
+      ],
+    };
+
+    expect(ThreadCreateBatchResultSchema().parse(result)).toEqual(result);
+    expect(ThreadCreateBatchResultSchema().safeParse({
+      results: [{ ...result.results[0], placement: { type: "direct", path: "C:/secret" } }],
     }).success).toBe(false);
   });
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -40,11 +40,23 @@ export {
   WORKSPACE_SEARCH_QUERY_MAX_LENGTH,
   WORKSPACE_SEARCH_LIMIT_MAX,
   WORKSPACE_SEARCH_LIMIT_DEFAULT,
+  THREAD_CREATE_BATCH_MAX_ITEMS,
+  THREAD_CREATE_TITLE_MAX_LENGTH,
+  THREAD_CREATE_PROMPT_MAX_LENGTH,
+  THREAD_CREATE_EXECUTION_ID_MAX_LENGTH,
+  THREAD_CREATE_GIT_REF_MAX_LENGTH,
   WorkspaceSearchInputSchema,
   WorkspaceSearchResultSchema,
   WorktreeListInputSchema,
   WorktreeListResultSchema,
   ThreadControlErrorSchema,
+  ThreadPlacementSchema,
+  ResolvedExecutionSchema,
+  ResolvedPlacementSchema,
+  ThreadCreateInputSchema,
+  ThreadCreateBatchInputSchema,
+  ThreadCreateItemResultSchema,
+  ThreadCreateBatchResultSchema,
 } from "./thread-control.js";
 export type {
   WorkspaceSearchInput,
@@ -52,6 +64,13 @@ export type {
   WorktreeListInput,
   WorktreeListResult,
   ThreadControlError,
+  ThreadPlacement,
+  ResolvedExecution,
+  ResolvedPlacement,
+  ThreadCreateInput,
+  ThreadCreateBatchInput,
+  ThreadCreateItemResult,
+  ThreadCreateBatchResult,
 } from "./thread-control.js";
 
 export {

--- a/packages/contracts/src/thread-control.ts
+++ b/packages/contracts/src/thread-control.ts
@@ -16,7 +16,7 @@ export const THREAD_CREATE_BATCH_MAX_ITEMS = 20;
 export const THREAD_CREATE_TITLE_MAX_LENGTH = 256;
 /** Maximum characters accepted for a delegated thread's initial prompt. */
 export const THREAD_CREATE_PROMPT_MAX_LENGTH = 100_000;
-/** Maximum characters accepted for provider, model, base-ref, and branch identifiers. */
+/** Maximum characters accepted for provider and model identifiers. */
 export const THREAD_CREATE_EXECUTION_ID_MAX_LENGTH = 128;
 /** Maximum characters accepted for a Git base ref or branch name. */
 export const THREAD_CREATE_GIT_REF_MAX_LENGTH = 250;

--- a/packages/contracts/src/thread-control.ts
+++ b/packages/contracts/src/thread-control.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { lazySchema } from "./utils/lazySchema.js";
+import { InteractionModeSchema, PermissionModeSchema } from "./models/enums.js";
 
 /** Maximum characters accepted for an opaque thread-control identifier. */
 export const THREAD_CONTROL_OPAQUE_ID_MAX_LENGTH = 128;
@@ -9,6 +10,16 @@ export const WORKSPACE_SEARCH_QUERY_MAX_LENGTH = 256;
 export const WORKSPACE_SEARCH_LIMIT_MAX = 50;
 /** Default workspace search result limit. */
 export const WORKSPACE_SEARCH_LIMIT_DEFAULT = 20;
+/** Maximum items accepted by one thread_create_batch request. */
+export const THREAD_CREATE_BATCH_MAX_ITEMS = 20;
+/** Maximum trimmed characters accepted for a delegated thread title. */
+export const THREAD_CREATE_TITLE_MAX_LENGTH = 256;
+/** Maximum characters accepted for a delegated thread's initial prompt. */
+export const THREAD_CREATE_PROMPT_MAX_LENGTH = 100_000;
+/** Maximum characters accepted for provider, model, base-ref, and branch identifiers. */
+export const THREAD_CREATE_EXECUTION_ID_MAX_LENGTH = 128;
+/** Maximum characters accepted for a Git base ref or branch name. */
+export const THREAD_CREATE_GIT_REF_MAX_LENGTH = 250;
 
 const opaqueId = z.string().trim().min(1).max(THREAD_CONTROL_OPAQUE_ID_MAX_LENGTH);
 
@@ -46,7 +57,18 @@ export type WorktreeListInput = z.infer<ReturnType<typeof WorktreeListInputSchem
 /** Public error payload for thread-control discovery operations. */
 export const ThreadControlErrorSchema = lazySchema(() =>
   z.object({
-    code: z.enum(["forbidden", "not_found", "invalid_request", "internal_error"]),
+    code: z.enum([
+      "forbidden",
+      "not_found",
+      "invalid_provider",
+      "invalid_model",
+      "invalid_placement",
+      "thread_busy",
+      "limit_exceeded",
+      "conflict",
+      "invalid_request",
+      "internal_error",
+    ]),
     message: z.string().min(1).max(512),
     retryable: z.boolean(),
     retryAfterSeconds: z.number().int().positive().optional(),
@@ -77,3 +99,137 @@ export const WorktreeListResultSchema = lazySchema(() =>
 );
 /** Internal worktree_list result. */
 export type WorktreeListResult = z.infer<ReturnType<typeof WorktreeListResultSchema>>;
+
+const executionId = z.string().trim().min(1).max(THREAD_CREATE_EXECUTION_ID_MAX_LENGTH);
+const gitRef = z.string().trim().min(1).max(THREAD_CREATE_GIT_REF_MAX_LENGTH);
+
+/** Placement requested for one delegated thread. */
+export const ThreadPlacementSchema = lazySchema(() =>
+  z.discriminatedUnion("type", [
+    z.object({ type: z.literal("direct") }).strict(),
+    z.object({
+      type: z.literal("new_worktree"),
+      baseRef: gitRef,
+      branchName: gitRef.optional(),
+    }).strict(),
+    z.object({
+      type: z.literal("existing_worktree"),
+      worktreeId: opaqueId,
+    }).strict(),
+  ]),
+);
+/** Placement requested for one delegated thread. */
+export type ThreadPlacement = z.infer<ReturnType<typeof ThreadPlacementSchema>>;
+
+/** Resolved provider, model, permission, and interaction settings for a delegated turn. */
+export const ResolvedExecutionSchema = lazySchema(() =>
+  z.object({
+    providerId: executionId,
+    modelId: executionId,
+    permissionMode: PermissionModeSchema,
+    interactionMode: InteractionModeSchema,
+  }).strict(),
+);
+/** Resolved execution settings for a delegated turn. */
+export type ResolvedExecution = z.infer<ReturnType<typeof ResolvedExecutionSchema>>;
+
+/** Server-resolved placement returned without filesystem paths. */
+export const ResolvedPlacementSchema = lazySchema(() =>
+  z.discriminatedUnion("type", [
+    z.object({ type: z.literal("direct") }).strict(),
+    z.object({
+      type: z.literal("new_worktree"),
+      baseRef: gitRef,
+      branchName: gitRef.optional(),
+      worktreeId: opaqueId,
+    }).strict(),
+    z.object({
+      type: z.literal("existing_worktree"),
+      worktreeId: opaqueId,
+    }).strict(),
+  ]),
+);
+/** Server-resolved placement returned without filesystem paths. */
+export type ResolvedPlacement = z.infer<ReturnType<typeof ResolvedPlacementSchema>>;
+
+/** One requested delegated thread and its initial turn. */
+export const ThreadCreateInputSchema = lazySchema(() =>
+  z.object({
+    workspaceId: opaqueId,
+    title: z.string().trim().min(1).max(THREAD_CREATE_TITLE_MAX_LENGTH),
+    prompt: z.string().min(1).max(THREAD_CREATE_PROMPT_MAX_LENGTH),
+    placement: ThreadPlacementSchema(),
+    providerId: executionId.optional(),
+    modelId: executionId.optional(),
+    permissionMode: PermissionModeSchema.optional(),
+    interactionMode: InteractionModeSchema.optional(),
+  }).strict(),
+);
+/** One requested delegated thread and its initial turn. */
+export type ThreadCreateInput = z.infer<ReturnType<typeof ThreadCreateInputSchema>>;
+
+/** Ordered one-to-twenty input accepted by thread_create_batch. */
+export const ThreadCreateBatchInputSchema = lazySchema(() =>
+  z.object({
+    items: z.array(ThreadCreateInputSchema()).min(1).max(THREAD_CREATE_BATCH_MAX_ITEMS),
+  }).strict(),
+);
+/** Ordered thread_create_batch input. */
+export type ThreadCreateBatchInput = z.infer<ReturnType<typeof ThreadCreateBatchInputSchema>>;
+
+/** Result for one item in a thread_create_batch response. */
+export const ThreadCreateItemResultSchema = lazySchema(() =>
+  z.discriminatedUnion("status", [
+    z.object({
+      index: z.number().int().nonnegative(),
+      status: z.literal("created"),
+      workspaceId: opaqueId,
+      threadId: opaqueId,
+      turnId: opaqueId,
+      execution: ResolvedExecutionSchema(),
+      placement: ResolvedPlacementSchema(),
+      state: z.discriminatedUnion("status", [
+        z.object({ status: z.literal("starting") }).strict(),
+        z.object({ status: z.literal("running") }).strict(),
+      ]),
+    }).strict(),
+    z.object({
+      index: z.number().int().nonnegative(),
+      status: z.literal("pending_approval"),
+      workspaceId: opaqueId,
+      threadId: opaqueId,
+      approvalId: opaqueId,
+      execution: ResolvedExecutionSchema(),
+      requestedPlacement: ThreadPlacementSchema(),
+      state: z.object({
+        status: z.literal("waiting_for_approval"),
+        approvalId: opaqueId,
+      }).strict(),
+    }).strict(),
+    z.object({
+      index: z.number().int().nonnegative(),
+      status: z.literal("failed"),
+      workspaceId: opaqueId,
+      threadId: opaqueId,
+      error: ThreadControlErrorSchema(),
+      state: z.object({ status: z.literal("failed") }).strict(),
+    }).strict(),
+    z.object({
+      index: z.number().int().nonnegative(),
+      status: z.literal("rejected"),
+      workspaceId: opaqueId.optional(),
+      error: ThreadControlErrorSchema(),
+    }).strict(),
+  ]),
+);
+/** Result for one item in a thread_create_batch response. */
+export type ThreadCreateItemResult = z.infer<ReturnType<typeof ThreadCreateItemResultSchema>>;
+
+/** Ordered partial-success result emitted by thread_create_batch. */
+export const ThreadCreateBatchResultSchema = lazySchema(() =>
+  z.object({
+    results: z.array(ThreadCreateItemResultSchema()),
+  }).strict(),
+);
+/** Ordered thread_create_batch result. */
+export type ThreadCreateBatchResult = z.infer<ReturnType<typeof ThreadCreateBatchResultSchema>>;

--- a/packages/thread-orchestration/src/index.ts
+++ b/packages/thread-orchestration/src/index.ts
@@ -9,6 +9,37 @@ export interface InternalThreadControlAuthority {
   permissionMode: "supervised" | "full";
 }
 
+/** Operation scopes granted to a paired external thread-control integration. */
+export type ExternalThreadControlScope =
+  | "projects:read"
+  | "worktrees:read"
+  | "threads:create"
+  | "threads:read-owned"
+  | "threads:read-project"
+  | "threads:send-owned"
+  | "threads:send-project"
+  | "threads:stop-owned"
+  | "threads:stop-project"
+  | "worktrees:create"
+  | "execution:full";
+
+/** Server-owned authority for a paired external thread-control integration. */
+export interface ExternalThreadControlAuthority {
+  type: "external";
+  integrationId: string;
+  allowedWorkspaceIds: readonly string[];
+  scopes: readonly ExternalThreadControlScope[];
+  limits: {
+    callsPerMinute: number;
+    maxActiveThreads: number;
+  };
+}
+
+/** Server-owned authority accepted by the shared thread-control service. */
+export type ThreadControlAuthority =
+  | InternalThreadControlAuthority
+  | ExternalThreadControlAuthority;
+
 /** Lineage written when a thread is created through delegation. */
 export interface ThreadDelegationLineage {
   coordinatorThreadId: string;


### PR DESCRIPTION
## What
Adds batched delegated thread creation for issue #960.

## Why
Allows authorized callers to create multiple delegated threads with durable approval, restart recovery, idempotent worktree cleanup, and audit records.

## Key Changes
- Adds thread_create_batch contracts and service orchestration.
- Persists approval phases and stable turn identifiers.
- Recovers interrupted approvals safely after restart.
- Audits approval and item outcomes without prompts, secrets, or paths.
- Adds focused recovery, audit, idempotency, DI, and capacity coverage.

## Verification
- Focused recovery suite: 32/32 passed.
- Idempotency suite: 37/37 passed.
- Live canonical orphan and already-absent restart recovery: passed.
- High-risk reviewer: recommend release.
- bun run verify: typecheck and lint passed; parallel unit run 2009/2013 with 4 unrelated Windows timing/process failures; serial rerun of affected files 35/35 passed.

Closes #960

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787699593&installation_model_id=20477&pr_number=971&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F971&signature=40003ac03eaeb174e0f2ddedf937b53e747377d045271eca96787cb5cf5d2701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch delegated thread creation with ordered per-item results.
  * Added supervised thread creation requiring approval, with persistent pending requests and recovery after interruptions.
  * Added support for provisioning new worktrees from a selected base branch.
  * Added external integration controls, workspace allowlists, and active-thread limits.
  * Added audit tracking for thread-control operations.
* **Bug Fixes**
  * Improved interrupted worktree cleanup and handling of already-removed worktrees.
  * Pending permissions now include both agent and delegated thread approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->