### PR TITLE
feat(web): polish inline slash command tokens

### DIFF
--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -384,8 +384,18 @@ describe("MarkdownContent variant styling", () => {
 
       expect(container.querySelector('[data-entity-token="skill"]')).toHaveTextContent("$impeccable");
       expect(container.querySelector('[data-entity-token="plugin"]')).toHaveTextContent("plugin:figma");
-      expect(container.querySelector('[data-entity-token="command"]')).toHaveTextContent("/review");
+      expect(container.querySelector('[data-entity-token="command"]')).toHaveTextContent("review");
       expect(container.querySelector('[data-entity-token="agent"]')).toHaveTextContent("@reviewer_qa");
+    });
+
+    it("renders command references as inline invocations, not chips", () => {
+      const { container } = render(<MarkdownContent content="Run `/review` after the changes." />);
+      const command = container.querySelector('[data-entity-token="command"]');
+
+      expect(command).toHaveTextContent("review");
+      expect(command).toHaveClass("text-primary");
+      expect(command).not.toHaveClass("bg-muted", "ring-1", "rounded-md");
+      expect(command?.querySelector("[data-entity-icon='command']")).toHaveClass("text-current");
     });
 
     it("renders links with cool text-link", () => {

--- a/apps/web/src/__tests__/MessageBubble.test.tsx
+++ b/apps/web/src/__tests__/MessageBubble.test.tsx
@@ -177,7 +177,11 @@ describe("MessageBubble user messages", () => {
     };
 
     const { container } = render(<MessageBubble message={message} />);
-    expect(container.querySelector('[data-entity-token="skill"]')).toHaveTextContent("/impeccable");
+    const command = container.querySelector('[data-entity-token="skill"]');
+    expect(command).toHaveTextContent("impeccable");
+    expect(command).toHaveClass("text-primary");
+    expect(command).not.toHaveClass("bg-muted", "ring-1", "rounded-md");
+    expect(command?.querySelector("[data-entity-icon='skill']")).toHaveClass("text-current");
     expect(container.querySelector('[data-entity-token="agent"]')).toHaveTextContent("@reviewer_qa");
     expect(container.querySelector('[data-entity-token="file"]')).toHaveTextContent("@App.ts");
   });

--- a/apps/web/src/__tests__/slash-command-node.test.ts
+++ b/apps/web/src/__tests__/slash-command-node.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
 import { createEditor, $createParagraphNode, $createTextNode, $getRoot } from "lexical";
 import {
   SlashCommandNode,
@@ -41,6 +42,22 @@ describe("SlashCommandNode", () => {
       expect(node.isInline()).toBe(true);
       expect(node.isIsolated()).toBe(false);
     });
+  });
+
+  it("decorates a slash invocation as a slash-free inline token with its source icon", () => {
+    const editor = createTestEditor();
+    let decoration: ReturnType<SlashCommandNode["decorate"]>;
+    editor.update(() => {
+      const node = $createSlashCommandNode("impeccable", "skill");
+      decoration = node.decorate(editor, {} as never);
+    });
+    render(decoration!);
+
+    const label = screen.getByText("impeccable");
+    const token = label.closest("[data-entity-token]");
+    expect(screen.queryByText("/impeccable")).not.toBeInTheDocument();
+    expect(token).toHaveAttribute("data-entity-token", "skill");
+    expect(token?.querySelector(".lucide-badge-check")).not.toBeNull();
   });
 
   it("exports to JSON with type, name, and namespace", () => {

--- a/apps/web/src/components/chat/EntityToken.tsx
+++ b/apps/web/src/components/chat/EntityToken.tsx
@@ -1,5 +1,14 @@
 import type { ComponentProps } from "react";
-import { Blocks, Sparkles, SquareTerminal, Zap } from "lucide-react";
+import {
+  BadgeCheck,
+  Gauge,
+  ListTodo,
+  Minimize2,
+  Plug,
+  SquareTerminal,
+  Target,
+  Zap,
+} from "lucide-react";
 import { FileTypeIcon } from "@/components/ui/file-type-icon";
 import { cn } from "@/lib/utils";
 import { StackedLayersIcon } from "./narrative/StackedLayersIcon";
@@ -15,6 +24,8 @@ export interface EntityIconProps extends ComponentProps<"span"> {
   filePath?: string;
   /** Animate the sub-agent stack while its delegated work is running. */
   animated?: boolean;
+  /** Slash-command name used to resolve a command's semantic icon. */
+  commandName?: string;
   /** Pixel size of the glyph inside the icon frame. */
   size?: number;
 }
@@ -24,6 +35,7 @@ export function EntityIcon({
   kind,
   filePath,
   animated = false,
+  commandName,
   size = 13,
   className,
   ...props
@@ -49,13 +61,21 @@ export function EntityIcon({
     );
   }
 
+  const namedCommandIcon =
+    commandName === "goal"
+      ? Target
+      : commandName === "plan"
+        ? ListTodo
+        : commandName === "ultra"
+          ? Gauge
+          : commandName === "compact"
+            ? Minimize2
+            : null;
   const Icon = kind === "skill"
-    ? Sparkles
+    ? BadgeCheck
     : kind === "plugin"
-      ? Blocks
-      : kind === "mcode"
-        ? Zap
-        : SquareTerminal;
+      ? Plug
+      : namedCommandIcon ?? (kind === "mcode" ? Zap : SquareTerminal);
 
   return (
     <span data-entity-icon={kind} className={iconClassName} {...props}>
@@ -74,6 +94,8 @@ export interface EntityTokenProps extends ComponentProps<"span"> {
   filePath?: string;
   /** Surface-specific contrast treatment. */
   tone?: "assistant" | "composer" | "user";
+  /** Renders the entity as a slash-command invocation while retaining its source namespace. */
+  invocation?: boolean;
 }
 
 /** Renders a compact, baseline-aligned entity reference with a stable icon vocabulary. */
@@ -82,18 +104,24 @@ export function EntityToken({
   label,
   filePath,
   tone = "assistant",
+  invocation = false,
   className,
   ...props
 }: EntityTokenProps) {
+  const isCommandInvocation = kind === "command" || invocation;
+  const displayLabel = isCommandInvocation ? label.replace(/^\/+/, "") : label;
+
   return (
     <span
       data-entity-token={kind}
       className={cn(
-        "mx-px inline-flex h-5 max-w-full items-center gap-1 rounded-md px-1.5 align-[-0.2em] font-sans text-xs font-medium leading-none ring-1 ring-inset",
-        tone === "user"
-          ? "bg-background/45 text-accent-foreground ring-foreground/10"
-          : "bg-muted/70 text-foreground ring-border/70",
-        tone === "composer" && "bg-muted/80",
+        "mx-px inline-flex max-w-full items-center gap-1 align-[-0.2em] font-sans text-[length:inherit] font-medium leading-none",
+        isCommandInvocation
+          ? "text-primary"
+          : tone === "user"
+            ? "h-5 rounded-md bg-background/45 px-1.5 text-accent-foreground ring-1 ring-inset ring-foreground/10"
+            : "h-5 rounded-md bg-muted/70 px-1.5 text-foreground ring-1 ring-inset ring-border/70",
+        tone === "composer" && !isCommandInvocation && "bg-muted/80",
         className,
       )}
       {...props}
@@ -101,13 +129,15 @@ export function EntityToken({
       <EntityIcon
         kind={kind}
         filePath={filePath}
+        commandName={isCommandInvocation ? displayLabel : undefined}
         className={cn(
           "flex size-3.5 items-center justify-center text-muted-foreground",
-          tone === "user" && "text-accent-foreground/60",
+          isCommandInvocation && "text-current",
+          tone === "user" && !isCommandInvocation && "text-accent-foreground/60",
           kind === "mcode" && tone !== "user" && "text-primary/80",
         )}
       />
-      <span className="min-w-0 truncate">{label}</span>
+      <span className="min-w-0 truncate">{displayLabel}</span>
     </span>
   );
 }

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -94,6 +94,7 @@ function MentionedUserText({
         filePath={mention.kind === "file" ? mention.path : undefined}
         title={rawMention}
         tone="user"
+        invocation={mention.kind === "command"}
       />,
     );
     cursor = mention.range.end;

--- a/apps/web/src/components/chat/SlashCommandPopup.tsx
+++ b/apps/web/src/components/chat/SlashCommandPopup.tsx
@@ -1,12 +1,4 @@
 import { useEffect, useRef } from "react";
-import {
-  BadgeCheck,
-  Gauge,
-  ListTodo,
-  Minimize2,
-  Plug,
-  Target,
-} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -19,8 +11,6 @@ const VISIBLE_ITEMS = 8;
 const STATUS_ROW_HEIGHT = ITEM_HEIGHT;
 const LIST_SURFACE_PADDING = 8;
 const LIST_BOTTOM_FADE_HEIGHT = 20;
-const NAMED_MCODE_CAPABILITIES = new Set(["goal", "plan", "ultra", "compact"]);
-
 function commandDisplayLabel(command: Command): string {
   if (command.capabilityKind === "plugin") return `@${command.name}`;
   if (command.namespace === "skill") return command.name;
@@ -270,24 +260,6 @@ function CommandIdentityMark({
   command: Command;
   tone: "default" | "dark";
 }) {
-  const semanticIcon =
-    command.name === "goal"
-      ? Target
-      : command.name === "plan"
-        ? ListTodo
-        : command.name === "ultra"
-          ? Gauge
-          : command.name === "compact"
-            ? Minimize2
-            : null;
-  const CapabilityIcon =
-    command.capabilityKind === "skill"
-      ? BadgeCheck
-      : command.capabilityKind === "plugin"
-        ? Plug
-        : null;
-  const Icon = CapabilityIcon ?? semanticIcon;
-
   return (
     <span
       aria-hidden="true"
@@ -298,23 +270,21 @@ function CommandIdentityMark({
           : "bg-muted/65 text-muted-foreground ring-border/60",
       )}
     >
-      {Icon ? (
-        <Icon className="size-4" strokeWidth={2.2} />
-      ) : (
-        <EntityIcon
-          kind={
-            command.capabilityKind === "mcode" ||
-            NAMED_MCODE_CAPABILITIES.has(command.name)
-              ? "mcode"
-              : command.capabilityKind === "customPrompt" ||
-                  command.capabilityKind === "providerCommand"
-                ? "command"
-                : command.capabilityKind
-          }
-          size={14}
-          className="flex items-center justify-center"
-        />
-      )}
+      <EntityIcon
+        kind={
+          command.capabilityKind === "skill"
+            ? "skill"
+            : command.capabilityKind === "plugin"
+              ? "plugin"
+              : command.capabilityKind === "mcode" ||
+                  ["goal", "plan", "ultra", "compact"].includes(command.name)
+                ? "mcode"
+                : "command"
+        }
+        commandName={command.name}
+        size={14}
+        className="flex items-center justify-center"
+      />
     </span>
   );
 }

--- a/apps/web/src/components/chat/__tests__/EntityToken.test.tsx
+++ b/apps/web/src/components/chat/__tests__/EntityToken.test.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EntityToken } from "../EntityToken";
+
+describe("EntityToken command invocations", () => {
+  it("matches autocomplete icons while omitting the slash from rendered text", () => {
+    const { container } = render(
+      <div>
+        <EntityToken kind="skill" label="/review" invocation />
+        <EntityToken kind="command" label="/review" invocation />
+        <EntityToken kind="plugin" label="/figma" invocation />
+        <EntityToken kind="mcode" label="/plan" invocation />
+      </div>,
+    );
+
+    expect(container.querySelector('[data-entity-token="skill"]')).toHaveTextContent("review");
+    expect(container.querySelector('[data-entity-token="command"]')).toHaveTextContent("review");
+    expect(container.querySelector('[data-entity-token="plugin"]')).toHaveTextContent("figma");
+    expect(container.querySelector('[data-entity-token="mcode"]')).toHaveTextContent("plan");
+    expect(container.querySelector('[data-entity-token="skill"] [data-entity-icon="skill"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-entity-token="command"] [data-entity-icon="command"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-entity-token="plugin"] [data-entity-icon="plugin"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-entity-token="mcode"] [data-entity-icon="mcode"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-entity-token="skill"] .lucide-badge-check')).toBeInTheDocument();
+    expect(container.querySelector('[data-entity-token="command"] .lucide-square-terminal')).toBeInTheDocument();
+    expect(container.querySelector('[data-entity-token="plugin"] .lucide-plug')).toBeInTheDocument();
+    expect(container.querySelector('[data-entity-token="mcode"] .lucide-list-todo')).toBeInTheDocument();
+    expect(container.querySelector('[data-entity-token="skill"]')).toHaveClass("text-[length:inherit]");
+  });
+});

--- a/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
+++ b/apps/web/src/components/chat/__tests__/slash-command-popup-icons.test.tsx
@@ -34,6 +34,7 @@ function makeAnchorRect(): DOMRect {
 
 const COMMANDS: Command[] = [
   { id: "command:deploy", name: "deploy", description: "Deploy command", namespace: "command", capabilityKind: "providerCommand", nativeId: "deploy" },
+  { id: "mcode:custom", name: "custom", description: "Custom command", namespace: "mcode", capabilityKind: "mcode", nativeId: "custom" },
   { id: "skill:my-skill", name: "my-skill", description: "A skill", namespace: "skill", capabilityKind: "skill", nativeId: "my-skill" },
   { id: "skill:figma:use", name: "figma:use", description: "A plugin skill", namespace: "plugin", capabilityKind: "skill", nativeId: "figma:use" },
   { id: "plugin:browser", name: "Browser", description: "A native plugin", namespace: "plugin", capabilityKind: "plugin", nativeId: "browser@openai-bundled", mentionPath: "plugin://browser@openai-bundled" },
@@ -266,6 +267,15 @@ describe("SlashCommandPopup capability icons", () => {
     const commandRow = screen.getByRole("option", { name: /deploy/ });
     const terminalIcon = commandRow.querySelector(".lucide-square-terminal");
     expect(terminalIcon).not.toBeNull();
+  });
+
+  it("maps provider and custom commands through the popup icon caller", () => {
+    renderPopup();
+
+    const providerRow = screen.getByRole("option", { name: /Deploy command/ });
+    const customRow = screen.getByRole("option", { name: /Custom command/ });
+    expect(providerRow.querySelector(".lucide-square-terminal")).not.toBeNull();
+    expect(customRow.querySelector(".lucide-zap")).not.toBeNull();
   });
 
   it("native plugin entries render a Plug icon", () => {

--- a/apps/web/src/components/chat/lexical/SlashCommandNode.tsx
+++ b/apps/web/src/components/chat/lexical/SlashCommandNode.tsx
@@ -49,7 +49,7 @@ function SlashCommandChip({
   readonly namespace: SlashCommandNamespace;
 }): JSX.Element {
   return (
-    <EntityToken kind={namespace} label={`/${commandName}`} tone="composer" />
+    <EntityToken kind={namespace} label={`/${commandName}`} tone="composer" invocation />
   );
 }
 


### PR DESCRIPTION
## What
Render slash-command invocations inline with the same icon and typography as the composer.

## Why
Slash command tokens should match autocomplete and surrounding prose instead of reading as smaller generic chips.

## Key Changes
- Share the autocomplete icon mapping with inline command tokens.
- Inherit surrounding text size while preserving slash-free display text.
- Cover composer, user-message, and assistant-response rendering.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787738903&installation_model_id=20477&pr_number=973&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F973&signature=1201683b7837830933626a3eba87f90bac9509422e29cbef79e76867982aadda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Slash-command references now display as clean inline invocations without the leading slash.
  * Command and entity tokens use clearer styling and command-specific icons.
  * Updated command indicators provide more consistent visual distinctions across skills, plugins, and other command types.

* **Tests**
  * Added coverage to verify invocation labels, icons, styling, and entity identity rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->