### PR TITLE
fix(runtime): unify Electron SQLite bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,11 +133,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # Unit tests run under Node/vitest with Electron fully mocked; skip the
-      # binary download and better-sqlite3 Electron prebuild so bun install does
-      # not flake on 504s.
-      SKIP_ELECTRON_REBUILD: "1"
-      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      # Server tests launch Electron to load its runtime and native SQLite binding.
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -96,9 +96,10 @@ function findUnpackedServer() {
     const useRenamed = !isMac && existsSync(c.renamedBinary);
     const runtime = useRenamed ? c.renamedBinary : c.electron;
     if (existsSync(c.server) && existsSync(runtime)) {
-      const electronBinding = resolve(c.sqlite, "better_sqlite3.electron.node");
-      const nodeBinding = resolve(c.sqlite, "better_sqlite3.node");
-      const binding = existsSync(electronBinding) ? electronBinding : existsSync(nodeBinding) ? nodeBinding : undefined;
+      const binding = resolve(c.sqlite, "better_sqlite3.node");
+      if (!existsSync(binding)) {
+        throw new Error(`Packaged better-sqlite3 binding not found: ${binding}`);
+      }
       const electronDir = useRenamed ? dirname(c.electron) : undefined;
       return {
         server: c.server,

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -19,7 +19,7 @@
  */
 
 import { spawn, execFileSync } from "child_process";
-import { existsSync, mkdirSync, rmSync } from "fs";
+import { existsSync, mkdirSync, realpathSync, rmSync } from "fs";
 import { resolve, dirname } from "path";
 import { createRequire } from "module";
 import { fileURLToPath } from "url";
@@ -54,6 +54,7 @@ function findUnpackedServer() {
       server: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/dist/server/server.cjs"),
       renamedBinary: resolve(releaseDir, "win-unpacked/resources/bin/mcode-server.exe"),
       electron: resolve(releaseDir, "win-unpacked/Mcode.exe"),
+      resourcesRoot: resolve(releaseDir, "win-unpacked/resources"),
       sqlite: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
       koffi: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/koffi"),
       nodePty: resolve(releaseDir, "win-unpacked/resources/app.asar.unpacked/node_modules/node-pty"),
@@ -63,6 +64,7 @@ function findUnpackedServer() {
       server: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/dist/server/server.cjs"),
       renamedBinary: resolve(releaseDir, "linux-unpacked/resources/bin/mcode-server"),
       electron: resolve(releaseDir, "linux-unpacked/mcode-desktop"),
+      resourcesRoot: resolve(releaseDir, "linux-unpacked/resources"),
       sqlite: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
       koffi: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/koffi"),
       nodePty: resolve(releaseDir, "linux-unpacked/resources/app.asar.unpacked/node_modules/node-pty"),
@@ -72,6 +74,7 @@ function findUnpackedServer() {
       server: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/dist/server/server.cjs"),
       renamedBinary: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/bin/mcode-server"),
       electron: resolve(releaseDir, "mac/Mcode.app/Contents/MacOS/Mcode"),
+      resourcesRoot: resolve(releaseDir, "mac/Mcode.app/Contents/Resources"),
       sqlite: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
       koffi: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/koffi"),
       nodePty: resolve(releaseDir, "mac/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty"),
@@ -81,6 +84,7 @@ function findUnpackedServer() {
       server: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/dist/server/server.cjs"),
       renamedBinary: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/bin/mcode-server"),
       electron: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/MacOS/Mcode"),
+      resourcesRoot: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources"),
       sqlite: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release"),
       koffi: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/koffi"),
       nodePty: resolve(releaseDir, "mac-arm64/Mcode.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty"),
@@ -105,6 +109,7 @@ function findUnpackedServer() {
         server: c.server,
         electron: runtime,
         binding,
+        resourcesRoot: realpathSync(c.resourcesRoot),
         electronDir,
         koffi: c.koffi,
         nodePty: c.nodePty,
@@ -268,6 +273,9 @@ const env = {
 
 if (found.binding) {
   env.BETTER_SQLITE3_BINDING = found.binding;
+}
+if (found.resourcesRoot) {
+  env.MCODE_PACKAGED_RESOURCES_ROOT = found.resourcesRoot;
 }
 
 // When using the renamed binary in a different directory, the dynamic linker

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -21,6 +21,7 @@
 import { spawn, execFileSync } from "child_process";
 import { existsSync, mkdirSync, rmSync } from "fs";
 import { resolve, dirname } from "path";
+import { createRequire } from "module";
 import { fileURLToPath } from "url";
 import { tmpdir } from "os";
 import { randomUUID } from "crypto";
@@ -32,6 +33,8 @@ import {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
 const releaseDir = resolve(desktopRoot, "release");
+const desktopRequire = createRequire(resolve(desktopRoot, "package.json"));
+const serverRequire = createRequire(resolve(desktopRoot, "..", "server", "package.json"));
 
 const SMOKE_PORT = 19899;
 const TIMEOUT_MS = 30_000;
@@ -134,15 +137,19 @@ function inferPackagedSdkTarget(serverPath) {
 }
 
 /**
- * --bundle mode: test the pre-packaging bundle with the system node/bun.
- * Skips native module verification but catches JS bundle errors.
+ * --bundle mode: test the pre-packaging bundle with the workspace Electron runtime.
  */
 function findBundleServer() {
   const server = resolve(desktopRoot, "dist/server/server.cjs");
   if (!existsSync(server)) {
     return null;
   }
-  return { server, electron: process.execPath, binding: undefined };
+  const betterSqliteDir = dirname(serverRequire.resolve("better-sqlite3/package.json"));
+  const binding = resolve(betterSqliteDir, "build", "Release", "better_sqlite3.electron.node");
+  if (!existsSync(binding)) {
+    throw new Error(`Workspace Electron better-sqlite3 binding not found: ${binding}`);
+  }
+  return { server, electron: desktopRequire("electron"), binding };
 }
 
 const bundleOnly = process.argv.includes("--bundle");

--- a/apps/desktop/src/main/__tests__/server-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/server-manager.test.ts
@@ -529,6 +529,7 @@ describe("ServerManager", () => {
     const opts = spawnCall[2] as Record<string, unknown>;
     const env = opts.env as Record<string, string>;
     expect(env.BETTER_SQLITE3_BINDING).toContain("better_sqlite3.node");
+    expect(env.MCODE_PACKAGED_RESOURCES_ROOT).toBe("/test/resources");
   });
 
   it("fails before spawn when the packaged Electron binding is unavailable", async () => {

--- a/apps/desktop/src/main/__tests__/server-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/server-manager.test.ts
@@ -420,14 +420,19 @@ describe("ServerManager", () => {
   });
 
   it("replaces an inherited Node binding with the workspace Electron binding in dev", async () => {
+    const previousBinding = process.env.BETTER_SQLITE3_BINDING;
     process.env.BETTER_SQLITE3_BINDING = "/inherited/better_sqlite3.node";
 
-    await manager.start();
+    try {
+      await manager.start();
 
-    const spawnCall = vi.mocked(spawn).mock.calls[0];
-    const options = spawnCall[2] as { env: Record<string, string> };
-    expect(options.env.BETTER_SQLITE3_BINDING).toContain("better_sqlite3.electron.node");
-    delete process.env.BETTER_SQLITE3_BINDING;
+      const spawnCall = vi.mocked(spawn).mock.calls[0];
+      const options = spawnCall[2] as { env: Record<string, string> };
+      expect(options.env.BETTER_SQLITE3_BINDING).toContain("better_sqlite3.electron.node");
+    } finally {
+      if (previousBinding === undefined) delete process.env.BETTER_SQLITE3_BINDING;
+      else process.env.BETTER_SQLITE3_BINDING = previousBinding;
+    }
   });
 
   it("spawns the bundled server.cjs when app.isPackaged is true", async () => {

--- a/apps/desktop/src/main/__tests__/server-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/server-manager.test.ts
@@ -17,7 +17,7 @@ const refs = vi.hoisted(() => {
   };
 
   // Shared existsSync spy used by "fs"/"node:fs" mocks.
-  const existsSyncSpy = vi.fn((path) => String(path).includes("better_sqlite3.electron.node"));
+  const existsSyncSpy = vi.fn((path) => String(path).includes("better_sqlite3"));
 
   // Spy for resolveServerBinary — lets tests override the resolved binary path
   // directly without depending on node:fs mock aliasing behaviour.
@@ -167,9 +167,7 @@ describe("ServerManager", () => {
     // Mock fetch: first call returns healthy (waitForReady); subsequent calls
     // also return ok so tryExistingServer health probes work too.
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
-    vi.mocked(existsSync).mockImplementation((path) =>
-      String(path).includes("better_sqlite3.electron.node"),
-    );
+    vi.mocked(existsSync).mockImplementation((path) => String(path).includes("better_sqlite3"));
 
     setupDefaultReadFileMock();
   });
@@ -180,9 +178,7 @@ describe("ServerManager", () => {
     delete process.env.MCODE_SERVER_HEAP_MB;
     refs.setIsPackaged(false);
     delete (process as Record<string, unknown>).resourcesPath;
-    vi.mocked(existsSync).mockImplementation((path) =>
-      String(path).includes("better_sqlite3.electron.node"),
-    );
+    vi.mocked(existsSync).mockImplementation((path) => String(path).includes("better_sqlite3"));
   });
 
   // -----------------------------------------------------------------------
@@ -525,16 +521,14 @@ describe("ServerManager", () => {
       configurable: true,
       writable: true,
     });
-    vi.mocked(existsSync).mockImplementation((p) =>
-      String(p).includes("better_sqlite3.electron.node"),
-    );
+    vi.mocked(existsSync).mockImplementation((p) => String(p).includes("better_sqlite3.node"));
 
     await manager.start();
 
     const spawnCall = vi.mocked(spawn).mock.calls[0];
     const opts = spawnCall[2] as Record<string, unknown>;
     const env = opts.env as Record<string, string>;
-    expect(env.BETTER_SQLITE3_BINDING).toContain("better_sqlite3.electron.node");
+    expect(env.BETTER_SQLITE3_BINDING).toContain("better_sqlite3.node");
   });
 
   it("fails before spawn when the packaged Electron binding is unavailable", async () => {
@@ -546,7 +540,7 @@ describe("ServerManager", () => {
     });
     vi.mocked(existsSync).mockReturnValue(false);
 
-    await expect(manager.start()).rejects.toThrow("Workspace Electron better-sqlite3 binding not found");
+    await expect(manager.start()).rejects.toThrow("Packaged better-sqlite3 binding not found");
     expect(spawn).not.toHaveBeenCalled();
   });
 
@@ -687,7 +681,7 @@ describe("ServerManager", () => {
 
   it("rotates the previous stderr log before opening a new one", async () => {
     vi.mocked(existsSync).mockImplementation((path) =>
-      String(path).endsWith("server-stderr.log") || String(path).includes("better_sqlite3.electron.node"),
+      String(path).endsWith("server-stderr.log") || String(path).includes("better_sqlite3"),
     );
 
     await manager.start();

--- a/apps/desktop/src/main/__tests__/server-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/server-manager.test.ts
@@ -17,7 +17,7 @@ const refs = vi.hoisted(() => {
   };
 
   // Shared existsSync spy used by "fs"/"node:fs" mocks.
-  const existsSyncSpy = vi.fn(() => false);
+  const existsSyncSpy = vi.fn((path) => String(path).includes("better_sqlite3.electron.node"));
 
   // Spy for resolveServerBinary — lets tests override the resolved binary path
   // directly without depending on node:fs mock aliasing behaviour.
@@ -167,6 +167,9 @@ describe("ServerManager", () => {
     // Mock fetch: first call returns healthy (waitForReady); subsequent calls
     // also return ok so tryExistingServer health probes work too.
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+    vi.mocked(existsSync).mockImplementation((path) =>
+      String(path).includes("better_sqlite3.electron.node"),
+    );
 
     setupDefaultReadFileMock();
   });
@@ -177,7 +180,9 @@ describe("ServerManager", () => {
     delete process.env.MCODE_SERVER_HEAP_MB;
     refs.setIsPackaged(false);
     delete (process as Record<string, unknown>).resourcesPath;
-    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(existsSync).mockImplementation((path) =>
+      String(path).includes("better_sqlite3.electron.node"),
+    );
   });
 
   // -----------------------------------------------------------------------
@@ -418,6 +423,17 @@ describe("ServerManager", () => {
     expect(options.env.ELECTRON_RUN_AS_NODE).toBe("1");
   });
 
+  it("replaces an inherited Node binding with the workspace Electron binding in dev", async () => {
+    process.env.BETTER_SQLITE3_BINDING = "/inherited/better_sqlite3.node";
+
+    await manager.start();
+
+    const spawnCall = vi.mocked(spawn).mock.calls[0];
+    const options = spawnCall[2] as { env: Record<string, string> };
+    expect(options.env.BETTER_SQLITE3_BINDING).toContain("better_sqlite3.electron.node");
+    delete process.env.BETTER_SQLITE3_BINDING;
+  });
+
   it("spawns the bundled server.cjs when app.isPackaged is true", async () => {
     refs.setIsPackaged(true);
     Object.defineProperty(process, "resourcesPath", {
@@ -519,6 +535,19 @@ describe("ServerManager", () => {
     const opts = spawnCall[2] as Record<string, unknown>;
     const env = opts.env as Record<string, string>;
     expect(env.BETTER_SQLITE3_BINDING).toContain("better_sqlite3.electron.node");
+  });
+
+  it("fails before spawn when the packaged Electron binding is unavailable", async () => {
+    refs.setIsPackaged(true);
+    Object.defineProperty(process, "resourcesPath", {
+      value: "/test/resources",
+      configurable: true,
+      writable: true,
+    });
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await expect(manager.start()).rejects.toThrow("Workspace Electron better-sqlite3 binding not found");
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   // -----------------------------------------------------------------------
@@ -658,7 +687,7 @@ describe("ServerManager", () => {
 
   it("rotates the previous stderr log before opening a new one", async () => {
     vi.mocked(existsSync).mockImplementation((path) =>
-      String(path).endsWith("server-stderr.log"),
+      String(path).endsWith("server-stderr.log") || String(path).includes("better_sqlite3.electron.node"),
     );
 
     await manager.start();

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -405,6 +405,9 @@ export class ServerManager {
       }
 
       env.BETTER_SQLITE3_BINDING = nativeBindingPath;
+      if (app.isPackaged) {
+        env.MCODE_PACKAGED_RESOURCES_ROOT = process.resourcesPath;
+      }
 
       // The renamed server binary lives in resources/bin/ which lacks Electron's
       // shared libraries (libffmpeg.so). Point LD_LIBRARY_PATH at the original

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -40,7 +40,7 @@ const SettingsSchema = globalThis.__v8Snapshot?.contracts?.SettingsSchema ?? Bun
  * bundled CJS entry (`dist/server/server.cjs`); dev builds it via
  * `apps/desktop/scripts/dev-electron.mjs` (tsc → esbuild watch).
  *
- * Returns the Electron-native better-sqlite3 binding for every server child.
+ * Returns the approved better-sqlite3 binding for every server child.
  */
 function getServerPaths(): {
   entry: string;
@@ -59,10 +59,10 @@ function getServerPaths(): {
       "better-sqlite3",
       "build",
       "Release",
-      "better_sqlite3.electron.node",
+      "better_sqlite3.node",
     );
     if (!existsSync(nativeBindingPath)) {
-      throw new Error(`Workspace Electron better-sqlite3 binding not found: ${nativeBindingPath}`);
+      throw new Error(`Packaged better-sqlite3 binding not found: ${nativeBindingPath}`);
     }
     return { entry: serverBundle, cwd: dirname(serverBundle), nativeBindingPath };
   }

--- a/apps/desktop/src/main/server-manager.ts
+++ b/apps/desktop/src/main/server-manager.ts
@@ -9,6 +9,7 @@
 
 import { app } from "electron";
 import { execSync, spawn, type ChildProcess } from "child_process";
+import { createRequire } from "module";
 import {
   createWriteStream,
   existsSync,
@@ -39,13 +40,12 @@ const SettingsSchema = globalThis.__v8Snapshot?.contracts?.SettingsSchema ?? Bun
  * bundled CJS entry (`dist/server/server.cjs`); dev builds it via
  * `apps/desktop/scripts/dev-electron.mjs` (tsc → esbuild watch).
  *
- * Also returns the native binding path for better-sqlite3 when packaged so
- * the server child process can find it outside the asar archive.
+ * Returns the Electron-native better-sqlite3 binding for every server child.
  */
 function getServerPaths(): {
   entry: string;
   cwd: string;
-  nativeBindingPath?: string;
+  nativeBindingPath: string;
 } {
   if (app.isPackaged) {
     // The server bundle and native deps are asarUnpack'd to real filesystem
@@ -53,16 +53,34 @@ function getServerPaths(): {
     // not go through Electron's asar virtual filesystem layer.
     const unpackedRoot = resolve(process.resourcesPath, "app.asar.unpacked");
     const serverBundle = resolve(unpackedRoot, "dist", "server", "server.cjs");
-    const nativeBindingPath = [
-      resolve(unpackedRoot, "node_modules", "better-sqlite3", "build", "Release", "better_sqlite3.electron.node"),
-      resolve(unpackedRoot, "node_modules", "better-sqlite3", "build", "Release", "better_sqlite3.node"),
-    ].find((candidate) => existsSync(candidate));
+    const nativeBindingPath = resolve(
+      unpackedRoot,
+      "node_modules",
+      "better-sqlite3",
+      "build",
+      "Release",
+      "better_sqlite3.electron.node",
+    );
+    if (!existsSync(nativeBindingPath)) {
+      throw new Error(`Workspace Electron better-sqlite3 binding not found: ${nativeBindingPath}`);
+    }
     return { entry: serverBundle, cwd: dirname(serverBundle), nativeBindingPath };
   }
 
   /** Matches both `src/main/` (Vitest) and bundled `dist/main/` (`__dirname`). */
   const serverBundle = resolve(__dirname, "..", "..", "dist", "server", "server.cjs");
-  return { entry: serverBundle, cwd: dirname(serverBundle) };
+  const desktopRequire = createRequire(resolve(__dirname, "..", "..", "package.json"));
+  const betterSqliteDir = dirname(desktopRequire.resolve("better-sqlite3/package.json"));
+  const nativeBindingPath = resolve(
+    betterSqliteDir,
+    "build",
+    "Release",
+    "better_sqlite3.electron.node",
+  );
+  if (!existsSync(nativeBindingPath)) {
+    throw new Error(`Workspace Electron better-sqlite3 binding not found: ${nativeBindingPath}`);
+  }
+  return { entry: serverBundle, cwd: dirname(serverBundle), nativeBindingPath };
 }
 
 /**
@@ -386,9 +404,7 @@ export class ServerManager {
         env.MCODE_GIT_TOPLEVEL = process.env.MCODE_GIT_TOPLEVEL;
       }
 
-      if (nativeBindingPath) {
-        env.BETTER_SQLITE3_BINDING = nativeBindingPath;
-      }
+      env.BETTER_SQLITE3_BINDING = nativeBindingPath;
 
       // The renamed server binary lives in resources/bin/ which lacks Electron's
       // shared libraries (libffmpeg.so). Point LD_LIBRARY_PATH at the original

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.ts",
   "scripts": {
     "start": "bun src/index.ts",
-    "test": "node ../../scripts/run-electron-node.mjs ./node_modules/vitest/vitest.mjs run",
+    "test": "node ../../scripts/run-electron-node.mjs --workspace-cli vitest vitest.mjs run",
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.ts",
   "scripts": {
     "start": "bun src/index.ts",
-    "test": "vitest run",
+    "test": "node ../../scripts/run-electron-node.mjs ./node_modules/vitest/vitest.mjs run",
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/apps/server/src/__tests__/bootstrap-drizzle.test.ts
+++ b/apps/server/src/__tests__/bootstrap-drizzle.test.ts
@@ -1,10 +1,11 @@
 import { createHash } from "crypto";
-import Database from "better-sqlite3";
+import type Database from "better-sqlite3";
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { bootstrapDrizzle } from "../store/bootstrap-drizzle.js";
+import { openElectronMemoryDatabase } from "./electron-sqlite.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DRIZZLE_DIR = join(__dirname, "../../drizzle");
@@ -22,7 +23,7 @@ function baselineSqlHash(): string {
 }
 
 function freshDb(): Database.Database {
-  const db = new Database(":memory:");
+  const db = openElectronMemoryDatabase();
   db.pragma("foreign_keys = ON");
   return db;
 }

--- a/apps/server/src/__tests__/database-schema-patches.test.ts
+++ b/apps/server/src/__tests__/database-schema-patches.test.ts
@@ -3,12 +3,13 @@
  * databases created before sort_order was added to the workspaces table.
  */
 
-import Database from "better-sqlite3";
+import type Database from "better-sqlite3";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { applySchemaPatches } from "../store/database.js";
+import { openElectronMemoryDatabase } from "./electron-sqlite.js";
 
 function freshDb(): Database.Database {
-  const db = new Database(":memory:");
+  const db = openElectronMemoryDatabase();
   db.pragma("foreign_keys = ON");
   return db;
 }

--- a/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
+++ b/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
@@ -10,6 +10,7 @@ describe("Electron SQLite test runtime", () => {
   let db: Database.Database | undefined;
   let temporaryResourcesPath: string | undefined;
   const binding = process.env.BETTER_SQLITE3_BINDING;
+  const packagedResourcesRoot = process.env.MCODE_PACKAGED_RESOURCES_ROOT;
   const resourcesPathDescriptor = Object.getOwnPropertyDescriptor(process, "resourcesPath");
 
   function createPackagedBinding(bindingName: string): string {
@@ -27,8 +28,9 @@ describe("Electron SQLite test runtime", () => {
     );
     mkdirSync(dirname(packagedBinding), { recursive: true });
     copyFileSync(binding, packagedBinding);
+    process.env.MCODE_PACKAGED_RESOURCES_ROOT = temporaryResourcesPath;
     Object.defineProperty(process, "resourcesPath", {
-      value: temporaryResourcesPath,
+      value: join(temporaryResourcesPath, "bin"),
       configurable: true,
     });
     return packagedBinding;
@@ -39,6 +41,8 @@ describe("Electron SQLite test runtime", () => {
     db = undefined;
     if (binding === undefined) delete process.env.BETTER_SQLITE3_BINDING;
     else process.env.BETTER_SQLITE3_BINDING = binding;
+    if (packagedResourcesRoot === undefined) delete process.env.MCODE_PACKAGED_RESOURCES_ROOT;
+    else process.env.MCODE_PACKAGED_RESOURCES_ROOT = packagedResourcesRoot;
     if (resourcesPathDescriptor) Object.defineProperty(process, "resourcesPath", resourcesPathDescriptor);
     else delete (process as Record<string, unknown>).resourcesPath;
     if (temporaryResourcesPath) rmSync(temporaryResourcesPath, { recursive: true, force: true });
@@ -70,6 +74,22 @@ describe("Electron SQLite test runtime", () => {
     process.env.BETTER_SQLITE3_BINDING = packagedBinding;
 
     expect(resolveElectronNativeBinding()).toBe(realpathSync(packagedBinding));
+  });
+
+  it("rejects a packaged binding without an authoritative resources root", () => {
+    const packagedBinding = createPackagedBinding("better_sqlite3.node");
+    process.env.BETTER_SQLITE3_BINDING = packagedBinding;
+    delete process.env.MCODE_PACKAGED_RESOURCES_ROOT;
+
+    expect(() => resolveElectronNativeBinding()).toThrow("MCODE_PACKAGED_RESOURCES_ROOT");
+  });
+
+  it("rejects a packaged binding with a non-canonical resources root", () => {
+    const packagedBinding = createPackagedBinding("better_sqlite3.node");
+    process.env.BETTER_SQLITE3_BINDING = packagedBinding;
+    process.env.MCODE_PACKAGED_RESOURCES_ROOT = `${temporaryResourcesPath}${process.platform === "win32" ? "\\\\." : "/."}`;
+
+    expect(() => resolveElectronNativeBinding()).toThrow("MCODE_PACKAGED_RESOURCES_ROOT");
   });
 
   it("rejects an existing generic binding outside packaged resources", () => {
@@ -119,7 +139,8 @@ describe("Electron SQLite test runtime", () => {
 
   it("rejects an unexpected native binding path before loading SQLite", () => {
     process.env.BETTER_SQLITE3_BINDING = "C:/unexpected/better_sqlite3.electron.node";
+    process.env.MCODE_PACKAGED_RESOURCES_ROOT = process.cwd();
 
-    expect(() => openMemoryDatabase()).toThrow("workspace Electron binding");
+    expect(() => openMemoryDatabase()).toThrow("packaged binding");
   });
 });

--- a/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
+++ b/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type Database from "better-sqlite3";
+import { openMemoryDatabase } from "../store/database";
+
+describe("Electron SQLite test runtime", () => {
+  let db: Database.Database | undefined;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it("runs in Electron Node and opens an in-memory database", () => {
+    expect(process.versions.electron).toBeDefined();
+
+    db = openMemoryDatabase();
+
+    expect(db.prepare("SELECT 1 AS value").get()).toEqual({ value: 1 });
+  });
+});

--- a/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
+++ b/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import type Database from "better-sqlite3";
 import { openMemoryDatabase } from "../store/database";
+import { openElectronMemoryDatabase } from "./electron-sqlite.js";
 
 describe("Electron SQLite test runtime", () => {
   let db: Database.Database | undefined;
@@ -13,6 +14,12 @@ describe("Electron SQLite test runtime", () => {
     expect(process.versions.electron).toBeDefined();
 
     db = openMemoryDatabase();
+
+    expect(db.prepare("SELECT 1 AS value").get()).toEqual({ value: 1 });
+  });
+
+  it("opens direct test databases with the Electron binding", () => {
+    db = openElectronMemoryDatabase();
 
     expect(db.prepare("SELECT 1 AS value").get()).toEqual({ value: 1 });
   });

--- a/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
+++ b/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
@@ -1,17 +1,48 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join, resolve } from "path";
 import type Database from "better-sqlite3";
-import { openMemoryDatabase } from "../store/database";
+import { openMemoryDatabase, resolveElectronNativeBinding } from "../store/database";
 import { openElectronMemoryDatabase } from "./electron-sqlite.js";
 
 describe("Electron SQLite test runtime", () => {
   let db: Database.Database | undefined;
+  let temporaryResourcesPath: string | undefined;
   const binding = process.env.BETTER_SQLITE3_BINDING;
+  const resourcesPathDescriptor = Object.getOwnPropertyDescriptor(process, "resourcesPath");
+
+  function createPackagedBinding(bindingName: string): string {
+    if (!binding) throw new Error("BETTER_SQLITE3_BINDING is required for Electron SQLite tests");
+
+    temporaryResourcesPath = mkdtempSync(join(tmpdir(), "mcode-sqlite-"));
+    const packagedBinding = resolve(
+      temporaryResourcesPath,
+      "app.asar.unpacked",
+      "node_modules",
+      "better-sqlite3",
+      "build",
+      "Release",
+      bindingName,
+    );
+    mkdirSync(dirname(packagedBinding), { recursive: true });
+    copyFileSync(binding, packagedBinding);
+    Object.defineProperty(process, "resourcesPath", {
+      value: temporaryResourcesPath,
+      configurable: true,
+    });
+    return packagedBinding;
+  }
 
   afterEach(() => {
     db?.close();
     db = undefined;
     if (binding === undefined) delete process.env.BETTER_SQLITE3_BINDING;
     else process.env.BETTER_SQLITE3_BINDING = binding;
+    if (resourcesPathDescriptor) Object.defineProperty(process, "resourcesPath", resourcesPathDescriptor);
+    else delete (process as Record<string, unknown>).resourcesPath;
+    if (temporaryResourcesPath) rmSync(temporaryResourcesPath, { recursive: true, force: true });
+    temporaryResourcesPath = undefined;
   });
 
   it("runs in Electron Node and opens an in-memory database", () => {
@@ -34,13 +65,35 @@ describe("Electron SQLite test runtime", () => {
     expect(() => openMemoryDatabase()).toThrow("BETTER_SQLITE3_BINDING must be");
   });
 
-  it("rejects a Node-native binding path before loading SQLite", () => {
-    process.env.BETTER_SQLITE3_BINDING = binding?.replace(
-      "better_sqlite3.electron.node",
-      "better_sqlite3.node",
-    );
+  it("accepts the canonical packaged Node binding", () => {
+    const packagedBinding = createPackagedBinding("better_sqlite3.node");
+    process.env.BETTER_SQLITE3_BINDING = packagedBinding;
 
-    expect(() => openMemoryDatabase()).toThrow("workspace Electron binding");
+    expect(resolveElectronNativeBinding()).toBe(realpathSync(packagedBinding));
+  });
+
+  it("rejects an existing generic binding outside packaged resources", () => {
+    createPackagedBinding("placeholder.node");
+    const outsideBinding = resolve(tmpdir(), `mcode-sqlite-outside-${Date.now()}.node`);
+    if (!binding) throw new Error("BETTER_SQLITE3_BINDING is required for Electron SQLite tests");
+    copyFileSync(binding, outsideBinding);
+    process.env.BETTER_SQLITE3_BINDING = outsideBinding;
+
+    try {
+      expect(() => resolveElectronNativeBinding()).toThrow("packaged binding under");
+    } finally {
+      rmSync(outsideBinding, { force: true });
+    }
+  });
+
+  it("rejects a packaged binding symlink that escapes the release directory", () => {
+    const placeholder = createPackagedBinding("placeholder.node");
+    const escapedBinding = join(dirname(placeholder), "better_sqlite3.node");
+    if (!binding) throw new Error("BETTER_SQLITE3_BINDING is required for Electron SQLite tests");
+    symlinkSync(binding, escapedBinding, "file");
+    process.env.BETTER_SQLITE3_BINDING = escapedBinding;
+
+    expect(() => resolveElectronNativeBinding()).toThrow("packaged binding under");
   });
 
   it("rejects an unexpected native binding path before loading SQLite", () => {

--- a/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
+++ b/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
@@ -5,9 +5,13 @@ import { openElectronMemoryDatabase } from "./electron-sqlite.js";
 
 describe("Electron SQLite test runtime", () => {
   let db: Database.Database | undefined;
+  const binding = process.env.BETTER_SQLITE3_BINDING;
 
   afterEach(() => {
     db?.close();
+    db = undefined;
+    if (binding === undefined) delete process.env.BETTER_SQLITE3_BINDING;
+    else process.env.BETTER_SQLITE3_BINDING = binding;
   });
 
   it("runs in Electron Node and opens an in-memory database", () => {
@@ -22,5 +26,26 @@ describe("Electron SQLite test runtime", () => {
     db = openElectronMemoryDatabase();
 
     expect(db.prepare("SELECT 1 AS value").get()).toEqual({ value: 1 });
+  });
+
+  it("rejects a missing native binding before loading SQLite", () => {
+    delete process.env.BETTER_SQLITE3_BINDING;
+
+    expect(() => openMemoryDatabase()).toThrow("BETTER_SQLITE3_BINDING must be");
+  });
+
+  it("rejects a Node-native binding path before loading SQLite", () => {
+    process.env.BETTER_SQLITE3_BINDING = binding?.replace(
+      "better_sqlite3.electron.node",
+      "better_sqlite3.node",
+    );
+
+    expect(() => openMemoryDatabase()).toThrow("workspace Electron binding");
+  });
+
+  it("rejects an unexpected native binding path before loading SQLite", () => {
+    process.env.BETTER_SQLITE3_BINDING = "C:/unexpected/better_sqlite3.electron.node";
+
+    expect(() => openMemoryDatabase()).toThrow("workspace Electron binding");
   });
 });

--- a/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
+++ b/apps/server/src/__tests__/electron-sqlite-runtime.test.ts
@@ -80,7 +80,7 @@ describe("Electron SQLite test runtime", () => {
     process.env.BETTER_SQLITE3_BINDING = outsideBinding;
 
     try {
-      expect(() => resolveElectronNativeBinding()).toThrow("packaged binding under");
+      expect(() => resolveElectronNativeBinding()).toThrow("packaged binding");
     } finally {
       rmSync(outsideBinding, { force: true });
     }
@@ -93,7 +93,28 @@ describe("Electron SQLite test runtime", () => {
     symlinkSync(binding, escapedBinding, "file");
     process.env.BETTER_SQLITE3_BINDING = escapedBinding;
 
-    expect(() => resolveElectronNativeBinding()).toThrow("packaged binding under");
+    expect(() => resolveElectronNativeBinding()).toThrow("packaged binding");
+  });
+
+  it("rejects a packaged release directory symlink that escapes resources", () => {
+    const placeholder = createPackagedBinding("placeholder.node");
+    const releaseDir = dirname(placeholder);
+    const escapedReleaseDir = mkdtempSync(join(tmpdir(), "mcode-sqlite-release-"));
+    if (!binding) throw new Error("BETTER_SQLITE3_BINDING is required for Electron SQLite tests");
+    copyFileSync(binding, join(escapedReleaseDir, "better_sqlite3.node"));
+    rmSync(releaseDir, { recursive: true, force: true });
+    symlinkSync(
+      escapedReleaseDir,
+      releaseDir,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    process.env.BETTER_SQLITE3_BINDING = join(releaseDir, "better_sqlite3.node");
+
+    try {
+      expect(() => resolveElectronNativeBinding()).toThrow("packaged binding");
+    } finally {
+      rmSync(escapedReleaseDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects an unexpected native binding path before loading SQLite", () => {

--- a/apps/server/src/__tests__/electron-sqlite.ts
+++ b/apps/server/src/__tests__/electron-sqlite.ts
@@ -1,0 +1,10 @@
+import Database from "better-sqlite3";
+
+/** Opens an in-memory SQLite database with the Electron-native binding. */
+export function openElectronMemoryDatabase(): Database.Database {
+  const nativeBinding = process.env.BETTER_SQLITE3_BINDING;
+  if (!nativeBinding) {
+    throw new Error("BETTER_SQLITE3_BINDING is required for Electron SQLite tests.");
+  }
+  return new Database(":memory:", { nativeBinding });
+}

--- a/apps/server/src/__tests__/electron-sqlite.ts
+++ b/apps/server/src/__tests__/electron-sqlite.ts
@@ -1,10 +1,7 @@
 import Database from "better-sqlite3";
+import { resolveElectronNativeBinding } from "../store/database.js";
 
 /** Opens an in-memory SQLite database with the Electron-native binding. */
 export function openElectronMemoryDatabase(): Database.Database {
-  const nativeBinding = process.env.BETTER_SQLITE3_BINDING;
-  if (!nativeBinding) {
-    throw new Error("BETTER_SQLITE3_BINDING is required for Electron SQLite tests.");
-  }
-  return new Database(":memory:", { nativeBinding });
+  return new Database(":memory:", { nativeBinding: resolveElectronNativeBinding() });
 }

--- a/apps/server/src/__tests__/message-repo.test.ts
+++ b/apps/server/src/__tests__/message-repo.test.ts
@@ -1,10 +1,11 @@
 import "reflect-metadata";
 import { describe, it, expect, beforeEach } from "vitest";
-import Database from "better-sqlite3";
+import type Database from "better-sqlite3";
 import { MessageRepo } from "../repositories/message-repo.js";
+import { openElectronMemoryDatabase } from "./electron-sqlite.js";
 
 function createTestDb(): Database.Database {
-  const db = new Database(":memory:");
+  const db = openElectronMemoryDatabase();
   db.exec(`
     CREATE TABLE messages (
       id TEXT PRIMARY KEY,

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -3,9 +3,9 @@
  */
 
 import Database from "better-sqlite3";
-import { existsSync, mkdirSync } from "fs";
+import { existsSync, mkdirSync, realpathSync } from "fs";
 import { createRequire } from "module";
-import { dirname, join, resolve } from "path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 import { getMcodeDir, resolveDbPath } from "@mcode/shared";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -76,7 +76,18 @@ function getDrizzleMigrationsDir(): string {
   return drizzleDirMemo;
 }
 
-/** Resolves and validates the Electron-native better-sqlite3 binding for this process. */
+/** Returns whether a canonical path is contained by a canonical directory. */
+function isPathInside(directory: string, candidate: string): boolean {
+  const pathFromDirectory = relative(directory, candidate);
+  return (
+    pathFromDirectory.length > 0 &&
+    pathFromDirectory !== ".." &&
+    !pathFromDirectory.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) &&
+    !isAbsolute(pathFromDirectory)
+  );
+}
+
+/** Resolves and validates the approved better-sqlite3 binding for this process. */
 export function resolveElectronNativeBinding(): string {
   if (!process.versions.electron) {
     throw new Error("SQLite requires Electron's Node.js runtime.");
@@ -97,18 +108,41 @@ export function resolveElectronNativeBinding(): string {
       `BETTER_SQLITE3_BINDING must be ${expectedBinding}. Run 'bun install' to install the Electron binding.`,
     );
   }
-  if (resolve(configuredBinding) !== resolve(expectedBinding)) {
-    throw new Error(
-      `BETTER_SQLITE3_BINDING must reference the workspace Electron binding: ${expectedBinding}`,
-    );
+  if (resolve(configuredBinding) === resolve(expectedBinding)) {
+    if (!existsSync(expectedBinding)) {
+      throw new Error(
+        `Workspace Electron better-sqlite3 binding not found: ${expectedBinding}. Run 'bun install'.`,
+      );
+    }
+    return expectedBinding;
   }
-  if (!existsSync(expectedBinding)) {
+
+  const packagedReleaseDir = resolve(
+    process.resourcesPath,
+    "app.asar.unpacked",
+    "node_modules",
+    "better-sqlite3",
+    "build",
+    "Release",
+  );
+  if (!existsSync(configuredBinding) || !existsSync(packagedReleaseDir)) {
     throw new Error(
-      `Workspace Electron better-sqlite3 binding not found: ${expectedBinding}. Run 'bun install'.`,
+      `BETTER_SQLITE3_BINDING must reference the workspace Electron binding or a packaged binding under: ${packagedReleaseDir}`,
     );
   }
 
-  return expectedBinding;
+  const canonicalReleaseDir = realpathSync(packagedReleaseDir);
+  const canonicalBinding = realpathSync(configuredBinding);
+  if (
+    basename(canonicalBinding) !== "better_sqlite3.node" ||
+    !isPathInside(canonicalReleaseDir, canonicalBinding)
+  ) {
+    throw new Error(
+      `BETTER_SQLITE3_BINDING must reference the workspace Electron binding or a packaged binding under: ${packagedReleaseDir}`,
+    );
+  }
+
+  return canonicalBinding;
 }
 
 /**

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -76,41 +76,39 @@ function getDrizzleMigrationsDir(): string {
   return drizzleDirMemo;
 }
 
-/**
- * Resolve the correct native binding for better-sqlite3 based on runtime.
- *
- * Priority:
- * 1. `BETTER_SQLITE3_BINDING` env var — set by server-manager when the app is
- *    packaged, pointing to the asarUnpack'd `.node` file outside the asar archive.
- * 2. Electron runtime path resolution — used in dev mode when running under
- *    Electron with the source tree present.
- * 3. `undefined` — falls back to better-sqlite3's default binding resolution
- *    for plain Node.js (e.g. vitest).
- */
-function resolveNativeBinding(): string | undefined {
-  if (process.env.BETTER_SQLITE3_BINDING) {
-    return process.env.BETTER_SQLITE3_BINDING;
+/** Resolves and validates the Electron-native better-sqlite3 binding for this process. */
+export function resolveElectronNativeBinding(): string {
+  if (!process.versions.electron) {
+    throw new Error("SQLite requires Electron's Node.js runtime.");
   }
 
-  if (!process.versions.electron) return undefined;
-
   const localRequire = createRequire(import.meta.url);
-  const betterSqliteDir = dirname(
-    localRequire.resolve("better-sqlite3/package.json"),
+  const betterSqliteDir = dirname(localRequire.resolve("better-sqlite3/package.json"));
+  const expectedBinding = join(
+    betterSqliteDir,
+    "build",
+    "Release",
+    "better_sqlite3.electron.node",
   );
-  const bindingCandidates = [
-    join(betterSqliteDir, "build", "Release", "better_sqlite3.electron.node"),
-    join(betterSqliteDir, "build", "Release", "better_sqlite3.node"),
-  ];
-  const bindingPath = bindingCandidates.find((candidate) => existsSync(candidate));
+  const configuredBinding = process.env.BETTER_SQLITE3_BINDING;
 
-  if (!bindingPath) {
+  if (!configuredBinding) {
     throw new Error(
-      `Electron prebuild not found. Checked: ${bindingCandidates.join(", ")}. Run 'bun install' to download it.`,
+      `BETTER_SQLITE3_BINDING must be ${expectedBinding}. Run 'bun install' to install the Electron binding.`,
+    );
+  }
+  if (resolve(configuredBinding) !== resolve(expectedBinding)) {
+    throw new Error(
+      `BETTER_SQLITE3_BINDING must reference the workspace Electron binding: ${expectedBinding}`,
+    );
+  }
+  if (!existsSync(expectedBinding)) {
+    throw new Error(
+      `Workspace Electron better-sqlite3 binding not found: ${expectedBinding}. Run 'bun install'.`,
     );
   }
 
-  return bindingPath;
+  return expectedBinding;
 }
 
 /**
@@ -324,7 +322,7 @@ export function openDatabase(opts?: {
     mkdirSync(dir, { recursive: true });
   }
 
-  const nativeBinding = resolveNativeBinding();
+  const nativeBinding = resolveElectronNativeBinding();
   const db = new Database(resolvedPath, { nativeBinding });
   applyPragmas(db, true);
   try {
@@ -345,7 +343,7 @@ export function openDatabase(opts?: {
  * and migrations as a file-backed database.
  */
 export function openMemoryDatabase(): Database.Database {
-  const nativeBinding = resolveNativeBinding();
+  const nativeBinding = resolveElectronNativeBinding();
   const db = new Database(":memory:", { nativeBinding });
   applyPragmas(db, false);
   try {

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -5,7 +5,7 @@
 import Database from "better-sqlite3";
 import { existsSync, mkdirSync, realpathSync } from "fs";
 import { createRequire } from "module";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "path";
+import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { getMcodeDir, resolveDbPath } from "@mcode/shared";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -76,17 +76,6 @@ function getDrizzleMigrationsDir(): string {
   return drizzleDirMemo;
 }
 
-/** Returns whether a canonical path is contained by a canonical directory. */
-function isPathInside(directory: string, candidate: string): boolean {
-  const pathFromDirectory = relative(directory, candidate);
-  return (
-    pathFromDirectory.length > 0 &&
-    pathFromDirectory !== ".." &&
-    !pathFromDirectory.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) &&
-    !isAbsolute(pathFromDirectory)
-  );
-}
-
 /** Resolves and validates the approved better-sqlite3 binding for this process. */
 export function resolveElectronNativeBinding(): string {
   if (!process.versions.electron) {
@@ -117,28 +106,31 @@ export function resolveElectronNativeBinding(): string {
     return expectedBinding;
   }
 
-  const packagedReleaseDir = resolve(
-    process.resourcesPath,
+  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+  if (!resourcesPath) {
+    throw new Error("Electron resources path is unavailable for packaged SQLite binding.");
+  }
+
+  const canonicalResourcesRoot = realpathSync(resourcesPath);
+  const expectedPackagedBinding = join(
+    canonicalResourcesRoot,
     "app.asar.unpacked",
     "node_modules",
     "better-sqlite3",
     "build",
     "Release",
+    "better_sqlite3.node",
   );
-  if (!existsSync(configuredBinding) || !existsSync(packagedReleaseDir)) {
+  if (!existsSync(configuredBinding) || !existsSync(expectedPackagedBinding)) {
     throw new Error(
-      `BETTER_SQLITE3_BINDING must reference the workspace Electron binding or a packaged binding under: ${packagedReleaseDir}`,
+      `BETTER_SQLITE3_BINDING must reference the workspace Electron binding or the packaged binding: ${expectedPackagedBinding}`,
     );
   }
 
-  const canonicalReleaseDir = realpathSync(packagedReleaseDir);
   const canonicalBinding = realpathSync(configuredBinding);
-  if (
-    basename(canonicalBinding) !== "better_sqlite3.node" ||
-    !isPathInside(canonicalReleaseDir, canonicalBinding)
-  ) {
+  if (canonicalBinding !== expectedPackagedBinding) {
     throw new Error(
-      `BETTER_SQLITE3_BINDING must reference the workspace Electron binding or a packaged binding under: ${packagedReleaseDir}`,
+      `BETTER_SQLITE3_BINDING must reference the workspace Electron binding or the packaged binding: ${expectedPackagedBinding}`,
     );
   }
 

--- a/apps/server/src/store/database.ts
+++ b/apps/server/src/store/database.ts
@@ -5,7 +5,7 @@
 import Database from "better-sqlite3";
 import { existsSync, mkdirSync, realpathSync } from "fs";
 import { createRequire } from "module";
-import { dirname, join, resolve } from "path";
+import { dirname, isAbsolute, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { getMcodeDir, resolveDbPath } from "@mcode/shared";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -106,12 +106,16 @@ export function resolveElectronNativeBinding(): string {
     return expectedBinding;
   }
 
-  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
-  if (!resourcesPath) {
-    throw new Error("Electron resources path is unavailable for packaged SQLite binding.");
+  const packagedResourcesRoot = process.env.MCODE_PACKAGED_RESOURCES_ROOT;
+  if (!packagedResourcesRoot || !isAbsolute(packagedResourcesRoot)) {
+    throw new Error("MCODE_PACKAGED_RESOURCES_ROOT must be an absolute canonical packaged resources directory.");
   }
 
-  const canonicalResourcesRoot = realpathSync(resourcesPath);
+  const canonicalResourcesRoot = realpathSync(packagedResourcesRoot);
+  if (packagedResourcesRoot !== canonicalResourcesRoot) {
+    throw new Error("MCODE_PACKAGED_RESOURCES_ROOT must be a canonical packaged resources directory.");
+  }
+
   const expectedPackagedBinding = join(
     canonicalResourcesRoot,
     "app.asar.unpacked",

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts"],
+    pool: "forks",
+    // Electron child processes are heavier than Node's. Two workers keep Windows
+    // process-integration tests within their timing bounds without serializing the suite.
+    maxWorkers: 2,
     env: {
       MCODE_DATA_DIR: testDataDir,
       MCODE_DRIZZLE_MIGRATIONS_DIR: resolve(serverPackageRoot, "drizzle"),

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -14,11 +14,6 @@ export default defineConfig({
     env: {
       MCODE_DATA_DIR: testDataDir,
       MCODE_DRIZZLE_MIGRATIONS_DIR: resolve(serverPackageRoot, "drizzle"),
-      // A globally-set BETTER_SQLITE3_BINDING (e.g. dev shell pointing at the
-      // installed app's Electron-ABI binary) crashes tests under host Node.
-      // Empty string short-circuits the truthy check in store/database.ts so
-      // better-sqlite3 falls back to its default Node binding lookup.
-      BETTER_SQLITE3_BINDING: "",
     },
     globalSetup: ["../../scripts/vitest-global-setup.ts"],
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "node scripts/dev-web.mjs",
     "dev:desktop": "cd apps/desktop && bun run dev",
     "dev:web": "node scripts/dev-web.mjs",
-    "dev:server": "cd apps/server && bun run start",
+    "dev:server": "node scripts/dev-web.mjs --server-only",
     "prod:desktop": "cd apps/desktop && bun run prod",
     "build": "turbo run build",
     "test": "node scripts/node-runtime.mjs && turbo run test",

--- a/scripts/agent/__tests__/db-info.test.mjs
+++ b/scripts/agent/__tests__/db-info.test.mjs
@@ -1,0 +1,38 @@
+/** Tests the db:info Electron wrapper against a real temporary SQLite database. */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+test("db:info opens a SQLite database through Electron Node", () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "mcode-db-info-"));
+  const dbPath = join(dataDir, "mcode.db");
+  const env = { ...process.env, MCODE_DB_PATH: dbPath };
+
+  try {
+    const createDatabase = spawnSync(
+      process.execPath,
+      [
+        "scripts/run-electron-node.mjs",
+        "-e",
+        "const { createRequire } = require('module'); const Database = createRequire(process.cwd() + '/apps/server/package.json')('better-sqlite3'); const db = new Database(process.env.MCODE_DB_PATH, { nativeBinding: process.env.BETTER_SQLITE3_BINDING }); db.exec('CREATE TABLE _migrations (version INTEGER); INSERT INTO _migrations VALUES (7); CREATE TABLE workspaces (id TEXT); CREATE TABLE threads (id TEXT); CREATE TABLE messages (id TEXT);'); db.close();",
+      ],
+      { cwd: process.cwd(), env, encoding: "utf8" },
+    );
+    assert.equal(createDatabase.status, 0, createDatabase.stderr);
+
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/run-electron-node.mjs", "scripts/db-info.mjs"],
+      { cwd: process.cwd(), env, encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Schema   : v7/);
+    assert.match(result.stdout, /workspaces: 0 rows/);
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/agent/__tests__/db-info.test.mjs
+++ b/scripts/agent/__tests__/db-info.test.mjs
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -10,6 +11,8 @@ test("db:info opens a SQLite database through Electron Node", () => {
   const dataDir = mkdtempSync(join(tmpdir(), "mcode-db-info-"));
   const dbPath = join(dataDir, "mcode.db");
   const env = { ...process.env, MCODE_DB_PATH: dbPath };
+  const electronRequire = createRequire(join(process.cwd(), "apps", "desktop", "package.json"));
+  const electronBinary = electronRequire("electron");
 
   try {
     const createDatabase = spawnSync(
@@ -19,19 +22,50 @@ test("db:info opens a SQLite database through Electron Node", () => {
         "-e",
         "const { createRequire } = require('module'); const Database = createRequire(process.cwd() + '/apps/server/package.json')('better-sqlite3'); const db = new Database(process.env.MCODE_DB_PATH, { nativeBinding: process.env.BETTER_SQLITE3_BINDING }); db.exec('CREATE TABLE _migrations (version INTEGER); INSERT INTO _migrations VALUES (7); CREATE TABLE workspaces (id TEXT); CREATE TABLE threads (id TEXT); CREATE TABLE messages (id TEXT);'); db.close();",
       ],
-      { cwd: process.cwd(), env, encoding: "utf8" },
+      { cwd: process.cwd(), env, encoding: "utf8", timeout: 60_000 },
     );
+    assert.equal(createDatabase.error, undefined);
     assert.equal(createDatabase.status, 0, createDatabase.stderr);
 
     const result = spawnSync(
       process.execPath,
       ["scripts/run-electron-node.mjs", "scripts/db-info.mjs"],
-      { cwd: process.cwd(), env, encoding: "utf8" },
+      { cwd: process.cwd(), env, encoding: "utf8", timeout: 60_000 },
     );
 
+    assert.equal(result.error, undefined);
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /Schema   : v7/);
     assert.match(result.stdout, /workspaces: 0 rows/);
+
+    const missingBindingEnv = { ...env, ELECTRON_RUN_AS_NODE: "1" };
+    delete missingBindingEnv.BETTER_SQLITE3_BINDING;
+    const missingBinding = spawnSync(
+      electronBinary,
+      ["scripts/db-info.mjs"],
+      { cwd: process.cwd(), env: missingBindingEnv, encoding: "utf8", timeout: 60_000 },
+    );
+    assert.equal(missingBinding.error, undefined);
+    assert.equal(missingBinding.status, 1, missingBinding.stderr);
+    assert.match(missingBinding.stderr, /BETTER_SQLITE3_BINDING is required/);
+
+    const invalidBinding = spawnSync(
+      electronBinary,
+      ["scripts/db-info.mjs"],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...env,
+          ELECTRON_RUN_AS_NODE: "1",
+          BETTER_SQLITE3_BINDING: join(dataDir, "missing.node"),
+        },
+        encoding: "utf8",
+        timeout: 60_000,
+      },
+    );
+    assert.equal(invalidBinding.error, undefined);
+    assert.equal(invalidBinding.status, 1, invalidBinding.stderr);
+    assert.match(invalidBinding.stderr, /must reference an existing absolute file/);
   } finally {
     rmSync(dataDir, { recursive: true, force: true });
   }

--- a/scripts/agent/__tests__/dev-web-lifecycle.test.mjs
+++ b/scripts/agent/__tests__/dev-web-lifecycle.test.mjs
@@ -1,0 +1,10 @@
+/** Tests the dev:server exit status mapping. */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { resolveServerOnlyExitCode } from "../../dev-web-lifecycle.mjs";
+
+test("dev:server reports unexpected signal exits as failures", () => {
+  assert.equal(resolveServerOnlyExitCode({ code: null, signal: "SIGTERM", cleanupRequested: false }), 1);
+  assert.equal(resolveServerOnlyExitCode({ code: 23, signal: null, cleanupRequested: false }), 23);
+  assert.equal(resolveServerOnlyExitCode({ code: null, signal: "SIGTERM", cleanupRequested: true }), 0);
+});

--- a/scripts/agent/__tests__/dev-web-lifecycle.test.mjs
+++ b/scripts/agent/__tests__/dev-web-lifecycle.test.mjs
@@ -3,8 +3,18 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { resolveServerOnlyExitCode } from "../../dev-web-lifecycle.mjs";
 
-test("dev:server reports unexpected signal exits as failures", () => {
-  assert.equal(resolveServerOnlyExitCode({ code: null, signal: "SIGTERM", cleanupRequested: false }), 1);
-  assert.equal(resolveServerOnlyExitCode({ code: 23, signal: null, cleanupRequested: false }), 23);
+test("dev:server preserves numeric exit codes", () => {
+  assert.equal(resolveServerOnlyExitCode({ code: 23, signal: "SIGTERM", cleanupRequested: true }), 23);
+  assert.equal(resolveServerOnlyExitCode({ code: 0, signal: "SIGTERM", cleanupRequested: true }), 0);
+});
+
+test("dev:server maps expected cleanup signals to success", () => {
+  assert.equal(resolveServerOnlyExitCode({ code: null, signal: "SIGINT", cleanupRequested: true }), 0);
   assert.equal(resolveServerOnlyExitCode({ code: null, signal: "SIGTERM", cleanupRequested: true }), 0);
+});
+
+test("dev:server maps unexpected or unrequested signals to failure", () => {
+  assert.equal(resolveServerOnlyExitCode({ code: null, signal: "SIGKILL", cleanupRequested: true }), 1);
+  assert.equal(resolveServerOnlyExitCode({ code: null, signal: "SIGTERM", cleanupRequested: false }), 1);
+  assert.equal(resolveServerOnlyExitCode({ code: null, signal: null, cleanupRequested: false }), 1);
 });

--- a/scripts/agent/__tests__/root-dev-script.test.mjs
+++ b/scripts/agent/__tests__/root-dev-script.test.mjs
@@ -11,3 +11,15 @@ test("root dev uses the paired dev:web runtime", () => {
 
   assert.equal(packageJson.scripts.dev, "node scripts/dev-web.mjs");
 });
+
+test("root dev:server runs only the Electron-backed server launcher", () => {
+  const packageJson = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
+
+  assert.equal(packageJson.scripts["dev:server"], "node scripts/dev-web.mjs --server-only");
+});
+
+test("root db:info dispatches to the Electron SQLite runtime", () => {
+  const packageJson = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
+
+  assert.equal(packageJson.scripts["db:info"], "bun scripts/db-info.mjs");
+});

--- a/scripts/agent/__tests__/run-electron-node.test.mjs
+++ b/scripts/agent/__tests__/run-electron-node.test.mjs
@@ -1,0 +1,42 @@
+/** Tests workspace CLI entry containment in the Electron Node wrapper. */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const wrapper = "scripts/run-electron-node.mjs";
+const options = {
+  cwd: process.cwd(),
+  encoding: "utf8",
+  timeout: 60_000,
+};
+
+function runWorkspaceCli(entryFile) {
+  return spawnSync(
+    process.execPath,
+    [wrapper, "--workspace-cli", "better-sqlite3", entryFile],
+    options,
+  );
+}
+
+test("workspace CLI accepts a nested package entry", () => {
+  const result = runWorkspaceCli("lib/index.js");
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("workspace CLI preserves missing-entry errors", () => {
+  const result = runWorkspaceCli("missing-entry.mjs");
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Workspace CLI entry not found/);
+});
+
+test("workspace CLI rejects entries outside the package directory", () => {
+  const result = runWorkspaceCli("../package.json");
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Workspace CLI entry must stay inside its package directory/);
+});

--- a/scripts/agent/__tests__/runtime-lifecycle.test.mjs
+++ b/scripts/agent/__tests__/runtime-lifecycle.test.mjs
@@ -3,7 +3,7 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { once } from "node:events";
 
 import { agentDown } from "../agent-down.mjs";
 import { agentUp, setAgentUpTestHooks } from "../agent-up.mjs";
@@ -163,6 +164,60 @@ test("dev web single-instance flag preserves explicit false legacy mode", () => 
   assert.equal(resolveDevSingleInstanceFlag("no"), false);
   assert.equal(resolveDevSingleInstanceFlag("off"), false);
 });
+
+test("dev:server SIGTERM stops the Electron server without a Vite reference error", async () => {
+  const child = spawn(process.execPath, ["scripts/dev-web.mjs", "--server-only"], {
+    cwd: resolve(process.cwd()),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  let errors = "";
+  child.stdout.on("data", (chunk) => {
+    output += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+
+  try {
+    const port = await waitForServerPort(() => output);
+    const health = await fetch(`http://127.0.0.1:${port}/health`);
+    assert.equal(health.ok, true);
+
+    child.kill("SIGTERM");
+    await once(child, "exit");
+
+    await waitForServerStop(port);
+    assert.doesNotMatch(errors, /ReferenceError.*vite/i);
+  } finally {
+    if (child.exitCode === null) child.kill("SIGTERM");
+  }
+});
+
+/** Waits for dev-web to report the server-only health port. */
+async function waitForServerPort(readOutput) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const match = /Server ready on port (\d+)/.exec(readOutput());
+    if (match) return Number(match[1]);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+  throw new Error(`dev:server did not become ready: ${readOutput()}`);
+}
+
+/** Waits for the server-only child to release its health endpoint. */
+async function waitForServerStop(port) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`http://127.0.0.1:${port}/health`);
+    } catch {
+      return;
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+  throw new Error(`dev:server still responds on port ${port} after SIGTERM`);
+}
 
 /**
  * Creates a minimal git repository for runtime lifecycle tests.

--- a/scripts/agent/__tests__/runtime-lifecycle.test.mjs
+++ b/scripts/agent/__tests__/runtime-lifecycle.test.mjs
@@ -105,9 +105,10 @@ test("agentUp removes stale PID files before launching server and web processes"
     computeAvailablePorts: async () => ({ serverPort: 41_223, webPort: 41_224 }),
     getElectronBinary: () => process.execPath,
     rebuildServerDevBundle: async () => {},
-    spawnLogged: () => {
+    spawnLogged: (_command, _args, options) => {
       spawnAttempted = true;
       assert.equal(existsSync(join(getRuntimePaths(repo).pidsDir, "server.pid")), false);
+      assert.match(options.env.BETTER_SQLITE3_BINDING, /better_sqlite3\.electron\.node$/);
       throw new Error("stop before real launch");
     },
   });

--- a/scripts/agent/agent-up.mjs
+++ b/scripts/agent/agent-up.mjs
@@ -92,6 +92,7 @@ export async function agentUp(repoRoot = resolveRepoRoot()) {
   if (!electronBin) {
     throw new Error("Electron binary not found. Run 'bun install' in the project root.");
   }
+  const electronBinding = getElectronBinding();
 
   const rebuildRuntimeServerBundle = agentUpTestHooks.rebuildServerDevBundle ?? rebuildServerDevBundle;
   await rebuildRuntimeServerBundle();
@@ -107,6 +108,7 @@ export async function agentUp(repoRoot = resolveRepoRoot()) {
         env: {
           ...process.env,
           ELECTRON_RUN_AS_NODE: "1",
+          BETTER_SQLITE3_BINDING: electronBinding,
           NODE_ENV: "development",
           ...buildRuntimeStateEnv(repoRoot, {
             MCODE_AGENT_FIXTURE_REPO: fixtureRepo,
@@ -169,6 +171,17 @@ function getElectronBinary() {
   } catch {
     return null;
   }
+}
+
+/** Resolve the workspace Electron-native better-sqlite3 binding. */
+function getElectronBinding() {
+  const serverRequire = createRequire(resolve(rootDir, "apps", "server", "package.json"));
+  const packagePath = serverRequire.resolve("better-sqlite3/package.json");
+  const bindingPath = resolve(dirname(packagePath), "build", "Release", "better_sqlite3.electron.node");
+  if (!existsSync(bindingPath)) {
+    throw new Error(`Workspace Electron better-sqlite3 binding not found: ${bindingPath}`);
+  }
+  return bindingPath;
 }
 
 /**

--- a/scripts/db-info.mjs
+++ b/scripts/db-info.mjs
@@ -1,18 +1,32 @@
-#!/usr/bin/env bun
 /**
  * Print SQLite database location, schema version, and basic table stats.
  * Opens the database read-only; safe to run while the server is running.
  */
-import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 import { resolveMainRoot } from './utils.mjs';
-import { resolveCliDbPath } from './resolve-cli-db-path.mjs';
 
-const require = createRequire(import.meta.url);
-const root    = resolveMainRoot();
+if (!process.versions.electron) {
+  const { resolveCliDbPath } = await import('./resolve-cli-db-path.mjs');
+  const result = spawnSync(
+    process.execPath,
+    ['scripts/run-electron-node.mjs', fileURLToPath(import.meta.url), ...process.argv.slice(2)],
+    {
+      cwd: resolveMainRoot(),
+      env: { ...process.env, MCODE_DB_PATH: resolveCliDbPath() },
+      stdio: 'inherit',
+    },
+  );
+  if (result.error) throw result.error;
+  process.exit(result.status ?? 1);
+}
 
-const dbPath  = resolveCliDbPath();
+const dbPath = process.env.MCODE_DB_PATH;
+if (!dbPath) {
+  throw new Error('MCODE_DB_PATH is required when db-info runs under Electron Node.');
+}
+const root = resolveMainRoot();
 
 console.log(`Database : ${dbPath}`);
 
@@ -22,15 +36,13 @@ if (!existsSync(dbPath)) {
 }
 
 try {
-  // Bun workspaces may hoist better-sqlite3 to the root or keep it in apps/server.
-  const modulePaths = [
-    resolve(root, 'node_modules/better-sqlite3'),
-    resolve(root, 'apps/server/node_modules/better-sqlite3'),
-  ];
-  const modulePath = modulePaths.find(p => existsSync(p));
-  if (!modulePath) throw new Error('better-sqlite3 not found — run bun install first');
-  const Database = require(modulePath);
-  const db       = new Database(dbPath, { readonly: true });
+  const { createRequire } = await import('node:module');
+  const serverRequire = createRequire(`${root}/apps/server/package.json`);
+  const Database = serverRequire('better-sqlite3');
+  const db = new Database(dbPath, {
+    readonly: true,
+    nativeBinding: process.env.BETTER_SQLITE3_BINDING,
+  });
 
   const vRow = db.prepare('SELECT version FROM _migrations ORDER BY version DESC LIMIT 1').get();
   console.log(`Schema   : v${vRow ? vRow.version : 0}`);

--- a/scripts/db-info.mjs
+++ b/scripts/db-info.mjs
@@ -3,7 +3,8 @@
  * Opens the database read-only; safe to run while the server is running.
  */
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveMainRoot } from './utils.mjs';
 
@@ -27,6 +28,13 @@ if (!dbPath) {
   throw new Error('MCODE_DB_PATH is required when db-info runs under Electron Node.');
 }
 const root = resolveMainRoot();
+const bindingPath = process.env.BETTER_SQLITE3_BINDING;
+if (!bindingPath) {
+  throw new Error('BETTER_SQLITE3_BINDING is required when db-info runs under Electron Node.');
+}
+if (!isAbsolute(bindingPath) || !existsSync(bindingPath) || !statSync(bindingPath).isFile()) {
+  throw new Error(`BETTER_SQLITE3_BINDING must reference an existing absolute file: ${bindingPath}`);
+}
 
 console.log(`Database : ${dbPath}`);
 
@@ -41,7 +49,7 @@ try {
   const Database = serverRequire('better-sqlite3');
   const db = new Database(dbPath, {
     readonly: true,
-    nativeBinding: process.env.BETTER_SQLITE3_BINDING,
+    nativeBinding: bindingPath,
   });
 
   const vRow = db.prepare('SELECT version FROM _migrations ORDER BY version DESC LIMIT 1').get();

--- a/scripts/dev-web-lifecycle.mjs
+++ b/scripts/dev-web-lifecycle.mjs
@@ -1,7 +1,6 @@
 /** Resolves the dev:server parent process exit code after its server exits. */
 export function resolveServerOnlyExitCode({ code, signal, cleanupRequested }) {
-  if (cleanupRequested) return 0;
   if (Number.isInteger(code)) return code;
-  if (signal) return 1;
+  if (cleanupRequested && (signal === "SIGINT" || signal === "SIGTERM")) return 0;
   return 1;
 }

--- a/scripts/dev-web-lifecycle.mjs
+++ b/scripts/dev-web-lifecycle.mjs
@@ -1,0 +1,7 @@
+/** Resolves the dev:server parent process exit code after its server exits. */
+export function resolveServerOnlyExitCode({ code, signal, cleanupRequested }) {
+  if (cleanupRequested) return 0;
+  if (Number.isInteger(code)) return code;
+  if (signal) return 1;
+  return 1;
+}

--- a/scripts/dev-web.mjs
+++ b/scripts/dev-web.mjs
@@ -188,6 +188,8 @@ try {
   }
 }
 
+let vite;
+
 if (serverOnly) {
   const cleanup = () => killProcessTree(server);
   process.on("SIGINT", cleanup);
@@ -214,7 +216,7 @@ console.log(
   `\x1b[36m[dev:web]\x1b[0m Starting Vite dev server${webPort ? ` on http://localhost:${webPort}` : ""}...`,
 );
 
-const vite = spawn("bun", viteArgs, {
+vite = spawn("bun", viteArgs, {
   cwd: resolve(rootDir, "apps", "web"),
   env: {
     ...process.env,

--- a/scripts/dev-web.mjs
+++ b/scripts/dev-web.mjs
@@ -15,6 +15,7 @@ import { resolve, dirname } from "node:path";
 import { existsSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { rebuildServerDevBundle } from "./build-server-dev-bundle.mjs";
+import { resolveServerOnlyExitCode } from "./dev-web-lifecycle.mjs";
 import { killProcessTree } from "./kill-process-tree.mjs";
 import {
   buildPortsContract,
@@ -191,10 +192,16 @@ try {
 let vite;
 
 if (serverOnly) {
-  const cleanup = () => killProcessTree(server);
+  let cleanupRequested = false;
+  const cleanup = () => {
+    cleanupRequested = true;
+    killProcessTree(server);
+  };
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
-  server.on("exit", (code) => process.exit(code ?? 0));
+  server.on("exit", (code, signal) => {
+    process.exit(resolveServerOnlyExitCode({ code, signal, cleanupRequested }));
+  });
   await new Promise(() => {});
 }
 

--- a/scripts/dev-web.mjs
+++ b/scripts/dev-web.mjs
@@ -32,6 +32,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, "..");
 const desktopRoot = resolve(rootDir, "apps", "desktop");
 const serverCjs = resolve(desktopRoot, "dist", "server", "server.cjs");
+const serverOnly = process.argv.includes("--server-only");
 
 /**
  * Resolve the Electron binary path. The native module (better-sqlite3)
@@ -49,6 +50,17 @@ function getElectronBinary() {
     // fall through
   }
   return null;
+}
+
+/** Resolves the workspace Electron-native better-sqlite3 binding. */
+function getElectronBinding() {
+  const serverRequire = createRequire(resolve(rootDir, "apps", "server", "package.json"));
+  const packagePath = serverRequire.resolve("better-sqlite3/package.json");
+  const bindingPath = resolve(dirname(packagePath), "build", "Release", "better_sqlite3.electron.node");
+  if (!existsSync(bindingPath)) {
+    throw new Error(`Workspace Electron better-sqlite3 binding not found: ${bindingPath}`);
+  }
+  return bindingPath;
 }
 
 /** Poll until the server's /health endpoint responds 200. */
@@ -95,12 +107,20 @@ const contract = buildPortsContract({
   },
 });
 const electronBin = getElectronBinary();
+let electronBinding;
 
 if (!electronBin) {
   console.error(
     "\x1b[31m[dev:web]\x1b[0m Electron binary not found. " +
     "Run 'bun install' in the project root to install dependencies.",
   );
+  process.exit(1);
+}
+
+try {
+  electronBinding = getElectronBinding();
+} catch (err) {
+  console.error(`[dev:web] ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);
 }
 
@@ -126,6 +146,7 @@ const server = spawn(
     env: {
       ...process.env,
       ELECTRON_RUN_AS_NODE: "1",
+      BETTER_SQLITE3_BINDING: electronBinding,
       NODE_ENV: "development",
       ...runtimeStateEnv,
       MCODE_PORT: String(serverPort),
@@ -165,6 +186,14 @@ try {
       "Starting Vite anyway — the web app will show a connection error.",
     );
   }
+}
+
+if (serverOnly) {
+  const cleanup = () => killProcessTree(server);
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+  server.on("exit", (code) => process.exit(code ?? 0));
+  await new Promise(() => {});
 }
 
 // `MCODE_WEB_PORT` lets a caller (e.g. scripts/agent/demo.mjs) pin Vite to a

--- a/scripts/run-electron-node.mjs
+++ b/scripts/run-electron-node.mjs
@@ -30,7 +30,24 @@ if (cliArgs.length === 0) {
   throw new Error("Expected a JavaScript CLI entry and its arguments.");
 }
 
-const result = spawnSync(electronRequire("electron"), cliArgs, {
+function resolveWorkspaceCli(args) {
+  if (args[0] !== "--workspace-cli") return args;
+
+  const [_, packageName, entryFile, ...entryArgs] = args;
+  if (!packageName || !entryFile) {
+    throw new Error("Expected a package name and CLI entry after --workspace-cli.");
+  }
+
+  const packageDir = dirname(serverRequire.resolve(`${packageName}/package.json`));
+  const cliEntry = join(packageDir, entryFile);
+  if (!existsSync(cliEntry)) {
+    throw new Error(`Workspace CLI entry not found: ${cliEntry}`);
+  }
+
+  return [cliEntry, ...entryArgs];
+}
+
+const result = spawnSync(electronRequire("electron"), resolveWorkspaceCli(cliArgs), {
   cwd: process.cwd(),
   env: {
     ...process.env,

--- a/scripts/run-electron-node.mjs
+++ b/scripts/run-electron-node.mjs
@@ -1,0 +1,44 @@
+/** Runs a JavaScript CLI with the workspace Electron runtime and SQLite binding. */
+
+import { spawnSync } from "child_process";
+import { existsSync } from "fs";
+import { createRequire } from "module";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDir, "..");
+const electronRequire = createRequire(resolve(workspaceRoot, "apps", "desktop", "package.json"));
+const serverRequire = createRequire(resolve(workspaceRoot, "apps", "server", "package.json"));
+
+function resolveElectronBinding() {
+  const betterSqliteDir = dirname(serverRequire.resolve("better-sqlite3/package.json"));
+  const bindingPath = join(
+    betterSqliteDir,
+    "build",
+    "Release",
+    "better_sqlite3.electron.node",
+  );
+  if (!existsSync(bindingPath)) {
+    throw new Error(`Workspace Electron better-sqlite3 binding not found: ${bindingPath}`);
+  }
+  return bindingPath;
+}
+
+const cliArgs = process.argv.slice(2);
+if (cliArgs.length === 0) {
+  throw new Error("Expected a JavaScript CLI entry and its arguments.");
+}
+
+const result = spawnSync(electronRequire("electron"), cliArgs, {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    ELECTRON_RUN_AS_NODE: "1",
+    BETTER_SQLITE3_BINDING: resolveElectronBinding(),
+  },
+  stdio: "inherit",
+});
+
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/scripts/run-electron-node.mjs
+++ b/scripts/run-electron-node.mjs
@@ -3,7 +3,7 @@
 import { spawnSync } from "child_process";
 import { existsSync } from "fs";
 import { createRequire } from "module";
-import { dirname, join, resolve } from "path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "path";
 import { fileURLToPath } from "url";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -39,7 +39,16 @@ function resolveWorkspaceCli(args) {
   }
 
   const packageDir = dirname(serverRequire.resolve(`${packageName}/package.json`));
-  const cliEntry = join(packageDir, entryFile);
+  const cliEntry = resolve(packageDir, entryFile);
+  const packageRelativeEntry = relative(packageDir, cliEntry);
+  if (
+    isAbsolute(entryFile)
+    || packageRelativeEntry === ".."
+    || packageRelativeEntry.startsWith(`..${sep}`)
+    || isAbsolute(packageRelativeEntry)
+  ) {
+    throw new Error("Workspace CLI entry must stay inside its package directory.");
+  }
   if (!existsSync(cliEntry)) {
     throw new Error(`Workspace CLI entry not found: ${cliEntry}`);
   }


### PR DESCRIPTION
## What
Run all supported SQLite access paths with Electron's native SQLite binding.

## Why
The previous Node, Bun, and Electron split could load an incompatible better-sqlite3 binary.

## Key Changes
- Run server tests and supported server launchers through Electron Node.
- Reject missing or mismatched SQLite bindings before a database opens.
- Propagate the Electron binding to desktop, development, and database-info paths.
- Bound Electron Vitest workers and cover server-only shutdown.

Related to the SQLite runtime stability work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787745589&installation_model_id=20477&pr_number=974&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F974&signature=eefc3a3175b796cd8a8b3446e07206489ebfb6e144c3e565cb4b98f4cdbc30e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Electron SQLite startup by reliably resolving and validating the native binding across dev and packaged modes.
  * Added stricter handling for missing/invalid bindings and ensured the server process receives the resolved configuration.
  * Updated log rotation and related checks to account for native binding path existence.

* **New Features**
  * Added a server-only development mode with better readiness/shutdown behavior.
  * Routed database-info execution through the Electron runtime.

* **Tests**
  * Expanded Electron SQLite runtime, binding resolution, and lifecycle coverage; updated smoke tests to use Electron-native access.

* **Chores**
  * Adjusted test runner configuration and CI environment behavior for Electron-based execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->