### PR TITLE
feat(web): make terminal rail tabs repeatable

### DIFF
--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -424,6 +424,22 @@ describe("diffStore", () => {
   });
 
   describe("setRightPanelTab", () => {
+    it("interleaves PTY-backed terminal instances with singleton tabs", () => {
+      const { addRightPanelTerminalTab, setRightPanelTab, getRightPanel } = useDiffStore.getState();
+      setRightPanelTab("ws-1", "thread-1", "preview");
+      addRightPanelTerminalTab("ws-1", "thread-1", "pty-1");
+      setRightPanelTab("ws-1", "thread-1", "changes");
+      addRightPanelTerminalTab("ws-1", "thread-1", "pty-2");
+
+      const panel = getRightPanel("ws-1", "thread-1");
+      expect(panel.tabInstances.map((instance) => instance.id)).toEqual([
+        "singleton:preview",
+        "terminal:pty-1",
+        "singleton:changes",
+        "terminal:pty-2",
+      ]);
+      expect(panel.activeTabId).toBe("terminal:pty-2");
+    });
     it("preserves an explicit canonical null over a stale compatibility active tab", () => {
       const panel = createRightPanelState({
         visible: true,

--- a/apps/web/src/__tests__/terminalStore.test.ts
+++ b/apps/web/src/__tests__/terminalStore.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/transport", () => ({
   getTransport: () => ({ terminalPause }),
 }));
 
-import { useTerminalStore, TERMINAL_PANEL_DEFAULTS } from "@/stores/terminalStore";
+import { MAX_TERMINALS_PER_SCOPE, useTerminalStore, TERMINAL_PANEL_DEFAULTS } from "@/stores/terminalStore";
 
 describe("TerminalStore", () => {
   beforeEach(() => {
@@ -63,6 +63,16 @@ describe("TerminalStore", () => {
 
       expect(useTerminalStore.getState().terminals["thread-1"]).toHaveLength(1);
       expect(useTerminalStore.getState().terminals["thread-2"]).toHaveLength(1);
+    });
+
+    it("caps one scope at four terminal sessions", () => {
+      for (let index = 1; index <= MAX_TERMINALS_PER_SCOPE + 1; index += 1) {
+        useTerminalStore.getState().addTerminal("thread-1", `pty-${index}`);
+      }
+
+      expect(useTerminalStore.getState().terminals["thread-1"]).toHaveLength(
+        MAX_TERMINALS_PER_SCOPE,
+      );
     });
   });
 

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -103,19 +103,27 @@ describe("ActivityRail expansion", () => {
     expect(rail).toHaveClass("w-12");
   });
 
-  it("anchors tab, Browser-page, and maximize controls to the same trailing edge", () => {
+  it("anchors trailing controls right and reserves their label space", () => {
     const { rerender } = renderRail();
     fireEvent.focus(screen.getByRole("button", { name: "Terminal" }));
 
     expect(screen.getByRole("button", { name: "Close Terminal" })).toHaveClass(
       "absolute",
-      "left-[7.75rem]",
+      "right-0",
       "top-0",
     );
     expect(screen.getByTestId("rail-maximize-toggle")).toHaveClass(
       "absolute",
-      "left-[7.75rem]",
+      "right-0",
       "top-0",
+    );
+    expect(screen.getByRole("button", { name: "Terminal" }).querySelector("span")).toHaveClass(
+      "left-8",
+      "right-8",
+    );
+    expect(screen.getByTestId("rail-panel-toggle").querySelector("span")).toHaveClass(
+      "left-8",
+      "right-8",
     );
 
     rerender(
@@ -134,8 +142,12 @@ describe("ActivityRail expansion", () => {
 
     expect(screen.getByRole("button", { name: "Close page Example" })).toHaveClass(
       "absolute",
-      "left-[7.75rem]",
+      "right-0",
       "top-0",
+    );
+    expect(screen.getByRole("button", { name: "Browser page: Example" }).querySelector("span")).toHaveClass(
+      "left-8",
+      "right-8",
     );
   });
 

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -45,7 +45,7 @@ const RAIL_EXPAND_DELAY_MS = 140;
 const RAIL_COLLAPSE_DELAY_MS = 250;
 
 /** Shared trailing anchor for expanded-rail actions. */
-const RAIL_TRAILING_CONTROL_CLASS = "absolute left-[7.75rem] top-0";
+const RAIL_TRAILING_CONTROL_CLASS = "absolute right-0 top-0";
 /** Pointer and keyboard reorder boundary for one top-level rail instance. */
 function ReorderableRailItem({
   instanceId,

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -221,6 +221,7 @@ function RailStatus({
 /** One rail entry: a select glyph with an active lamp, plus a hover-revealed × to close. */
 function RailTab({
   id,
+  label: labelOverride,
   active,
   expanded,
   scope,
@@ -230,6 +231,7 @@ function RailTab({
   onClose,
 }: {
   id: RightPanelTab;
+  label?: string;
   active: boolean;
   expanded: boolean;
   scope: ScopeProgress;
@@ -241,7 +243,7 @@ function RailTab({
   const meta = metaForTab(id);
   if (!meta) return null;
   const Icon = meta.icon;
-  const label = meta.label;
+  const label = labelOverride ?? meta.label;
   return (
     <div className="group relative w-full">
       <Button
@@ -474,14 +476,18 @@ function RailAddControl({
   openTabs,
   expanded,
   onCreate,
+  terminalCapReached,
 }: {
   scope: PanelScope;
   openTabs: readonly RightPanelTab[];
   expanded: boolean;
   onCreate: (id: RightPanelTab) => void;
+  readonly terminalCapReached?: boolean;
 }) {
   const shown = shownTabTypes(scope, openTabs);
-  const creatable = creatableTypes(scope, openTabs);
+  const creatable = creatableTypes(scope, openTabs).filter(
+    (type) => !(terminalCapReached && type.id === "terminal"),
+  );
 
   // Nothing openable hides the control entirely, even if a coming-soon teaser remains.
   if (creatable.length === 0) return null;
@@ -542,8 +548,10 @@ function RailAddControl({
           return (
             <DropdownMenuItem
               key={type.id}
-              disabled={type.comingSoon}
-              onClick={type.comingSoon ? undefined : () => onCreate(type.id as RightPanelTab)}
+            disabled={type.comingSoon || (terminalCapReached && type.id === "terminal")}
+            onClick={type.comingSoon || (terminalCapReached && type.id === "terminal")
+              ? undefined
+              : () => onCreate(type.id as RightPanelTab)}
               className="flex items-center justify-between gap-3 px-2.5 py-1.5 text-xs"
             >
               <span className="flex items-center gap-2">
@@ -586,6 +594,8 @@ export function ActivityRail({
   onClose,
   onReorder,
   onCreate,
+  terminalCapReached,
+  terminalLabels,
   onSelectBrowserPage,
   onCloseBrowserPage,
 }: {
@@ -605,6 +615,10 @@ export function ActivityRail({
   onClose: (instanceId: string) => void;
   onReorder: (instanceId: string, direction: -1 | 1) => void;
   onCreate: (id: RightPanelTab) => void;
+  /** Whether this scope already owns its four allowed shell sessions. */
+  readonly terminalCapReached?: boolean;
+  /** PTY-backed rail labels keyed by terminal tab identity. */
+  readonly terminalLabels?: Readonly<Record<string, string>>;
   onSelectBrowserPage: (instanceId: string, pageId: string) => void;
   onCloseBrowserPage: (pageId: string) => void;
 }) {
@@ -771,6 +785,7 @@ export function ActivityRail({
           <ReorderableRailItem key={instanceId} instanceId={instanceId} onReorder={onReorder}>
             <RailTab
               id={id}
+              label={id === "terminal" ? terminalLabels?.[instanceId] ?? "Terminal" : undefined}
               active={instanceId === activeTabId}
               expanded={expanded}
               scope={scopeProgress}
@@ -790,7 +805,13 @@ export function ActivityRail({
           openTabs={openTabs}
           expanded={expanded}
           onCreate={onCreate}
+          terminalCapReached={terminalCapReached}
         />
+      )}
+      {terminalCapReached && (
+        <span className="sr-only" role="status">
+          Maximum of 4 terminals reached for this scope.
+        </span>
       )}
       </div>
     </div>

--- a/apps/web/src/components/panels/RightPanel.test.tsx
+++ b/apps/web/src/components/panels/RightPanel.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ActivityRail", () => ({
+  ActivityRail: () => <div data-testid="activity-rail" />,
+}));
+vi.mock("./PanelEmptyState", () => ({
+  PanelEmptyState: () => <div />,
+}));
+vi.mock("./ResizableRightPanel", () => ({
+  ResizableRightPanel: ({ children, testId }: { children: React.ReactNode; testId?: string }) => (
+    <div data-testid={testId}>{children}</div>
+  ),
+}));
+vi.mock("./SubagentsPanel", () => ({ SubagentsPanel: () => <div /> }));
+vi.mock("./plan", () => ({ PlanPanel: () => <div /> }));
+vi.mock("@/components/diff", () => ({ DiffPanel: () => <div /> }));
+vi.mock("@/components/panels/PreviewPanel", () => ({ PreviewPanel: () => <div /> }));
+vi.mock("@/components/terminal/TerminalPoolSlotContext", () => ({
+  TerminalPoolSlot: () => <div data-testid="terminal-pool-slot" />,
+}));
+vi.mock("@/stores/previewTabsStore", () => ({
+  usePreviewDisplayTabSet: () => null,
+  usePreviewTabsStore: { getState: () => ({ activatePage: vi.fn(), closePage: vi.fn() }) },
+}));
+vi.mock("@/lib/ensure-terminal", () => ({ createTerminalForScope: vi.fn() }));
+vi.mock("@/lib/right-panel-layout", () => ({ toggleRightPanelAdaptive: vi.fn() }));
+vi.mock("@/transport", () => ({ getTransport: () => ({ terminalKill: vi.fn() }) }));
+
+import { RightPanel } from "./RightPanel";
+import { useDiffStore } from "@/stores/diffStore";
+import { useTerminalStore } from "@/stores/terminalStore";
+import { useUiStore } from "@/stores/uiStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+describe("RightPanel", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({ activeWorkspaceId: "workspace-1", activeThreadId: null });
+    useTerminalStore.setState({ terminals: {}, terminalPanelByThread: {}, ptyToThread: {} });
+    useDiffStore.setState({
+      rightPanelByThread: {},
+      rightPanelFallbackByWorkspace: {},
+      snapshotsByThread: {},
+    });
+    useUiStore.setState({ rightPanelMaximized: false });
+  });
+
+  afterEach(() => cleanup());
+
+  it("renders an empty workspace terminal scope without an external-store snapshot warning", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<RightPanel />);
+
+    expect(screen.getByTestId("right-panel")).toBeInTheDocument();
+    expect(error.mock.calls.flat().join(" ")).not.toContain(
+      "The result of getSnapshot should be cached",
+    );
+    error.mockRestore();
+  });
+});

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -24,12 +24,18 @@ import {
 } from "@/stores/previewTabsStore";
 import { TerminalPoolSlot } from "@/components/terminal/TerminalPoolSlotContext";
 import { createTerminalForScope } from "@/lib/ensure-terminal";
-import { MAX_TERMINALS_PER_SCOPE, useTerminalStore } from "@/stores/terminalStore";
+import {
+  MAX_TERMINALS_PER_SCOPE,
+  type TerminalInstance,
+  useTerminalStore,
+} from "@/stores/terminalStore";
 import { toggleRightPanelAdaptive } from "@/lib/right-panel-layout";
 import { getTransport } from "@/transport";
 import { cn } from "@/lib/utils";
 import { ResizableRightPanel } from "./ResizableRightPanel";
 import { SubagentsPanel } from "./SubagentsPanel";
+
+const EMPTY_SCOPE_TERMINALS: readonly TerminalInstance[] = [];
 
 /**
  * Tracks whether the Changes tab has unreviewed new files for the active
@@ -116,9 +122,10 @@ export function RightPanel() {
   // workspace itself in the threadless new-thread view (where they run against
   // the local workspace root). Their stores treat this as an opaque scope key.
   const panelScopeId = activeThreadId ?? activeWorkspaceId;
-  const scopeTerminals = useTerminalStore((s) =>
-    panelScopeId ? (s.terminals[panelScopeId] ?? []) : [],
-  );
+  const terminalsByScope = useTerminalStore((s) => s.terminals);
+  const scopeTerminals = panelScopeId
+    ? (terminalsByScope[panelScopeId] ?? EMPTY_SCOPE_TERMINALS)
+    : EMPTY_SCOPE_TERMINALS;
   const terminalLabels = useMemo(() => {
     const occurrences = new Map<string, number>();
     for (const terminal of scopeTerminals) {

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -22,10 +22,11 @@ import {
   usePreviewDisplayTabSet,
   usePreviewTabsStore,
 } from "@/stores/previewTabsStore";
-import { TerminalTabContent } from "@/components/terminal/TerminalTabContent";
 import { TerminalPoolSlot } from "@/components/terminal/TerminalPoolSlotContext";
-import { ensureTerminalForScope } from "@/lib/ensure-terminal";
+import { createTerminalForScope } from "@/lib/ensure-terminal";
+import { MAX_TERMINALS_PER_SCOPE, useTerminalStore } from "@/stores/terminalStore";
 import { toggleRightPanelAdaptive } from "@/lib/right-panel-layout";
+import { getTransport } from "@/transport";
 import { cn } from "@/lib/utils";
 import { ResizableRightPanel } from "./ResizableRightPanel";
 import { SubagentsPanel } from "./SubagentsPanel";
@@ -115,6 +116,24 @@ export function RightPanel() {
   // workspace itself in the threadless new-thread view (where they run against
   // the local workspace root). Their stores treat this as an opaque scope key.
   const panelScopeId = activeThreadId ?? activeWorkspaceId;
+  const scopeTerminals = useTerminalStore((s) =>
+    panelScopeId ? (s.terminals[panelScopeId] ?? []) : [],
+  );
+  const terminalLabels = useMemo(() => {
+    const occurrences = new Map<string, number>();
+    for (const terminal of scopeTerminals) {
+      occurrences.set(terminal.label, (occurrences.get(terminal.label) ?? 0) + 1);
+    }
+    const seen = new Map<string, number>();
+    return Object.fromEntries(scopeTerminals.map((terminal) => {
+      const ordinal = (seen.get(terminal.label) ?? 0) + 1;
+      seen.set(terminal.label, ordinal);
+      const label = occurrences.get(terminal.label)! > 1
+        ? `${terminal.label} (${ordinal})`
+        : terminal.label;
+      return [`terminal:${terminal.id}`, label];
+    }));
+  }, [scopeTerminals]);
 
   // The Browser tab's open pages drive the rail's page switcher. The store is
   // seeded by the mounted PreviewPanel; reading it here lets the rail render
@@ -169,17 +188,6 @@ export function RightPanel() {
     changesCount,
     isChangesActive,
   );
-
-  // Anticipate the next step: opening the Terminal tab spawns a shell when the
-  // thread has none, so the user lands in a ready terminal instead of an empty
-  // pane. Gated on visibility so a hidden (persisted) terminal tab never spawns
-  // in the background, and intentionally not gated on the terminal count so
-  // killing the last terminal does not immediately respawn one.
-  useEffect(() => {
-    if (panelVisible && terminalActive && panelScopeId) {
-      ensureTerminalForScope(panelScopeId);
-    }
-  }, [panelVisible, terminalActive, panelScopeId]);
 
   // Exit maximize when the panel is hidden so the user never lands on a blank
   // full-screen shell with no panel chrome to restore from.
@@ -272,11 +280,28 @@ export function RightPanel() {
             toggleRightPanelAdaptive(activeWorkspaceId, activeThreadId)
           }
           onToggleMaximized={toggleMaximized}
-          onSelect={(instanceId) =>
-            setRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId)
-          }
+          onSelect={(instanceId) => {
+            setRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId);
+            const terminal = tabInstances.find((instance) => instance.id === instanceId);
+            if (terminal?.type === "terminal" && panelScopeId) {
+              useTerminalStore
+                .getState()
+                .setActiveTerminal(panelScopeId, instanceId.slice("terminal:".length));
+            }
+          }}
           onClose={(instanceId) =>
-            closeRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId)
+            {
+              const terminal = tabInstances.find((instance) => instance.id === instanceId);
+              if (terminal?.type === "terminal") {
+                const ptyId = instanceId.slice("terminal:".length);
+                void getTransport().terminalKill(ptyId).then(() => {
+                  useTerminalStore.getState().removeTerminal(ptyId);
+                  closeRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId);
+                });
+              } else {
+                closeRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId);
+              }
+            }
           }
           onReorder={(instanceId, direction) =>
             reorderRightPanelTab(
@@ -286,9 +311,15 @@ export function RightPanel() {
               direction,
             )
           }
-          onCreate={(id) =>
-            setRightPanelTab(activeWorkspaceId!, activeThreadId, id)
-          }
+          terminalCapReached={scopeTerminals.length >= MAX_TERMINALS_PER_SCOPE}
+          terminalLabels={terminalLabels}
+          onCreate={(id) => {
+            if (id === "terminal" && panelScopeId) {
+              createTerminalForScope(panelScopeId);
+              return;
+            }
+            setRightPanelTab(activeWorkspaceId!, activeThreadId, id);
+          }}
           onSelectBrowserPage={(instanceId, pageId) => {
             // Focus the Browser tab and switch the guest to that page.
             setRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId);
@@ -325,7 +356,9 @@ export function RightPanel() {
               scope={panelScope}
               openTabs={openTabs}
               onOpen={(id) =>
-                setRightPanelTab(activeWorkspaceId!, activeThreadId, id)
+                id === "terminal" && panelScopeId
+                  ? createTerminalForScope(panelScopeId)
+                  : setRightPanelTab(activeWorkspaceId!, activeThreadId, id)
               }
             />
           )}
@@ -356,9 +389,6 @@ export function RightPanel() {
             aria-hidden={!terminalActive}
             inert={!terminalActive ? true : undefined}
           >
-            {terminalActive && panelScopeId && (
-              <TerminalTabContent threadId={panelScopeId} />
-            )}
             <TerminalPoolSlot className="relative min-h-0 min-w-0 flex-1 overflow-hidden p-2" />
           </div>
         </div>

--- a/apps/web/src/components/terminal/TerminalPoolHost.tsx
+++ b/apps/web/src/components/terminal/TerminalPoolHost.tsx
@@ -11,6 +11,7 @@ import { useTerminalPoolSlot } from "./TerminalPoolSlotContext";
 import { isContainerReadyForFit } from "./safeFit";
 import { dispatchTerminalPoolRefit } from "./terminalPoolRefit";
 import { resolveActiveTerminalId } from "./resolveActiveTerminalId";
+import { onPtyExit } from "./ptyDataRegistry";
 
 /**
  * Mounts at most one terminal view (ADR-0010): the active shell on the active
@@ -55,6 +56,29 @@ export function TerminalPoolHost() {
   }, [terminalTabVisible]);
 
   const terminals = useTerminalStore((s) => s.terminals);
+
+  useEffect(() => {
+    const unsubs = Object.values(terminals).flat().map((terminal) =>
+      onPtyExit(terminal.id, () => {
+        const state = useTerminalStore.getState();
+        const scopeId = state.ptyToThread[terminal.id];
+        if (!scopeId) return;
+        state.removeTerminal(terminal.id);
+        const workspace = useWorkspaceStore.getState();
+        const thread = workspace.threads.find((candidate) => candidate.id === scopeId);
+        const workspaceId = thread?.workspace_id ??
+          (workspace.workspaces.some((candidate) => candidate.id === scopeId) ? scopeId : undefined);
+        if (workspaceId) {
+          useDiffStore.getState().closeRightPanelTabInstance(
+            workspaceId,
+            thread ? scopeId : undefined,
+            `terminal:${terminal.id}`,
+          );
+        }
+      }),
+    );
+    return () => unsubs.forEach((unsubscribe) => unsubscribe());
+  }, [terminals]);
   const storedActiveTerminalId = useTerminalStore((s) =>
     terminalScopeId
       ? (s.terminalPanelByThread[terminalScopeId] ?? TERMINAL_PANEL_DEFAULTS)

--- a/apps/web/src/components/terminal/TerminalView.tsx
+++ b/apps/web/src/components/terminal/TerminalView.tsx
@@ -4,6 +4,9 @@ import type { FitAddon } from "@xterm/addon-fit";
 import type { SerializeAddon } from "@xterm/addon-serialize";
 import { getTransport } from "@/transport";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useDiffStore } from "@/stores/diffStore";
+import { useTerminalStore } from "@/stores/terminalStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { shouldInterceptKeyEvent } from "./terminalKeyHandler";
 import { ClientTerminalFlowControl } from "./terminalFlowControl";
 import { onPtyData, onPtyExit, onPtyReconnectGap, type PtyDataPayload } from "./ptyDataRegistry";
@@ -555,6 +558,21 @@ export const TerminalView = memo(function TerminalView({
         );
         // The PTY is gone and cannot remount; drop any saved scroll anchor.
         dropRemountAnchor(ptyId);
+        const terminal = useTerminalStore.getState();
+        const scopeId = terminal.ptyToThread[ptyId];
+        if (!scopeId) return;
+        terminal.removeTerminal(ptyId);
+        const workspace = useWorkspaceStore.getState();
+        const thread = workspace.threads.find((candidate) => candidate.id === scopeId);
+        const workspaceId = thread?.workspace_id ??
+          (workspace.workspaces.some((candidate) => candidate.id === scopeId) ? scopeId : undefined);
+        if (workspaceId) {
+          useDiffStore.getState().closeRightPanelTabInstance(
+            workspaceId,
+            thread ? scopeId : undefined,
+            `terminal:${ptyId}`,
+          );
+        }
       });
 
       // Resize handling:

--- a/apps/web/src/components/terminal/ptyDataRegistry.ts
+++ b/apps/web/src/components/terminal/ptyDataRegistry.ts
@@ -26,7 +26,7 @@ type PtyReconnectGapCallback = (detail: PtyReconnectGapPayload) => void;
  * the browser's full event dispatch machinery on every PTY data chunk.
  */
 const dataListeners = new Map<string, PtyDataCallback>();
-const exitListeners = new Map<string, PtyExitCallback>();
+const exitListeners = new Map<string, Set<PtyExitCallback>>();
 const reconnectGapListeners = new Map<string, PtyReconnectGapCallback>();
 
 /**
@@ -44,14 +44,16 @@ export function onPtyData(ptyId: string, cb: PtyDataCallback): () => void {
 
 /**
  * Register an exit listener for a specific PTY. Returns an unsubscribe function.
- * Only one listener per PTY is allowed.
+ * Terminal lifecycle consumers may observe the same exit independently.
  */
 export function onPtyExit(ptyId: string, cb: PtyExitCallback): () => void {
-  if (import.meta.env.DEV && exitListeners.has(ptyId)) {
-    console.warn(`[ptyDataRegistry] overwriting existing exit listener for PTY ${ptyId}`);
-  }
-  exitListeners.set(ptyId, cb);
-  return () => { exitListeners.delete(ptyId); };
+  const listeners = exitListeners.get(ptyId) ?? new Set<PtyExitCallback>();
+  listeners.add(cb);
+  exitListeners.set(ptyId, listeners);
+  return () => {
+    listeners.delete(cb);
+    if (listeners.size === 0) exitListeners.delete(ptyId);
+  };
 }
 
 /**
@@ -73,7 +75,7 @@ export function emitPtyData(detail: PtyDataPayload): void {
 
 /** Dispatch an exit event to the registered listener for the given PTY. */
 export function emitPtyExit(detail: PtyExitPayload): void {
-  exitListeners.get(detail.ptyId)?.(detail);
+  for (const listener of exitListeners.get(detail.ptyId) ?? []) listener(detail);
 }
 
 /** Dispatch a reconnect-gap event to the registered listener for the given PTY. */

--- a/apps/web/src/lib/__tests__/panel-tabs.test.ts
+++ b/apps/web/src/lib/__tests__/panel-tabs.test.ts
@@ -90,10 +90,10 @@ describe("shownTabTypes — cardinality filter", () => {
     ]);
   });
 
-  it("keeps the coming-soon teaser even when every openable type is open", () => {
+  it("keeps Terminal creatable after other singleton tools are open", () => {
     expect(
       ids(shownTabTypes("thread", ["preview", "terminal", "changes", "tasks", "subagents"])),
-    ).toEqual(["files"]);
+    ).toEqual(["terminal", "files"]);
   });
 
   it("ignores open ids that the scope filter already removed", () => {
@@ -144,10 +144,10 @@ describe("creatableTypes — combined scope + cardinality", () => {
     ]);
   });
 
-  it("returns an empty set when every openable type is open", () => {
+  it("keeps Terminal creatable when every singleton tool is open", () => {
     expect(
       ids(creatableTypes("thread", ["preview", "terminal", "changes", "tasks", "subagents"])),
-    ).toEqual([]);
+    ).toEqual(["terminal"]);
   });
 
   it("is a strict subset of shownTabTypes (only the coming-soon teaser differs)", () => {

--- a/apps/web/src/lib/__tests__/summon-tab.test.ts
+++ b/apps/web/src/lib/__tests__/summon-tab.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+const { createTerminalForScope } = vi.hoisted(() => ({
+  createTerminalForScope: vi.fn(),
+}));
+
+vi.mock("@/lib/ensure-terminal", () => ({ createTerminalForScope }));
+
 import { summonTab } from "@/lib/summon-tab";
 import { useDiffStore } from "@/stores/diffStore";
+import { useTerminalStore } from "@/stores/terminalStore";
 import { useUiStore } from "@/stores/uiStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
@@ -20,13 +27,25 @@ function panel() {
 
 describe("summonTab", () => {
   beforeEach(() => {
+    createTerminalForScope.mockReset();
     useDiffStore.setState({
       rightPanelByThread: {},
       rightPanelFallbackByWorkspace: {},
     });
+    useTerminalStore.setState({
+      terminals: {},
+      terminalPanelByThread: {},
+      ptyToThread: {},
+    });
     useUiStore.setState({ primarySurface: "chat" });
     useWorkspaceStore.setState({ activeWorkspaceId: WID, activeThreadId: TID });
   });
+
+  function seedTerminal(): void {
+    useTerminalStore.getState().addTerminal(TID, "pty-1", "pwsh");
+    useDiffStore.getState().addRightPanelTerminalTab(WID, TID, "pty-1");
+    useDiffStore.getState().showRightPanel(WID, TID);
+  }
 
   describe("create-or-focus", () => {
     it("opens the panel and focuses the tab when the panel is closed", () => {
@@ -39,17 +58,17 @@ describe("summonTab", () => {
       expect(panel().openTabs).toContain("preview");
     });
 
-    it("creates the tab if absent (adds it to the open set)", () => {
+    it("requests the first PTY when no terminal tab exists", () => {
       summonTab("preview");
       expect(panel().openTabs).toEqual(["preview"]);
 
       summonTab("terminal");
-      // preview stays open; terminal is created and focused.
-      expect(panel().openTabs).toEqual(["preview", "terminal"]);
-      expect(panel().activeTab).toBe("terminal");
+      expect(createTerminalForScope).toHaveBeenCalledWith(TID);
+      expect(panel().visible).toBe(true);
     });
 
     it("focuses an open-but-inactive tab without hiding the panel", () => {
+      seedTerminal();
       summonTab("preview");
       summonTab("terminal");
       expect(panel().activeTab).toBe("terminal");
@@ -59,12 +78,13 @@ describe("summonTab", () => {
       expect(panel().visible).toBe(true);
       expect(panel().activeTab).toBe("preview");
       // No tab was closed — both remain open.
-      expect(panel().openTabs).toEqual(["preview", "terminal"]);
+      expect(panel().openTabs).toEqual(["terminal", "preview"]);
     });
 
-    it("recreates a closed active tab instead of hiding the empty panel", () => {
-      summonTab("terminal");
-      useDiffStore.getState().closeRightPanelTab(WID, TID, "terminal");
+    it("requests a replacement PTY after the final terminal tab closes", () => {
+      seedTerminal();
+      useDiffStore.getState().closeRightPanelTabInstance(WID, TID, "terminal:pty-1");
+      useTerminalStore.getState().removeTerminal("pty-1");
       expect(panel()).toMatchObject({
         visible: true,
         activeTab: "tasks",
@@ -73,11 +93,7 @@ describe("summonTab", () => {
 
       summonTab("terminal");
 
-      expect(panel()).toMatchObject({
-        visible: true,
-        activeTab: "terminal",
-        openTabs: ["terminal"],
-      });
+      expect(createTerminalForScope).toHaveBeenCalledWith(TID);
     });
   });
 
@@ -151,7 +167,7 @@ describe("summonTab", () => {
       summonTab("preview", onFocus); // open
       expect(onFocus).toHaveBeenCalledTimes(1);
 
-      summonTab("terminal");
+      seedTerminal();
       summonTab("preview", onFocus); // refocus
       expect(onFocus).toHaveBeenCalledTimes(2);
 
@@ -160,7 +176,7 @@ describe("summonTab", () => {
     });
 
     it("returns to Chat and shows the requested tab from Pull requests", () => {
-      summonTab("terminal");
+      seedTerminal();
       useUiStore.getState().setPrimarySurface("pullRequests");
 
       summonTab("terminal");

--- a/apps/web/src/lib/ensure-terminal.ts
+++ b/apps/web/src/lib/ensure-terminal.ts
@@ -1,5 +1,5 @@
 import { useDiffStore } from "@/stores/diffStore";
-import { useTerminalStore } from "@/stores/terminalStore";
+import { MAX_TERMINALS_PER_SCOPE, useTerminalStore } from "@/stores/terminalStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { getTransport } from "@/transport";
 
@@ -29,21 +29,16 @@ function resolveScopeWorkspace(scopeId: string): {
 }
 
 /**
- * Spawns a terminal for the scope when it has none, so opening the Terminal
- * tab lands the user in a ready shell instead of an empty pane (the "anticipate
- * the next step" product principle).
- *
- * No-op when a terminal already exists or a creation is already in flight. If
- * the Terminal tab is no longer the visible target by the time the PTY is ready
- * (the user closed the panel or switched tabs mid-creation), the orphaned PTY
- * is killed rather than added to the store.
+ * Creates one terminal and its matching right-panel rail tab. Creation is
+ * serialized per scope so concurrent UI and shortcut requests cannot exceed the
+ * session cap.
  *
  * @param scopeId - A thread id, or a workspace id for the threadless shell.
  */
-export function ensureTerminalForScope(scopeId: string): void {
+export function createTerminalForScope(scopeId: string): void {
   if (creationInFlight.has(scopeId)) return;
   const existing = useTerminalStore.getState().terminals[scopeId];
-  if (existing && existing.length > 0) return;
+  if ((existing?.length ?? 0) >= MAX_TERMINALS_PER_SCOPE) return;
 
   creationInFlight.add(scopeId);
   try {
@@ -64,23 +59,29 @@ export function ensureTerminalForScope(scopeId: string): void {
         const panelVisible = workspaceId
           ? diff.getRightPanelVisible(workspaceId, panelThreadId)
           : false;
-        // Panel closed or tab switched while creation was in flight — dispose
-        // the orphaned PTY instead of adding a terminal nobody asked to see.
-        if (!panel || !panelVisible || panel.activeTab !== "terminal") {
+        if (!panel || !panelVisible) {
           transport.terminalKill(ptyId).catch(() => {});
           return;
         }
         const current = useTerminalStore.getState().terminals[scopeId];
-        if (!current || current.length === 0) {
-          useTerminalStore.getState().addTerminal(scopeId, ptyId, shell);
-        } else {
+        if ((current?.length ?? 0) >= MAX_TERMINALS_PER_SCOPE) {
           transport.terminalKill(ptyId).catch(() => {});
+          return;
         }
+        useTerminalStore.getState().addTerminal(scopeId, ptyId, shell);
+        diff.addRightPanelTerminalTab(workspaceId!, panelThreadId, ptyId);
       })
       .catch(() => {
         creationInFlight.delete(scopeId);
       });
   } catch {
     creationInFlight.delete(scopeId);
+  }
+}
+
+/** Ensures a Terminal tab has its first PTY-backed rail instance. */
+export function ensureTerminalForScope(scopeId: string): void {
+  if ((useTerminalStore.getState().terminals[scopeId]?.length ?? 0) === 0) {
+    createTerminalForScope(scopeId);
   }
 }

--- a/apps/web/src/lib/panel-tabs.ts
+++ b/apps/web/src/lib/panel-tabs.ts
@@ -103,7 +103,7 @@ export const PANEL_TAB_TYPES: readonly PanelTabType[] = [
 /**
  * Tab types displayed in the current scope, in catalog order: scope-filtered
  * (thread-only types dropped when threadless) then cardinality-filtered
- * (singletons already open dropped). Coming-soon teasers (Files) are kept so the
+ * (singletons already open dropped). Terminal remains repeatable. Coming-soon teasers (Files) are kept so the
  * empty-state grid can render them disabled. Pure — does not read or mutate any
  * external state.
  */
@@ -113,7 +113,7 @@ export function shownTabTypes(
 ): readonly PanelTabType[] {
   return PANEL_TAB_TYPES.filter((type) => {
     const allowedInScope = scope === "thread" || !type.needsThread;
-    return allowedInScope && !openTabs.includes(type.id);
+    return allowedInScope && (type.id === "terminal" || !openTabs.includes(type.id));
   });
 }
 

--- a/apps/web/src/lib/summon-tab.ts
+++ b/apps/web/src/lib/summon-tab.ts
@@ -3,6 +3,8 @@ import { useDiffStore, type RightPanelTab } from "@/stores/diffStore";
 import { useUiStore } from "@/stores/uiStore";
 import { PANEL_TAB_TYPES } from "@/lib/panel-tabs";
 import { hideRightPanelAdaptive, showRightPanelAdaptive } from "@/lib/right-panel-layout";
+import { createTerminalForScope } from "@/lib/ensure-terminal";
+import { useTerminalStore } from "@/stores/terminalStore";
 
 /** Whether a tab type only makes sense once a thread exists. */
 function tabNeedsThread(tab: RightPanelTab): boolean {
@@ -30,24 +32,35 @@ export function summonTab(tab: RightPanelTab, onFocus?: () => void): void {
   if (!wid) return;
   if (tabNeedsThread(tab) && !tid) return;
 
-  const { getRightPanel, getRightPanelVisible, setRightPanelTab } = useDiffStore.getState();
+  const { getRightPanel, getRightPanelVisible, setRightPanelTab, setRightPanelTabInstance } = useDiffStore.getState();
   const ui = useUiStore.getState();
   const panel = getRightPanel(wid, tid);
+
+  const scopeId = tid ?? wid;
+  const latestTerminal = useTerminalStore.getState().terminals[scopeId]?.at(-1);
+  const focusTerminal = () => {
+    if (latestTerminal) {
+      setRightPanelTabInstance(wid, tid, `terminal:${latestTerminal.id}`);
+      useTerminalStore.getState().setActiveTerminal(scopeId, latestTerminal.id);
+      return;
+    }
+    createTerminalForScope(scopeId);
+  };
 
   if (ui.primarySurface !== "chat") {
     ui.setPrimarySurface("chat");
     showRightPanelAdaptive(wid, tid);
-    setRightPanelTab(wid, tid, tab);
+    if (tab === "terminal") focusTerminal(); else setRightPanelTab(wid, tid, tab);
     onFocus?.();
     return;
   }
 
   if (!getRightPanelVisible(wid, tid)) {
     showRightPanelAdaptive(wid, tid);
-    setRightPanelTab(wid, tid, tab);
+    if (tab === "terminal") focusTerminal(); else setRightPanelTab(wid, tid, tab);
     onFocus?.();
   } else if (!panel.openTabs.includes(tab) || panel.activeTab !== tab) {
-    setRightPanelTab(wid, tid, tab);
+    if (tab === "terminal") focusTerminal(); else setRightPanelTab(wid, tid, tab);
     onFocus?.();
   } else {
     hideRightPanelAdaptive(wid, tid);

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -163,6 +163,11 @@ export function rightPanelSingletonId(type: RightPanelTab): string {
   return `singleton:${type}`;
 }
 
+/** Stable rail identity for one PTY-backed Terminal tab. */
+export function rightPanelTerminalId(ptyId: string): string {
+  return `terminal:${ptyId}`;
+}
+
 /** Resolve ordered instances from current or legacy in-memory panel state. */
 export function rightPanelTabInstances(
   state: Pick<RightPanelState, "openTabs"> & Partial<Pick<RightPanelState, "tabInstances">>,
@@ -516,6 +521,12 @@ interface DiffState {
     threadId: string | null | undefined,
     instanceId: string,
   ) => void;
+  /** Append or focus one PTY-backed Terminal rail tab. */
+  addRightPanelTerminalTab: (
+    workspaceId: string,
+    threadId: string | null | undefined,
+    ptyId: string,
+  ) => void;
   /** Move one tab instance by one bounded position in its scope. */
   reorderRightPanelTab: (
     workspaceId: string,
@@ -708,6 +719,24 @@ export const useDiffStore = create<DiffState>((set, get) => ({
       return writeRightPanel(state, workspaceId, threadId, {
         ...current,
         activeTabId: instance.id,
+      });
+    }),
+
+  addRightPanelTerminalTab: (workspaceId, threadId, ptyId) =>
+    set((state) => {
+      const current = effectiveRightPanel(state, workspaceId, threadId);
+      const instanceId = rightPanelTerminalId(ptyId);
+      const tabInstances = rightPanelTabInstances(current);
+      if (tabInstances.some((instance) => instance.id === instanceId)) {
+        return writeRightPanel(state, workspaceId, threadId, {
+          ...current,
+          activeTabId: instanceId,
+        });
+      }
+      return writeRightPanel(state, workspaceId, threadId, {
+        ...current,
+        tabInstances: [...tabInstances, { id: instanceId, type: "terminal" }],
+        activeTabId: instanceId,
       });
     }),
 

--- a/apps/web/src/stores/terminalStore.ts
+++ b/apps/web/src/stores/terminalStore.ts
@@ -29,6 +29,9 @@ export const TERMINAL_PANEL_DEFAULTS: TerminalPanelState = {
   activeTerminalId: null,
 } as const;
 
+/** Maximum concurrent shell sessions in one thread or workspace scope. */
+export const MAX_TERMINALS_PER_SCOPE = 4;
+
 interface TerminalState {
   readonly terminals: Record<string, readonly TerminalInstance[]>;
   readonly terminalPanelByThread: Record<string, TerminalPanelState>;
@@ -150,6 +153,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   addTerminal: (threadId, ptyId, shell) =>
     set((state) => {
       const existing = state.terminals[threadId] ?? [];
+      if (existing.length >= MAX_TERMINALS_PER_SCOPE) return state;
       const label = shell ?? generateLabel(existing);
       const instance: TerminalInstance = { id: ptyId, threadId, label };
       const currentPanel = state.terminalPanelByThread[threadId] ?? TERMINAL_PANEL_DEFAULTS;


### PR DESCRIPTION
## What
Migrates shell sessions into repeatable Terminal tabs in the shared right-panel rail.

## Why
Each shell needs its own selectable, reorderable tab instead of a nested terminal navigator.

## Key Changes
- Maps each terminal session to a rail tab with bounded per-scope creation and accessible labels.
- Preserves terminal selection, close lifecycle, restoration, and Mod+J behavior.
- Stabilizes the empty-terminal subscription and reserves rail label space beside trailing controls.

Closes #948

Verification: focused terminal and ActivityRail tests passed. Live browser checks covered terminal creation, selection, close, and the corrected rail layout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787784511&installation_model_id=20477&pr_number=975&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F975&signature=4348296a734cbdc8f41c52dc1c2837380cb0324741af19ec33440e8e1673e6c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple terminal tabs per workspace or thread, with distinct labels for each terminal.
  * Terminal shortcuts and panel controls now open or focus the appropriate terminal.
  * Terminal sessions are limited to four per workspace or thread, with creation controls disabled when the limit is reached.
* **Bug Fixes**
  * Terminal tabs now close automatically when their session exits.
  * Improved terminal tab ordering, selection, shutdown, and panel visibility behavior.
  * Updated activity-rail controls for more consistent alignment and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->