### PR TITLE
refactor(codex): centralize provider preflight and failures

### DIFF
--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -9,9 +9,16 @@ vi.mock("@mcode/shared", () => ({
   logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }));
 
+const { checkCodexVersionMock, meetsMinVersionMock } = vi.hoisted(() => ({
+  checkCodexVersionMock: vi.fn<() =>
+    | { ok: true; version: string }
+    | { ok: false; error: string }>(() => ({ ok: true, version: "0.40.0" })),
+  meetsMinVersionMock: vi.fn(() => true),
+}));
+
 vi.mock("../codex-version.js", () => ({
-  checkCodexVersion: () => ({ ok: true, version: "0.40.0" }),
-  meetsMinVersion: () => true,
+  checkCodexVersion: checkCodexVersionMock,
+  meetsMinVersion: meetsMinVersionMock,
 }));
 
 const { sendTurnMock, appServers } = vi.hoisted(() => ({
@@ -85,6 +92,8 @@ describe("CodexProvider first turn on new session", () => {
 
   beforeEach(() => {
     sendTurnMock.mockClear();
+    checkCodexVersionMock.mockClear();
+    meetsMinVersionMock.mockClear();
     appServers.length = 0;
   });
 
@@ -124,6 +133,113 @@ describe("CodexProvider first turn on new session", () => {
     });
 
     await ended;
+  });
+
+  it("emits Error before Ended when CLI preflight fails before runtime acquire", async () => {
+    checkCodexVersionMock.mockReturnValueOnce({ ok: false, error: "Codex CLI unavailable" });
+    const provider = makeProvider();
+    const events: AgentEvent[] = [];
+    provider.on("event", (event: AgentEvent) => events.push(event));
+
+    await provider.sendTurn({
+      sessionId: "mcode-preflight-failure",
+      threadId: "preflight-failure",
+      message: "hello",
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "auto",
+    });
+
+    expect(events).toEqual([
+      { type: AgentEventType.Error, threadId: "preflight-failure", error: "Codex CLI unavailable" },
+      { type: AgentEventType.Ended, threadId: "preflight-failure" },
+    ]);
+    expect(appServers).toHaveLength(0);
+  });
+
+  it("skips CLI preflight when reusing a live session", async () => {
+    const provider = makeProvider();
+    const sessionId = "mcode-reusable-session";
+    const threadId = "reusable-session";
+    const events: AgentEvent[] = [];
+    provider.on("event", (event: AgentEvent) => events.push(event));
+    const request = {
+      sessionId,
+      threadId,
+      message: "first",
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build" as const,
+      providerOptions: {},
+      permissionMode: "auto" as const,
+    };
+
+    await provider.sendTurn(request);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(checkCodexVersionMock).toHaveBeenCalledTimes(1);
+    const runtime = (provider as unknown as {
+      runtime: { get: (id: string) => { server: { emit: (event: string, value: unknown) => void } } | undefined };
+    }).runtime;
+    const state = runtime.get(sessionId);
+    expect(state).toBeDefined();
+    state!.server.emit("notification", {
+      method: "turn/completed",
+      params: { turn: { id: "turn-test-id", status: "completed" } },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    await provider.sendTurn({ ...request, message: "second" });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(checkCodexVersionMock).toHaveBeenCalledTimes(1);
+    state!.server.emit("notification", {
+      method: "turn/completed",
+      params: { turn: { id: "turn-test-id", status: "completed" } },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(events.filter((event) => event.type === AgentEventType.Ended)).toHaveLength(2);
+  });
+
+  it("keeps caller-specific policy for unsupported CLI versions", async () => {
+    checkCodexVersionMock.mockReturnValueOnce({ ok: true, version: "0.36.0" });
+    meetsMinVersionMock.mockReturnValueOnce(false);
+    const provider = makeProvider();
+    const events: AgentEvent[] = [];
+    provider.on("event", (event: AgentEvent) => events.push(event));
+
+    await provider.sendTurn({
+      sessionId: "mcode-unsupported-version",
+      threadId: "unsupported-version",
+      message: "hello",
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "auto",
+    });
+
+    expect(events).toEqual([
+      {
+        type: AgentEventType.Error,
+        threadId: "unsupported-version",
+        error: "Codex CLI version 0.36.0 is not supported. Minimum required: 0.37.0. Update with: npm install -g @openai/codex",
+      },
+      { type: AgentEventType.Ended, threadId: "unsupported-version" },
+    ]);
+
+    checkCodexVersionMock.mockReturnValueOnce({ ok: true, version: "0.36.0" });
+    meetsMinVersionMock.mockReturnValueOnce(false);
+    await expect(provider.runSideChannelQuery({
+      parentThreadId: "parent-thread",
+      parentSdkSessionId: "sdk-thread-1",
+      prompt: "Generate the handoff.",
+      cwd: process.cwd(),
+    })).rejects.toMatchObject({
+      code: "ETIMEDOUT",
+      message: "Codex CLI version 0.36.0 is too old for side-channel handoff",
+    });
+    expect(appServers).toHaveLength(0);
   });
 
   it("starts the first turn from cached Skills without waiting for catalog I/O", async () => {
@@ -639,5 +755,21 @@ describe("CodexProvider first turn on new session", () => {
     });
 
     await expect(result).resolves.toBe("# Handoff");
+  });
+
+  it("maps side-channel CLI preflight failures to transient errors before creating a server", async () => {
+    checkCodexVersionMock.mockReturnValueOnce({ ok: false, error: "Codex CLI unavailable" });
+    const provider = makeProvider();
+
+    await expect(provider.runSideChannelQuery({
+      parentThreadId: "parent-thread",
+      parentSdkSessionId: "sdk-thread-1",
+      prompt: "Generate the handoff.",
+      cwd: process.cwd(),
+    })).rejects.toMatchObject({
+      code: "ETIMEDOUT",
+      message: "Codex CLI unavailable",
+    });
+    expect(appServers).toHaveLength(0);
   });
 });

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -84,8 +84,14 @@ const TURN_TIMEOUT_MS = 5 * 60 * 1000;
 const SIDE_CHANNEL_TIMEOUT_MS = 120_000;
 const USAGE_WARMUP_TIMEOUT_MS = 10_000;
 const USAGE_WARMUP_RETRY_MS = 60_000;
+const CODEX_MIN_VERSION = "0.37.0";
 
 type CodexEndedOutcome = "completed" | "errored" | "cancelled";
+
+type CodexCliPreflightResult =
+  | { ok: true; version: string }
+  | { ok: false; reason: "unavailable"; error: string }
+  | { ok: false; reason: "unsupported"; version: string };
 
 function codexRateLimitLabel(windowDurationMins: number | undefined, fallback: string): string {
   if (windowDurationMins === 300) return "5-hour limit";
@@ -610,6 +616,35 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     return sessionId.startsWith("mcode-") ? sessionId.slice(6) : sessionId;
   }
 
+  /** Check Codex CLI availability and minimum version without applying caller policy. */
+  private checkCodexCliPreflight(cliPath: string): CodexCliPreflightResult {
+    const versionResult = checkCodexVersion(cliPath);
+    if (!versionResult.ok) {
+      return { ok: false, reason: "unavailable", error: versionResult.error };
+    }
+    if (!meetsMinVersion(versionResult.version, CODEX_MIN_VERSION)) {
+      return { ok: false, reason: "unsupported", version: versionResult.version };
+    }
+    return { ok: true, version: versionResult.version };
+  }
+
+  /** Emit a failed turn's error and terminal events, optionally deferring Ended. */
+  private emitTurnFailure(
+    threadId: string,
+    error: string,
+    outcome?: CodexEndedOutcome,
+    emitEnded = true,
+  ): AgentEvent {
+    this.emit("event", { type: AgentEventType.Error, threadId, error } satisfies AgentEvent);
+    const ended = {
+      type: AgentEventType.Ended,
+      threadId,
+      ...(outcome ? { outcome } : {}),
+    } satisfies AgentEvent;
+    if (emitEnded) this.emit("event", ended);
+    return ended;
+  }
+
   /** Convert a native Codex goal into Mcode's provider-neutral goal state. */
   private mapCodexGoal(sessionId: string, goal: ThreadGoal, turnId?: string | null): GoalState {
     return {
@@ -843,8 +878,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
         promptName: err.promptName,
         cause: err.cause instanceof Error ? err.cause.message : String(err.cause),
       });
-      this.emit("event", { type: AgentEventType.Error, threadId, error: err.message } satisfies AgentEvent);
-      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+      this.emitTurnFailure(threadId, err.message);
       return;
     }
 
@@ -905,17 +939,12 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     // never spawns a child.
     const reusable = existing && existing.server.isAlive && existing.sandboxMode === sandbox;
     if (!reusable) {
-      const versionResult = checkCodexVersion(cliPath);
-      if (!versionResult.ok) {
-        this.emit("event", { type: AgentEventType.Error, threadId, error: versionResult.error } satisfies AgentEvent);
-        this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
-        return;
-      }
-
-      if (!meetsMinVersion(versionResult.version, "0.37.0")) {
-        const errorMsg = `Codex CLI version ${versionResult.version} is not supported. Minimum required: 0.37.0. Update with: npm install -g @openai/codex`;
-        this.emit("event", { type: AgentEventType.Error, threadId, error: errorMsg } satisfies AgentEvent);
-        this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+      const preflight = this.checkCodexCliPreflight(cliPath);
+      if (!preflight.ok) {
+        const errorMessage = preflight.reason === "unavailable"
+          ? preflight.error
+          : `Codex CLI version ${preflight.version} is not supported. Minimum required: ${CODEX_MIN_VERSION}. Update with: npm install -g @openai/codex`;
+        this.emitTurnFailure(threadId, errorMessage);
         return;
       }
     }
@@ -938,8 +967,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       this.pendingSpawnTurns.delete(sessionId);
       const errorMessage = e instanceof Error ? e.message : String(e);
       logger.error("CodexAppServer start failed", { sessionId, error: errorMessage });
-      this.emit("event", { type: AgentEventType.Error, threadId, error: errorMessage } satisfies AgentEvent);
-      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+      this.emitTurnFailure(threadId, errorMessage);
       return;
     }
     this.runtime.recordUsage(sessionId);
@@ -1051,8 +1079,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       for (const event of mapper.drainPendingAssistantBoundary(false)) {
         this.emit("event", event);
       }
-      this.emit("event", { type: AgentEventType.Error, threadId, error } satisfies AgentEvent);
-      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+      this.emitTurnFailure(threadId, error);
       void this.runtime.stop(sessionId);
     });
 
@@ -1219,10 +1246,12 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
 
     const settings = await this.settingsService.get();
     const cliPath = settings.provider.cli.codex || "codex";
-    const versionResult = checkCodexVersion(cliPath);
-    if (!versionResult.ok) throw transientHandoffError(versionResult.error);
-    if (!meetsMinVersion(versionResult.version, "0.37.0")) {
-      throw transientHandoffError(`Codex CLI version ${versionResult.version} is too old for side-channel handoff`);
+    const preflight = this.checkCodexCliPreflight(cliPath);
+    if (!preflight.ok) {
+      const errorMessage = preflight.reason === "unavailable"
+        ? preflight.error
+        : `Codex CLI version ${preflight.version} is too old for side-channel handoff`;
+      throw transientHandoffError(errorMessage);
     }
 
     const server = new CodexAppServer({
@@ -1360,8 +1389,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       const error = err instanceof Error ? err.message : String(err);
       logger.error("Codex goal install failed", { sessionId, error });
       this.emitGoalCleared(sessionId, "rollback");
-      this.emit("event", { type: AgentEventType.Error, threadId, error } satisfies AgentEvent);
-      this.emit("event", { type: AgentEventType.Ended, threadId, outcome: "errored" } satisfies AgentEvent);
+      this.emitTurnFailure(threadId, error, "errored");
       return;
     }
     await this.runTurn(sessionId, threadId, server, input, turnOptions);
@@ -1407,6 +1435,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     let serverDied = false;
     let endedEmitted = false;
     let endedOutcome: CodexEndedOutcome | undefined;
+    let deferredEnded: AgentEvent | undefined;
 
     try {
       await new Promise<void>((resolve, reject) => {
@@ -1535,7 +1564,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
         for (const event of entry.mapper.drainPendingAssistantBoundary(false)) {
           this.emit("event", event);
         }
-        this.emit("event", { type: AgentEventType.Error, threadId, error: errorMessage } satisfies AgentEvent);
+        deferredEnded = this.emitTurnFailure(threadId, errorMessage, endedOutcome, false);
       }
     } finally {
       if (seq === entry.runTurnSeq) {
@@ -1546,7 +1575,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       }
       if (!serverDied && seq === entry.runTurnSeq && !endedEmitted) {
         endedEmitted = true;
-        this.emit("event", {
+        this.emit("event", deferredEnded ?? {
           type: AgentEventType.Ended,
           threadId,
           ...(endedOutcome ? { outcome: endedOutcome } : {}),


### PR DESCRIPTION
## What
Centralize repeated Codex CLI preflight checks and failed-turn terminal event emission inside `CodexProvider`.

## Why
Normal turns and side-channel queries duplicated CLI availability and minimum-version checks while applying different caller policies. Failed-turn branches also repeated `Error` and `Ended` event construction. Shared mechanics reduce divergence while keeping retry, permission, session, timeout, and error policy in their existing callers.

## Key Changes
- Add one structured provider-local CLI preflight helper for normal and side-channel flows.
- Add one failed-turn helper that preserves `Error` before `Ended` ordering and optional outcomes.
- Add characterization tests for unavailable and unsupported CLIs, side-channel error mapping, and reusable-session preflight skipping.

## Verification
- `bun run test -- src/providers/codex`: 19 files and 253 tests passed.
- `bun run verify:changed`: passed.
- Live Codex turn returned `LIVE_OK` and completed exactly once.
- Independent high-risk review found no issues and recommended release.
- `bun run verify` still reproduces two unrelated baseline failures in `PullRequestSummary.test.tsx`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787824543&installation_model_id=20477&pr_number=976&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F976&signature=ff3b4396ae646b8f1feaf7ccc7c29625b937c9ad78068ff9fb0f33279f570591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the Codex CLI is unavailable or below the supported version.
  * Standardized turn failure reporting with clear error and completion events.
  * Prevented unnecessary app server creation when preflight checks fail.
  * Preserved active sessions without repeating unnecessary CLI checks.
  * Improved side-channel error reporting for transient CLI preflight failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->