### PR TITLE
feat(thread-control): expose secured external MCP

### DIFF
--- a/apps/server/drizzle/0032_external_thread_control.sql
+++ b/apps/server/drizzle/0032_external_thread_control.sql
@@ -1,0 +1,34 @@
+CREATE TABLE `external_thread_control_pairings` (
+  `pairing_id` text PRIMARY KEY NOT NULL,
+  `integration_id` text NOT NULL,
+  `credential_hash` text NOT NULL UNIQUE,
+  `workspace_ids_json` text DEFAULT '[]' NOT NULL,
+  `scopes_json` text DEFAULT '[]' NOT NULL,
+  `calls_per_minute` integer NOT NULL,
+  `max_active_threads` integer NOT NULL,
+  `status` text DEFAULT 'active' NOT NULL,
+  `authority_epoch` integer NOT NULL,
+  `created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+  `updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+  `replaced_by_pairing_id` text,
+  `replaces_pairing_id` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_external_thread_control_pairings_integration`
+  ON `external_thread_control_pairings` (`integration_id`, `status`);
+--> statement-breakpoint
+CREATE TABLE `external_thread_control_deliveries` (
+  `pairing_id` text NOT NULL,
+  `authority_epoch` integer NOT NULL,
+  `delivery_id` text NOT NULL,
+  `fingerprint` text NOT NULL,
+  `status` text DEFAULT 'in_flight' NOT NULL,
+  `result_json` text,
+  `created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+  `updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+  `expires_at` text NOT NULL,
+  PRIMARY KEY (`pairing_id`, `authority_epoch`, `delivery_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_external_thread_control_delivery_retention`
+  ON `external_thread_control_deliveries` (`pairing_id`, `status`, `expires_at`);

--- a/apps/server/drizzle/0033_external_thread_control_active_integration.sql
+++ b/apps/server/drizzle/0033_external_thread_control_active_integration.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX `idx_external_thread_control_active_integration`
+  ON `external_thread_control_pairings` (`integration_id`)
+  WHERE `status` = 'active';

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -232,6 +232,20 @@
       "when": 1785268426090,
       "tag": "0031_free_greymalkin",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1785268426091,
+      "tag": "0032_external_thread_control",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1785268426092,
+      "tag": "0033_external_thread_control_active_integration",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -81,6 +81,8 @@ import { ThreadControlApprovalRepo } from "./repositories/thread-control-approva
 import { ThreadControlAuditRepo } from "./repositories/thread-control-audit-repo";
 import { InternalThreadControlMcpAuthority } from "./services/thread-control-mcp-authority";
 import { InternalThreadControlMcpRuntime } from "./services/thread-control-mcp-runtime";
+import { ExternalThreadControlPairingService } from "./services/external-thread-control-pairing-service";
+import { ExternalThreadControlMcpRuntime } from "./services/external-thread-control-mcp-runtime";
 import { UtilityCompletionService } from "./services/utility-completion-service";
 import { DiffSummaryService } from "./services/diff-summary-service";
 import { RecapService } from "./services/recap-service";
@@ -354,6 +356,8 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.register(ThreadControlService, { useClass: ThreadControlService }, { lifecycle: Lifecycle.Singleton });
   container.register(InternalThreadControlMcpAuthority, { useClass: InternalThreadControlMcpAuthority }, { lifecycle: Lifecycle.Singleton });
   container.register(InternalThreadControlMcpRuntime, { useClass: InternalThreadControlMcpRuntime }, { lifecycle: Lifecycle.Singleton });
+  container.register(ExternalThreadControlPairingService, { useClass: ExternalThreadControlPairingService }, { lifecycle: Lifecycle.Singleton });
+  container.register(ExternalThreadControlMcpRuntime, { useClass: ExternalThreadControlMcpRuntime }, { lifecycle: Lifecycle.Singleton });
   container.register(
     ThreadTeardownService,
     { useClass: ThreadTeardownService },

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -22,6 +22,8 @@ import { WorkspaceService } from "./services/workspace-service";
 import { ThreadService } from "./services/thread-service";
 import { AgentService } from "./services/agent-service";
 import { ThreadControlService } from "./services/thread-control-service";
+import { ExternalThreadControlPairingService } from "./services/external-thread-control-pairing-service";
+import { ExternalThreadControlMcpRuntime } from "./services/external-thread-control-mcp-runtime";
 import { NarrativeStore } from "./services/narrative-store";
 import { GitService } from "./services/git-service";
 import { GithubService } from "./services/github-service";
@@ -216,6 +218,8 @@ const workspaceService = container.resolve(WorkspaceService);
 const threadService = container.resolve(ThreadService);
 const agentService = container.resolve(AgentService);
 const threadControlService = container.resolve(ThreadControlService);
+const externalThreadControlPairingService = container.resolve(ExternalThreadControlPairingService);
+const externalThreadControlMcpRuntime = container.resolve(ExternalThreadControlMcpRuntime);
 const gitService = container.resolve(GitService);
 const githubService = container.resolve(GithubService);
 const pullRequestService = container.resolve(PullRequestService);
@@ -606,6 +610,8 @@ const { httpServer, wss } = createWsServer({
   threadService,
   agentService,
   threadControlService,
+  externalThreadControlPairingService,
+  externalThreadControlMcpRuntime,
   gitService,
   githubService,
   pullRequestService,
@@ -665,6 +671,7 @@ function listen(port: number, attempt = 1): void {
     }
   });
   httpServer.listen(port, HOST, () => {
+    externalThreadControlMcpRuntime.setPort(port);
     logger.info(`Mcode server listening on ${HOST}:${port}`);
 
     // Write lock file so other instances can discover this server
@@ -733,6 +740,7 @@ reapOrphanedPtys(pidRegistry, logger);
 async function bootstrapServer(): Promise<void> {
   try {
     await threadControlService.recoverApprovals();
+    externalThreadControlMcpRuntime.reconcileOnStartup();
   } catch (err) {
     logger.error("Thread-control approval recovery failed; refusing to accept work", {
       error: err instanceof Error ? err.message : String(err),
@@ -770,6 +778,8 @@ async function shutdown(): Promise<void> {
 
   // Close IPC push server
   await ipcServer.close();
+
+  await externalThreadControlMcpRuntime.close();
 
   // Clean up IPC socket file on non-Windows
   if (process.platform !== "win32") {

--- a/apps/server/src/services/__tests__/external-thread-control-mcp-transport.test.ts
+++ b/apps/server/src/services/__tests__/external-thread-control-mcp-transport.test.ts
@@ -1,0 +1,122 @@
+import "reflect-metadata";
+import { describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createExternalThreadControlMcpSession } from "../external-thread-control-mcp-transport.js";
+
+const pairing = {
+  pairingId: "pairing-1",
+  integrationId: "integration-1",
+  workspaceIds: ["workspace-1"],
+  scopes: ["threads:read-project"],
+  callsPerMinute: 10,
+  maxActiveThreads: 2,
+  status: "active",
+  authorityEpoch: 1,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+} as const;
+
+function createHarness() {
+  const service = {
+    workspaceSearch: vi.fn(),
+    worktreeList: vi.fn(),
+    threadCreateBatch: vi.fn(),
+    threadSearch: vi.fn().mockReturnValue({ threads: [] }),
+    threadGet: vi.fn(),
+    threadSend: vi.fn(),
+    threadStop: vi.fn(),
+    threadWait: vi.fn(),
+  };
+  const pairingService = {
+    authenticate: vi.fn().mockReturnValue({
+      pairing,
+      authority: {
+        type: "external",
+        pairingId: pairing.pairingId,
+        authorityEpoch: pairing.authorityEpoch,
+        integrationId: pairing.integrationId,
+        allowedWorkspaceIds: pairing.workspaceIds,
+        scopes: pairing.scopes,
+        limits: { callsPerMinute: pairing.callsPerMinute, maxActiveThreads: pairing.maxActiveThreads },
+      },
+    }),
+    beginDelivery: vi.fn()
+      .mockReturnValueOnce({ status: "reserved", key: "pairing-1:1:delivery-1" })
+      .mockReturnValueOnce({ status: "joined", key: "pairing-1:1:delivery-1" })
+      .mockReturnValueOnce({ status: "reserved", key: "pairing-1:1:delivery-2" }),
+    finalizeDelivery: vi.fn(),
+  };
+  return { service, pairingService };
+}
+
+describe("external thread-control MCP transport", () => {
+  it("derives authority, deduplicates concurrent delivery, and preserves separate deliveries", async () => {
+    const { service, pairingService } = createHarness();
+    const session = createExternalThreadControlMcpSession({ pairingService: pairingService as never, service: service as never });
+    const first = session.dispatch({ bearerCredential: "credential", requestId: "request-1", deliveryId: "delivery-1", toolName: "thread_search", arguments: {} });
+    const second = session.dispatch({ bearerCredential: "credential", requestId: "request-2", deliveryId: "delivery-1", toolName: "thread_search", arguments: {} });
+    await expect(Promise.all([first, second])).resolves.toEqual([{ threads: [] }, { threads: [] }]);
+    await session.dispatch({ bearerCredential: "credential", requestId: "request-3", deliveryId: "delivery-2", toolName: "thread_search", arguments: {} });
+    expect(service.threadSearch).toHaveBeenCalledTimes(2);
+    expect(service.threadSearch).toHaveBeenCalledWith(expect.objectContaining({ pairingId: "pairing-1", authorityEpoch: 1 }), { limit: 20 });
+    expect(pairingService.finalizeDelivery).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects forged authority fields in tool arguments before service dispatch", async () => {
+    const { service, pairingService } = createHarness();
+    const session = createExternalThreadControlMcpSession({ pairingService: pairingService as never, service: service as never });
+    await expect(session.dispatch({
+      bearerCredential: "credential",
+      requestId: "request-1",
+      deliveryId: "delivery-1",
+      toolName: "thread_search",
+      arguments: { authority: { integrationId: "forged" } },
+    })).rejects.toThrow();
+    expect(service.threadSearch).not.toHaveBeenCalled();
+  });
+
+  it("uses the normal MCP request id as the delivery key when no delivery header exists", async () => {
+    const { service, pairingService } = createHarness();
+    const session = createExternalThreadControlMcpSession({ pairingService: pairingService as never, service: service as never });
+    const first = session.dispatch({
+      bearerCredential: "credential",
+      requestId: "normal-request-id",
+      toolName: "thread_search",
+      arguments: {},
+    });
+    const duplicate = session.dispatch({
+      bearerCredential: "credential",
+      requestId: "normal-request-id",
+      toolName: "thread_search",
+      arguments: {},
+    });
+    await expect(Promise.all([first, duplicate])).resolves.toEqual([{ threads: [] }, { threads: [] }]);
+    expect(service.threadSearch).toHaveBeenCalledTimes(1);
+    expect(pairingService.beginDelivery).toHaveBeenCalledWith(expect.anything(), "normal-request-id", expect.any(String));
+  });
+
+  it("registers exactly the eight public tools", async () => {
+    const { service, pairingService } = createHarness();
+    const session = createExternalThreadControlMcpSession({ pairingService: pairingService as never, service: service as never });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = session.createServer("credential");
+    const client = new Client({ name: "external-thread-control-test", version: "0.1.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    await expect(client.listTools()).resolves.toMatchObject({
+      tools: [
+        { name: "workspace_search" },
+        { name: "worktree_list" },
+        { name: "thread_create_batch" },
+        { name: "thread_search" },
+        { name: "thread_get" },
+        { name: "thread_send" },
+        { name: "thread_stop" },
+        { name: "thread_wait" },
+      ],
+    });
+    await client.close();
+    await server.close();
+  });
+});

--- a/apps/server/src/services/__tests__/external-thread-control-pairing-service.test.ts
+++ b/apps/server/src/services/__tests__/external-thread-control-pairing-service.test.ts
@@ -1,0 +1,229 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import type Database from "better-sqlite3";
+import {
+  ExternalThreadControlPairingError,
+  ExternalThreadControlPairingService,
+  type ExternalThreadControlAuthenticatedPairing,
+  type ExternalThreadControlPairingInput,
+} from "../external-thread-control-pairing-service.js";
+
+interface FakePairingRow {
+  pairing_id: string;
+  integration_id: string;
+  credential_hash: string;
+  workspace_ids_json: string;
+  scopes_json: string;
+  calls_per_minute: number;
+  max_active_threads: number;
+  status: "active" | "revoked";
+  authority_epoch: number;
+  created_at: string;
+  updated_at: string;
+  replaced_by_pairing_id: string | null;
+  replaces_pairing_id: string | null;
+}
+
+interface FakeDeliveryRow {
+  pairing_id: string;
+  authority_epoch: number;
+  delivery_id: string;
+  fingerprint: string;
+  status: "in_flight" | "terminal";
+  result_json: string | null;
+  created_at: string;
+  updated_at: string;
+  expires_at: string;
+}
+
+interface FakeApprovalRow {
+  caller_id: string;
+  status: "pending" | "processing" | "failed";
+}
+
+interface FakeDbState {
+  pairings: FakePairingRow[];
+  deliveries: FakeDeliveryRow[];
+  approvals: FakeApprovalRow[];
+}
+
+function createFakeDb(): FakeDbState & {
+  prepare: (sql: string) => { get: (...args: unknown[]) => unknown; run: (...args: unknown[]) => { changes: number } };
+  transaction: <T>(callback: () => T) => () => T;
+} {
+  const state: FakeDbState = { pairings: [], deliveries: [], approvals: [] };
+  const db = {
+    pairings: state.pairings,
+    deliveries: state.deliveries,
+    approvals: state.approvals,
+    prepare(sql: string) {
+      const statement = sql.trimStart();
+      return {
+        get(...args: unknown[]) {
+          if (statement.includes("external_thread_control_deliveries") && statement.includes("delivery_id = ?")) {
+            const row = state.deliveries.find((delivery) =>
+              delivery.pairing_id === args[0] && delivery.authority_epoch === args[1] && delivery.delivery_id === args[2]);
+            return row;
+          }
+          if (statement.includes("COUNT(*) AS count") && statement.includes("created_at > ?")) {
+            const [integrationId, cutoff] = args as [string, string];
+            return { count: state.deliveries.filter((delivery) => {
+              const pairing = state.pairings.find((candidate) => candidate.pairing_id === delivery.pairing_id);
+              return pairing?.integration_id === integrationId && delivery.created_at > cutoff;
+            }).length };
+          }
+          if (statement.includes("COUNT(*) AS count")) {
+            const [integrationId] = args as [string];
+            return { count: state.deliveries.filter((delivery) =>
+              state.pairings.find((pairing) => pairing.pairing_id === delivery.pairing_id)?.integration_id === integrationId).length };
+          }
+          if (statement.includes("ORDER BY d.updated_at ASC")) {
+            const [integrationId] = args as [string];
+            return state.deliveries
+              .filter((delivery) => delivery.status === "terminal"
+                && state.pairings.find((pairing) => pairing.pairing_id === delivery.pairing_id)?.integration_id === integrationId)
+              .sort((left, right) => left.updated_at.localeCompare(right.updated_at))[0];
+          }
+          if (statement.includes("integration_id = ?") && statement.includes("status = 'active'")) {
+            const [integrationId] = args as [string];
+            const row = state.pairings.find((pairing) => pairing.integration_id === integrationId && pairing.status === "active");
+            return row ? { pairing_id: row.pairing_id } : undefined;
+          }
+          if (statement.includes("credential_hash = ?")) {
+            return state.pairings.find((pairing) => pairing.credential_hash === args[0]);
+          }
+          if (statement.includes("external_thread_control_pairings") && statement.includes("pairing_id = ?")) {
+            return state.pairings.find((pairing) => pairing.pairing_id === args[0]);
+          }
+          throw new Error(`Unsupported fake get query: ${statement}`);
+        },
+        run(...args: unknown[]) {
+          if (statement.startsWith("INSERT INTO external_thread_control_pairings")) {
+            if (args.length === 9) {
+              state.pairings.push({
+                pairing_id: String(args[0]), integration_id: String(args[1]), credential_hash: String(args[2]),
+                workspace_ids_json: String(args[3]), scopes_json: String(args[4]), calls_per_minute: Number(args[5]),
+                max_active_threads: Number(args[6]), status: "active", authority_epoch: 1,
+                created_at: String(args[7]), updated_at: String(args[8]), replaced_by_pairing_id: null, replaces_pairing_id: null,
+              });
+            } else {
+              state.pairings.push({
+                pairing_id: String(args[0]), integration_id: String(args[1]), credential_hash: String(args[2]),
+                workspace_ids_json: String(args[3]), scopes_json: String(args[4]), calls_per_minute: Number(args[5]),
+                max_active_threads: Number(args[6]), status: "active", authority_epoch: Number(args[7]),
+                created_at: String(args[8]), updated_at: String(args[9]), replaced_by_pairing_id: null, replaces_pairing_id: String(args[10]),
+              });
+            }
+            return { changes: 1 };
+          }
+          if (statement.startsWith("UPDATE external_thread_control_pairings")) {
+            const replacing = statement.includes("replaced_by_pairing_id");
+            const pairingId = String(args[replacing ? 2 : 1]);
+            const row = state.pairings.find((pairing) => pairing.pairing_id === pairingId && pairing.status === "active");
+            if (!row) return { changes: 0 };
+            row.status = "revoked";
+            row.updated_at = String(args[1] ?? args[0]);
+            if (replacing) row.replaced_by_pairing_id = String(args[0]);
+            return { changes: 1 };
+          }
+          if (statement.startsWith("UPDATE thread_control_approvals")) {
+            const callerId = String(args[1]);
+            let changes = 0;
+            for (const approval of state.approvals) {
+              if (approval.caller_id === callerId && (approval.status === "pending" || approval.status === "processing")) {
+                approval.status = "failed";
+                changes += 1;
+              }
+            }
+            return { changes };
+          }
+          if (statement.startsWith("DELETE FROM external_thread_control_deliveries WHERE status = 'terminal'")) {
+            const cutoff = String(args[0]);
+            const before = state.deliveries.length;
+            state.deliveries.splice(0, state.deliveries.length, ...state.deliveries.filter((delivery) => !(delivery.status === "terminal" && delivery.expires_at <= cutoff)));
+            return { changes: before - state.deliveries.length };
+          }
+          if (statement.startsWith("DELETE FROM external_thread_control_deliveries WHERE pairing_id")) {
+            const [pairingId, epoch, deliveryId] = args as [string, number, string];
+            const before = state.deliveries.length;
+            state.deliveries.splice(0, state.deliveries.length, ...state.deliveries.filter((delivery) => !(delivery.pairing_id === pairingId
+              && delivery.authority_epoch === epoch && delivery.delivery_id === deliveryId && delivery.status === "terminal")));
+            return { changes: before - state.deliveries.length };
+          }
+          if (statement.startsWith("INSERT INTO external_thread_control_deliveries")) {
+            state.deliveries.push({
+              pairing_id: String(args[0]), authority_epoch: Number(args[1]), delivery_id: String(args[2]), fingerprint: String(args[3]),
+              status: "in_flight", result_json: null, created_at: String(args[4]), updated_at: String(args[5]), expires_at: String(args[6]),
+            });
+            return { changes: 1 };
+          }
+          throw new Error(`Unsupported fake run query: ${statement}`);
+        },
+      };
+    },
+    transaction<T>(callback: () => T) {
+      return () => callback();
+    },
+  };
+  return db;
+}
+
+const input = (overrides: Partial<ExternalThreadControlPairingInput> = {}): ExternalThreadControlPairingInput => ({
+  integrationId: "integration-1",
+  workspaceIds: ["workspace-1"],
+  scopes: ["threads:read-project"],
+  callsPerMinute: 10,
+  maxActiveThreads: 2,
+  ...overrides,
+});
+
+function authenticate(service: ExternalThreadControlPairingService, secret: string): ExternalThreadControlAuthenticatedPairing {
+  return service.authenticate(secret);
+}
+
+describe("external thread-control pairing service", () => {
+  it("rejects a second active pairing for one integration", () => {
+    const db = createFakeDb();
+    const service = new ExternalThreadControlPairingService(db as unknown as Database.Database);
+    const pairing = service.create(input());
+    expect(() => service.create(input())).toThrowError(new ExternalThreadControlPairingError("conflict", "External integration already has an active pairing"));
+    expect(() => service.replace(pairing.pairingId, input({ integrationId: "integration-2" }))).toThrowError("Pairing replacement must preserve integration identity");
+  });
+
+  it("does not let an old revoke cancel successor approvals", () => {
+    const db = createFakeDb();
+    const service = new ExternalThreadControlPairingService(db as unknown as Database.Database);
+    const old = service.create(input());
+    const successor = service.replace(old.pairingId, input());
+    db.approvals.push({ caller_id: "integration-1", status: "pending" });
+    expect(service.revoke(old.pairingId).status).toBe("revoked");
+    expect(service.findById(successor.pairingId)?.status).toBe("active");
+    expect(db.approvals[0]?.status).toBe("pending");
+  });
+
+  it("keeps rate reservations durable across service instances and free of duplicate charge", () => {
+    const db = createFakeDb();
+    const firstService = new ExternalThreadControlPairingService(db as unknown as Database.Database);
+    const secret = firstService.create(input({ callsPerMinute: 1 }));
+    const authority = authenticate(firstService, secret.credential);
+    expect(firstService.beginDelivery(authority, "delivery-1", "fingerprint").status).toBe("reserved");
+    const secondService = new ExternalThreadControlPairingService(db as unknown as Database.Database);
+    expect(secondService.beginDelivery(authority, "delivery-1", "fingerprint").status).toBe("joined");
+    expect(() => secondService.beginDelivery(authority, "delivery-2", "fingerprint")).toThrowError("External call rate limit exceeded");
+  });
+
+  it("rejects a new delivery when all 10,000 retained slots are in flight", () => {
+    const db = createFakeDb();
+    const service = new ExternalThreadControlPairingService(db as unknown as Database.Database);
+    const secret = service.create(input());
+    const authority = authenticate(service, secret.credential);
+    for (let index = 0; index < 10_000; index += 1) {
+      db.deliveries.push({
+        pairing_id: authority.pairing.pairingId, authority_epoch: authority.pairing.authorityEpoch, delivery_id: `delivery-${index}`,
+        fingerprint: "fingerprint", status: "in_flight", result_json: null,
+        created_at: "2026-07-29T00:00:00.000Z", updated_at: "2026-07-29T00:00:00.000Z", expires_at: "2026-07-30T00:00:00.000Z",
+      });
+    }
+    expect(() => service.beginDelivery(authority, "delivery-new", "fingerprint")).toThrowError("External replay retention is full");
+  });
+});

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -771,6 +771,27 @@ describe("ThreadControlService", () => {
     expect(agentService.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("restricts external Project discovery and worktree listing to selected scopes", async () => {
+    const service = createService();
+    const externalAuthority = {
+      type: "external" as const,
+      integrationId: "integration-a",
+      allowedWorkspaceIds: [workspace.id],
+      scopes: ["projects:read", "worktrees:read"] as const,
+      limits: { callsPerMinute: 10, maxActiveThreads: 10 },
+    };
+    const discovered = service.workspaceSearch(externalAuthority, { query: "", limit: 20 });
+    expect(discovered.workspaces).toEqual([{ workspaceId: workspace.id, name: workspace.name }]);
+    await expect(service.worktreeList(externalAuthority, { workspaceId: workspace.id })).resolves.toMatchObject({
+      status: "found",
+      workspaceId: workspace.id,
+    });
+    await expect(service.worktreeList({ ...externalAuthority, scopes: ["projects:read"] }, { workspaceId: workspace.id })).resolves.toEqual({
+      status: "rejected",
+      error: expect.objectContaining({ code: "not_found" }),
+    });
+  });
+
   it("audits denied reads without recording the unreadable target", async () => {
     const service = createService();
 

--- a/apps/server/src/services/external-thread-control-mcp-runtime.ts
+++ b/apps/server/src/services/external-thread-control-mcp-runtime.ts
@@ -1,0 +1,110 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { inject, injectable } from "tsyringe";
+import { ExternalThreadControlPairingService } from "./external-thread-control-pairing-service.js";
+import { createExternalThreadControlMcpSession, type ExternalThreadControlMcpSession } from "./external-thread-control-mcp-transport.js";
+import { ThreadControlService } from "./thread-control-service.js";
+
+/** Existing-server loopback path used by paired external MCP clients. */
+export const EXTERNAL_THREAD_CONTROL_MCP_PATH = "/mcp/external-thread-control";
+
+/** Loopback MCP runtime mounted into the existing HTTP server. */
+@injectable()
+export class ExternalThreadControlMcpRuntime {
+  private readonly session: ExternalThreadControlMcpSession;
+  private readonly server: McpServer;
+  private transport: StreamableHTTPServerTransport | undefined;
+  private connecting: Promise<void> | undefined;
+  private listenPort = Number.parseInt(process.env.MCODE_PORT ?? "19400", 10);
+
+  constructor(
+    @inject(ThreadControlService) service: ThreadControlService,
+    @inject(ExternalThreadControlPairingService) private readonly pairings: ExternalThreadControlPairingService,
+  ) {
+    this.session = createExternalThreadControlMcpSession({ pairingService: pairings, service });
+    this.server = this.session.createServer();
+  }
+
+  /** Return loopback endpoint URL for pairing-management responses. */
+  endpoint(): string {
+    return `http://127.0.0.1:${this.listenPort}${EXTERNAL_THREAD_CONTROL_MCP_PATH}`;
+  }
+
+  /** Publish the actual port after the shared HTTP server binds. */
+  setPort(port: number): void {
+    if (Number.isInteger(port) && port > 0 && port <= 65_535) this.listenPort = port;
+  }
+
+  /** Handle one authenticated loopback request without opening a second listener. */
+  async handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    if (request.method !== "POST") {
+      response.writeHead(404).end();
+      return;
+    }
+    const credential = bearerCredential(request.headers.authorization);
+    if (!credential) {
+      response.writeHead(401).end("Unauthorized");
+      return;
+    }
+    const context = {
+      bearerCredential: credential,
+      pairingId: headerValue(request, "x-mcode-pairing-id"),
+      authorityEpoch: parseEpoch(headerValue(request, "x-mcode-authority-epoch")),
+      deliveryId: headerValue(request, "x-mcode-delivery-id"),
+    };
+    try {
+      this.pairings.authenticate(context.bearerCredential, context.pairingId, context.authorityEpoch);
+    } catch {
+      response.writeHead(401).end("Unauthorized");
+      return;
+    }
+    await this.ensureConnected();
+    await this.session.contextStorage.run(context, () => this.transport!.handleRequest(request, response));
+  }
+
+  /** Reconcile uncertain external work before accepting new deliveries after restart. */
+  reconcileOnStartup(): number {
+    return this.pairings.reconcileInFlight();
+  }
+
+  /** Close MCP transport during server shutdown. */
+  async close(): Promise<void> {
+    await this.transport?.close().catch(() => undefined);
+    await this.server.close().catch(() => undefined);
+    this.transport = undefined;
+  }
+
+  private async ensureConnected(): Promise<void> {
+    if (this.transport) return;
+    if (this.connecting) return this.connecting;
+    const connecting = (async () => {
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      await this.server.connect(transport);
+      this.transport = transport;
+    })();
+    this.connecting = connecting;
+    try {
+      await connecting;
+    } finally {
+      if (this.connecting === connecting) this.connecting = undefined;
+    }
+  }
+}
+
+function bearerCredential(value: string | undefined): string | undefined {
+  if (!value?.startsWith("Bearer ")) return undefined;
+  const credential = value.slice("Bearer ".length).trim();
+  return credential.length > 0 ? credential : undefined;
+}
+
+function headerValue(request: IncomingMessage, name: string): string | undefined {
+  const value = request.headers[name];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parseEpoch(value: string | undefined): number | undefined {
+  if (!value || !/^\d+$/.test(value)) return undefined;
+  const epoch = Number(value);
+  return Number.isSafeInteger(epoch) && epoch > 0 ? epoch : undefined;
+}

--- a/apps/server/src/services/external-thread-control-mcp-transport.ts
+++ b/apps/server/src/services/external-thread-control-mcp-transport.ts
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ThreadCreateBatchInputSchema,
+  ThreadCreateBatchResultSchema,
+  ThreadGetInputSchema,
+  ThreadGetResultSchema,
+  ThreadSearchInputSchema,
+  ThreadSearchResultSchema,
+  ThreadSendInputSchema,
+  ThreadSendResultSchema,
+  ThreadStopInputSchema,
+  ThreadStopResultSchema,
+  ThreadWaitInputSchema,
+  ThreadWaitResultSchema,
+  WorkspaceSearchInputSchema,
+  WorkspaceSearchResultSchema,
+  WorktreeListInputSchema,
+  WorktreeListResultSchema,
+} from "@mcode/contracts";
+import type { ThreadControlService } from "./thread-control-service.js";
+import {
+  ExternalThreadControlPairingError,
+  ExternalThreadControlPairingService,
+} from "./external-thread-control-pairing-service.js";
+
+/** Context propagated from the loopback HTTP request into MCP tool callbacks. */
+export interface ExternalThreadControlMcpContext {
+  bearerCredential: string;
+  pairingId?: string;
+  authorityEpoch?: number;
+  deliveryId?: string;
+}
+
+/** Incoming external MCP request used by direct tests and the HTTP adapter. */
+export interface ExternalThreadControlMcpRequest extends ExternalThreadControlMcpContext {
+  requestId: string | number;
+  toolName: string;
+  arguments: unknown;
+  signal?: AbortSignal;
+}
+
+/** Session exposing exactly the eight public thread-control tools. */
+export interface ExternalThreadControlMcpSession {
+  dispatch(request: ExternalThreadControlMcpRequest): Promise<Record<string, unknown>>;
+  createServer(credential?: string): McpServer;
+  contextStorage: AsyncLocalStorage<ExternalThreadControlMcpContext>;
+}
+
+/** Creates an authenticated, replay-safe external MCP adapter. */
+export function createExternalThreadControlMcpSession(options: {
+  pairingService: ExternalThreadControlPairingService;
+  service: ThreadControlService;
+}): ExternalThreadControlMcpSession {
+  const contextStorage = new AsyncLocalStorage<ExternalThreadControlMcpContext>();
+  const inFlight = new Map<string, Promise<Record<string, unknown>>>();
+
+  const dispatch = async (request: ExternalThreadControlMcpRequest): Promise<Record<string, unknown>> => {
+    const pairing = options.pairingService.authenticate(
+      request.bearerCredential,
+      request.pairingId,
+      request.authorityEpoch,
+    );
+    const deliveryId = request.deliveryId ?? normalizeRequestId(request.requestId);
+    if (!deliveryId) throw new ExternalThreadControlPairingError("conflict", "External delivery id is required");
+    const fingerprint = requestFingerprint(request.toolName, request.arguments);
+    const reservation = options.pairingService.beginDelivery(pairing, deliveryId, fingerprint);
+    if (reservation.status === "replayed") return reservation.result ?? {};
+    if (reservation.status === "joined") {
+      const existing = inFlight.get(reservation.key);
+      if (existing) return existing;
+      throw new ExternalThreadControlPairingError("conflict", "External delivery is already being reconciled");
+    }
+    const execution = executeTool(options.service, pairing.authority, request);
+    inFlight.set(reservation.key, execution);
+    try {
+      const result = await execution;
+      options.pairingService.finalizeDelivery(pairing, deliveryId, result);
+      return result;
+    } catch (error) {
+      const replayResult = {
+        status: "rejected",
+        error: {
+          code: "internal_error",
+          message: "External thread-control delivery failed",
+          retryable: true,
+        },
+      } as Record<string, unknown>;
+      options.pairingService.finalizeDelivery(pairing, deliveryId, replayResult);
+      throw error;
+    } finally {
+      inFlight.delete(reservation.key);
+    }
+  };
+
+  return {
+    dispatch,
+    contextStorage,
+    createServer(credential) {
+      const server = new McpServer({ name: "mcode-external-thread-control", version: "0.1.0" });
+      registerTools(server, async (toolName, arguments_, extra) => {
+        const context = contextStorage.getStore();
+        return dispatch({
+          bearerCredential: context?.bearerCredential ?? credential ?? "",
+          pairingId: context?.pairingId,
+          authorityEpoch: context?.authorityEpoch,
+          deliveryId: context?.deliveryId,
+          requestId: extra.requestId,
+          toolName,
+          arguments: arguments_,
+          signal: extra.signal,
+        });
+      });
+      return server;
+    },
+  };
+}
+
+async function executeTool(
+  service: ThreadControlService,
+  authority: Parameters<ThreadControlService["threadSearch"]>[0],
+  request: ExternalThreadControlMcpRequest,
+): Promise<Record<string, unknown>> {
+  switch (request.toolName) {
+    case "workspace_search":
+      return WorkspaceSearchResultSchema().parse(service.workspaceSearch(authority, WorkspaceSearchInputSchema().parse(request.arguments)));
+    case "worktree_list":
+      return WorktreeListResultSchema().parse(await service.worktreeList(authority, WorktreeListInputSchema().parse(request.arguments)));
+    case "thread_create_batch":
+      return ThreadCreateBatchResultSchema().parse(await service.threadCreateBatch(authority, ThreadCreateBatchInputSchema().parse(request.arguments)));
+    case "thread_search":
+      return ThreadSearchResultSchema().parse(service.threadSearch(authority, ThreadSearchInputSchema().parse(request.arguments)));
+    case "thread_get":
+      return ThreadGetResultSchema().parse(service.threadGet(authority, ThreadGetInputSchema().parse(request.arguments)));
+    case "thread_send":
+      return ThreadSendResultSchema().parse(await service.threadSend(authority, ThreadSendInputSchema().parse(request.arguments)));
+    case "thread_stop":
+      return ThreadStopResultSchema().parse(await service.threadStop(authority, ThreadStopInputSchema().parse(request.arguments)));
+    case "thread_wait":
+      return ThreadWaitResultSchema().parse(await service.threadWait(authority, ThreadWaitInputSchema().parse(request.arguments), request.signal));
+    default:
+      throw new ExternalThreadControlPairingError("unauthorized", "External thread-control tool denied");
+  }
+}
+
+function registerTools(
+  server: McpServer,
+  dispatch: (toolName: string, arguments_: unknown, extra: { requestId: string | number; signal?: AbortSignal }) => Promise<Record<string, unknown>>,
+): void {
+  const register = (toolName: string, description: string, inputSchema: object, outputSchema: object | undefined) => {
+    server.registerTool(toolName, {
+      description,
+      inputSchema,
+      ...(outputSchema ? { outputSchema } : {}),
+    } as never, (async (arguments_: unknown, extra: { requestId: string | number; signal?: AbortSignal }) =>
+      createToolResult(await dispatch(toolName, arguments_, extra))) as never);
+  };
+  register("workspace_search", "Search selected Mcode Projects.", WorkspaceSearchInputSchema(), WorkspaceSearchResultSchema());
+  register("worktree_list", "List opaque worktrees in one selected Project.", WorktreeListInputSchema(), WorktreeListResultSchema());
+  register("thread_create_batch", "Create one to twenty delegated Mcode threads.", ThreadCreateBatchInputSchema(), ThreadCreateBatchResultSchema());
+  register("thread_search", "Search readable delegated threads.", ThreadSearchInputSchema(), ThreadSearchResultSchema());
+  register("thread_get", "Read one bounded delegated thread transcript.", ThreadGetInputSchema(), ThreadGetResultSchema());
+  register("thread_send", "Send a message to one readable delegated thread.", ThreadSendInputSchema(), ThreadSendResultSchema());
+  register("thread_stop", "Stop one mutable delegated thread.", ThreadStopInputSchema(), ThreadStopResultSchema());
+  register("thread_wait", "Wait for readable delegated threads.", ThreadWaitInputSchema(), ThreadWaitResultSchema());
+}
+
+function createToolResult(structuredContent: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(structuredContent) }],
+    structuredContent,
+  };
+}
+
+/** Stable request fingerprint used to reject same-delivery payload changes. */
+export function requestFingerprint(toolName: string, arguments_: unknown): string {
+  return createHash("sha256").update(stableStringify({ toolName, arguments: arguments_ }), "utf8").digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(object[key])}`).join(",")}}`;
+}
+
+function normalizeRequestId(requestId: string | number): string | undefined {
+  if (typeof requestId === "number") return Number.isSafeInteger(requestId) ? String(requestId) : undefined;
+  return requestId.length > 0 && requestId.length <= 256 ? requestId : undefined;
+}

--- a/apps/server/src/services/external-thread-control-pairing-registry.ts
+++ b/apps/server/src/services/external-thread-control-pairing-registry.ts
@@ -1,0 +1,5 @@
+/** Compatibility entry point for the durable external pairing registry. */
+export {
+  ExternalThreadControlPairingService as ExternalThreadControlPairingRegistry,
+} from "./external-thread-control-pairing-service.js";
+export * from "./external-thread-control-pairing-service.js";

--- a/apps/server/src/services/external-thread-control-pairing-service.ts
+++ b/apps/server/src/services/external-thread-control-pairing-service.ts
@@ -1,0 +1,456 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { inject, injectable } from "tsyringe";
+import type Database from "better-sqlite3";
+import type {
+  ExternalThreadControlAuthority,
+  ExternalThreadControlScope,
+} from "@mcode/thread-orchestration";
+
+const DELIVERY_RETENTION_MS = 24 * 60 * 60 * 1000;
+const MAX_DELIVERIES_PER_INTEGRATION = 10_000;
+const CREDENTIAL_BYTES = 32;
+const EXTERNAL_MCP_ENDPOINT = "/mcp/external-thread-control";
+const VALID_SCOPES = new Set<ExternalThreadControlScope>([
+  "projects:read",
+  "worktrees:read",
+  "threads:create",
+  "threads:read-owned",
+  "threads:read-project",
+  "threads:send-owned",
+  "threads:send-project",
+  "threads:stop-owned",
+  "threads:stop-project",
+  "worktrees:create",
+  "execution:full",
+]);
+
+type PairingStatus = "active" | "revoked";
+type DeliveryStatus = "in_flight" | "terminal";
+
+/** Input used by the authenticated local pairing-management methods. */
+export interface ExternalThreadControlPairingInput {
+  integrationId: string;
+  workspaceIds: readonly string[];
+  scopes: readonly ExternalThreadControlScope[];
+  callsPerMinute: number;
+  maxActiveThreads: number;
+}
+
+/** Durable pairing record. Credential material is intentionally absent. */
+export interface ExternalThreadControlPairingRecord {
+  pairingId: string;
+  integrationId: string;
+  workspaceIds: readonly string[];
+  scopes: readonly ExternalThreadControlScope[];
+  callsPerMinute: number;
+  maxActiveThreads: number;
+  status: PairingStatus;
+  authorityEpoch: number;
+  createdAt: string;
+  updatedAt: string;
+  replacedByPairingId?: string;
+  replacesPairingId?: string;
+}
+
+/** Pairing record plus one-time plaintext credential returned by creation. */
+export interface ExternalThreadControlPairingSecret extends ExternalThreadControlPairingRecord {
+  credential: string;
+  externalMcpEndpoint: string;
+}
+
+/** Authenticated, server-derived authority accepted by ThreadControlService. */
+export interface ExternalThreadControlAuthenticatedPairing {
+  pairing: ExternalThreadControlPairingRecord;
+  authority: ExternalThreadControlAuthority;
+}
+
+/** One durable replay result returned by delivery reservation. */
+export interface ExternalThreadControlDeliveryResult {
+  status: "replayed" | "joined" | "reserved";
+  key: string;
+  result?: Record<string, unknown>;
+}
+
+/** Errors raised by pairing authentication, replay, and rate-limit boundaries. */
+export class ExternalThreadControlPairingError extends Error {
+  constructor(
+    readonly code: "unauthorized" | "stale_epoch" | "conflict" | "rate_limited" | "replay_capacity",
+    message: string,
+    readonly retryAfterSeconds?: number,
+  ) {
+    super(message);
+    this.name = "ExternalThreadControlPairingError";
+  }
+}
+
+interface PairingRow {
+  pairing_id: string;
+  integration_id: string;
+  credential_hash: string;
+  workspace_ids_json: string;
+  scopes_json: string;
+  calls_per_minute: number;
+  max_active_threads: number;
+  status: PairingStatus;
+  authority_epoch: number;
+  created_at: string;
+  updated_at: string;
+  replaced_by_pairing_id: string | null;
+  replaces_pairing_id: string | null;
+}
+
+interface DeliveryRow {
+  pairing_id: string;
+  authority_epoch: number;
+  delivery_id: string;
+  fingerprint: string;
+  status: DeliveryStatus;
+  result_json: string | null;
+}
+
+/** Owns durable external pairings, credential hashing, replay retention, and rate reservations. */
+@injectable()
+export class ExternalThreadControlPairingService {
+  constructor(@inject("Database") private readonly db: Database.Database) {}
+
+  /** Create a pairing and return its plaintext credential exactly once. */
+  create(input: ExternalThreadControlPairingInput): ExternalThreadControlPairingSecret {
+    const normalized = normalizePairingInput(input);
+    const pairingId = randomUUID();
+    const credential = randomBytes(CREDENTIAL_BYTES).toString("base64url");
+    const now = new Date().toISOString();
+    const create = this.db.transaction(() => {
+      const active = this.db.prepare(
+        "SELECT pairing_id FROM external_thread_control_pairings WHERE integration_id = ? AND status = 'active' LIMIT 1",
+      ).get(normalized.integrationId) as { pairing_id: string } | undefined;
+      if (active) {
+        throw new ExternalThreadControlPairingError("conflict", "External integration already has an active pairing");
+      }
+      this.db.prepare(
+        `INSERT INTO external_thread_control_pairings
+         (pairing_id, integration_id, credential_hash, workspace_ids_json, scopes_json,
+          calls_per_minute, max_active_threads, status, authority_epoch, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'active', 1, ?, ?)`,
+      ).run(
+        pairingId,
+        normalized.integrationId,
+        hashCredential(credential),
+        JSON.stringify(normalized.workspaceIds),
+        JSON.stringify(normalized.scopes),
+        normalized.callsPerMinute,
+        normalized.maxActiveThreads,
+        now,
+        now,
+      );
+    });
+    create();
+    return { ...this.requireById(pairingId), credential, externalMcpEndpoint: EXTERNAL_MCP_ENDPOINT };
+  }
+
+  /** Named alias used by management callers that model pairings as resources. */
+  createPairing(input: ExternalThreadControlPairingInput): ExternalThreadControlPairingSecret {
+    return this.create(input);
+  }
+
+  /** Look up a pairing without exposing its credential hash. */
+  findById(pairingId: string): ExternalThreadControlPairingRecord | undefined {
+    const row = this.db.prepare(
+      "SELECT pairing_id, integration_id, credential_hash, workspace_ids_json, scopes_json, calls_per_minute, max_active_threads, status, authority_epoch, created_at, updated_at, replaced_by_pairing_id, replaces_pairing_id FROM external_thread_control_pairings WHERE pairing_id = ?",
+    ).get(pairingId) as PairingRow | undefined;
+    return row ? rowToPairing(row) : undefined;
+  }
+
+  /** Revoke one pairing. Repeated revocation is idempotent. */
+  revoke(pairingId: string): ExternalThreadControlPairingRecord {
+    const pairing = this.requireById(pairingId);
+    const now = new Date().toISOString();
+    const revoke = this.db.transaction(() => {
+      const result = this.db.prepare(
+        "UPDATE external_thread_control_pairings SET status = 'revoked', updated_at = ? WHERE pairing_id = ? AND status = 'active'",
+      ).run(now, pairingId);
+      if (result.changes === 1 && pairing.status === "active") {
+        this.db.prepare(
+          "UPDATE thread_control_approvals SET status = 'failed', resolved_at = ? WHERE caller_id = ? AND status IN ('pending', 'processing')",
+        ).run(now, pairing.integrationId);
+      }
+    });
+    revoke();
+    return this.requireById(pairingId);
+  }
+
+  /** Named alias used by management callers that model pairings as resources. */
+  revokePairing(pairingId: string): ExternalThreadControlPairingRecord {
+    return this.revoke(pairingId);
+  }
+
+  /** Atomically revoke old authority and create a successor with the next epoch. */
+  replace(pairingId: string, input: ExternalThreadControlPairingInput): ExternalThreadControlPairingSecret {
+    const old = this.requireById(pairingId);
+    if (old.status !== "active") {
+      throw new ExternalThreadControlPairingError("stale_epoch", "External thread-control pairing is stale");
+    }
+    const normalized = normalizePairingInput(input);
+    if (normalized.integrationId !== old.integrationId) {
+      throw new ExternalThreadControlPairingError("conflict", "Pairing replacement must preserve integration identity");
+    }
+    const successorId = randomUUID();
+    const credential = randomBytes(CREDENTIAL_BYTES).toString("base64url");
+    const now = new Date().toISOString();
+    const replace = this.db.transaction(() => {
+      const result = this.db.prepare(
+        "UPDATE external_thread_control_pairings SET status = 'revoked', replaced_by_pairing_id = ?, updated_at = ? WHERE pairing_id = ? AND status = 'active'",
+      ).run(successorId, now, pairingId);
+      if (result.changes !== 1) {
+        throw new ExternalThreadControlPairingError("stale_epoch", "External thread-control pairing is stale");
+      }
+      // Pending approvals are pre-dispatch external work. Replacement closes
+      // them before successor authority becomes visible, preventing a late
+      // callback from dispatching under the revoked epoch.
+      this.db.prepare(
+        "UPDATE thread_control_approvals SET status = 'failed', resolved_at = ? WHERE caller_id = ? AND status IN ('pending', 'processing')",
+      ).run(now, old.integrationId);
+      this.db.prepare(
+        `INSERT INTO external_thread_control_pairings
+         (pairing_id, integration_id, credential_hash, workspace_ids_json, scopes_json,
+          calls_per_minute, max_active_threads, status, authority_epoch, created_at, updated_at, replaces_pairing_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?)`,
+      ).run(
+        successorId,
+        normalized.integrationId,
+        hashCredential(credential),
+        JSON.stringify(normalized.workspaceIds),
+        JSON.stringify(normalized.scopes),
+        normalized.callsPerMinute,
+        normalized.maxActiveThreads,
+        old.authorityEpoch + 1,
+        now,
+        now,
+        pairingId,
+      );
+    });
+    replace();
+    return { ...this.requireById(successorId), credential, externalMcpEndpoint: EXTERNAL_MCP_ENDPOINT };
+  }
+
+  /** Named alias for atomic pairing replacement. */
+  replacePairing(pairingId: string, input: ExternalThreadControlPairingInput): ExternalThreadControlPairingSecret {
+    return this.replace(pairingId, input);
+  }
+
+  /** Derive identity and epoch from credential before any replay lookup. */
+  authenticate(
+    credential: string,
+    assertedPairingId?: string,
+    assertedAuthorityEpoch?: number,
+  ): ExternalThreadControlAuthenticatedPairing {
+    if (credential.length < 1 || credential.length > 256) {
+      throw new ExternalThreadControlPairingError("unauthorized", "External thread-control pairing denied");
+    }
+    const digest = hashCredential(credential);
+    const row = this.db.prepare(
+      "SELECT pairing_id, integration_id, credential_hash, workspace_ids_json, scopes_json, calls_per_minute, max_active_threads, status, authority_epoch, created_at, updated_at, replaced_by_pairing_id, replaces_pairing_id FROM external_thread_control_pairings WHERE credential_hash = ?",
+    ).get(digest) as PairingRow | undefined;
+    if (!row || !constantTimeHashEqual(row.credential_hash, digest)) {
+      throw new ExternalThreadControlPairingError("unauthorized", "External thread-control pairing denied");
+    }
+    if (row.status !== "active") {
+      throw new ExternalThreadControlPairingError("stale_epoch", "External thread-control pairing is stale");
+    }
+    if (assertedPairingId !== undefined && assertedPairingId !== row.pairing_id) {
+      throw new ExternalThreadControlPairingError("stale_epoch", "External thread-control pairing is stale");
+    }
+    if (assertedAuthorityEpoch !== undefined && assertedAuthorityEpoch !== row.authority_epoch) {
+      throw new ExternalThreadControlPairingError("stale_epoch", "External thread-control pairing is stale");
+    }
+    const pairing = rowToPairing(row);
+    return {
+      pairing,
+      authority: {
+        type: "external",
+        pairingId: pairing.pairingId,
+        authorityEpoch: pairing.authorityEpoch,
+        integrationId: pairing.integrationId,
+        allowedWorkspaceIds: pairing.workspaceIds,
+        scopes: pairing.scopes,
+        limits: {
+          callsPerMinute: pairing.callsPerMinute,
+          maxActiveThreads: pairing.maxActiveThreads,
+        },
+      },
+    };
+  }
+
+  /** Named alias emphasizing that callers receive derived authority, not grants. */
+  authorize(
+    credential: string,
+    assertedPairingId?: string,
+    assertedAuthorityEpoch?: number,
+  ): ExternalThreadControlAuthenticatedPairing {
+    return this.authenticate(credential, assertedPairingId, assertedAuthorityEpoch);
+  }
+
+  /** Reserve one delivery, joining or replaying an existing key without rate cost. */
+  beginDelivery(
+    pairing: ExternalThreadControlAuthenticatedPairing,
+    deliveryId: string,
+    fingerprint: string,
+  ): ExternalThreadControlDeliveryResult {
+    if (!/^[\x21-\x7e]{1,256}$/.test(deliveryId)) {
+      throw new ExternalThreadControlPairingError("conflict", "External delivery id is invalid");
+    }
+    if (fingerprint.length < 1 || fingerprint.length > 256) {
+      throw new ExternalThreadControlPairingError("conflict", "External delivery fingerprint is invalid");
+    }
+    const key = `${pairing.pairing.pairingId}:${pairing.pairing.authorityEpoch}:${deliveryId}`;
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const expiresAt = new Date(now.getTime() + DELIVERY_RETENTION_MS).toISOString();
+    const reserve = this.db.transaction(() => {
+      this.db.prepare(
+        "DELETE FROM external_thread_control_deliveries WHERE status = 'terminal' AND expires_at <= ?",
+      ).run(nowIso);
+      const existing = this.db.prepare(
+        "SELECT pairing_id, authority_epoch, delivery_id, fingerprint, status, result_json FROM external_thread_control_deliveries WHERE pairing_id = ? AND authority_epoch = ? AND delivery_id = ?",
+      ).get(pairing.pairing.pairingId, pairing.pairing.authorityEpoch, deliveryId) as DeliveryRow | undefined;
+      if (existing) {
+        if (existing.fingerprint !== fingerprint) {
+          throw new ExternalThreadControlPairingError("conflict", "External delivery fingerprint conflict");
+        }
+        return existing;
+      }
+      const count = this.db.prepare(
+        `SELECT COUNT(*) AS count FROM external_thread_control_deliveries d
+         JOIN external_thread_control_pairings p ON p.pairing_id = d.pairing_id
+         WHERE p.integration_id = ?`,
+      ).get(pairing.pairing.integrationId) as { count: number };
+      if (count.count >= MAX_DELIVERIES_PER_INTEGRATION) {
+        const removable = this.db.prepare(
+          `SELECT d.pairing_id, d.authority_epoch, d.delivery_id
+           FROM external_thread_control_deliveries d
+           JOIN external_thread_control_pairings p ON p.pairing_id = d.pairing_id
+           WHERE p.integration_id = ? AND d.status = 'terminal'
+           ORDER BY d.updated_at ASC LIMIT 1`,
+        ).get(pairing.pairing.integrationId) as { pairing_id: string; authority_epoch: number; delivery_id: string } | undefined;
+        if (!removable) {
+          throw new ExternalThreadControlPairingError("replay_capacity", "External replay retention is full", 60);
+        }
+        this.db.prepare(
+          "DELETE FROM external_thread_control_deliveries WHERE pairing_id = ? AND authority_epoch = ? AND delivery_id = ? AND status = 'terminal'",
+        ).run(removable.pairing_id, removable.authority_epoch, removable.delivery_id);
+      }
+      const cutoffIso = new Date(now.getTime() - 60_000).toISOString();
+      const recent = this.db.prepare(
+        `SELECT COUNT(*) AS count FROM external_thread_control_deliveries d
+         JOIN external_thread_control_pairings p ON p.pairing_id = d.pairing_id
+         WHERE p.integration_id = ? AND d.created_at > ?`,
+      ).get(pairing.pairing.integrationId, cutoffIso) as { count: number };
+      if (recent.count >= pairing.pairing.callsPerMinute) {
+        throw new ExternalThreadControlPairingError("rate_limited", "External call rate limit exceeded", 60);
+      }
+      this.db.prepare(
+        `INSERT INTO external_thread_control_deliveries
+         (pairing_id, authority_epoch, delivery_id, fingerprint, status, created_at, updated_at, expires_at)
+         VALUES (?, ?, ?, ?, 'in_flight', ?, ?, ?)`,
+      ).run(pairing.pairing.pairingId, pairing.pairing.authorityEpoch, deliveryId, fingerprint, nowIso, nowIso, expiresAt);
+      return undefined;
+    })();
+    if (reserve?.status === "terminal") {
+      return { status: "replayed", key, result: parseResult(reserve.result_json) };
+    }
+    if (reserve?.status === "in_flight") return { status: "joined", key };
+    return { status: "reserved", key };
+  }
+
+  /** Persist one terminal replay result. Safe to call repeatedly for one delivery. */
+  finalizeDelivery(pairing: ExternalThreadControlAuthenticatedPairing, deliveryId: string, result: Record<string, unknown>): void {
+    const resultJson = JSON.stringify(result);
+    const now = new Date().toISOString();
+    this.db.prepare(
+      `UPDATE external_thread_control_deliveries
+       SET status = 'terminal', result_json = ?, updated_at = ?
+       WHERE pairing_id = ? AND authority_epoch = ? AND delivery_id = ? AND status = 'in_flight'`,
+    ).run(resultJson, now, pairing.pairing.pairingId, pairing.pairing.authorityEpoch, deliveryId);
+  }
+
+  /** Reconcile uncertain work after restart without redispatching it. */
+  reconcileInFlight(): number {
+    const result = this.db.prepare(
+      `UPDATE external_thread_control_deliveries
+       SET status = 'terminal', result_json = ?, updated_at = ?
+       WHERE status = 'in_flight'`,
+    ).run(
+      JSON.stringify({ status: "rejected", error: { code: "internal_error", message: "External delivery outcome was reconciled after restart", retryable: true } }),
+      new Date().toISOString(),
+    );
+    return result.changes;
+  }
+
+  private requireById(pairingId: string): ExternalThreadControlPairingRecord {
+    const pairing = this.findById(pairingId);
+    if (!pairing) throw new ExternalThreadControlPairingError("unauthorized", "External thread-control pairing not found");
+    return pairing;
+  }
+}
+
+function normalizePairingInput(input: ExternalThreadControlPairingInput): ExternalThreadControlPairingInput {
+  const workspaceIds = [...new Set(input.workspaceIds.map((value) => value.trim()).filter(Boolean))];
+  const scopes = [...new Set(input.scopes)];
+  if (workspaceIds.length > 100 || workspaceIds.some((workspaceId) => workspaceId.length > 128)
+    || scopes.some((scope) => !VALID_SCOPES.has(scope))
+    || !input.integrationId.trim() || input.integrationId.trim().length > 128
+    || !Number.isSafeInteger(input.callsPerMinute) || input.callsPerMinute < 1 || input.callsPerMinute > 10_000
+    || !Number.isSafeInteger(input.maxActiveThreads) || input.maxActiveThreads < 1 || input.maxActiveThreads > 1_000) {
+    throw new ExternalThreadControlPairingError("conflict", "External pairing policy is invalid");
+  }
+  return {
+    integrationId: input.integrationId.trim(),
+    workspaceIds,
+    scopes,
+    callsPerMinute: Math.trunc(input.callsPerMinute),
+    maxActiveThreads: Math.trunc(input.maxActiveThreads),
+  };
+}
+
+function rowToPairing(row: PairingRow): ExternalThreadControlPairingRecord {
+  const workspaceIds = JSON.parse(row.workspace_ids_json) as string[];
+  const scopes = JSON.parse(row.scopes_json) as ExternalThreadControlScope[];
+  return {
+    pairingId: row.pairing_id,
+    integrationId: row.integration_id,
+    workspaceIds,
+    scopes,
+    callsPerMinute: row.calls_per_minute,
+    maxActiveThreads: row.max_active_threads,
+    status: row.status,
+    authorityEpoch: row.authority_epoch,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    ...(row.replaced_by_pairing_id ? { replacedByPairingId: row.replaced_by_pairing_id } : {}),
+    ...(row.replaces_pairing_id ? { replacesPairingId: row.replaces_pairing_id } : {}),
+  };
+}
+
+function hashCredential(credential: string): string {
+  return createHash("sha256").update(credential, "utf8").digest("hex");
+}
+
+function constantTimeHashEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "hex");
+  const rightBuffer = Buffer.from(right, "hex");
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function parseResult(resultJson: string | null): Record<string, unknown> {
+  if (!resultJson) return { status: "rejected", error: { code: "internal_error", message: "External delivery outcome unavailable", retryable: true } };
+  try {
+    const value = JSON.parse(resultJson) as unknown;
+    return value && typeof value === "object" ? value as Record<string, unknown> : { status: "rejected", error: { code: "internal_error", message: "External delivery outcome invalid", retryable: true } };
+  } catch {
+    return { status: "rejected", error: { code: "internal_error", message: "External delivery outcome invalid", retryable: true } };
+  }
+}
+
+/** Return the loopback path used by the external MCP adapter. */
+export function externalThreadControlMcpEndpoint(): string {
+  return EXTERNAL_MCP_ENDPOINT;
+}

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -39,7 +39,6 @@ import {
 } from "@mcode/contracts";
 import type {
   ExternalThreadControlAuthority,
-  InternalThreadControlAuthority,
   ThreadControlAuthority,
 } from "@mcode/thread-orchestration";
 export type {
@@ -104,11 +103,18 @@ export class ThreadControlService {
     this.mutationReservations = mutationReservations ?? new ThreadControlMutationReservationService();
   }
 
-  /** Search only registered workspaces; authority is intentionally not tool input. */
-  workspaceSearch(_authority: InternalThreadControlAuthority, input: WorkspaceSearchInput): WorkspaceSearchResult {
+  /** Search registered workspaces within the caller's server-owned authority. */
+  workspaceSearch(authority: ThreadControlAuthority, input: WorkspaceSearchInput): WorkspaceSearchResult {
     const query = input.query?.trim() ?? "";
+    const searchLimit = authority.type === "external"
+      ? Math.max(input.limit, authority.allowedWorkspaceIds.length)
+      : input.limit;
+    const workspaces = this.workspaces.search(query, searchLimit)
+      .filter((workspace) => authority.type === "internal"
+        ? true
+        : authority.scopes.includes("projects:read") && authority.allowedWorkspaceIds.includes(workspace.id));
     return {
-      workspaces: this.workspaces.search(query, input.limit).map((workspace) => ({
+      workspaces: workspaces.map((workspace) => ({
         workspaceId: workspace.id,
         name: workspace.name,
         ...(workspace.last_opened_at ? { lastUsedAt: new Date(workspace.last_opened_at).toISOString() } : {}),
@@ -251,9 +257,10 @@ export class ThreadControlService {
   }
 
   /** Revalidate workspace registration and return only opaque worktree identities. */
-  async worktreeList(authority: InternalThreadControlAuthority, input: WorktreeListInput): Promise<WorktreeListResult> {
-    void authority;
-    if (!this.workspaces.findById(input.workspaceId)) {
+  async worktreeList(authority: ThreadControlAuthority, input: WorktreeListInput): Promise<WorktreeListResult> {
+    if (!this.workspaces.findById(input.workspaceId)
+      || (authority.type === "external" && (!authority.allowedWorkspaceIds.includes(input.workspaceId)
+        || !authority.scopes.includes("worktrees:read")))) {
       return { status: "rejected", error: this.error("not_found", "Workspace not found", false) };
     }
     const discovered = await this.git.listWorktrees(input.workspaceId);

--- a/apps/server/src/store/schema.ts
+++ b/apps/server/src/store/schema.ts
@@ -158,6 +158,54 @@ export const threadControlAudit = sqliteTable(
   (table) => [index("idx_thread_control_audit_thread").on(table.threadId, table.createdAt)],
 );
 
+/** Durable credentials and server-owned policy for paired external MCP clients. */
+export const externalThreadControlPairings = sqliteTable(
+  "external_thread_control_pairings",
+  {
+    pairingId: text("pairing_id").primaryKey().notNull(),
+    integrationId: text("integration_id").notNull(),
+    credentialHash: text("credential_hash").notNull().unique(),
+    workspaceIdsJson: text("workspace_ids_json").notNull().default("[]"),
+    scopesJson: text("scopes_json").notNull().default("[]"),
+    callsPerMinute: integer("calls_per_minute").notNull(),
+    maxActiveThreads: integer("max_active_threads").notNull(),
+    status: text("status").notNull().default("active"),
+    authorityEpoch: integer("authority_epoch").notNull(),
+    createdAt: text("created_at").notNull().default(timestampDefault),
+    updatedAt: text("updated_at").notNull().default(timestampDefault),
+    replacedByPairingId: text("replaced_by_pairing_id"),
+    replacesPairingId: text("replaces_pairing_id"),
+  },
+  (table) => [
+    index("idx_external_thread_control_pairings_integration").on(table.integrationId, table.status),
+    uniqueIndex("idx_external_thread_control_active_integration").on(table.integrationId).where(sql`status = 'active'`),
+  ],
+);
+
+/** Durable replay outcomes and reservations for external MCP deliveries. */
+export const externalThreadControlDeliveries = sqliteTable(
+  "external_thread_control_deliveries",
+  {
+    pairingId: text("pairing_id").notNull(),
+    authorityEpoch: integer("authority_epoch").notNull(),
+    deliveryId: text("delivery_id").notNull(),
+    fingerprint: text("fingerprint").notNull(),
+    status: text("status").notNull().default("in_flight"),
+    resultJson: text("result_json"),
+    createdAt: text("created_at").notNull().default(timestampDefault),
+    updatedAt: text("updated_at").notNull().default(timestampDefault),
+    expiresAt: text("expires_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("idx_external_thread_control_delivery_identity").on(
+      table.pairingId,
+      table.authorityEpoch,
+      table.deliveryId,
+    ),
+    index("idx_external_thread_control_delivery_retention").on(table.pairingId, table.status, table.expiresAt),
+  ],
+);
+
 export const pullRequestReviewLinks = sqliteTable(
   "pull_request_review_links",
   {

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -97,6 +97,8 @@ import type { ThreadTeardownService } from "../services/thread-teardown-service.
 import type { PullRequestService } from "../services/pull-requests/pull-request-service.js";
 import type { PullRequestMutationService } from "../services/pull-requests/pull-request-mutation-service.js";
 import type { ReviewWorktreeService } from "../services/pull-requests/review-worktree-service.js";
+import type { ExternalThreadControlPairingService } from "../services/external-thread-control-pairing-service.js";
+import type { ExternalThreadControlMcpRuntime } from "../services/external-thread-control-mcp-runtime.js";
 
 const DEFAULT_PULL_REQUEST_CONNECTION = {};
 
@@ -211,6 +213,10 @@ export interface RouterDeps {
   pullRequestMutationService: PullRequestMutationService;
   /** Creates and restores local Review worktrees linked to pull requests. */
   reviewWorktreeService: ReviewWorktreeService;
+  /** Durable paired external MCP authority management. */
+  externalThreadControlPairingService?: ExternalThreadControlPairingService;
+  /** Existing HTTP server's loopback external MCP adapter. */
+  externalThreadControlMcpRuntime?: ExternalThreadControlMcpRuntime;
 }
 
 /**
@@ -381,6 +387,34 @@ async function dispatch(
   context: { client?: WebSocket },
 ): Promise<unknown> {
   switch (method) {
+    case "threadControl.pairing.create": {
+      const pairings = deps.externalThreadControlPairingService;
+      if (!pairings) throw new Error("External thread-control pairing service unavailable");
+      const pairing = pairings.create(params);
+      return {
+        ...pairing,
+        externalMcpEndpoint: deps.externalThreadControlMcpRuntime?.endpoint() ?? pairing.externalMcpEndpoint,
+      };
+    }
+    case "threadControl.pairing.revoke": {
+      const pairings = deps.externalThreadControlPairingService;
+      if (!pairings) throw new Error("External thread-control pairing service unavailable");
+      const pairing = pairings.revoke(params.pairingId);
+      return {
+        ...pairing,
+        externalMcpEndpoint: deps.externalThreadControlMcpRuntime?.endpoint() ?? "/mcp/external-thread-control",
+      };
+    }
+    case "threadControl.pairing.replace": {
+      const pairings = deps.externalThreadControlPairingService;
+      if (!pairings) throw new Error("External thread-control pairing service unavailable");
+      const { pairingId, ...input } = params;
+      const pairing = pairings.replace(pairingId, input);
+      return {
+        ...pairing,
+        externalMcpEndpoint: deps.externalThreadControlMcpRuntime?.endpoint() ?? pairing.externalMcpEndpoint,
+      };
+    }
     case "push.subscribeThread":
       if (context.client) {
         subscribeClientToThread(context.client, params.threadId);

--- a/apps/server/src/transport/ws-server.ts
+++ b/apps/server/src/transport/ws-server.ts
@@ -17,6 +17,7 @@ import { extractToken, buildAuthCookie } from "./auth";
 import { createReadStream, existsSync } from "fs";
 import { join } from "path";
 import { getMcodeDir } from "@mcode/shared";
+import { EXTERNAL_THREAD_CONTROL_MCP_PATH } from "../services/external-thread-control-mcp-runtime.js";
 
 /** Constant-time string comparison to prevent timing attacks on token validation. */
 function safeTokenEqual(a: string, b: string): boolean {
@@ -104,6 +105,17 @@ export function createWsServer(deps: WsServerDeps): {
   wss: WebSocketServer;
 } {
   const httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const requestPath = req.url?.split("?", 1)[0];
+    if (requestPath === EXTERNAL_THREAD_CONTROL_MCP_PATH && deps.externalThreadControlMcpRuntime) {
+      void deps.externalThreadControlMcpRuntime.handleRequest(req, res).catch((error: unknown) => {
+        logger.error("External thread-control MCP request failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        if (!res.headersSent) res.writeHead(500);
+        res.end();
+      });
+      return;
+    }
     const token = extractToken(req);
 
     if (req.method === "GET" && req.url?.startsWith("/health")) {

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -69,6 +69,45 @@ import {
   PullRequestMergeResultSchema,
 } from "../pull-requests.js";
 
+const ExternalThreadControlScopeSchema = z.enum([
+  "projects:read",
+  "worktrees:read",
+  "threads:create",
+  "threads:read-owned",
+  "threads:read-project",
+  "threads:send-owned",
+  "threads:send-project",
+  "threads:stop-owned",
+  "threads:stop-project",
+  "worktrees:create",
+  "execution:full",
+]);
+
+const ExternalThreadControlPairingInputSchema = z.object({
+  integrationId: z.string().trim().min(1).max(128),
+  workspaceIds: z.array(z.string().trim().min(1).max(128)).max(100).default([]),
+  scopes: z.array(ExternalThreadControlScopeSchema).max(11).default([]),
+  callsPerMinute: z.number().int().positive().max(10_000).default(60),
+  maxActiveThreads: z.number().int().positive().max(1_000).default(5),
+}).strict();
+
+const ExternalThreadControlPairingResultSchema = z.object({
+  pairingId: z.string().min(1),
+  integrationId: z.string().min(1),
+  credential: z.string().min(1).optional(),
+  workspaceIds: z.array(z.string().min(1)),
+  scopes: z.array(ExternalThreadControlScopeSchema),
+  callsPerMinute: z.number().int().positive(),
+  maxActiveThreads: z.number().int().positive(),
+  status: z.enum(["active", "revoked"]),
+  authorityEpoch: z.number().int().positive(),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1),
+  replacedByPairingId: z.string().min(1).optional(),
+  replacesPairingId: z.string().min(1).optional(),
+  externalMcpEndpoint: z.string().url().or(z.string().startsWith("/")),
+}).strict();
+
 /** Maximum recap input messages accepted by recap.generate. */
 export const RECAP_MAX_MESSAGES = 80;
 /** Maximum characters accepted per recap input message. */
@@ -534,6 +573,28 @@ export const WS_METHODS = lazySchema(() => ({
   "agent.createAndSend": {
     params: CreateAndSendSchema(),
     result: CreateAndSendResultSchema(),
+  },
+  /** Create one external thread-control pairing and return its credential once. */
+  "threadControl.pairing.create": {
+    params: ExternalThreadControlPairingInputSchema,
+    result: ExternalThreadControlPairingResultSchema,
+  },
+  /** Revoke an external thread-control pairing and all authority derived from it. */
+  "threadControl.pairing.revoke": {
+    params: z.object({ pairingId: z.string().trim().min(1).max(128) }).strict(),
+    result: ExternalThreadControlPairingResultSchema,
+  },
+  /** Replace one pairing atomically, returning the successor credential once. */
+  "threadControl.pairing.replace": {
+    params: z.object({
+      pairingId: z.string().trim().min(1).max(128),
+      integrationId: z.string().trim().min(1).max(128),
+      workspaceIds: z.array(z.string().trim().min(1).max(128)).max(100).default([]),
+      scopes: z.array(ExternalThreadControlScopeSchema).max(11).default([]),
+      callsPerMinute: z.number().int().positive().max(10_000).default(60),
+      maxActiveThreads: z.number().int().positive().max(1_000).default(5),
+    }).strict(),
+    result: ExternalThreadControlPairingResultSchema,
   },
   "agent.stop": {
     params: z.object({ threadId: z.string() }),

--- a/packages/thread-orchestration/src/index.ts
+++ b/packages/thread-orchestration/src/index.ts
@@ -26,6 +26,10 @@ export type ExternalThreadControlScope =
 /** Server-owned authority for a paired external thread-control integration. */
 export interface ExternalThreadControlAuthority {
   type: "external";
+  /** Durable pairing identity derived by the authenticated external adapter. */
+  pairingId?: string;
+  /** Monotonic authority epoch; stale epochs cannot dispatch. */
+  authorityEpoch?: number;
   integrationId: string;
   allowedWorkspaceIds: readonly string[];
   scopes: readonly ExternalThreadControlScope[];


### PR DESCRIPTION
## What

Add a paired external MCP surface for secured thread control.

## Why

External clients need scoped access to selected Mcode Projects without bypassing thread-control policy or repeating delivered operations.

## Key Changes

- Add durable pairings with hashed credentials, authority epochs, revocation, replacement, and local management methods.
- Expose the eight thread-control tools through an authenticated loopback MCP endpoint with durable replay and rate-limit handling.
- Keep workspace, scope, ownership, execution, and capacity policy in `ThreadControlService`.
- Add focused coverage for pairing lifecycle, replay behavior, rate limits, and external authority enforcement.

## Verification

- Focused pairing, external transport, and thread-control tests: 45 passed.
- Typecheck, lint, and Drizzle schema checks passed.
- `bun run verify:changed` is blocked locally because the worktree lacks the Electron binary required by the server test runner.

Closes #963

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787900786&installation_model_id=20477&pr_number=997&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F997&signature=31a3da1a5ca91e3ebfe1a180a1e0f905cb9a5b7aa7d38fc5ccd9d15a3f58fbf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->