### PR TITLE
feat(browser): add web development registration foundation

### DIFF
--- a/apps/server/src/__tests__/startup-policy.test.ts
+++ b/apps/server/src/__tests__/startup-policy.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveWebAutomationFlag } from "../startup-policy.js";
+
+describe("web automation startup policy", () => {
+  it.each(["production", "test", "staging", undefined])(
+    "disables truthy flag outside development (%s)",
+    (NODE_ENV) => {
+      expect(resolveWebAutomationFlag({ NODE_ENV, MCODE_WEB_AUTOMATION: "1" })).toBe(false);
+    },
+  );
+
+  it("enables explicit truthy development flag", () => {
+    expect(resolveWebAutomationFlag({ NODE_ENV: "development", MCODE_WEB_AUTOMATION: "true" })).toBe(true);
+  });
+
+  it.each([undefined, "0", "false", "off"])(
+    "disables absent or false development flag (%s)",
+    (MCODE_WEB_AUTOMATION) => {
+      expect(resolveWebAutomationFlag({ NODE_ENV: "development", MCODE_WEB_AUTOMATION })).toBe(false);
+    },
+  );
+
+  it("rejects invalid development values with explicit error", () => {
+    expect(() => resolveWebAutomationFlag({ NODE_ENV: "development", MCODE_WEB_AUTOMATION: "maybe" }))
+      .toThrow("MCODE_WEB_AUTOMATION must be true or false when set");
+  });
+});

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -75,6 +75,7 @@ import type { AgentEvent } from "@mcode/contracts";
 import { normalizeAgentProviderError } from "./services/provider-agent-error-normalize.js";
 import type Database from "better-sqlite3";
 import type { JobObject } from "./services/job-object.js";
+import { resolveWebAutomationFlag } from "./startup-policy.js";
 import {
   BrowserAutomationAccessService,
   BrowserAutomationBroker,
@@ -153,6 +154,7 @@ function resolveSingleInstanceFlag(env: NodeJS.ProcessEnv): boolean {
 }
 
 const SINGLE_INSTANCE = resolveSingleInstanceFlag(process.env);
+const WEB_AUTOMATION_ENABLED = resolveWebAutomationFlag(process.env);
 const INSTANCE_TOKEN = process.env.MCODE_INSTANCE_TOKEN?.trim() || null;
 const WORKTREE_IDENTITY = process.env.MCODE_WORKTREE_IDENTITY?.trim() || null;
 
@@ -678,6 +680,7 @@ const { httpServer, wss } = createWsServer({
     desktopInstanceId: randomUUID(),
     worktreeIdentity: WORKTREE_IDENTITY ?? "shared-server",
     allowedWorkspaceIds: workspaceService.list().map((workspace) => workspace.id),
+    allowWebRuntime: WEB_AUTOMATION_ENABLED,
   }),
   shutdown: requestShutdown,
 });

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -54,6 +54,7 @@ function registration(hostId: string, workspaceId: string): BrowserAutomationHos
   return {
     contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
     hostId,
+    runtime: "electron",
     desktopInstanceId: `desktop-${hostId}`,
     worktreeIdentity: "worktree-a",
     workspaceIds: [workspaceId],

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -65,6 +65,8 @@ export interface BrowserAutomationHostConnectionAuthorization {
   desktopInstanceId: string;
   worktreeIdentity: string;
   allowedWorkspaceIds: readonly string[];
+  /** Whether this connection may register the development-only web runtime. */
+  allowWebRuntime?: boolean;
 }
 
 /** Options controlling browser host routing, timing, and delivery. */
@@ -205,6 +207,12 @@ export class BrowserAutomationBroker {
     authorization: BrowserAutomationHostConnectionAuthorization | null,
   ): { generation: number; desktopInstanceId: string } {
     const registration = BrowserAutomationHostRegistrationSchema().parse(input);
+    if (registration.runtime === "web" && authorization?.allowWebRuntime !== true) {
+      throw new Error("Browser automation web host registration is disabled");
+    }
+    if (registration.runtime !== "web" && registration.targetIdentity) {
+      throw new Error("Browser automation target identity is reserved for web hosts");
+    }
     if (
       !authorization ||
       registration.workspaceIds.some((workspaceId) => !authorization.allowedWorkspaceIds.includes(workspaceId))
@@ -216,6 +224,25 @@ export class BrowserAutomationBroker {
       desktopInstanceId: authorization.desktopInstanceId,
       worktreeIdentity: authorization.worktreeIdentity,
     };
+    if (
+      trustedRegistration.targetIdentity &&
+      trustedRegistration.targetIdentity.worktreeIdentity !== trustedRegistration.worktreeIdentity
+    ) {
+      throw new Error("Browser automation target identity does not match its authorized worktree");
+    }
+    if (
+      trustedRegistration.targetIdentity &&
+      trustedRegistration.targetIdentity.connectionId !== registration.desktopInstanceId &&
+      trustedRegistration.targetIdentity.connectionId !== "pending-desktop"
+    ) {
+      throw new Error("Browser automation target identity does not match its connection");
+    }
+    if (
+      trustedRegistration.targetIdentity &&
+      !trustedRegistration.workspaceIds.includes(trustedRegistration.targetIdentity.workspaceId)
+    ) {
+      throw new Error("Browser automation target identity workspace is not authorized");
+    }
     this.disconnect(socket);
     if (this.hostsBySocket.size >= this.maxHosts) {
       throw new Error("Browser automation host capacity is exhausted");

--- a/apps/server/src/startup-policy.ts
+++ b/apps/server/src/startup-policy.ts
@@ -1,0 +1,10 @@
+/** Resolves the development-only web browser automation opt-in. */
+export function resolveWebAutomationFlag(env: NodeJS.ProcessEnv): boolean {
+  if (env.NODE_ENV !== "development") return false;
+  const raw = env.MCODE_WEB_AUTOMATION;
+  if (raw === undefined) return false;
+  const normalized = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  throw new Error("MCODE_WEB_AUTOMATION must be true or false when set");
+}

--- a/apps/server/src/transport/browser-automation-router.test.ts
+++ b/apps/server/src/transport/browser-automation-router.test.ts
@@ -88,4 +88,71 @@ describe("browser automation router authorization", () => {
     });
     expect(broker.status().hosts).toBe(0);
   });
+
+  it("rejects web host registration unless authorization explicitly opts in", async () => {
+    const broker = new BrowserAutomationBroker({ send: () => true });
+    const deps = { browserAutomationBroker: broker } as unknown as RouterDeps;
+    const client = {} as WebSocket;
+    const webRegistration = {
+      ...registration("desktop-web", ["workspace-a"], "worktree-trusted"),
+      runtime: "web",
+      targetIdentity: {
+        worktreeIdentity: "worktree-trusted",
+        connectionId: "pending-desktop",
+        workspaceId: "workspace-a",
+        threadId: "thread-a",
+        tabId: "tab-a",
+        generation: 1,
+      },
+    };
+    const disabled = await routeMessage(JSON.stringify({
+      id: "web-disabled",
+      method: "browserAutomation.host.register",
+      params: { registration: webRegistration },
+    }), deps, {
+      client,
+      browserAutomationAuthorization: {
+        desktopInstanceId: "desktop-trusted",
+        worktreeIdentity: "worktree-trusted",
+        allowedWorkspaceIds: ["workspace-a"],
+      },
+    });
+    expect(disabled).toMatchObject({ id: "web-disabled", error: { code: "INTERNAL_ERROR" } });
+
+    const enabled = await routeMessage(JSON.stringify({
+      id: "web-enabled",
+      method: "browserAutomation.host.register",
+      params: { registration: webRegistration },
+    }), deps, {
+      client,
+      browserAutomationAuthorization: {
+        desktopInstanceId: "desktop-trusted",
+        worktreeIdentity: "worktree-trusted",
+        allowedWorkspaceIds: ["workspace-a"],
+        allowWebRuntime: true,
+      },
+    });
+    expect(enabled).toMatchObject({ id: "web-enabled", result: { generation: 1 } });
+    broker.disconnect(client);
+  });
+
+  it("keeps production-style authorization closed even when the env flag would be truthy", async () => {
+    const broker = new BrowserAutomationBroker({ send: () => true });
+    const deps = { browserAutomationBroker: broker } as unknown as RouterDeps;
+    const response = await routeMessage(JSON.stringify({
+      id: "production-web",
+      method: "browserAutomation.host.register",
+      params: { registration: { ...registration(), runtime: "web" } },
+    }), deps, {
+      client: {} as WebSocket,
+      browserAutomationAuthorization: {
+        desktopInstanceId: "desktop-production",
+        worktreeIdentity: "worktree-production",
+        allowedWorkspaceIds: ["workspace-a"],
+        allowWebRuntime: false,
+      },
+    });
+    expect(response).toMatchObject({ id: "production-web", error: { code: "INTERNAL_ERROR" } });
+    expect(broker.status().hosts).toBe(0);
+  });
 });

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -10,6 +10,7 @@ import {
   type BrowserAutomationOperation,
   type BrowserAutomationResponse,
   type BrowserAutomationRequest,
+  type BrowserAutomationTargetIdentity,
 } from "@mcode/contracts";
 import { getTransport, pushEmitter } from "@/transport";
 import { useConnectionStore } from "@/stores/connectionStore";
@@ -31,6 +32,30 @@ import type { PreviewAutomationBridge } from "@/transport/desktop-bridge";
 const HEARTBEAT_INTERVAL_MS = 10_000;
 const UNAVAILABLE_OPERATIONS = new Map<BrowserAutomationOperation, string>([
 ]);
+
+const WEB_AUTOMATION_UNAVAILABLE_REASON = "Web automation executor is unavailable";
+
+/** Resolves explicit web-runtime browser automation opt-in. */
+export function isBrowserAutomationWebRuntimeEnabled(
+  env: Pick<ImportMetaEnv, "VITE_MCODE_WEB_AUTOMATION"> = import.meta.env,
+): boolean {
+  return env.VITE_MCODE_WEB_AUTOMATION === "1";
+}
+
+function webTargetIdentity(
+  worktreeIdentity: string,
+  connectionId: string,
+  target: { workspaceId: string; threadId: string; tabId: string; revision: number },
+): BrowserAutomationTargetIdentity {
+  return {
+    worktreeIdentity,
+    connectionId,
+    workspaceId: target.workspaceId,
+    threadId: target.threadId,
+    tabId: target.tabId,
+    generation: Math.max(1, target.revision),
+  };
+}
 
 function recordingAvailable(): boolean {
   const mediaRecorder = globalThis.MediaRecorder;
@@ -327,21 +352,42 @@ export function BrowserAutomationHost() {
   }, []);
 
   useEffect(() => {
-    if (!stableHostId || !window.desktopBridge?.preview?.automation) return;
+    const desktopAutomation = window.desktopBridge?.preview?.automation;
+    const webAutomationEnabled = isBrowserAutomationWebRuntimeEnabled();
+    if (!desktopAutomation && !webAutomationEnabled) {
+      useBrowserAutomationStore.getState().setStatus("disabled");
+      useBrowserAutomationStore.getState().setRegistered(false);
+      return;
+    }
+    if (!stableHostId) {
+      useBrowserAutomationStore.getState().setStatus("unavailable");
+      return;
+    }
     if (connectionStatus !== "connected" || workspaceIds.length === 0) {
       leaseRef.current = null;
       useBrowserAutomationStore.getState().setRegistered(false);
+      useBrowserAutomationStore.getState().setStatus("unavailable");
       return;
     }
     const epoch = ++registrationEpochRef.current;
     const transport = getTransport();
+    const liveTargetSnapshot = useBrowserAutomationStore.getState().liveTargets;
+    const activeTarget = [...liveTargetSnapshot.values()].find((target) => target.workspaceId === activeWorkspaceId);
+    const worktreeIdentity = import.meta.env.VITE_MCODE_WORKTREE_IDENTITY?.trim() || "web-runtime";
     void transport.registerBrowserAutomationHost({
       contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
       hostId: stableHostId,
+      runtime: desktopAutomation ? "electron" : "web",
       desktopInstanceId: "pending-desktop",
-      worktreeIdentity: "pending-worktree",
+      worktreeIdentity: desktopAutomation ? "pending-worktree" : worktreeIdentity,
       workspaceIds,
+      ...(activeTarget && !desktopAutomation && webAutomationEnabled ? {
+        targetIdentity: webTargetIdentity(worktreeIdentity, "pending-desktop", activeTarget),
+      } : {}),
       capabilities: BROWSER_AUTOMATION_OPERATIONS.map((operation) => {
+        if (!desktopAutomation) {
+          return { operation, available: false, unavailableReason: WEB_AUTOMATION_UNAVAILABLE_REASON };
+        }
         const recordingUnavailable =
           (operation === "recordingStart" || operation === "recordingStop") &&
           !recordingAvailable();
@@ -363,10 +409,12 @@ export function BrowserAutomationHost() {
       };
       shutdownLeaseRef.current = leaseRef.current;
       useBrowserAutomationStore.getState().setRegistered(true);
+      useBrowserAutomationStore.getState().setStatus("registered");
     }).catch(() => {
       if (registrationEpochRef.current === epoch) {
         leaseRef.current = null;
         useBrowserAutomationStore.getState().setRegistered(false);
+        useBrowserAutomationStore.getState().setStatus("unavailable");
       }
     });
     return () => {
@@ -374,6 +422,7 @@ export function BrowserAutomationHost() {
         registrationEpochRef.current += 1;
         leaseRef.current = null;
         useBrowserAutomationStore.getState().setRegistered(false);
+        useBrowserAutomationStore.getState().setStatus("unavailable");
       }
     };
   }, [connectionStatus, stableHostId, workspaceSignature]);
@@ -383,7 +432,26 @@ export function BrowserAutomationHost() {
     if (!lease || connectionStatus !== "connected") return;
     let cancelled = false;
     const bridge = window.desktopBridge?.preview?.automation;
-    if (!bridge) return;
+    if (!bridge && !isBrowserAutomationWebRuntimeEnabled()) return;
+    if (!bridge) {
+      const targets = [...liveTargets.values()].slice(0, 64).map((candidate) => ({
+        desktopInstanceId: lease.desktopInstanceId,
+        windowId: 1,
+        connectionGeneration: lease.generation,
+        threadId: candidate.threadId,
+        tabId: candidate.tabId,
+        targetGeneration: Math.max(1, candidate.revision),
+        active: candidate.threadId === useWorkspaceStore.getState().activeThreadId,
+        focused: candidate.threadId === useWorkspaceStore.getState().activeThreadId,
+        lastUsedAt: candidate.lastUsedAt,
+      } satisfies BrowserAutomationHostDispatchTarget));
+      void getTransport().updateBrowserAutomationHostTargets(
+        lease.hostId,
+        lease.generation,
+        targets,
+      ).catch(() => undefined);
+      return;
+    }
     const targets = [...liveTargets.values()].slice(0, 64);
     void Promise.all(targets.map(async (candidate) => {
       const described = await bridge.describeTarget({

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -55,7 +55,7 @@ vi.mock("../PreviewPanel", () => ({
   ),
 }));
 
-import { BrowserAutomationHost } from "../BrowserAutomationHost";
+import { BrowserAutomationHost, isBrowserAutomationWebRuntimeEnabled } from "../BrowserAutomationHost";
 import { BrowserAutomationRecorder } from "../browserAutomationRecorder";
 
 function deferred<T>() {
@@ -205,6 +205,12 @@ describe("BrowserAutomationHost", () => {
     );
   });
 
+  it("keeps web automation disabled by default and recognizes explicit opt-in", () => {
+    expect(isBrowserAutomationWebRuntimeEnabled({})).toBe(false);
+    expect(isBrowserAutomationWebRuntimeEnabled({ VITE_MCODE_WEB_AUTOMATION: "0" })).toBe(false);
+    expect(isBrowserAutomationWebRuntimeEnabled({ VITE_MCODE_WEB_AUTOMATION: "1" })).toBe(true);
+  });
+
   afterEach(() => {
     delete window.desktopBridge;
   });
@@ -216,6 +222,7 @@ describe("BrowserAutomationHost", () => {
 
     await act(async () => Promise.resolve());
     expect(harness.transport.registerBrowserAutomationHost).not.toHaveBeenCalled();
+    expect(useBrowserAutomationStore.getState().status).toBe("disabled");
     expect(view.container).toBeEmptyDOMElement();
     view.unmount();
   });

--- a/apps/web/src/stores/browserAutomationStore.ts
+++ b/apps/web/src/stores/browserAutomationStore.ts
@@ -7,6 +7,9 @@ import { create } from "zustand";
 /** Maximum number of inactive, non-busy Browser targets retained warm. */
 export const BROWSER_AUTOMATION_WARM_TARGET_LIMIT = 3;
 
+/** Discovery state for the browser automation host in the current runtime. */
+export type BrowserAutomationHostStatus = "disabled" | "unavailable" | "registered";
+
 /** Renderer-owned Browser tab currently eligible for desktop target discovery. */
 export interface BrowserAutomationLiveTarget {
   readonly workspaceId: string;
@@ -27,6 +30,7 @@ interface BrowserAutomationState {
   readonly controllers: ReadonlyMap<string, BrowserAutomationControllerState>;
   readonly activeRequests: ReadonlyMap<string, BrowserAutomationActiveRequest>;
   readonly registered: boolean;
+  readonly status: BrowserAutomationHostStatus;
   readonly viewportByTarget: ReadonlyMap<string, { readonly width: number; readonly height: number }>;
   readonly hostedScopeIds: ReadonlySet<string>;
   registerTarget: (workspaceId: string, threadId: string, tabId: string) => void;
@@ -41,6 +45,7 @@ interface BrowserAutomationState {
   setActiveRequest: (request: BrowserAutomationActiveRequest) => void;
   clearActiveRequest: (requestId: string, sequence: number) => void;
   setRegistered: (registered: boolean) => void;
+  setStatus: (status: BrowserAutomationHostStatus) => void;
   setViewport: (threadId: string, tabId: string, width: number, height: number) => void;
   setHostedScopeIds: (scopeIds: ReadonlySet<string>) => void;
 }
@@ -70,6 +75,7 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set) =>
   controllers: new Map(),
   activeRequests: new Map(),
   registered: false,
+  status: "unavailable",
   viewportByTarget: new Map(),
   hostedScopeIds: new Set(),
   registerTarget: (workspaceId, threadId, tabId) =>
@@ -143,6 +149,7 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set) =>
       return { activeRequests };
     }),
   setRegistered: (registered) => set({ registered }),
+  setStatus: (status) => set({ status }),
   setHostedScopeIds: (hostedScopeIds) => set({ hostedScopeIds: new Set(hostedScopeIds) }),
   setViewport: (threadId, tabId, width, height) =>
     set((state) => {

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_MCODE_WEB_AUTOMATION?: string;
+}
+
 declare module "*.css" {
   const content: string;
   export default content;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -406,6 +406,9 @@ export {
   BrowserAutomationResultSchema,
   BrowserAutomationErrorSchema,
   BrowserAutomationResponseSchema,
+  BROWSER_AUTOMATION_WEB_DEV_FLAG,
+  BrowserAutomationHostRuntimeSchema,
+  BrowserAutomationTargetIdentitySchema,
 } from "./models/browser-automation.js";
 export type {
   BrowserAutomationOperation,
@@ -425,6 +428,8 @@ export type {
   BrowserAutomationErrorCode,
   BrowserAutomationError,
   BrowserAutomationResponse,
+  BrowserAutomationHostRuntime,
+  BrowserAutomationTargetIdentity,
 } from "./models/browser-automation.js";
 
 // Events

--- a/packages/contracts/src/models/__tests__/browser-automation.test.ts
+++ b/packages/contracts/src/models/__tests__/browser-automation.test.ts
@@ -26,6 +26,7 @@ import {
   BrowserAutomationResultSchema,
   BrowserAutomationResponseSchema,
   BrowserAutomationSnapshotSchema,
+  BrowserAutomationTargetIdentitySchema,
   BrowserAutomationTargetSchema,
   BrowserAutomationUrlSchema,
 } from "../browser-automation.js";
@@ -536,6 +537,37 @@ describe("browser automation boundaries", () => {
         ],
       }).success,
     ).toBe(false);
+  });
+
+  it("validates opt-in web runtime target identity and positive generations", () => {
+    const registration = {
+      contractVersion: 1,
+      hostId: "host-web",
+      runtime: "web",
+      desktopInstanceId: "connection-web",
+      worktreeIdentity: "worktree-a",
+      workspaceIds: ["workspace-a"],
+      targetIdentity: {
+        worktreeIdentity: "worktree-a",
+        connectionId: "connection-web",
+        workspaceId: "workspace-a",
+        threadId: "thread-a",
+        tabId: "tab-a",
+        generation: 1,
+      },
+      capabilities: [{ operation: "status", available: false, unavailableReason: "disabled" }],
+      maxPendingRequests: 1,
+      connectedAt: 1,
+    };
+    expect(BrowserAutomationHostRegistrationSchema().safeParse(registration).success).toBe(true);
+    expect(BrowserAutomationTargetIdentitySchema().safeParse({
+      ...registration.targetIdentity,
+      generation: 0,
+    }).success).toBe(false);
+    expect(BrowserAutomationHostRegistrationSchema().safeParse({
+      ...registration,
+      targetIdentity: { ...registration.targetIdentity, worktreeIdentity: "other-worktree" },
+    }).success).toBe(true);
   });
 
   it("requires expiring credential claims with unique operations", () => {

--- a/packages/contracts/src/models/browser-automation.ts
+++ b/packages/contracts/src/models/browser-automation.ts
@@ -30,6 +30,9 @@ export const BROWSER_AUTOMATION_MAX_PENDING_REQUESTS = 32;
 /** Maximum text characters accepted by a type operation. */
 export const BROWSER_AUTOMATION_MAX_TYPED_TEXT_CHARS = 16_384;
 
+/** Explicit opt-in environment flag for registration by the pure web runtime. */
+export const BROWSER_AUTOMATION_WEB_DEV_FLAG = "MCODE_WEB_AUTOMATION" as const;
+
 const ID_MAX = 256;
 const SHORT_TEXT_MAX = 1_024;
 const SELECTOR_MAX = 4_096;
@@ -572,6 +575,27 @@ export type BrowserAutomationControllerState = z.infer<
   ReturnType<typeof BrowserAutomationControllerStateSchema>
 >;
 
+/** Runtime that owns one browser automation host connection. */
+export const BrowserAutomationHostRuntimeSchema = z.enum(["electron", "web"]);
+/** Browser automation host runtime discriminator. */
+export type BrowserAutomationHostRuntime = z.infer<typeof BrowserAutomationHostRuntimeSchema>;
+
+/** Provider-neutral identity for one bounded web target registration. */
+export const BrowserAutomationTargetIdentitySchema = lazySchema(() =>
+  z.object({
+    worktreeIdentity: idSchema,
+    connectionId: idSchema,
+    workspaceId: idSchema,
+    threadId: idSchema,
+    tabId: idSchema,
+    generation: z.number().int().positive(),
+  }).strict(),
+);
+/** Provider-neutral identity for one bounded web target registration. */
+export type BrowserAutomationTargetIdentity = z.infer<
+  ReturnType<typeof BrowserAutomationTargetIdentitySchema>
+>;
+
 /** One operation capability advertised by a connected browser host. */
 export const BrowserAutomationHostCapabilitySchema = lazySchema(() =>
   z
@@ -603,9 +627,11 @@ export const BrowserAutomationHostRegistrationSchema = lazySchema(() =>
     .object({
       contractVersion: z.literal(BROWSER_AUTOMATION_CONTRACT_VERSION),
       hostId: idSchema,
+      runtime: BrowserAutomationHostRuntimeSchema.default("electron"),
       desktopInstanceId: idSchema,
       worktreeIdentity: idSchema,
       workspaceIds: z.array(idSchema).min(1).max(32),
+      targetIdentity: BrowserAutomationTargetIdentitySchema().optional(),
       capabilities: z
         .array(BrowserAutomationHostCapabilitySchema())
         .min(1)

--- a/scripts/agent/__tests__/agent-up-web-flag.test.mjs
+++ b/scripts/agent/__tests__/agent-up-web-flag.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { isWebAutomationEnabled } from "../agent-up.mjs";
+
+test("web automation forwarding stays disabled unless explicitly enabled", () => {
+  assert.equal(isWebAutomationEnabled({}), false);
+  assert.equal(isWebAutomationEnabled({ MCODE_WEB_AUTOMATION: "0" }), false);
+  assert.equal(isWebAutomationEnabled({ MCODE_WEB_AUTOMATION: "true" }), true);
+  assert.equal(isWebAutomationEnabled({ MCODE_WEB_AUTOMATION: "1" }), true);
+});

--- a/scripts/agent/agent-up.mjs
+++ b/scripts/agent/agent-up.mjs
@@ -9,7 +9,6 @@ import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { rebuildServerDevBundle } from "../build-server-dev-bundle.mjs";
 import {
   buildPortsContract,
   buildRuntimeStateEnv,
@@ -30,6 +29,12 @@ const desktopRoot = resolve(rootDir, "apps", "desktop");
 const serverCjs = resolve(desktopRoot, "dist", "server", "server.cjs");
 let agentUpTestHooks = {};
 
+/** Resolves the explicit web-automation opt-in for the Vite child process. */
+export function isWebAutomationEnabled(env = process.env) {
+  const normalized = env.MCODE_WEB_AUTOMATION?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
 /**
  * Installs process-local hooks for focused agentUp tests.
  *
@@ -38,7 +43,7 @@ let agentUpTestHooks = {};
  *   seedFixtureRepo: typeof seedFixtureRepo,
  *   computeAvailablePorts: typeof computeAvailablePorts,
  *   getElectronBinary: typeof getElectronBinary,
- *   rebuildServerDevBundle: typeof rebuildServerDevBundle,
+ *   rebuildServerDevBundle: () => Promise<void>,
  *   spawnLogged: typeof spawnLogged,
  * }>} hooks
  * @returns {() => void}
@@ -93,7 +98,8 @@ export async function agentUp(repoRoot = resolveRepoRoot()) {
   }
   const electronBinding = getElectronBinding();
 
-  const rebuildRuntimeServerBundle = agentUpTestHooks.rebuildServerDevBundle ?? rebuildServerDevBundle;
+  const rebuildRuntimeServerBundle = agentUpTestHooks.rebuildServerDevBundle ??
+    (await import("../build-server-dev-bundle.mjs")).rebuildServerDevBundle;
   await rebuildRuntimeServerBundle();
 
   const startedPidFiles = [];
@@ -140,6 +146,7 @@ export async function agentUp(repoRoot = resolveRepoRoot()) {
           VITE_MCODE_SINGLE_INSTANCE: "true",
           VITE_MCODE_WORKTREE_IDENTITY: repoRoot,
           VITE_MCODE_RUNTIME_CONTRACT: paths.portsFile,
+          VITE_MCODE_WEB_AUTOMATION: isWebAutomationEnabled() ? "1" : "0",
         },
       },
       resolve(paths.logsDir, "web.log"),


### PR DESCRIPTION
## What
Add the web development browser automation foundation: bounded target identity, an explicit default-off flag, server-authorized registration, status discovery, and focused coverage.

## Why
Agents running the worktree-local web runtime need to discover a visible browser target without launching Electron. The server remains the authority, and the Electron path stays unchanged.

## Key Changes
- Add provider-neutral web runtime and target identity contracts with bounded validation.
- Gate pure web host registration behind MCODE_WEB_AUTOMATION in development only.
- Preserve server authorization, routing ownership, and Electron registration behavior.
- Add contract, server, web, script, and startup-policy tests.

## Verification
- Focused contract tests: 76 passed.
- Focused server browser tests: 28 passed.
- Startup policy tests: 10 passed.
- Focused web tests: 26 passed.
- Flag-forwarding script test: passed.
- Live in-app Browser: enabled runtime registered one host; disabled runtime registered zero hosts.
- Required repository gate: blocked by existing Windows path and broad-suite baseline failures. See .dev/verification/runs/2026-07-29T13-15-17-337Z-45896-b4a39ba9/manifest.json locally.

Closes #980
Continues #883

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787923410&installation_model_id=20477&pr_number=1000&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1000&signature=89040fa39ca98c1217d473be1ee5533d665592d833246649930cbef2e902bb04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->