### PR TITLE
fix(web): unify inline entity token formatting

### DIFF
--- a/apps/web/src/components/chat/EntityToken.tsx
+++ b/apps/web/src/components/chat/EntityToken.tsx
@@ -103,13 +103,12 @@ export function EntityToken({
   kind,
   label,
   filePath,
-  tone = "assistant",
+  tone: _tone = "assistant",
   invocation = false,
   className,
   ...props
 }: EntityTokenProps) {
   const isCommandInvocation = kind === "command" || invocation;
-  const isCapabilityReference = isCommandInvocation || kind === "plugin";
   const displayLabel = isCommandInvocation
     ? label.replace(/^\/+/, "")
     : kind === "plugin"
@@ -121,12 +120,7 @@ export function EntityToken({
       data-entity-token={kind}
       className={cn(
         "mx-px inline-flex max-w-full items-center gap-1 align-[-0.2em] font-sans text-[length:inherit] font-medium leading-none",
-        isCapabilityReference
-          ? "text-primary"
-          : tone === "user"
-            ? "h-5 rounded-md bg-background/45 px-1.5 text-accent-foreground ring-1 ring-inset ring-foreground/10"
-            : "h-5 rounded-md bg-muted/70 px-1.5 text-foreground ring-1 ring-inset ring-border/70",
-        tone === "composer" && !isCapabilityReference && "bg-muted/80",
+        "text-primary",
         className,
       )}
       {...props}
@@ -135,12 +129,7 @@ export function EntityToken({
         kind={kind}
         filePath={filePath}
         commandName={isCommandInvocation ? displayLabel : undefined}
-        className={cn(
-          "flex size-3.5 items-center justify-center text-muted-foreground",
-          isCapabilityReference && "text-current",
-          tone === "user" && !isCapabilityReference && "text-accent-foreground/60",
-          kind === "mcode" && tone !== "user" && "text-primary/80",
-        )}
+        className="flex size-3.5 items-center justify-center text-current"
       />
       <span className="min-w-0 truncate">{displayLabel}</span>
     </span>

--- a/apps/web/src/components/chat/__tests__/EntityToken.test.tsx
+++ b/apps/web/src/components/chat/__tests__/EntityToken.test.tsx
@@ -29,8 +29,8 @@ describe("EntityToken command invocations", () => {
   });
 });
 
-describe("EntityToken capability references", () => {
-  it("renders rich plugin mentions as frameless inline references", () => {
+describe("EntityToken inline references", () => {
+  it("renders plugin mentions as frameless inline references", () => {
     const { container } = render(
       <EntityToken kind="plugin" label="@impeccable" tone="composer" />,
     );
@@ -43,7 +43,7 @@ describe("EntityToken capability references", () => {
     expect(token?.querySelector(".lucide-plug")).toBeInTheDocument();
   });
 
-  it("keeps file and agent mentions as padded chips", () => {
+  it("renders file and agent mentions with the same frameless style", () => {
     const { container } = render(
       <div>
         <EntityToken kind="file" label="@index.ts" tone="composer" filePath="index.ts" />
@@ -52,11 +52,18 @@ describe("EntityToken capability references", () => {
     );
 
     for (const kind of ["file", "agent"]) {
-      expect(container.querySelector(`[data-entity-token="${kind}"]`)).toHaveClass(
+      const token = container.querySelector(`[data-entity-token="${kind}"]`);
+
+      expect(token).toHaveClass("text-primary");
+      expect(token).not.toHaveClass(
         "h-5",
         "rounded-md",
         "px-1.5",
+        "bg-muted",
+        "bg-background",
+        "ring-1",
       );
+      expect(token?.querySelector(`[data-entity-icon="${kind}"]`)).toHaveClass("text-current");
     }
   });
 });


### PR DESCRIPTION
## What
Unify inline entity-token formatting for files and sub-agents.

## Why
Files and sub-agents rendered as padded chips while skills and plugins rendered as inline references.

## Key Changes
- Use one frameless inline style for every entity-token kind.
- Keep entity icons aligned with the reference text color.
- Add regression coverage for file and sub-agent tokens.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787925606&installation_model_id=20477&pr_number=1001&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1001&signature=39231de888d3f58fb9ae86b673cc8978c72e56adaae47b1331d72aa7921b0902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated inline references in chat to appear as simpler, frameless text tokens.
  * Standardized reference text and icon colors for a more consistent appearance.
  * Removed chip-like padding, sizing, background, and ring styling from plugin, file, and agent references.

* **Tests**
  * Updated coverage to verify the new inline reference appearance and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->