### PR TITLE
feat(web): connect Browser panel to agent runtime

### DIFF
--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -28,6 +28,7 @@ import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { BrowserAutomationRecorder } from "./browserAutomationRecorder";
 import { PreviewPanel } from "./PreviewPanel";
 import type { PreviewAutomationBridge } from "@/transport/desktop-bridge";
+import { isBrowserAutomationWebRuntimeEnabled } from "./browserAutomationRuntime";
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
 const UNAVAILABLE_OPERATIONS = new Map<BrowserAutomationOperation, string>([
@@ -35,12 +36,7 @@ const UNAVAILABLE_OPERATIONS = new Map<BrowserAutomationOperation, string>([
 
 const WEB_AUTOMATION_UNAVAILABLE_REASON = "Web automation executor is unavailable";
 
-/** Resolves explicit web-runtime browser automation opt-in. */
-export function isBrowserAutomationWebRuntimeEnabled(
-  env: Pick<ImportMetaEnv, "VITE_MCODE_WEB_AUTOMATION"> = import.meta.env,
-): boolean {
-  return env.VITE_MCODE_WEB_AUTOMATION === "1";
-}
+export { isBrowserAutomationWebRuntimeEnabled } from "./browserAutomationRuntime";
 
 function webTargetIdentity(
   worktreeIdentity: string,
@@ -311,8 +307,8 @@ function PersistentAutomationPreviewSurface({ scope }: { readonly scope: Backgro
 }
 
 /**
- * Connects renderer-owned visible Browser tabs to the server broker while all
- * page execution remains inside the desktop control kernel.
+ * Connects visible Browser tabs to the server broker, preserving the Electron
+ * bridge when present and exposing the explicitly enabled web runtime seam.
  */
 export function BrowserAutomationHost() {
   const connectionStatus = useConnectionStore((state) => state.status);

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1536,22 +1536,36 @@ function WebRuntimePreview({ threadId }: { readonly threadId: string }) {
   const storedUrl = useDiffStore((state) => state.previewUrlByThread[threadId] ?? "");
   const [inputUrl, setInputUrl] = useState(storedUrl);
   const [src, setSrc] = useState<string | null>(() => normalizeWebPreviewUrl(storedUrl));
+  const [crossOriginObserved, setCrossOriginObserved] = useState(false);
   const enabled = isBrowserAutomationWebRuntimeEnabled();
-  const state = resolveWebPreviewState(src, enabled);
+  const requestedState = resolveWebPreviewState(src, enabled);
+  const state = crossOriginObserved ? "cross-origin" : requestedState;
 
   useEffect(() => {
     setInputUrl(storedUrl);
     setSrc(normalizeWebPreviewUrl(storedUrl));
+    setCrossOriginObserved(false);
   }, [storedUrl]);
 
   const navigate = (): void => {
     const next = normalizeWebPreviewUrl(inputUrl);
     if (!next) {
       setSrc(null);
+      setCrossOriginObserved(false);
       return;
     }
     setSrc(next);
+    setCrossOriginObserved(false);
     useDiffStore.getState().setPreviewUrlForThread(threadId, next);
+  };
+
+  const onIframeLoad = (event: React.SyntheticEvent<HTMLIFrameElement>): void => {
+    try {
+      const actualOrigin = event.currentTarget.contentWindow?.location.origin;
+      setCrossOriginObserved(actualOrigin !== window.location.origin);
+    } catch {
+      setCrossOriginObserved(true);
+    }
   };
 
   return (
@@ -1568,6 +1582,7 @@ function WebRuntimePreview({ threadId }: { readonly threadId: string }) {
             data-testid="web-runtime-preview-iframe"
             className="h-full w-full border-0"
             referrerPolicy="no-referrer"
+            onLoad={onIframeLoad}
           />
         ) : state === "cross-origin" && src ? (
           <>
@@ -1577,6 +1592,7 @@ function WebRuntimePreview({ threadId }: { readonly threadId: string }) {
               data-testid="web-runtime-preview-iframe"
               className="h-full w-full border-0"
               referrerPolicy="no-referrer"
+              onLoad={onIframeLoad}
             />
             <div data-testid="web-runtime-cross-origin" className="pointer-events-none absolute inset-x-3 top-3 rounded-md border border-amber-500/40 bg-background/95 px-3 py-2 text-xs text-amber-700 shadow-sm">
               Cross-origin preview is visible, but web automation and DOM access are unsupported.
@@ -2357,7 +2373,7 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
   const hasDesktopPreview = !!window.desktopBridge?.preview;
   const webRuntimeEnabled = isBrowserAutomationWebRuntimeEnabled();
   if (!hasDesktopPreview && webRuntimeEnabled) {
-    return <WebRuntimePreview threadId={threadId} />;
+    return <WebRuntimePreview key={threadId} threadId={threadId} />;
   }
   if (!hasDesktopPreview) {
     return (

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -79,6 +79,11 @@ import {
   selectWarmBrowserTabIds,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
+import {
+  isBrowserAutomationWebRuntimeEnabled,
+  normalizeWebPreviewUrl,
+  resolveWebPreviewState,
+} from "./browserAutomationRuntime";
 
 /** Human-readable label for the capture confirmation badge. */
 const CAPTURE_KIND_LABEL: Record<PreviewCaptureKind, string> = {
@@ -1526,6 +1531,69 @@ export interface PreviewPanelProps {
   readonly automationOnly?: boolean;
 }
 
+/** Visible same-origin iframe surface used by the worktree-local web runtime. */
+function WebRuntimePreview({ threadId }: { readonly threadId: string }) {
+  const storedUrl = useDiffStore((state) => state.previewUrlByThread[threadId] ?? "");
+  const [inputUrl, setInputUrl] = useState(storedUrl);
+  const [src, setSrc] = useState<string | null>(() => normalizeWebPreviewUrl(storedUrl));
+  const enabled = isBrowserAutomationWebRuntimeEnabled();
+  const state = resolveWebPreviewState(src, enabled);
+
+  useEffect(() => {
+    setInputUrl(storedUrl);
+    setSrc(normalizeWebPreviewUrl(storedUrl));
+  }, [storedUrl]);
+
+  const navigate = (): void => {
+    const next = normalizeWebPreviewUrl(inputUrl);
+    if (!next) {
+      setSrc(null);
+      return;
+    }
+    setSrc(next);
+    useDiffStore.getState().setPreviewUrlForThread(threadId, next);
+  };
+
+  return (
+    <div data-testid="web-runtime-preview" className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <form className="flex items-center gap-2 border-b border-border/60 px-2 py-1.5" onSubmit={(event) => { event.preventDefault(); navigate(); }}>
+        <Input aria-label="Preview URL" value={inputUrl} onChange={(event) => setInputUrl(event.target.value)} placeholder="Enter an http(s) URL" />
+        <Button type="submit" size="sm">Open</Button>
+      </form>
+      <div className="relative min-h-0 min-w-0 flex-1 bg-muted/10">
+        {state === "same-origin" && src ? (
+          <iframe
+            title="Web browser preview"
+            src={src}
+            data-testid="web-runtime-preview-iframe"
+            className="h-full w-full border-0"
+            referrerPolicy="no-referrer"
+          />
+        ) : state === "cross-origin" && src ? (
+          <>
+            <iframe
+              title="Cross-origin web preview"
+              src={src}
+              data-testid="web-runtime-preview-iframe"
+              className="h-full w-full border-0"
+              referrerPolicy="no-referrer"
+            />
+            <div data-testid="web-runtime-cross-origin" className="pointer-events-none absolute inset-x-3 top-3 rounded-md border border-amber-500/40 bg-background/95 px-3 py-2 text-xs text-amber-700 shadow-sm">
+              Cross-origin preview is visible, but web automation and DOM access are unsupported.
+            </div>
+          </>
+        ) : (
+          <div data-testid={`web-runtime-${state}`} className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            {state === "disabled"
+              ? "Web preview automation is disabled. Set MCODE_WEB_AUTOMATION=1 and restart agent:up to enable it."
+              : "Web preview is unavailable until an HTTP(S) same-origin target is loaded."}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 /**
  * Embedded site preview: a clean URL header above a region aligned to an
  * Electron BrowserView. The header morphs across empty / focused / loaded
@@ -2286,7 +2354,12 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
       window.removeEventListener("mcode:preview-design-escape", onDesignEscape);
   }, [designModeActive, handleDesignEscape, threadId]);
 
-  if (!window.desktopBridge?.preview) {
+  const hasDesktopPreview = !!window.desktopBridge?.preview;
+  const webRuntimeEnabled = isBrowserAutomationWebRuntimeEnabled();
+  if (!hasDesktopPreview && webRuntimeEnabled) {
+    return <WebRuntimePreview threadId={threadId} />;
+  }
+  if (!hasDesktopPreview) {
     return (
       <div
         className="flex flex-1 flex-col items-center justify-center gap-2 px-4 py-8 text-center text-sm text-muted-foreground"
@@ -2294,8 +2367,8 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
       >
         <Globe className="size-8 opacity-50" aria-hidden />
         <p className="max-w-xs text-balance">
-          Embedded preview runs in the desktop app. Open Mcode from Electron to
-          browse http and https sites alongside this thread.
+          Web preview automation is disabled. Set MCODE_WEB_AUTOMATION=1 and
+          restart agent:up to enable the same-origin Browser preview.
         </p>
       </div>
     );

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -265,6 +265,8 @@ describe("PreviewPanel: unavailable state", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).desktopBridge = undefined;
     mockUsePreviewBridge.mockClear();
+    vi.unstubAllEnvs();
+    useDiffStore.setState({ previewUrlByThread: {} });
   });
 
   it("renders the unavailable state when desktopBridge is absent", () => {
@@ -277,6 +279,35 @@ describe("PreviewPanel: unavailable state", () => {
   it("does not render the full panel when desktopBridge is absent", () => {
     render(<PreviewPanel threadId="thread-1" />);
     expect(screen.queryByTestId("preview-panel")).not.toBeInTheDocument();
+  });
+
+  it("renders the enabled same-origin web preview without an Electron bridge", () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    useDiffStore.setState({ previewUrlByThread: { "thread-1": window.location.origin + "/fixture" } });
+    render(<PreviewPanel threadId="thread-1" />);
+    expect(screen.getByTestId("web-runtime-preview-iframe")).toHaveAttribute(
+      "src",
+      window.location.origin + "/fixture",
+    );
+    expect(screen.queryByTestId("web-runtime-cross-origin")).not.toBeInTheDocument();
+  });
+
+  it("keeps a cross-origin page visible while identifying DOM automation as unsupported", () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    useDiffStore.setState({ previewUrlByThread: { "thread-1": "https://example.com/fixture" } });
+    render(<PreviewPanel threadId="thread-1" />);
+    expect(screen.getByTestId("web-runtime-preview-iframe")).toBeInTheDocument();
+    expect(screen.getByTestId("web-runtime-cross-origin")).toHaveTextContent(
+      "automation and DOM access are unsupported",
+    );
+  });
+
+  it("explains that web preview automation is disabled by default", () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "0");
+    render(<PreviewPanel threadId="thread-1" />);
+    expect(screen.getByTestId("preview-panel-unavailable")).toHaveTextContent(
+      "Web preview automation is disabled",
+    );
   });
 });
 

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -292,11 +292,43 @@ describe("PreviewPanel: unavailable state", () => {
     expect(screen.queryByTestId("web-runtime-cross-origin")).not.toBeInTheDocument();
   });
 
+  it("switches thread URL and iframe synchronously without stale preview state", () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    useDiffStore.setState({
+      previewUrlByThread: {
+        "thread-1": window.location.origin + "/first",
+        "thread-2": window.location.origin + "/second",
+      },
+    });
+    const view = render(<PreviewPanel threadId="thread-1" />);
+    view.rerender(<PreviewPanel threadId="thread-2" />);
+    expect(screen.getByLabelText("Preview URL")).toHaveValue(window.location.origin + "/second");
+    expect(screen.getByTestId("web-runtime-preview-iframe")).toHaveAttribute(
+      "src",
+      window.location.origin + "/second",
+    );
+  });
+
   it("keeps a cross-origin page visible while identifying DOM automation as unsupported", () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     useDiffStore.setState({ previewUrlByThread: { "thread-1": "https://example.com/fixture" } });
     render(<PreviewPanel threadId="thread-1" />);
     expect(screen.getByTestId("web-runtime-preview-iframe")).toBeInTheDocument();
+    expect(screen.getByTestId("web-runtime-cross-origin")).toHaveTextContent(
+      "automation and DOM access are unsupported",
+    );
+  });
+
+  it("marks a same-origin requested page unsupported after cross-origin iframe navigation", () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    useDiffStore.setState({ previewUrlByThread: { "thread-1": window.location.origin + "/fixture" } });
+    render(<PreviewPanel threadId="thread-1" />);
+    const iframe = screen.getByTestId("web-runtime-preview-iframe");
+    Object.defineProperty(iframe, "contentWindow", {
+      configurable: true,
+      value: { location: { origin: "https://example.com" } },
+    });
+    fireEvent.load(iframe);
     expect(screen.getByTestId("web-runtime-cross-origin")).toHaveTextContent(
       "automation and DOM access are unsupported",
     );

--- a/apps/web/src/components/panels/browserAutomationRuntime.ts
+++ b/apps/web/src/components/panels/browserAutomationRuntime.ts
@@ -1,0 +1,41 @@
+/** Resolves the explicit development opt-in for the web browser runtime. */
+export function isBrowserAutomationWebRuntimeEnabled(
+  env: Pick<ImportMetaEnv, "VITE_MCODE_WEB_AUTOMATION"> = import.meta.env,
+): boolean {
+  return env.VITE_MCODE_WEB_AUTOMATION === "1";
+}
+
+/** Observable preview states exposed by the pure web Browser surface. */
+export type WebPreviewState = "disabled" | "unavailable" | "same-origin" | "cross-origin";
+
+/** Classifies a preview URL without granting cross-origin DOM access. */
+export function resolveWebPreviewState(
+  url: string | null | undefined,
+  enabled: boolean,
+  origin: string = window.location.origin,
+): WebPreviewState {
+  if (!enabled) return "disabled";
+  if (!url?.trim()) return "unavailable";
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return "unavailable";
+    if (parsed.username || parsed.password) return "unavailable";
+    return parsed.origin === origin ? "same-origin" : "cross-origin";
+  } catch {
+    return "unavailable";
+  }
+}
+
+/** Accepts only bounded HTTP(S) URLs suitable for an iframe source. */
+export function normalizeWebPreviewUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 2_048) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    if (parsed.username || parsed.password) return null;
+    return parsed.href;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/agent/__tests__/agent-up-web-flag.test.mjs
+++ b/scripts/agent/__tests__/agent-up-web-flag.test.mjs
@@ -1,10 +1,21 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { isWebAutomationEnabled } from "../agent-up.mjs";
+import { buildWebAutomationEnv, isWebAutomationEnabled } from "../agent-up.mjs";
 
 test("web automation forwarding stays disabled unless explicitly enabled", () => {
   assert.equal(isWebAutomationEnabled({}), false);
   assert.equal(isWebAutomationEnabled({ MCODE_WEB_AUTOMATION: "0" }), false);
   assert.equal(isWebAutomationEnabled({ MCODE_WEB_AUTOMATION: "true" }), true);
   assert.equal(isWebAutomationEnabled({ MCODE_WEB_AUTOMATION: "1" }), true);
+});
+
+test("web automation opt-in is forwarded to both runtime children", () => {
+  assert.deepEqual(buildWebAutomationEnv({ MCODE_WEB_AUTOMATION: "1" }), {
+    MCODE_WEB_AUTOMATION: "1",
+    VITE_MCODE_WEB_AUTOMATION: "1",
+  });
+  assert.deepEqual(buildWebAutomationEnv({ MCODE_WEB_AUTOMATION: "0" }), {
+    MCODE_WEB_AUTOMATION: "0",
+    VITE_MCODE_WEB_AUTOMATION: "0",
+  });
 });

--- a/scripts/agent/agent-up.mjs
+++ b/scripts/agent/agent-up.mjs
@@ -35,6 +35,15 @@ export function isWebAutomationEnabled(env = process.env) {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
+/** Builds matching server and Vite child-process opt-in values. */
+export function buildWebAutomationEnv(env = process.env) {
+  const enabled = isWebAutomationEnabled(env);
+  return {
+    MCODE_WEB_AUTOMATION: enabled ? "1" : "0",
+    VITE_MCODE_WEB_AUTOMATION: enabled ? "1" : "0",
+  };
+}
+
 /**
  * Installs process-local hooks for focused agentUp tests.
  *
@@ -124,6 +133,7 @@ export async function agentUp(repoRoot = resolveRepoRoot()) {
           MCODE_SINGLE_INSTANCE: "true",
           MCODE_INSTANCE_TOKEN: instanceToken,
           MCODE_WORKTREE_IDENTITY: repoRoot,
+          MCODE_WEB_AUTOMATION: buildWebAutomationEnv().MCODE_WEB_AUTOMATION,
         },
       },
       resolve(paths.logsDir, "server.log"),
@@ -146,7 +156,7 @@ export async function agentUp(repoRoot = resolveRepoRoot()) {
           VITE_MCODE_SINGLE_INSTANCE: "true",
           VITE_MCODE_WORKTREE_IDENTITY: repoRoot,
           VITE_MCODE_RUNTIME_CONTRACT: paths.portsFile,
-          VITE_MCODE_WEB_AUTOMATION: isWebAutomationEnabled() ? "1" : "0",
+          VITE_MCODE_WEB_AUTOMATION: buildWebAutomationEnv().VITE_MCODE_WEB_AUTOMATION,
         },
       },
       resolve(paths.logsDir, "web.log"),


### PR DESCRIPTION
## What
Connect the visible Browser panel to the explicitly enabled worktree web runtime while preserving the Electron preview path.

## Why
`agent:up` could register the web automation host, but the Browser panel still presented an Electron-only state. The runtime also needed one normalized opt-in value for both server authorization and the Vite client.

## Key Changes
- Render a bounded HTTP(S) iframe preview only when web automation is explicitly enabled and Electron is unavailable.
- Report disabled, unavailable, same-origin, and cross-origin states without claiming cross-origin DOM access.
- Keep iframe authority current across thread switches and iframe navigation.
- Forward the normalized flag to both the server and Vite child processes while keeping the default disabled.
- Preserve Electron preview selection when `desktopBridge.preview` is present.
- Add focused UI and runtime flag coverage.

## Verification
- `bunx vitest run src/components/panels/__tests__/PreviewPanel.test.tsx src/components/panels/__tests__/BrowserAutomationHost.test.tsx`: 91 passed.
- `bun test scripts/agent/__tests__/agent-up-web-flag.test.mjs`: 2 passed.
- `bun run verify:changed`: typecheck and lint passed. The broader unit phase reached 2698 of 2699 passing tests; an unrelated pull-request diff memory test timed out. The wrapper then timed out before completing the final script phase.
- Enabled and disabled `agent:up` startup attempts were blocked before `.dev/ports.json` because this worktree's Bun dependency tree could not resolve `esbuild`. No exact app URL was available for Browser navigation.
- Independent high-risk review: `RECOMMEND_RELEASE`, no open findings.

Closes #985
Continues #883

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787931676&installation_model_id=20477&pr_number=1002&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1002&signature=63dff0130fbe052f0120db280869c0c5fa2bd05bc39adc70ae16939fb83f2a22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->