### PR TITLE
feat(browser): harden target stickiness and lifecycle cleanup

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -829,6 +829,7 @@ async function shutdown(): Promise<void> {
 
   // 3. Shutdown provider registry
   providerRegistry.shutdown();
+  browserAutomationBroker.shutdown();
   browserAutomationAccess.shutdown();
 
   // 4. Mark active threads as interrupted

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -256,6 +256,41 @@ describe("BrowserAutomationBroker", () => {
     await expect(pending).resolves.toMatchObject({ ok: false, error: { code: "HOST_UNAVAILABLE" } });
   });
 
+  it("replaces a reconnecting owner deterministically and cancels its old work", async () => {
+    const broker = new BrowserAutomationBroker(options({ now: () => 10, send: () => true }));
+    const firstSocket = socket("first");
+    const firstGeneration = register(broker, firstSocket, "first", "workspace-a");
+    updateTargets(broker, firstSocket, "first", firstGeneration, ["thread-a"]);
+    const scope = claims("thread-a", "workspace-a");
+    const pending = broker.execute(scope, request(scope));
+
+    const replacementSocket = socket("replacement");
+    const replacementGeneration = broker.registerHost(
+      replacementSocket,
+      registration("first", "workspace-a"),
+      authorization("first"),
+    ).generation;
+
+    await expect(pending).resolves.toMatchObject({ error: { code: "HOST_UNAVAILABLE" } });
+    expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 0 });
+    expect(() => broker.heartbeat(firstSocket, "first", firstGeneration)).toThrow("stale or invalid");
+    updateTargets(broker, replacementSocket, "first", replacementGeneration, ["thread-a"]);
+  });
+
+  it("settles all pending work during broker shutdown", async () => {
+    const broker = new BrowserAutomationBroker(options({ now: () => 10, send: () => true }));
+    const hostSocket = socket("first");
+    const generation = register(broker, hostSocket, "first", "workspace-a");
+    updateTargets(broker, hostSocket, "first", generation, ["thread-a"]);
+    const scope = claims("thread-a", "workspace-a");
+    const pending = broker.execute(scope, request(scope));
+
+    broker.shutdown();
+
+    await expect(pending).resolves.toMatchObject({ error: { code: "HOST_UNAVAILABLE" } });
+    expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
+  });
+
   it("requires trusted targets and rejects self-asserted workspace or stale target generations", async () => {
     const broker = new BrowserAutomationBroker(options({ now: () => 10, send: () => true }));
     const hostSocket = socket("first");

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -96,8 +96,30 @@ function failure(
   };
 }
 
+function assignmentKeyParts(
+  providerId: string,
+  providerSessionId: string,
+  worktreeIdentity: string,
+  workspaceId: string,
+  threadId: string,
+): string {
+  return JSON.stringify([
+    providerId,
+    providerSessionId,
+    worktreeIdentity,
+    workspaceId,
+    threadId,
+  ]);
+}
+
 function assignmentKey(claims: BrowserAutomationCredentialClaims): string {
-  return JSON.stringify([claims.providerId, claims.providerSessionId, claims.threadId]);
+  return assignmentKeyParts(
+    claims.providerId,
+    claims.providerSessionId,
+    claims.worktreeIdentity,
+    claims.workspaceId,
+    claims.threadId,
+  );
 }
 
 function pendingKey(host: RegisteredHost, requestId: string, sequence: number): string {
@@ -106,6 +128,18 @@ function pendingKey(host: RegisteredHost, requestId: string, sequence: number): 
 
 function targetKey(target: Pick<BrowserAutomationHostDispatchTarget, "threadId" | "tabId">): string {
   return JSON.stringify([target.threadId, target.tabId]);
+}
+
+function targetsMatch(
+  left: BrowserAutomationHostDispatchTarget,
+  right: BrowserAutomationHostDispatchTarget,
+): boolean {
+  return left.desktopInstanceId === right.desktopInstanceId &&
+    left.windowId === right.windowId &&
+    left.connectionGeneration === right.connectionGeneration &&
+    left.threadId === right.threadId &&
+    left.tabId === right.tabId &&
+    left.targetGeneration === right.targetGeneration;
 }
 
 function incrementBounded(value: number, amount = 1): number {
@@ -244,13 +278,20 @@ export class BrowserAutomationBroker {
       throw new Error("Browser automation target identity workspace is not authorized");
     }
     this.disconnect(socket);
-    if (this.hostsBySocket.size >= this.maxHosts) {
-      throw new Error("Browser automation host capacity is exhausted");
-    }
-    for (const host of this.hostsBySocket.values()) {
-      if (host.registration.hostId === trustedRegistration.hostId) {
+    const existingOwner = [...this.hostsBySocket.values()].find(
+      (host) => host.registration.hostId === trustedRegistration.hostId,
+    );
+    if (existingOwner) {
+      if (
+        existingOwner.registration.desktopInstanceId !== trustedRegistration.desktopInstanceId ||
+        existingOwner.registration.worktreeIdentity !== trustedRegistration.worktreeIdentity
+      ) {
         throw new Error("Browser automation host ID is already registered");
       }
+      this.disconnect(existingOwner.socket);
+    }
+    if (this.hostsBySocket.size >= this.maxHosts) {
+      throw new Error("Browser automation host capacity is exhausted");
     }
     const generation = this.nextGeneration++;
     const host: RegisteredHost = {
@@ -376,11 +417,18 @@ export class BrowserAutomationBroker {
         this.settle(key, pending, failure(pending.request, "INVALID_REQUEST", targetError, false));
         return;
       }
-    } else if (responseTarget && pending.target && targetKey(responseTarget) !== targetKey(pending.target)) {
+    } else if (responseTarget && pending.target && !targetsMatch(responseTarget, pending.target)) {
       this.settle(
         key,
         pending,
-        failure(pending.request, "INVALID_REQUEST", "Browser response target does not match its request", false),
+        failure(
+          pending.request,
+          targetKey(responseTarget) === targetKey(pending.target)
+            ? "STALE_TARGET_GENERATION"
+            : "INVALID_REQUEST",
+          "Browser response target does not match its request",
+          false,
+        ),
       );
       return;
     }
@@ -586,6 +634,20 @@ export class BrowserAutomationBroker {
         );
       }
     }
+  }
+
+  /** Settles all pending work and releases every broker-owned lifecycle resource. */
+  shutdown(): void {
+    for (const socket of [...this.hostsBySocket.keys()]) this.disconnect(socket);
+    this.assignments.clear();
+    for (const pending of [...this.pending.values()]) {
+      this.settle(
+        pendingKey(pending.host, pending.request.requestId, pending.request.sequence),
+        pending,
+        failure(pending.request, "HOST_UNAVAILABLE", "Browser automation broker shut down", true),
+      );
+    }
+    this.pending.clear();
   }
 
   /** Returns bounded broker counts for status and tests. */
@@ -841,7 +903,13 @@ export class BrowserAutomationBroker {
     }
     while (this.assignments.size >= this.maxAssignments) this.evictOldestAssignment();
     this.assignments.set(
-      JSON.stringify([pending.providerId, pending.request.providerSessionId, pending.request.threadId]),
+      assignmentKeyParts(
+        pending.providerId,
+        pending.request.providerSessionId,
+        host.registration.worktreeIdentity,
+        pending.request.workspaceId,
+        pending.request.threadId,
+      ),
       { host, targetKey: key, lastUsedAt: this.now() },
     );
     pending.target = target;

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   BROWSER_AUTOMATION_CONTRACT_VERSION,
   BROWSER_AUTOMATION_MAX_PENDING_REQUESTS,
@@ -336,6 +336,32 @@ export function BrowserAutomationHost() {
   ), [activeWorkspaceId, liveTargets, workspaces]);
   const workspaceSignature = JSON.stringify(workspaceIds);
 
+  const cancelHostedRequest = useCallback((
+    key: string,
+    dispatch: BrowserAutomationHostDispatch,
+    reason: "human-interrupted" | "user-stopped" | "host-shutdown",
+    leaseOverride?: HostLease | null,
+  ): void => {
+    if (cancelledRef.current.has(key)) return;
+    cancelledRef.current.add(key);
+    recorderRef.current.cancel(dispatch);
+    void window.desktopBridge?.preview?.automation?.cancel(dispatch.request.requestId);
+    const lease = leaseOverride ?? leaseRef.current;
+    if (lease) {
+      void getTransport().cancelBrowserAutomationRequest(
+        lease.hostId,
+        lease.generation,
+        dispatch.request.requestId,
+        dispatch.request.sequence,
+        reason,
+      ).catch(() => undefined);
+    }
+    useBrowserAutomationStore.getState().clearActiveRequest(
+      dispatch.request.requestId,
+      dispatch.request.sequence,
+    );
+  }, []);
+
   useEffect(() => {
     backgroundScopesRef.current = backgroundScopes;
     useBrowserAutomationStore.getState().setHostedScopeIds(
@@ -415,13 +441,30 @@ export function BrowserAutomationHost() {
     });
     return () => {
       if (registrationEpochRef.current === epoch) {
+        const previousLease = leaseRef.current;
+        for (const [key, dispatch] of inFlightRef.current) {
+          cancelHostedRequest(key, dispatch, "host-shutdown", previousLease);
+        }
+        for (const [key, request] of bootstrapRequestRef.current) {
+          bootstrapAbortRef.current.get(key)?.abort(new Error("Browser host registration was replaced"));
+          const lease = previousLease;
+          if (lease) {
+            void getTransport().cancelBrowserAutomationRequest(
+              lease.hostId,
+              lease.generation,
+              request.requestId,
+              request.sequence,
+              "host-shutdown",
+            ).catch(() => undefined);
+          }
+        }
         registrationEpochRef.current += 1;
         leaseRef.current = null;
         useBrowserAutomationStore.getState().setRegistered(false);
         useBrowserAutomationStore.getState().setStatus("unavailable");
       }
     };
-  }, [connectionStatus, stableHostId, workspaceSignature]);
+  }, [cancelHostedRequest, connectionStatus, stableHostId, workspaceSignature]);
 
   useEffect(() => {
     const lease = leaseRef.current;
@@ -441,11 +484,13 @@ export function BrowserAutomationHost() {
         focused: candidate.threadId === useWorkspaceStore.getState().activeThreadId,
         lastUsedAt: candidate.lastUsedAt,
       } satisfies BrowserAutomationHostDispatchTarget));
-      void getTransport().updateBrowserAutomationHostTargets(
-        lease.hostId,
-        lease.generation,
-        targets,
-      ).catch(() => undefined);
+      if (leaseRef.current === lease) {
+        void getTransport().updateBrowserAutomationHostTargets(
+          lease.hostId,
+          lease.generation,
+          targets,
+        ).catch(() => undefined);
+      }
       return;
     }
     const targets = [...liveTargets.values()].slice(0, 64);
@@ -474,7 +519,7 @@ export function BrowserAutomationHost() {
     return () => {
       cancelled = true;
     };
-  }, [connectionStatus, liveTargets, registered]);
+  }, [cancelHostedRequest, connectionStatus, liveTargets, registered]);
 
   useEffect(() => {
     const next = new Set(liveTargets.keys());
@@ -482,9 +527,13 @@ export function BrowserAutomationHost() {
       if (next.has(removed)) continue;
       const [threadId, tabId] = JSON.parse(removed) as [string, string];
       recorderRef.current.disposeTarget(threadId, tabId);
+      for (const [key, dispatch] of inFlightRef.current) {
+        if (dispatch.target.threadId !== threadId || dispatch.target.tabId !== tabId) continue;
+        cancelHostedRequest(key, dispatch, "host-shutdown");
+      }
     }
     priorLiveTargetKeysRef.current = next;
-  }, [liveTargets]);
+  }, [cancelHostedRequest, liveTargets]);
 
   useEffect(() => {
     const lease = leaseRef.current;
@@ -561,7 +610,7 @@ export function BrowserAutomationHost() {
       unsubscribeRequest();
       unsubscribeCancel();
     };
-  }, []);
+  }, [cancelHostedRequest]);
 
   useEffect(() => {
     const bridge = window.desktopBridge?.preview?.automation;
@@ -761,18 +810,10 @@ export function BrowserAutomationHost() {
         const lease = leaseRef.current;
         if (!lease) continue;
         const key = browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence);
-        if (cancelledRef.current.has(key)) continue;
-        cancelledRef.current.add(key);
-        void getTransport().cancelBrowserAutomationRequest(
-          lease.hostId,
-          lease.generation,
-          dispatch.request.requestId,
-          dispatch.request.sequence,
-          "human-interrupted",
-        ).catch(() => undefined);
+        cancelHostedRequest(key, dispatch, "human-interrupted", lease);
       }
     });
-  }, []);
+  }, [cancelHostedRequest]);
 
   useEffect(() => onBrowserAutomationInterruption((threadId, tabId, reason) => {
     recorderRef.current.disposeTarget(threadId, tabId);
@@ -781,19 +822,9 @@ export function BrowserAutomationHost() {
       const lease = leaseRef.current;
       if (!lease) continue;
       const key = browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence);
-      if (cancelledRef.current.has(key)) continue;
-      cancelledRef.current.add(key);
-      recorderRef.current.cancel(dispatch);
-      void window.desktopBridge?.preview?.automation.cancel(dispatch.request.requestId);
-      void getTransport().cancelBrowserAutomationRequest(
-        lease.hostId,
-        lease.generation,
-        dispatch.request.requestId,
-        dispatch.request.sequence,
-        reason,
-      ).catch(() => undefined);
+      cancelHostedRequest(key, dispatch, reason, lease);
     }
-  }), []);
+  }), [cancelHostedRequest]);
 
   useEffect(() => onBrowserAutomationScopeRelease((release) => {
     const matches = (threadId: string, workspaceId: string): boolean =>
@@ -825,37 +856,34 @@ export function BrowserAutomationHost() {
     }
     for (const [key, dispatch] of inFlightRef.current) {
       if (!matches(dispatch.scope.threadId, dispatch.scope.workspaceId)) continue;
-      if (cancelledRef.current.has(key)) continue;
-      cancelledRef.current.add(key);
-      recorderRef.current.cancel(dispatch);
-      void window.desktopBridge?.preview?.automation.cancel(dispatch.request.requestId);
-      if (lease) {
-        void getTransport().cancelBrowserAutomationRequest(
-          lease.hostId,
-          lease.generation,
-          dispatch.request.requestId,
-          dispatch.request.sequence,
-          "host-shutdown",
-        ).catch(() => undefined);
-      }
+      cancelHostedRequest(key, dispatch, "host-shutdown", lease);
     }
-  }), []);
+  }), [cancelHostedRequest]);
 
   useEffect(() => () => {
     // Registration cleanup runs before this effect during unmount, so retain
     // the last authorized lease solely for bounded shutdown cancellation.
     const lease = shutdownLeaseRef.current;
     if (lease) {
-      for (const dispatch of inFlightRef.current.values()) {
+      for (const [key, dispatch] of inFlightRef.current) {
+        cancelHostedRequest(key, dispatch, "host-shutdown", lease);
+      }
+      for (const [key, request] of bootstrapRequestRef.current) {
+        bootstrapAbortRef.current.get(key)?.abort(new Error("Browser host unmounted"));
         void getTransport().cancelBrowserAutomationRequest(
           lease.hostId,
           lease.generation,
-          dispatch.request.requestId,
-          dispatch.request.sequence,
+          request.requestId,
+          request.sequence,
           "host-shutdown",
         ).catch(() => undefined);
       }
     }
+    bootstrapAbortRef.current.clear();
+    bootstrapRequestRef.current.clear();
+    bootstrapPendingRef.current.clear();
+    inFlightRef.current.clear();
+    cancelledRef.current.clear();
     recorderRef.current.dispose();
   }, []);
 

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -127,6 +127,26 @@ function response(request: BrowserAutomationHostDispatch["request"]): BrowserAut
   };
 }
 
+function successResponse(request: BrowserAutomationHostDispatch["request"]): BrowserAutomationResponse {
+  return {
+    contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+    requestId: request.requestId,
+    sequence: request.sequence,
+    ok: true,
+    result: {
+      operation: "status",
+      available: true,
+      active: true,
+      tabId: "tab-1",
+      url: "about:blank",
+      loading: false,
+      focused: true,
+      viewport: { width: 800, height: 600 },
+      capabilities: [],
+    },
+  };
+}
+
 describe("BrowserAutomationHost", () => {
   const execute = vi.fn();
   const beginRendererOperation = vi.fn();
@@ -254,6 +274,75 @@ describe("BrowserAutomationHost", () => {
     view.unmount();
   });
 
+  it("cancels in-flight dispatch and bootstrap work when registration is replaced", async () => {
+    const executing = deferred<BrowserAutomationResponse>();
+    const creating = deferred<{
+      ok: true;
+      data: {
+        tabId: string;
+        tabs: { threadId: string; activeTabId: string; tabs: Array<{ id: string; threadId: string; url: string | null; title: string | null; faviconUrl: string | null; warm: boolean }> };
+      };
+    }>();
+    execute.mockReturnValueOnce(executing.promise);
+    createTab.mockReturnValueOnce(creating.promise);
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const activeDispatch = dispatch(1, 21);
+    act(() => harness.emit("browserAutomation.request", {
+      hostId,
+      generation: 1,
+      dispatch: activeDispatch,
+    }));
+    await waitFor(() => expect(execute).toHaveBeenCalledWith(activeDispatch));
+
+    const openRequest = {
+      ...dispatch(1, 22).request,
+      operation: "open" as const,
+      args: { url: "https://example.com/", activate: false },
+    };
+    act(() => harness.emit("browserAutomation.bootstrap", {
+      hostId,
+      generation: 1,
+      request: openRequest,
+    }));
+    await waitFor(() => expect(createTab).toHaveBeenCalledOnce());
+
+    act(() => useConnectionStore.setState({ status: "reconnecting" }));
+    await waitFor(() => expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      activeDispatch.request.requestId,
+      activeDispatch.request.sequence,
+      "host-shutdown",
+    ));
+    expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      openRequest.requestId,
+      openRequest.sequence,
+      "host-shutdown",
+    );
+    expect(cancel).toHaveBeenCalledWith(activeDispatch.request.requestId);
+    expect(useBrowserAutomationStore.getState().activeRequests).toHaveLength(0);
+
+    creating.resolve({
+      ok: true,
+      data: {
+        tabId: "bootstrap-tab",
+        tabs: {
+          threadId: "thread-1",
+          activeTabId: "bootstrap-tab",
+          tabs: [{ id: "bootstrap-tab", threadId: "thread-1", url: null, title: null, faviconUrl: null, warm: true }],
+        },
+      },
+    });
+    executing.resolve(successResponse(activeDispatch.request));
+    await act(async () => Promise.all([creating.promise, executing.promise]));
+    expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
+    view.unmount();
+  });
+
   it("publishes targets after registration and refreshes desktop identity on replacement", async () => {
     const view = render(<BrowserAutomationHost />);
     await waitFor(() => expect(harness.transport.updateBrowserAutomationHostTargets).toHaveBeenCalledTimes(1));
@@ -309,6 +398,37 @@ describe("BrowserAutomationHost", () => {
     view.unmount();
   });
 
+  it("cancels an exact removed target and suppresses its late success response", async () => {
+    const executing = deferred<BrowserAutomationResponse>();
+    execute.mockReturnValueOnce(executing.promise);
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const activeDispatch = dispatch(1, 23);
+    act(() => harness.emit("browserAutomation.request", {
+      hostId,
+      generation: 1,
+      dispatch: activeDispatch,
+    }));
+    await waitFor(() => expect(useBrowserAutomationStore.getState().activeRequests).toHaveLength(1));
+
+    act(() => useBrowserAutomationStore.getState().unregisterTarget("thread-1", "tab-1"));
+    await waitFor(() => expect(cancel).toHaveBeenCalledWith(activeDispatch.request.requestId));
+    expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      activeDispatch.request.requestId,
+      activeDispatch.request.sequence,
+      "host-shutdown",
+    );
+    expect(useBrowserAutomationStore.getState().activeRequests).toHaveLength(0);
+
+    executing.resolve(successResponse(activeDispatch.request));
+    await act(async () => executing.promise);
+    expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
+    view.unmount();
+  });
+
   it("interrupts only the exact thread and tab selected by the human", async () => {
     const first = deferred<BrowserAutomationResponse>();
     const second = deferred<BrowserAutomationResponse>();
@@ -354,6 +474,77 @@ describe("BrowserAutomationHost", () => {
     )).toBe(true);
     first.resolve(response(dispatch(1, 1).request));
     second.resolve(response(dispatch(1, 2).request));
+  });
+
+  it("aborts bootstrap work and clears hosted scope state on unmount", async () => {
+    useBrowserAutomationStore.setState({ liveTargets: new Map() });
+    const creating = deferred<{
+      ok: true;
+      data: {
+        tabId: string;
+        tabs: { threadId: string; activeTabId: string; tabs: Array<{ id: string; threadId: string; url: string | null; title: string | null; faviconUrl: string | null; warm: boolean }> };
+      };
+    }>();
+    const executing = deferred<BrowserAutomationResponse>();
+    createTab.mockReturnValueOnce(creating.promise);
+    execute.mockReturnValueOnce(executing.promise);
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const activeDispatch = dispatch(1, 24);
+    act(() => harness.emit("browserAutomation.request", {
+      hostId,
+      generation: 1,
+      dispatch: activeDispatch,
+    }));
+    await waitFor(() => expect(execute).toHaveBeenCalledOnce());
+
+    const openRequest = {
+      ...dispatch(1, 25).request,
+      operation: "open" as const,
+      args: { url: "https://example.com/", activate: false },
+    };
+    act(() => harness.emit("browserAutomation.bootstrap", {
+      hostId,
+      generation: 1,
+      request: openRequest,
+    }));
+    await waitFor(() => expect(createTab).toHaveBeenCalledOnce());
+    await waitFor(() => expect(useBrowserAutomationStore.getState().hostedScopeIds.has("thread-1")).toBe(true));
+
+    view.unmount();
+    expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      activeDispatch.request.requestId,
+      activeDispatch.request.sequence,
+      "host-shutdown",
+    );
+    expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      openRequest.requestId,
+      openRequest.sequence,
+      "host-shutdown",
+    );
+    expect(cancel).toHaveBeenCalledWith(activeDispatch.request.requestId);
+    expect(useBrowserAutomationStore.getState().activeRequests).toHaveLength(0);
+    expect(useBrowserAutomationStore.getState().hostedScopeIds).toHaveLength(0);
+
+    creating.resolve({
+      ok: true,
+      data: {
+        tabId: "unmounted-tab",
+        tabs: {
+          threadId: "thread-1",
+          activeTabId: "unmounted-tab",
+          tabs: [{ id: "unmounted-tab", threadId: "thread-1", url: null, title: null, faviconUrl: null, warm: true }],
+        },
+      },
+    });
+    executing.resolve(successResponse(activeDispatch.request));
+    await act(async () => Promise.all([creating.promise, executing.promise]));
+    expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
   });
 
   it("bootstraps open from zero targets, reveals Browser, creates a tab, and navigates it", async () => {

--- a/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
+++ b/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { BROWSER_AUTOMATION_MAX_PENDING_REQUESTS } from "@mcode/contracts";
 import {
   browserAutomationRequestKey,
   browserAutomationTargetKey,
@@ -8,6 +9,7 @@ import {
   resolveBrowserAutomationControllerTarget,
   selectWarmBrowserTabIds,
   useBrowserAutomationStore,
+  type BrowserAutomationActiveRequest,
   type BrowserAutomationLiveTarget,
 } from "../browserAutomationStore";
 import { selectBrowserAutomationWorkspaceIds } from "@/components/panels/BrowserAutomationHost";
@@ -86,6 +88,45 @@ describe("browser automation renderer scope", () => {
     const settled = selectWarmBrowserTabIds(tabs, "thread-a", "tab-0");
     expect(settled.size).toBe(3);
     expect(settled.has("tab-0")).toBe(true);
+  });
+
+  it("bounds active requests while keeping the newest in-flight target visible for cancellation", () => {
+    useBrowserAutomationStore.setState({ activeRequests: new Map() });
+    const requests = Array.from({ length: BROWSER_AUTOMATION_MAX_PENDING_REQUESTS + 1 }, (_, index) => {
+      const activeDispatch = {
+        request: { requestId: `request-${index}`, sequence: index },
+        target: { threadId: "thread-a", tabId: `tab-${index}` },
+      } as BrowserAutomationActiveRequest["dispatch"];
+      return {
+        dispatch: activeDispatch,
+        startedAt: index,
+      };
+    });
+
+    for (const request of requests) useBrowserAutomationStore.getState().setActiveRequest(request);
+
+    const activeRequests = useBrowserAutomationStore.getState().activeRequests;
+    const newest = requests.at(-1)!;
+    const newestRequestId = `request-${BROWSER_AUTOMATION_MAX_PENDING_REQUESTS}`;
+    expect(activeRequests).toHaveLength(BROWSER_AUTOMATION_MAX_PENDING_REQUESTS);
+    expect(activeRequests.has(browserAutomationRequestKey("request-0", 0))).toBe(false);
+    expect(activeRequests.has(browserAutomationRequestKey(
+      newestRequestId,
+      BROWSER_AUTOMATION_MAX_PENDING_REQUESTS,
+    ))).toBe(true);
+    expect(selectWarmBrowserTabIds(
+      requests.map((request) => ({ id: request.dispatch.target.tabId })),
+      "thread-a",
+      "tab-0",
+    )).toContain("tab-32");
+
+    useBrowserAutomationStore.getState().clearActiveRequest(
+      newest.dispatch.request.requestId,
+      newest.dispatch.request.sequence,
+    );
+    expect(useBrowserAutomationStore.getState().activeRequests.has(
+      browserAutomationRequestKey(newestRequestId, BROWSER_AUTOMATION_MAX_PENDING_REQUESTS),
+    )).toBe(false);
   });
 
   it("routes authoritative thread and workspace cleanup to exact host scopes", () => {

--- a/apps/web/src/stores/browserAutomationStore.ts
+++ b/apps/web/src/stores/browserAutomationStore.ts
@@ -2,6 +2,7 @@ import type {
   BrowserAutomationControllerState,
   BrowserAutomationHostDispatch,
 } from "@mcode/contracts";
+import { BROWSER_AUTOMATION_MAX_PENDING_REQUESTS } from "@mcode/contracts";
 import { create } from "zustand";
 
 /** Maximum number of inactive, non-busy Browser targets retained warm. */
@@ -138,6 +139,11 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set) =>
       const activeRequests = new Map(state.activeRequests);
       const { requestId, sequence } = request.dispatch.request;
       activeRequests.set(browserAutomationRequestKey(requestId, sequence), request);
+      while (activeRequests.size > BROWSER_AUTOMATION_MAX_PENDING_REQUESTS) {
+        const oldest = activeRequests.keys().next().value as string | undefined;
+        if (!oldest) break;
+        activeRequests.delete(oldest);
+      }
       return { activeRequests };
     }),
   clearActiveRequest: (requestId, sequence) =>
@@ -150,7 +156,7 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set) =>
     }),
   setRegistered: (registered) => set({ registered }),
   setStatus: (status) => set({ status }),
-  setHostedScopeIds: (hostedScopeIds) => set({ hostedScopeIds: new Set(hostedScopeIds) }),
+  setHostedScopeIds: (hostedScopeIds) => set({ hostedScopeIds: new Set([...hostedScopeIds].slice(0, 5)) }),
   setViewport: (threadId, tabId, width, height) =>
     set((state) => {
       const key = browserAutomationTargetKey(threadId, tabId);


### PR DESCRIPTION
## What
Harden browser automation routing so provider sessions stay on the authorized worktree, workspace, thread, tab, and target generation, with deterministic lifecycle cleanup.

## Why
Reconnects, tab replacements, disconnects, and late responses must not reuse stale target ownership or retain pending work.

## Key Changes
- Expand sticky assignment identity across provider session and workspace boundaries.
- Replace matching host owners deterministically and reject stale target generations.
- Centralize host cancellation mechanics for replacement, removal, unmount, and shutdown.
- Bound active request and hosted-scope registries.
- Add focused lifecycle, reconnect, cancellation, late-completion, expiry, and shutdown tests.

## Verification
- Server browser automation suites: 29 tests passed.
- Web host and store suites: 30 tests passed.
- Live reload reconnected to one host with zero pending requests and assignments.
- Changed-files gate passed typecheck and lint. Broad unrelated UI tests timed out, and the existing Electron db-info script test timed out.
- Independent high-risk review: recommend release, zero findings.

Closes #984
Continues #883

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787932002&installation_model_id=20477&pr_number=1003&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1003&signature=462bc820c7c4e16fad35587a2c5e58b0728d252659e7c7664a3a3a0e837f142c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->