### PR TITLE
feat(server): let providers create Mcode tasks via MCP

### DIFF
--- a/apps/desktop/scripts/__tests__/build-server-dev-bundle.test.mjs
+++ b/apps/desktop/scripts/__tests__/build-server-dev-bundle.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, stat, access } from "node:fs/promises";
+import { mkdtemp, rm, stat, lstat, access } from "node:fs/promises";
 import { constants } from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -14,6 +14,11 @@ import {
   findClaudeSdkCliPath,
   resolveClaudeSdkCliSources,
   resolvePackagedServerDir,
+  copilotSdkPlatformPackageName,
+  copyCopilotSdkNextTo,
+  copyCopilotSdkToDir,
+  findCopilotSdkPath,
+  resolveCopilotSdkSources,
 } from "../../../../scripts/build-server-dev-bundle.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "../../../..");
@@ -167,5 +172,42 @@ describe("copyClaudeSdkCliNextTo", () => {
     copyClaudeSdkCliNextTo(serverCjs, serverRoot);
     const secondMtime = (await stat(binDst)).mtimeMs;
     expect(secondMtime).toBe(firstMtime);
+  });
+});
+
+describe("Copilot SDK staging", () => {
+  it("resolves the SDK package and target platform dependency from the SDK graph", () => {
+    const sources = resolveCopilotSdkSources(serverRoot, process.platform, process.arch);
+    expect(sources.copilotPackageDir).toMatch(/[\\/]@github[\\/]copilot$/);
+    expect(sources.platformPackageDir.endsWith(`copilot-${process.platform}-${process.arch}`)).toBe(true);
+    expect(sources.platformPkg).toBe(copilotSdkPlatformPackageName(process.platform, process.arch));
+  });
+
+  it("stages both complete package trees for dev and packaged destinations", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "copilot-sdk-stage-"));
+    try {
+      const serverCjs = path.join(tmpDir, "server.cjs");
+      const dev = copyCopilotSdkNextTo(serverCjs, serverRoot);
+      expect(findCopilotSdkPath(serverCjs, process.platform, process.arch)).toBe(dev.copilotDst + path.sep + "index.js");
+      expect((await lstat(dev.copilotDst)).isSymbolicLink()).toBe(false);
+      expect((await lstat(dev.platformDst)).isSymbolicLink()).toBe(false);
+
+      const packagedDir = path.join(tmpDir, "resources", "app.asar.unpacked", "dist", "server");
+      const packaged = copyCopilotSdkToDir({
+        destServerDir: packagedDir,
+        serverPackageRoot: serverRoot,
+        platform: process.platform,
+        arch: process.arch,
+      });
+      expect(packaged.copilotDst).toContain(path.join("node_modules", "@github", "copilot"));
+      expect(findCopilotSdkPath(path.join(packagedDir, "server.cjs"), process.platform, process.arch)).toBe(
+        path.join(packaged.copilotDst, "index.js"),
+      );
+      expect((await lstat(packaged.copilotDst)).isSymbolicLink()).toBe(false);
+      expect((await lstat(packaged.platformDst)).isSymbolicLink()).toBe(false);
+      await access(path.join(packaged.platformDst, process.platform === "win32" ? "copilot.exe" : "copilot"), constants.R_OK);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -3,8 +3,9 @@
  *
  * 1. Built renamed `mcode-server` Electron binary (before fuse flip)
  * 2. Copied Claude Agent SDK native CLI into the asar-unpacked server tree
- * 3. Restored node-pty's Windows ConPTY runtime after the native rebuild
- * 4. Copied browser V8 snapshot (when generated) and flipped security fuses
+ * 3. Copied Copilot SDK's bundled CLI package tree into the asar-unpacked server tree
+ * 4. Restored node-pty's Windows ConPTY runtime after the native rebuild
+ * 5. Copied browser V8 snapshot (when generated) and flipped security fuses
  *
  * This script is invoked automatically by electron-builder via the
  * "afterPack" config in package.json.
@@ -17,6 +18,7 @@ import { fileURLToPath } from "url";
 import { buildServerBinary } from "./build-server-binary.mjs";
 import {
   copyClaudeSdkCliToDir,
+  copyCopilotSdkToDir,
   electronArchToNpm,
   electronPlatformToNpm,
   resolvePackagedServerDir,
@@ -103,6 +105,14 @@ export default async function afterPack(context) {
     arch: npmArch,
   });
   console.log(`[after-pack] Copied Claude SDK CLI (${platformPkg}) to ${binDst}`);
+
+  const { platformPkg: copilotPlatformPkg, copilotDst } = copyCopilotSdkToDir({
+    destServerDir: packagedServerDir,
+    serverPackageRoot,
+    platform: npmPlatform,
+    arch: npmArch,
+  });
+  console.log(`[after-pack] Copied Copilot SDK packages (${copilotPlatformPkg}) to ${copilotDst}`);
 
   if (npmPlatform === "win32") {
     const nodePtyRoot = resolve(

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -42,6 +42,7 @@ const { mockExecFile, mockClient, MockCopilotClient } = vi.hoisted(() => {
     getState: vi.fn().mockReturnValue("connected"),
     listModels: vi.fn().mockResolvedValue([]),
     createSession: vi.fn(),
+    resumeSession: vi.fn(),
   };
   // Must use a regular function (not arrow) so it can be called with `new`.
   // Returning an object from a constructor makes `new` use that object.
@@ -613,6 +614,45 @@ describe("CopilotProvider.complete()", () => {
       "network error",
     );
     expect(mockSession.disconnect).toHaveBeenCalled();
+  });
+});
+
+describe("CopilotProvider.runSideChannelQuery()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.getState.mockReturnValue("connected");
+    mockClient.start.mockResolvedValue(undefined);
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, result?: { stdout: string }) => void) => {
+        cb(null, { stdout: "gho_faketoken\n" });
+      },
+    );
+  });
+
+  it("creates a fresh MCP-free session instead of resuming the parent", async () => {
+    const mockSession = makeMockSession();
+    mockClient.createSession.mockResolvedValue(mockSession);
+    mockSession.send.mockImplementation(async () => {
+      mockSession.fire("assistant.message", { content: "isolated answer" });
+      mockSession.fire("session.idle");
+    });
+
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+    const result = await provider.runSideChannelQuery({
+      parentThreadId: "thread-1",
+      parentSdkSessionId: "parent-sdk-session",
+      prompt: "summarize",
+      conversationHistory: "prior context",
+      cwd: "/tmp",
+    });
+
+    expect(result).toBe("isolated answer");
+    expect(mockClient.resumeSession).not.toHaveBeenCalled();
+    expect(mockClient.createSession).toHaveBeenCalledTimes(1);
+    expect(mockClient.createSession.mock.calls[0]?.[0]).not.toHaveProperty("mcpServers");
+    expect(mockSession.send).toHaveBeenCalledWith({
+      prompt: expect.stringContaining("prior context"),
+    });
   });
 });
 

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -116,6 +116,18 @@ function makeSettingsService(cliPath = "") {
   };
 }
 
+/** Supplies the MCP connection required by provider send-turn fixtures. */
+function makeThreadControlMcp() {
+  return {
+    createHttpConnection: vi.fn().mockResolvedValue({
+      name: "mcode_internal_thread_control",
+      url: "http://127.0.0.1:43123/session",
+      headers: { Authorization: "Bearer fixture" },
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe("CopilotProvider bootstrap", () => {
   let origElectron: string | undefined;
 
@@ -246,7 +258,7 @@ describe("CopilotProvider bootstrap", () => {
         new Error("CLI server exited with code 1"),
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService(), makeThreadControlMcp() as any);
 
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
@@ -274,7 +286,7 @@ describe("CopilotProvider bootstrap", () => {
         new Error("Could not find @github/copilot"),
       );
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService(), makeThreadControlMcp() as any);
 
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
@@ -382,7 +394,7 @@ async function runWithMockSession(
     mockSession.fire("session.idle");
   });
 
-  const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+  const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService(), makeThreadControlMcp() as any);
   const events: AgentEvent[] = [];
   provider.on("event", (e: AgentEvent) => events.push(e));
 

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -173,19 +173,24 @@ describe("CopilotProvider bootstrap", () => {
       // which should not be called when not in Electron
       expect(which).not.toHaveBeenCalled();
       const ctorCall = MockCopilotClient.mock.calls[0]?.[0] ?? {};
-      expect(ctorCall.cliPath).toBe("/global/@github/copilot/index.js");
+      expect(ctorCall.cliPath).toBeUndefined();
+      expect(resolveCopilotCliMock).not.toHaveBeenCalled();
     });
 
-    it("passes the resolver's index.js entry to the SDK as cliPath", async () => {
+    it("passes an explicitly configured CLI entry to the SDK as cliPath", async () => {
       resolveCopilotCliMock.mockReturnValueOnce({
-        source: "npm-global",
-        entry: "/global/@github/copilot/index.js",
+        source: "configured",
+        entry: "/configured/copilot.js",
         version: "1.0.24",
       });
-      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService("/configured/copilot.js") as any, stubJobObject(), stubEnvService());
       await provider.listModels();
       const ctorCall = MockCopilotClient.mock.calls[0]?.[0];
-      expect(ctorCall?.cliPath).toBe("/global/@github/copilot/index.js");
+      expect(resolveCopilotCliMock).toHaveBeenCalledWith(
+        { configuredPath: "/configured/copilot.js" },
+        expect.anything(),
+      );
+      expect(ctorCall?.cliPath).toBe("/configured/copilot.js");
     });
   });
 
@@ -297,7 +302,7 @@ describe("CopilotProvider bootstrap", () => {
         message: "GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot",
       });
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService("/configured/copilot.js") as any, stubJobObject(), stubEnvService());
       const events: AgentEvent[] = [];
       provider.on("event", (e: AgentEvent) => events.push(e));
 
@@ -325,7 +330,7 @@ describe("CopilotProvider bootstrap", () => {
         message: "GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot",
       });
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService("/configured/copilot.js") as any, stubJobObject(), stubEnvService());
       await expect(provider.listModels()).resolves.toEqual([]);
     });
 
@@ -337,7 +342,7 @@ describe("CopilotProvider bootstrap", () => {
         message: "GitHub Copilot CLI not found. Install it with: npm install -g @github/copilot",
       });
 
-      const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService());
+      const provider = new CopilotProvider(makeSettingsService("/configured/copilot.js") as any, stubJobObject(), stubEnvService());
       await expect(provider.complete("hello", "gpt-4o", "/tmp")).rejects.toThrow(
         "npm install -g @github/copilot",
       );

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -71,6 +71,7 @@ function makeProvider(
     onSkillsChanged: vi.fn(() => () => undefined),
     shutdown: vi.fn(async () => undefined),
   },
+  threadControlMcp: { createCodexConfiguration?: () => Promise<unknown>; close?: (sessionId: string) => Promise<void> } = undefined as never,
 ): CodexProvider {
   return new CodexProvider(
     { get: async () => ({ provider: { cli: { codex: "codex" } } }) } as never,
@@ -78,6 +79,7 @@ function makeProvider(
     stubEnvService() as never,
     { persistGeneratedImageFromPath: vi.fn() } as never,
     catalogService as never,
+    threadControlMcp as never,
   );
 }
 
@@ -744,7 +746,9 @@ describe("CodexProvider first turn on new session", () => {
     expect(sideChannelServer.options).toMatchObject({
       sandbox: "read-only",
       approvalPolicy: "on-request",
+      resumeThreadId: undefined,
     });
+    expect(sideChannelServer.options).not.toHaveProperty("configOverrides");
     sideChannelServer.emit("notification", {
       method: "item/agentMessage/delta",
       params: { delta: "# Handoff" },
@@ -755,6 +759,28 @@ describe("CodexProvider first turn on new session", () => {
     });
 
     await expect(result).resolves.toBe("# Handoff");
+  });
+
+  it("closes internal MCP authority when spawn setup fails before runtime registration", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const provider = makeProvider(undefined, {
+      createCodexConfiguration: vi.fn().mockRejectedValue(new Error("MCP setup failed")),
+      close,
+    });
+
+    await provider.sendTurn({
+      sessionId: "mcode-mcp-failure",
+      threadId: "mcp-failure",
+      message: "hello",
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "auto",
+    });
+
+    expect(close).toHaveBeenCalledWith("mcode-mcp-failure");
+    expect((provider as unknown as { runtime: { get: (sessionId: string) => unknown } }).runtime.get("mcode-mcp-failure")).toBeUndefined();
   });
 
   it("maps side-channel CLI preflight failures to transient errors before creating a server", async () => {

--- a/apps/server/src/providers/codex/__tests__/codex-trace.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-trace.test.ts
@@ -57,4 +57,38 @@ describe("codex-trace", () => {
       parentToolCallId: "parent-9",
     });
   });
+
+  it("summarizes MCP startup status with bounded redacted diagnostics", () => {
+    const s = summarizeCodexNotificationParams("mcpServer/startupStatus/updated", {
+      threadId: "thread-1",
+      name: "mcode_internal_thread_control",
+      status: "failed",
+      failureReason: "Bearer super-secret-credential caused startup failure",
+      error: "authorization=another-secret-value",
+    });
+
+    expect(s).toMatchObject({
+      threadId: "thread-1",
+      name: "mcode_internal_thread_control",
+      status: "failed",
+      errorPreview: "authorization=[redacted]",
+      failureReasonPreview: "Bearer [redacted] caused startup failure",
+    });
+    expect(JSON.stringify(s)).not.toContain("super-secret-credential");
+    expect(JSON.stringify(s)).not.toContain("another-secret-value");
+  });
+
+  it("summarizes ready MCP startup status without diagnostics", () => {
+    expect(
+      summarizeCodexNotificationParams("mcpServer/startupStatus/updated", {
+        name: "mcode_internal_thread_control",
+        status: "ready",
+      }),
+    ).toEqual({
+      name: "mcode_internal_thread_control",
+      status: "ready",
+      errorPreview: undefined,
+      failureReasonPreview: undefined,
+    });
+  });
 });

--- a/apps/server/src/providers/codex/__tests__/codex-trace.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-trace.test.ts
@@ -91,4 +91,15 @@ describe("codex-trace", () => {
       failureReasonPreview: undefined,
     });
   });
+
+  it("retains a bounded diagnostic preview", () => {
+    const summary = summarizeCodexNotificationParams("mcpServer/startupStatus/updated", {
+      name: "mcode_internal_thread_control",
+      status: "failed",
+      failureReason: "x".repeat(400),
+    });
+
+    expect(String(summary.failureReasonPreview)).toHaveLength(257);
+    expect(String(summary.failureReasonPreview).endsWith("…")).toBe(true);
+  });
 });

--- a/apps/server/src/providers/codex/codex-mcp.test.ts
+++ b/apps/server/src/providers/codex/codex-mcp.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { hasCodexInternalThreadControlMcp } from "./codex-provider.js";
+
+describe("Codex internal MCP configuration validation", () => {
+  it("accepts effective config containing the internal server", () => {
+    expect(
+      hasCodexInternalThreadControlMcp({
+        config: { mcp_servers: { mcode_internal_thread_control: { url: "http://fixture" } } },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects effective config without the internal server", () => {
+    expect(hasCodexInternalThreadControlMcp({ config: { mcp_servers: {} } })).toBe(false);
+    expect(hasCodexInternalThreadControlMcp({ config: { mcp_servers: null } })).toBe(false);
+  });
+});

--- a/apps/server/src/providers/codex/codex-mcp.test.ts
+++ b/apps/server/src/providers/codex/codex-mcp.test.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import { describe, expect, it } from "vitest";
 import { hasCodexInternalThreadControlMcp } from "./codex-provider.js";
 

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -1063,7 +1063,13 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     // still runs locally), so this guard is defensive and keeps the wiring
     // obvious in logs.
     const supervised = approvalPolicy === "on-request";
-    const internalMcp = await this.threadControlMcp?.createCodexConfiguration(sessionId);
+    let internalMcp: Awaited<ReturnType<InternalThreadControlMcpRuntime["createCodexConfiguration"]>>;
+    try {
+      internalMcp = await this.threadControlMcp?.createCodexConfiguration(sessionId);
+    } catch (error) {
+      await this.threadControlMcp?.close(sessionId);
+      throw error;
+    }
 
     const server = new CodexAppServer({
       cliPath,
@@ -1148,6 +1154,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       await server.start();
     } catch (error) {
       internalMcpStartup?.cancel();
+      await this.threadControlMcp?.close(sessionId);
       throw error;
     }
     if (internalMcp) {
@@ -1159,6 +1166,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
         await internalMcpStartup!.promise;
       } catch (error) {
         internalMcpStartup?.cancel();
+        await this.threadControlMcp?.close(sessionId);
         await server.kill().catch(() => undefined);
         throw error;
       }
@@ -1310,7 +1318,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     conversationHistory?: string;
     cwd: string;
   }): Promise<string> {
-    const { parentThreadId, parentSdkSessionId, prompt, abortSignal, conversationHistory, cwd } = args;
+    const { parentThreadId, prompt, abortSignal, conversationHistory, cwd } = args;
     if (abortSignal?.aborted) throw transientHandoffError("Codex side-channel query aborted before start");
 
     const settings = await this.settingsService.get();
@@ -1330,7 +1338,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       // No approvalHandler is registered here, so side-channel tool requests
       // are denied while the handoff prompt still runs in the parent session.
       approvalPolicy: "on-request",
-      resumeThreadId: parentSdkSessionId || undefined,
+      // Side-channel work must never resume the MCP-enabled parent session.
+      // Conversation history is supplied explicitly when available.
+      resumeThreadId: undefined,
       jobObject: this.jobObject,
       getSpawnEnv: () => this.envService.getEnv(),
     });
@@ -1358,11 +1368,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
 
     try {
       await server.start();
-      if (server.resumeFailed && !conversationHistory) {
-        throw transientHandoffError(`Codex side-channel could not resume parent thread ${parentThreadId}`);
-      }
 
-      const sideChannelPrompt = server.resumeFailed && conversationHistory
+      const sideChannelPrompt = conversationHistory
         ? `Conversation history up to the fork point:\n\n${conversationHistory}\n\n---\n\n${prompt}`
         : prompt;
 

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -1094,6 +1094,22 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     // Propagates start failures to the runtime, which surfaces them to the
     // `acquire` caller in `sendTurn` (emits Error/Ended there).
     await server.start();
+    if (internalMcp) {
+      try {
+        const effectiveConfig = await server.readConfig(cwd);
+        const mcpServers = effectiveConfig.config.mcp_servers;
+        const registered =
+          mcpServers !== null &&
+          typeof mcpServers === "object" &&
+          Object.prototype.hasOwnProperty.call(mcpServers, "mcode_internal_thread_control");
+        if (!registered) {
+          throw new Error("Codex app-server did not register mcode_internal_thread_control in effective configuration");
+        }
+      } catch (error) {
+        await server.kill().catch(() => undefined);
+        throw error;
+      }
+    }
     this.refreshUsageFromServer(server, threadId);
 
     // Register after a successful handshake so a mid-handshake thread/started

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -83,6 +83,7 @@ import {
 const TURN_TIMEOUT_MS = 5 * 60 * 1000;
 const SIDE_CHANNEL_TIMEOUT_MS = 120_000;
 const USAGE_WARMUP_TIMEOUT_MS = 10_000;
+const CODEX_MCP_STARTUP_TIMEOUT_MS = 10_000;
 const USAGE_WARMUP_RETRY_MS = 60_000;
 const CODEX_MIN_VERSION = "0.37.0";
 
@@ -236,6 +237,44 @@ function transientHandoffError(message: string): Error & { code: string } {
   const err = new Error(message) as Error & { code: string };
   err.code = "ETIMEDOUT";
   return err;
+}
+
+function observeCodexInternalMcpStartup(server: CodexAppServer): {
+  promise: Promise<void>;
+  cancel: () => void;
+} {
+  let settled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let resolvePromise!: () => void;
+  let rejectPromise!: (error: Error) => void;
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  const finish = (error?: Error): void => {
+    if (settled) return;
+    settled = true;
+    if (timer) clearTimeout(timer);
+    server.off("notification", onNotification);
+    if (error) rejectPromise(error);
+    else resolvePromise();
+  };
+  const onNotification = (notification: unknown): void => {
+    const value = notification as { method?: unknown; params?: Record<string, unknown> };
+    if (value.method !== "mcpServer/startupStatus/updated") return;
+    if (value.params?.name !== "mcode_internal_thread_control") return;
+    const status = typeof value.params.status === "string" ? value.params.status : "";
+    if (status === "ready") finish();
+    else if (status === "failed" || status === "error") {
+      finish(new Error(`Codex internal MCP startup failed (${status})`));
+    }
+  };
+  server.on("notification", onNotification);
+  timer = setTimeout(
+    () => finish(new Error("Codex internal MCP startup timed out")),
+    CODEX_MCP_STARTUP_TIMEOUT_MS,
+  );
+  return { promise, cancel: () => finish(new Error("Codex internal MCP startup cancelled")) };
 }
 
 /**
@@ -1095,6 +1134,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     });
 
     this.attachFatalDrain(sessionId, server);
+    const internalMcpStartup = internalMcp ? observeCodexInternalMcpStartup(server) : undefined;
 
     server.on("exit", () => {
       if (!server.isAlive) {
@@ -1104,14 +1144,21 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
 
     // Propagates start failures to the runtime, which surfaces them to the
     // `acquire` caller in `sendTurn` (emits Error/Ended there).
-    await server.start();
+    try {
+      await server.start();
+    } catch (error) {
+      internalMcpStartup?.cancel();
+      throw error;
+    }
     if (internalMcp) {
       try {
         const effectiveConfig = await server.readConfig(cwd);
         if (!hasCodexInternalThreadControlMcp(effectiveConfig)) {
           throw new Error("Codex app-server did not register mcode_internal_thread_control in effective configuration");
         }
+        await internalMcpStartup!.promise;
       } catch (error) {
+        internalMcpStartup?.cancel();
         await server.kill().catch(() => undefined);
         throw error;
       }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -197,6 +197,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Reports whether Codex effective configuration registered the internal MCP server. */
+export function hasCodexInternalThreadControlMcp(effectiveConfig: unknown): boolean {
+  if (!isRecord(effectiveConfig) || !isRecord(effectiveConfig.config)) return false;
+  const mcpServers = effectiveConfig.config.mcp_servers;
+  return (
+    mcpServers !== null &&
+    typeof mcpServers === "object" &&
+    Object.prototype.hasOwnProperty.call(mcpServers, "mcode_internal_thread_control")
+  );
+}
+
 function codexResetDate(resetsAt: number | undefined): string | undefined {
   if (typeof resetsAt !== "number" || !Number.isFinite(resetsAt)) return undefined;
   const resetDate = new Date(resetsAt * 1000);
@@ -1097,12 +1108,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     if (internalMcp) {
       try {
         const effectiveConfig = await server.readConfig(cwd);
-        const mcpServers = effectiveConfig.config.mcp_servers;
-        const registered =
-          mcpServers !== null &&
-          typeof mcpServers === "object" &&
-          Object.prototype.hasOwnProperty.call(mcpServers, "mcode_internal_thread_control");
-        if (!registered) {
+        if (!hasCodexInternalThreadControlMcp(effectiveConfig)) {
           throw new Error("Codex app-server did not register mcode_internal_thread_control in effective configuration");
         }
       } catch (error) {

--- a/apps/server/src/providers/codex/codex-trace.ts
+++ b/apps/server/src/providers/codex/codex-trace.ts
@@ -24,6 +24,15 @@ function previewText(s: string, max = 72): string {
   return `${t.slice(0, max)}…`;
 }
 
+function previewDiagnostic(s: string): string {
+  const redacted = s
+    .replace(/\bBearer\s+[^\s,;}]+/gi, "Bearer [redacted]")
+    .replace(/\b(token|api[_-]?key|secret|password|authorization)\s*[:=]\s*["']?[^\s,;}"']+/gi, "$1=[redacted]")
+    .replace(/\beyJ[A-Za-z0-9_-]{20,}\b/g, "[redacted]")
+    .replace(/\b[A-Fa-f0-9]{32,}\b/g, "[redacted]");
+  return previewText(redacted, 96);
+}
+
 /** Pulls correlation ids from notification params when present (Codex app-server payloads). */
 function traceCorrelationIds(
   params: Record<string, unknown> | undefined,
@@ -106,6 +115,17 @@ export function summarizeCodexNotificationParams(
       ...ids,
       turnId: typeof turn?.id === "string" ? turn.id : undefined,
       status: typeof turn?.status === "string" ? turn.status : undefined,
+    };
+  }
+
+  if (method === "mcpServer/startupStatus/updated") {
+    return {
+      ...ids,
+      name: typeof params.name === "string" ? params.name : undefined,
+      status: typeof params.status === "string" ? params.status : undefined,
+      errorPreview: typeof params.error === "string" ? previewDiagnostic(params.error) : undefined,
+      failureReasonPreview:
+        typeof params.failureReason === "string" ? previewDiagnostic(params.failureReason) : undefined,
     };
   }
 

--- a/apps/server/src/providers/codex/codex-trace.ts
+++ b/apps/server/src/providers/codex/codex-trace.ts
@@ -30,7 +30,7 @@ function previewDiagnostic(s: string): string {
     .replace(/\b(token|api[_-]?key|secret|password|authorization)\s*[:=]\s*["']?[^\s,;}"']+/gi, "$1=[redacted]")
     .replace(/\beyJ[A-Za-z0-9_-]{20,}\b/g, "[redacted]")
     .replace(/\b[A-Fa-f0-9]{32,}\b/g, "[redacted]");
-  return previewText(redacted, 96);
+  return previewText(redacted, 256);
 }
 
 /** Pulls correlation ids from notification params when present (Codex app-server payloads). */

--- a/apps/server/src/providers/copilot/copilot-mcp.test.ts
+++ b/apps/server/src/providers/copilot/copilot-mcp.test.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import { describe, expect, it } from "vitest";
 import { buildCopilotInternalMcpServers } from "./copilot-provider.js";
 

--- a/apps/server/src/providers/copilot/copilot-mcp.test.ts
+++ b/apps/server/src/providers/copilot/copilot-mcp.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { buildCopilotInternalMcpServers } from "./copilot-provider.js";
+
+describe("Copilot internal MCP configuration", () => {
+  it("serializes the remote HTTP server with all tools enabled", () => {
+    expect(
+      buildCopilotInternalMcpServers({
+        name: "mcode_internal_thread_control",
+        url: "http://127.0.0.1:43123/session",
+        headers: { Authorization: "Bearer fixture" },
+      }),
+    ).toEqual({
+      mcode_internal_thread_control: {
+        type: "http",
+        url: "http://127.0.0.1:43123/session",
+        headers: { Authorization: "Bearer fixture" },
+        tools: ["*"],
+      },
+    });
+  });
+});

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -50,10 +50,25 @@ import type {
   CompletionOptions,
 } from "@mcode/contracts";
 import { AgentEventType } from "@mcode/contracts";
+import type { InternalThreadControlMcpHttpConnection } from "../../services/thread-control-mcp-runtime.js";
 
 /** Promisified execFile used to retrieve the gh auth token. */
 const execFileAsync = promisify(execFile);
 const SIDE_CHANNEL_TIMEOUT_MS = 120_000;
+
+/** Builds the Copilot SDK's remote HTTP MCP configuration for one provider session. */
+export function buildCopilotInternalMcpServers(
+  connection: InternalThreadControlMcpHttpConnection,
+): Record<string, { type: "http"; url: string; headers: Record<string, string>; tools: ["*"] }> {
+  return {
+    [connection.name]: {
+      type: "http",
+      url: connection.url,
+      headers: connection.headers,
+      tools: ["*"],
+    },
+  };
+}
 
 function transientHandoffError(message: string): Error & { code: string } {
   const err = new Error(message) as Error & { code: string };
@@ -876,14 +891,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
       model: staged?.model || undefined,
       workingDirectory: cwd,
       enableConfigDiscovery: true,
-      mcpServers: {
-        [internalMcp.name]: {
-          type: "http" as const,
-          url: internalMcp.url,
-          headers: internalMcp.headers,
-          tools: ["*"],
-        },
-      },
+      mcpServers: buildCopilotInternalMcpServers(internalMcp),
       ...(customAgents.length > 0 && { customAgents }),
       ...(skillDirs.length > 0 && { skillDirectories: skillDirs }),
       ...(userInstructions && { systemMessage: { content: userInstructions } }),
@@ -910,44 +918,57 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
       throw err;
     }
 
-    // Route to the appropriate Copilot SDK API based on the selected sub-agent.
-    // Built-in modes use session.rpc.mode.set(); custom YAML agents use session.rpc.agent.select().
-    if (copilotAgent) {
-      if (BUILTIN_MODE_NAMES.has(copilotAgent as "interactive" | "plan" | "autopilot")) {
-        await session.rpc.mode.set({ mode: copilotAgent as "interactive" | "plan" | "autopilot" });
-        logger.info("CopilotProvider: set built-in mode", { sessionId, mode: copilotAgent });
-      } else {
-        await session.rpc.agent.select({ name: copilotAgent });
-        logger.info("CopilotProvider: selected custom agent", { sessionId, agent: copilotAgent });
+    try {
+      // Route to the appropriate Copilot SDK API based on the selected sub-agent.
+      // Built-in modes use session.rpc.mode.set(); custom YAML agents use session.rpc.agent.select().
+      if (copilotAgent) {
+        if (BUILTIN_MODE_NAMES.has(copilotAgent as "interactive" | "plan" | "autopilot")) {
+          await session.rpc.mode.set({ mode: copilotAgent as "interactive" | "plan" | "autopilot" });
+          logger.info("CopilotProvider: set built-in mode", { sessionId, mode: copilotAgent });
+        } else {
+          await session.rpc.agent.select({ name: copilotAgent });
+          logger.info("CopilotProvider: selected custom agent", { sessionId, agent: copilotAgent });
+        }
       }
+
+      // Capture the SDK session ID for future resume and notify the service layer
+      const sdkId = session.sessionId;
+      if (sdkId && !this.sdkSessionIds.has(sessionId)) {
+        this.sdkSessionIds.set(sessionId, sdkId);
+        logger.info("Captured Copilot SDK session ID", { sessionId, sdkId });
+        this.emit("event", {
+          type: "system",
+          threadId,
+          subtype: "sdk_session_id:" + sdkId,
+        } satisfies AgentEvent);
+      }
+
+      const state: CopilotSessionState = {
+        sessionId,
+        session,
+        lastUsedAt: Date.now(),
+        turnActive: false,
+      };
+
+      if (this.pendingStops.has(sessionId)) {
+        logger.info("Pending stop consumed, tearing down new Copilot session", { sessionId });
+        session.disconnect().catch(() => {});
+        this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
+      }
+
+      return { state, pids: [] };
+    } catch (err) {
+      this.sdkSessionIds.delete(sessionId);
+      try {
+        await session.disconnect();
+      } catch (disconnectError) {
+        logger.debug("CopilotProvider: pre-return cleanup disconnect failed", {
+          error: disconnectError instanceof Error ? disconnectError.message : String(disconnectError),
+        });
+      }
+      await this.threadControlMcp?.close(sessionId);
+      throw err;
     }
-
-    // Capture the SDK session ID for future resume and notify the service layer
-    const sdkId = session.sessionId;
-    if (sdkId && !this.sdkSessionIds.has(sessionId)) {
-      this.sdkSessionIds.set(sessionId, sdkId);
-      logger.info("Captured Copilot SDK session ID", { sessionId, sdkId });
-      this.emit("event", {
-        type: "system",
-        threadId,
-        subtype: "sdk_session_id:" + sdkId,
-      } satisfies AgentEvent);
-    }
-
-    const state: CopilotSessionState = {
-      sessionId,
-      session,
-      lastUsedAt: Date.now(),
-      turnActive: false,
-    };
-
-    if (this.pendingStops.has(sessionId)) {
-      logger.info("Pending stop consumed, tearing down new Copilot session", { sessionId });
-      session.disconnect().catch(() => {});
-      this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
-    }
-
-    return { state, pids: [] };
   }
 
   /**

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -155,6 +155,7 @@ const BUILTIN_MODE_NAMES = new Set<"interactive" | "plan" | "autopilot">(
  * substitute: set true while a turn runs, false when it settles.
  */
 interface CopilotSessionState {
+  sessionId: string;
   session: CopilotSession;
   lastUsedAt: number;
   /**
@@ -888,20 +889,25 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
       ...(userInstructions && { systemMessage: { content: userInstructions } }),
     };
 
-    if (resumeFrom) {
-      try {
-        session = await client.resumeSession(resumeFrom, sessionBase);
-        logger.info("Resumed Copilot session", { sessionId, sdkSessionId: resumeFrom });
-      } catch (err) {
-        logger.warn("CopilotProvider: resume failed, starting fresh session", {
-          sessionId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        this.sdkSessionIds.delete(sessionId);
+    try {
+      if (resumeFrom) {
+        try {
+          session = await client.resumeSession(resumeFrom, sessionBase);
+          logger.info("Resumed Copilot session", { sessionId, sdkSessionId: resumeFrom });
+        } catch (err) {
+          logger.warn("CopilotProvider: resume failed, starting fresh session", {
+            sessionId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          this.sdkSessionIds.delete(sessionId);
+          session = await client.createSession(sessionBase);
+        }
+      } else {
         session = await client.createSession(sessionBase);
       }
-    } else {
-      session = await client.createSession(sessionBase);
+    } catch (err) {
+      await this.threadControlMcp?.close(sessionId);
+      throw err;
     }
 
     // Route to the appropriate Copilot SDK API based on the selected sub-agent.
@@ -929,6 +935,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     }
 
     const state: CopilotSessionState = {
+      sessionId,
       session,
       lastUsedAt: Date.now(),
       turnActive: false,
@@ -976,6 +983,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
         error: err instanceof Error ? err.message : String(err),
       });
     }
+    await this.threadControlMcp?.close(state.sessionId);
   }
 
   /**

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -30,6 +30,7 @@ import {
 import { logger } from "@mcode/shared";
 import { SettingsService } from "../../services/settings-service.js";
 import { EnvService } from "../../services/env-service.js";
+import { InternalThreadControlMcpRuntime } from "../../services/thread-control-mcp-runtime.js";
 import { JobObject } from "../../services/job-object.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
@@ -207,6 +208,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     @inject(SettingsService) private readonly settingsService: SettingsService,
     @inject("JobObject") private readonly jobObject: JobObject,
     @inject(EnvService) private readonly envService: EnvService,
+    @inject(InternalThreadControlMcpRuntime)
+    private readonly threadControlMcp: InternalThreadControlMcpRuntime = undefined as never,
   ) {
     super();
     this.runtime = new SessionRuntime<CopilotSessionState>(this, {
@@ -865,11 +868,21 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     // approved automatically regardless of the thread's permissionMode setting.
     const userInstructions = readUserInstructions();
     const skillDirs = userSkillDirectories();
+    const internalMcp = await this.threadControlMcp?.createHttpConnection(sessionId);
+    if (!internalMcp) throw new Error("Copilot internal thread-control MCP connection unavailable");
     const sessionBase = {
       onPermissionRequest: approveAll,
       model: staged?.model || undefined,
       workingDirectory: cwd,
       enableConfigDiscovery: true,
+      mcpServers: {
+        [internalMcp.name]: {
+          type: "http" as const,
+          url: internalMcp.url,
+          headers: internalMcp.headers,
+          tools: ["*"],
+        },
+      },
       ...(customAgents.length > 0 && { customAgents }),
       ...(skillDirs.length > 0 && { skillDirectories: skillDirs }),
       ...(userInstructions && { systemMessage: { content: userInstructions } }),

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -539,7 +539,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
 
   private async doRefreshClient(): Promise<void> {
     const settings = await this.settingsService.get();
-    const configuredCliPath = settings.provider.cli.copilot || undefined;
+    const configuredCliPath = settings.provider.cli.copilot?.trim() || undefined;
     const state = this.client?.getState();
 
     // Reuse the existing client only when it is healthy. A "disconnected" or
@@ -570,35 +570,40 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     } = {};
 
     opts.env = { ...this.envService.getEnv() };
-    // Pin the CLI version the resolver selected; without this the launcher can
-    // delegate to a newer build in ~/.copilot/pkg that breaks the SDK contract.
+    // Keep the SDK-managed or explicitly configured CLI from auto-updating during a session.
     opts.cliArgs = ["--no-auto-update"];
 
-    // Ordered resolution: configured path > npm-global index.js > PATH/shim follow.
-    const resolution = resolveCopilotCli(
-      { configuredPath: configuredCliPath },
-      createNodeResolverIO(this.envService.getEnv(), process.platform),
-    );
-    this.lastResolution = resolution;
-    if (resolution.source === "not-found") {
-      // Leave this.client null; sendTurn/listModels translate lastResolution
-      // into a user-facing error via the existing error seam.
-      logger.warn("CopilotProvider: CLI not found", { message: resolution.message });
-      this.lastCliPath = configuredCliPath;
-      return;
+    let resolution: CopilotCliResolution | undefined;
+    if (configuredCliPath) {
+      resolution = resolveCopilotCli(
+        { configuredPath: configuredCliPath },
+        createNodeResolverIO(this.envService.getEnv(), process.platform),
+      );
+      this.lastResolution = resolution;
+      if (resolution.source === "not-found") {
+        // Leave this.client null; sendTurn/listModels translate lastResolution
+        // into a user-facing error via the existing error seam.
+        logger.warn("CopilotProvider: CLI not found", { message: resolution.message });
+        this.lastCliPath = configuredCliPath;
+        return;
+      }
+      opts.cliPath = resolution.entry;
+      logger.info("CopilotProvider: resolved configured CLI", {
+        source: resolution.source,
+        version: resolution.version ?? "unknown",
+      });
+    } else {
+      // The SDK bundles a compatible CLI. Leaving cliPath unset is intentional:
+      // overriding it with a global install can mix incompatible SDK/CLI versions.
+      this.lastResolution = null;
     }
-    opts.cliPath = resolution.entry;
-    logger.info("CopilotProvider: resolved CLI", {
-      source: resolution.source,
-      version: resolution.version ?? "unknown",
-    });
 
     // Electron fix: resolve the real node binary path once. The SDK's
     // getNodeExecPath() reads process.execPath to spawn .js CLI files,
     // but in Electron that returns electron.exe which cannot host the
     // CLI's server mode. We temporarily override process.execPath during
     // client.start() and also prepend node's directory to PATH.
-    if (process.versions.electron && resolution.source !== "configured") {
+    if (process.versions.electron && !configuredCliPath) {
       if (this.cachedNodePath === undefined) {
         this.cachedNodePath = await which("node", { nothrow: true });
         if (!this.cachedNodePath) {
@@ -646,7 +651,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     // In Electron that returns electron.exe, causing the CLI to exit immediately.
     // Temporarily override process.execPath with the real node binary.
     const needsElectronExecPathOverride =
-      process.versions.electron && resolution.source !== "configured" && this.cachedNodePath;
+      process.versions.electron && !configuredCliPath && this.cachedNodePath;
     try {
       if (needsElectronExecPathOverride) {
         const origExecPath = process.execPath;

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -671,7 +671,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
           source: "not-found",
           entry: null,
           version: null,
-          message: formatCopilotUpgradeMessage(resolution.version),
+          message: formatCopilotUpgradeMessage(resolution?.version ?? null),
         };
         this.lastCliPath = configuredCliPath;
         logger.warn("CopilotProvider: CLI too old for SDK", { message: this.lastResolution.message });

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -337,7 +337,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     conversationHistory?: string;
     cwd: string;
   }): Promise<string> {
-    const { parentThreadId, parentSdkSessionId, prompt, abortSignal, conversationHistory, cwd } = args;
+    const { parentThreadId, prompt, abortSignal, conversationHistory, cwd } = args;
     if (abortSignal?.aborted) throw transientHandoffError("Copilot side-channel query aborted before start");
 
     await this.refreshClient();
@@ -357,19 +357,13 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     };
 
     let session: CopilotSession;
-    let usingSessionlessHistory = false;
+    const usingSessionlessHistory = Boolean(conversationHistory);
     try {
-      session = parentSdkSessionId
-        ? await client.resumeSession(parentSdkSessionId, sessionBase)
-        : await client.createSession(sessionBase);
-    } catch (err) {
-      if (!conversationHistory) {
-        throw transientHandoffError(
-          `Copilot side-channel could not resume parent thread ${parentThreadId}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-      usingSessionlessHistory = true;
       session = await client.createSession(sessionBase);
+    } catch (err) {
+      throw transientHandoffError(
+        `Copilot side-channel could not create isolated session for parent thread ${parentThreadId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     const sideChannelPrompt = usingSessionlessHistory && conversationHistory

--- a/apps/server/src/providers/cursor/cursor-mcp.test.ts
+++ b/apps/server/src/providers/cursor/cursor-mcp.test.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import { describe, expect, it } from "vitest";
 import { buildCursorInternalMcpServers } from "./cursor-provider.js";
 

--- a/apps/server/src/providers/cursor/cursor-mcp.test.ts
+++ b/apps/server/src/providers/cursor/cursor-mcp.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { buildCursorInternalMcpServers } from "./cursor-provider.js";
+
+describe("Cursor internal MCP configuration", () => {
+  it("serializes the ACP HTTP server with header entries", () => {
+    expect(
+      buildCursorInternalMcpServers({
+        name: "mcode_internal_thread_control",
+        url: "http://127.0.0.1:43123/session",
+        headers: { Authorization: "Bearer fixture" },
+      }),
+    ).toEqual([
+      {
+        type: "http",
+        name: "mcode_internal_thread_control",
+        url: "http://127.0.0.1:43123/session",
+        headers: [{ name: "Authorization", value: "Bearer fixture" }],
+      },
+    ]);
+  });
+});

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -454,6 +454,7 @@ export class CursorProvider
       await this.openLogicalSession(state, resumeFrom !== undefined);
     } catch (err) {
       this.liveSessionIds.delete(sessionId);
+      await this.threadControlMcp?.close(sessionId);
       try {
         state.child.kill();
       } catch {
@@ -488,9 +489,10 @@ export class CursorProvider
    * for this session (so orphaned approval cards clear) and drop it from the
    * live-id mirror. The child process is killed by the runtime's hard kill.
    */
-  close(state: CursorSessionState): void {
+  async close(state: CursorSessionState): Promise<void> {
     this.cancelPendingForThread(state.mcodeSessionId);
     this.liveSessionIds.delete(state.mcodeSessionId);
+    await this.threadControlMcp?.close(state.mcodeSessionId);
   }
 
   /** A pooled session must be discarded before reuse if the child died or the cwd/permission mode changed. */

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -27,7 +27,10 @@ import {
 } from "@agentclientprotocol/sdk";
 
 import { SettingsService } from "../../services/settings-service.js";
-import { InternalThreadControlMcpRuntime } from "../../services/thread-control-mcp-runtime.js";
+import {
+  InternalThreadControlMcpRuntime,
+  type InternalThreadControlMcpHttpConnection,
+} from "../../services/thread-control-mcp-runtime.js";
 import { SkillService } from "../../services/skill-service.js";
 import { EnvService } from "../../services/env-service.js";
 import { JobObject } from "../../services/job-object.js";
@@ -120,6 +123,18 @@ interface CursorSideChannelTransport {
   loadSession(args: { cwd: string; mcpServers: never[]; sessionId: string }): Promise<unknown>;
   prompt(args: { sessionId: string; prompt: { type: "text"; text: string }[] }): Promise<unknown>;
   dispose(): Promise<void> | void;
+}
+
+/** Builds the ACP HTTP MCP configuration for one provider session. */
+export function buildCursorInternalMcpServers(
+  connection: InternalThreadControlMcpHttpConnection,
+): McpServer[] {
+  return [{
+    type: "http",
+    name: connection.name,
+    url: connection.url,
+    headers: Object.entries(connection.headers).map(([name, value]) => ({ name, value })),
+  }];
 }
 
 /**
@@ -862,12 +877,7 @@ export class CursorProvider
     }
     const internalMcp = await this.threadControlMcp?.createHttpConnection(entry.mcodeSessionId);
     if (!internalMcp) throw new Error("Cursor internal thread-control MCP connection unavailable");
-    const mcpServers: McpServer[] = [{
-      type: "http",
-      name: internalMcp.name,
-      url: internalMcp.url,
-      headers: Object.entries(internalMcp.headers).map(([name, value]) => ({ name, value })),
-    }];
+    const mcpServers = buildCursorInternalMcpServers(internalMcp);
     let acpId: string;
 
     if (resume && stored) {

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -23,9 +23,11 @@ import {
   type RequestPermissionRequest,
   type RequestPermissionResponse,
   type SessionNotification,
+  type McpServer,
 } from "@agentclientprotocol/sdk";
 
 import { SettingsService } from "../../services/settings-service.js";
+import { InternalThreadControlMcpRuntime } from "../../services/thread-control-mcp-runtime.js";
 import { SkillService } from "../../services/skill-service.js";
 import { EnvService } from "../../services/env-service.js";
 import { JobObject } from "../../services/job-object.js";
@@ -165,6 +167,7 @@ interface CursorAcpSessionEntry {
   cursorModelAppliedPair: { acpSessionId: string; modelId: string } | null;
   /** Set immediately before issuing ACP cancel while a prompt is in flight (explicit Stop vs noisy upstream errors). */
   pendingUserStopAbort: boolean;
+  supportsHttpMcp: boolean;
 }
 
 /**
@@ -222,6 +225,8 @@ export class CursorProvider
     @inject(SkillService) private readonly skillService: SkillService,
     @inject(EnvService) private readonly envService: EnvService,
     @inject("JobObject") private readonly jobObject: JobObject,
+    @inject(InternalThreadControlMcpRuntime)
+    private readonly threadControlMcp: InternalThreadControlMcpRuntime = undefined as never,
   ) {
     super();
     this.runtime = new SessionRuntime<CursorSessionState>(this, {
@@ -564,6 +569,7 @@ export class CursorProvider
       stderrTailLines: [],
       cursorModelAppliedPair: null,
       pendingUserStopAbort: false,
+      supportsHttpMcp: false,
     };
 
     entry.connection = new ClientSideConnection(
@@ -599,7 +605,8 @@ export class CursorProvider
       void this.runtime.stop(mcodeSessionId);
     });
 
-    await this.acpHandshake(connection, threadId);
+    const supportsHttpMcp = await this.acpHandshake(connection, threadId);
+    entry.supportsHttpMcp = supportsHttpMcp;
 
     return entry as CursorAcpSessionEntry;
   }
@@ -609,7 +616,7 @@ export class CursorProvider
    * fresh connection. Shared by the pooled session spawn and the throwaway
    * side-channel transport.
    */
-  private async acpHandshake(connection: ClientSideConnection, threadId: string): Promise<void> {
+  private async acpHandshake(connection: ClientSideConnection, threadId: string): Promise<boolean> {
     const initResult = await connection.initialize({
       protocolVersion: PROTOCOL_VERSION,
       clientInfo: { name: "mcode", title: "Mcode", version: "0.0.1" },
@@ -629,6 +636,7 @@ export class CursorProvider
         });
       });
     }
+    return initResult.agentCapabilities?.mcpCapabilities?.http === true;
   }
 
   private buildAcpClient(entry: CursorAcpSessionEntry): Client {
@@ -847,13 +855,24 @@ export class CursorProvider
     if (entry.acpSessionId) return;
 
     const stored = this.sdkSessionIds.get(entry.mcodeSessionId);
+    if (!entry.supportsHttpMcp) {
+      throw new Error("Cursor ACP does not advertise HTTP MCP support; internal thread-control MCP is unavailable");
+    }
+    const internalMcp = await this.threadControlMcp?.createHttpConnection(entry.mcodeSessionId);
+    if (!internalMcp) throw new Error("Cursor internal thread-control MCP connection unavailable");
+    const mcpServers: McpServer[] = [{
+      type: "http",
+      name: internalMcp.name,
+      url: internalMcp.url,
+      headers: Object.entries(internalMcp.headers).map(([name, value]) => ({ name, value })),
+    }];
     let acpId: string;
 
     if (resume && stored) {
       try {
         await entry.connection.loadSession({
           cwd: entry.cwd,
-          mcpServers: [],
+          mcpServers,
           sessionId: stored,
         });
         acpId = stored;
@@ -864,14 +883,14 @@ export class CursorProvider
         });
         const created = await entry.connection.newSession({
           cwd: entry.cwd,
-          mcpServers: [],
+          mcpServers,
         });
         acpId = created.sessionId;
       }
     } else {
       const created = await entry.connection.newSession({
         cwd: entry.cwd,
-        mcpServers: [],
+        mcpServers,
       });
       acpId = created.sessionId;
     }

--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Thread, IProviderRegistry } from "@mcode/contracts";
-import { AgentService } from "../agent-service.js";
+import { AgentService, usesInternalThreadControlMcp } from "../agent-service.js";
 import { NarrativeStore } from "../narrative-store.js";
 import { PlanQuestionService } from "../plan-question-service.js";
 import { ProviderAvailabilityService } from "../provider-availability-service.js";
@@ -269,5 +269,15 @@ describe("AgentService.sendMessage — provider availability gate", () => {
 
     expect(assertUsable).not.toHaveBeenCalled();
     expect(resolveProvider).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentService internal MCP provider allowlist", () => {
+  it.each(["claude", "codex", "cursor", "copilot"])("includes %s for initial and retry activation", (provider) => {
+    expect(usesInternalThreadControlMcp(provider)).toBe(true);
+  });
+
+  it("excludes unsupported providers", () => {
+    expect(usesInternalThreadControlMcp("unknown")).toBe(false);
   });
 });

--- a/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
@@ -1,6 +1,8 @@
 import "reflect-metadata";
 import { request, type Server } from "node:http";
 import { describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
 import { InternalThreadControlMcpRuntime } from "../thread-control-mcp-runtime.js";
 
@@ -81,6 +83,35 @@ describe("InternalThreadControlMcpRuntime", () => {
     await instance.close("session");
     expect(sessions.has("session")).toBe(false);
     expect(authority.credential("session")).toBeUndefined();
+  });
+
+  it("completes an authenticated MCP HTTP handshake and lists internal tools", async () => {
+    const { runtime: instance, authority } = runtime();
+    authority.activate({
+      sessionId: "session",
+      sourceThreadId: "thread",
+      sourceTurnId: "turn",
+      sourceProviderId: "codex",
+      permissionMode: "full",
+    });
+    const connection = await instance.createHttpConnection("session");
+    expect(connection).toBeDefined();
+    const client = new Client({ name: "mcode-runtime-test", version: "0.1.0" });
+    const transport = new StreamableHTTPClientTransport(new URL(connection!.url), {
+      requestInit: { headers: connection!.headers },
+    });
+
+    try {
+      await client.connect(transport);
+      const listed = await client.listTools();
+      expect(listed.tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
+        "workspace_search",
+        "thread_create_batch",
+      ]));
+    } finally {
+      await client.close().catch(() => undefined);
+      await instance.close("session");
+    }
   });
 
   it("does not retain a loopback listener when close wins during startup", async () => {

--- a/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
@@ -4,16 +4,20 @@ import { describe, expect, it, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
-import { InternalThreadControlMcpRuntime } from "../thread-control-mcp-runtime.js";
+import {
+  INTERNAL_MCP_REQUEST_TIMEOUT_MS,
+  MAX_INTERNAL_MCP_REQUEST_BODY_BYTES,
+  InternalThreadControlMcpRuntime,
+} from "../thread-control-mcp-runtime.js";
 
-function status(url: string): Promise<number> {
+function status(url: string, options: { headers?: Record<string, string>; body?: Buffer } = {}): Promise<number> {
   return new Promise((resolve, reject) => {
-    const outgoing = request(url, { method: "POST" }, (response) => {
+    const outgoing = request(url, { method: "POST", headers: options.headers }, (response) => {
       response.resume();
       response.once("end", () => resolve(response.statusCode ?? 0));
     });
     outgoing.once("error", reject);
-    outgoing.end();
+    outgoing.end(options.body);
   });
 }
 
@@ -169,5 +173,50 @@ describe("InternalThreadControlMcpRuntime", () => {
     expect(server.close).toHaveBeenCalledOnce();
     expect(state.httpServer).toBeUndefined();
     expect(state.httpSessions).toHaveLength(0);
+  });
+
+  it("rejects oversized declared and streamed request bodies before MCP dispatch", async () => {
+    const { runtime: instance, authority } = runtime();
+    const lease = authority.activate({
+      sessionId: "bounded",
+      sourceThreadId: "thread",
+      sourceTurnId: "turn",
+      sourceProviderId: "codex",
+      permissionMode: "full",
+    });
+    const connection = await instance.createHttpConnection("bounded");
+    const oversized = await status(connection!.url, {
+      headers: {
+        ...connection!.headers,
+        "content-length": String(MAX_INTERNAL_MCP_REQUEST_BODY_BYTES + 1),
+      },
+    });
+    expect(oversized).toBe(413);
+
+    const streamed = await new Promise<number>((resolve, reject) => {
+      const outgoing = request(connection!.url, {
+        method: "POST",
+        headers: {
+          ...connection!.headers,
+          Accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "transfer-encoding": "chunked",
+        },
+      }, (response) => {
+        response.resume();
+        response.once("end", () => resolve(response.statusCode ?? 0));
+      });
+      outgoing.once("error", (error) => reject(error));
+      outgoing.write(Buffer.alloc(MAX_INTERNAL_MCP_REQUEST_BODY_BYTES, 0x20));
+      outgoing.end(Buffer.from("{}"));
+    });
+    expect(streamed).toBe(413);
+
+    const state = instance as unknown as { httpServer: Server & { requestTimeout: number; headersTimeout: number; timeout: number } };
+    expect(state.httpServer.requestTimeout).toBe(INTERNAL_MCP_REQUEST_TIMEOUT_MS);
+    expect(state.httpServer.headersTimeout).toBe(INTERNAL_MCP_REQUEST_TIMEOUT_MS);
+    expect(state.httpServer.timeout).toBe(INTERNAL_MCP_REQUEST_TIMEOUT_MS);
+    expect(authority.credential("bounded")).toBe(lease.credential);
+    await instance.close("bounded");
   });
 });

--- a/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
@@ -49,9 +49,10 @@ describe("InternalThreadControlMcpRuntime", () => {
     expect(await status(`http://127.0.0.1:${port}/%`)).toBe(401);
 
     const sessions = (instance as unknown as {
-      httpSessions: Map<string, { transport: { close: () => Promise<void> } }>;
+      httpSessions: Map<string, { clients: Map<string, { transport: { close: () => Promise<void> } }> }>;
     }).httpSessions;
-    vi.spyOn(sessions.get("session")!.transport, "close").mockRejectedValueOnce(new Error("transport close failed"));
+    const transport = { close: vi.fn().mockRejectedValueOnce(new Error("transport close failed")) };
+    sessions.get("session")!.clients.set("test-client", { transport });
     await expect(instance.close("session")).resolves.toBeUndefined();
     expect(authority.authorize(lease.credential, "call")).toBeUndefined();
 
@@ -85,7 +86,7 @@ describe("InternalThreadControlMcpRuntime", () => {
     expect(authority.credential("session")).toBeUndefined();
   });
 
-  it("completes an authenticated MCP HTTP handshake and lists internal tools", async () => {
+  it("supports concurrent and reconnecting authenticated MCP clients", async () => {
     const { runtime: instance, authority } = runtime();
     authority.activate({
       sessionId: "session",
@@ -96,20 +97,43 @@ describe("InternalThreadControlMcpRuntime", () => {
     });
     const connection = await instance.createHttpConnection("session");
     expect(connection).toBeDefined();
-    const client = new Client({ name: "mcode-runtime-test", version: "0.1.0" });
-    const transport = new StreamableHTTPClientTransport(new URL(connection!.url), {
-      requestInit: { headers: connection!.headers },
-    });
+    const createClient = () => {
+      const client = new Client({ name: "mcode-runtime-test", version: "0.1.0" });
+      const transport = new StreamableHTTPClientTransport(new URL(connection!.url), {
+        requestInit: { headers: connection!.headers },
+      });
+      return { client, transport };
+    };
+    const first = createClient();
+    const second = createClient();
+    const reconnect = createClient();
 
     try {
-      await client.connect(transport);
-      const listed = await client.listTools();
-      expect(listed.tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
+      await Promise.all([first.client.connect(first.transport), second.client.connect(second.transport)]);
+      const [firstTools, secondTools] = await Promise.all([first.client.listTools(), second.client.listTools()]);
+      for (const listed of [firstTools, secondTools]) {
+        expect(listed.tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
+          "workspace_search",
+          "thread_create_batch",
+        ]));
+      }
+      await first.client.close();
+      await reconnect.client.connect(reconnect.transport);
+      const reconnectedTools = await reconnect.client.listTools();
+      expect(reconnectedTools.tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
         "workspace_search",
         "thread_create_batch",
       ]));
+      const unknownSession = await fetch(connection!.url, {
+        method: "POST",
+        headers: { ...connection!.headers, "mcp-session-id": "unknown-session" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+      });
+      expect(unknownSession.status).toBe(404);
     } finally {
-      await client.close().catch(() => undefined);
+      await first.client.close().catch(() => undefined);
+      await second.client.close().catch(() => undefined);
+      await reconnect.client.close().catch(() => undefined);
       await instance.close("session");
     }
   });

--- a/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-runtime.test.ts
@@ -38,6 +38,10 @@ describe("InternalThreadControlMcpRuntime", () => {
     ]);
 
     expect(first?.configOverrides).toEqual(second?.configOverrides);
+    const connection = await instance.createHttpConnection("session");
+    expect(connection?.name).toBe("mcode_internal_thread_control");
+    expect(connection?.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/session$/);
+    expect(connection?.headers.Authorization).toMatch(/^Bearer /);
     const port = first?.configOverrides[0].match(/127\.0\.0\.1:(\d+)/)?.[1];
     expect(port).toBeDefined();
     expect(await status(`http://127.0.0.1:${port}/%`)).toBe(401);
@@ -58,6 +62,25 @@ describe("InternalThreadControlMcpRuntime", () => {
     });
     await expect(instance.createCodexConfiguration("session")).resolves.toBeDefined();
     await instance.close("session");
+  });
+
+  it("releases the shared HTTP session when the pooled provider closes", async () => {
+    const { runtime: instance, authority } = runtime();
+    authority.activate({
+      sessionId: "session",
+      sourceThreadId: "thread",
+      sourceTurnId: "turn",
+      sourceProviderId: "cursor",
+      permissionMode: "full",
+    });
+    await expect(instance.createHttpConnection("session")).resolves.toBeDefined();
+    const sessions = (instance as unknown as {
+      httpSessions: Map<string, unknown>;
+    }).httpSessions;
+    expect(sessions.has("session")).toBe(true);
+    await instance.close("session");
+    expect(sessions.has("session")).toBe(false);
+    expect(authority.credential("session")).toBeUndefined();
   });
 
   it("does not retain a loopback listener when close wins during startup", async () => {

--- a/apps/server/src/services/__tests__/thread-control-workflow.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-workflow.test.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThreadCreateBatchResultSchema } from "@mcode/contracts";
 import { MessageRepo } from "../../repositories/message-repo.js";
 import { ThreadControlApprovalRepo } from "../../repositories/thread-control-approval-repo.js";
 import { ThreadControlAuditRepo } from "../../repositories/thread-control-audit-repo.js";
@@ -152,11 +153,16 @@ describe("internal thread-control MCP workflow", () => {
         },
       ],
     });
-    expect(batch.results).toMatchObject([
+    const batchResult = ThreadCreateBatchResultSchema().parse(batch);
+    expect(batchResult.results).toMatchObject([
       { index: 0, status: "created", workspaceId: destinationWorkspace.id, placement: { type: "new_worktree", worktreeId: "worktree-created" } },
       { index: 1, status: "rejected", error: { code: "not_found" } },
     ]);
-    const destinationThreadId = (batch.results as Array<{ threadId: string }>)[0].threadId;
+    const destinationResult = batchResult.results.find((result) => result.index === 0);
+    if (!destinationResult || destinationResult.status !== "created") {
+      throw new Error("Expected first batch result to be created");
+    }
+    const destinationThreadId = destinationResult.threadId;
     expect(threads.findById(destinationThreadId)).toMatchObject({ workspace_id: destinationWorkspace.id, title: "Issue 965 child" });
     expect(threads.findDelegationLineage(destinationThreadId)).toEqual({
       coordinatorThreadId: sourceThread.id,

--- a/apps/server/src/services/__tests__/thread-control-workflow.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-workflow.test.ts
@@ -1,51 +1,40 @@
 import "reflect-metadata";
-import { describe, expect, it, vi } from "vitest";
-
-vi.mock("../../transport/push.js", () => ({ broadcast: vi.fn() }));
-
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MessageRepo } from "../../repositories/message-repo.js";
+import { ThreadControlApprovalRepo } from "../../repositories/thread-control-approval-repo.js";
+import { ThreadControlAuditRepo } from "../../repositories/thread-control-audit-repo.js";
+import { ThreadRepo } from "../../repositories/thread-repo.js";
+import { WorkspaceRepo } from "../../repositories/workspace-repo.js";
+import { openMemoryDatabase } from "../../store/database.js";
 import { InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
 import { createInternalThreadControlMcpSession } from "../thread-control-mcp-transport.js";
 import { ThreadControlMutationReservationService } from "../thread-control-mutation-reservation-service.js";
-import { ThreadControlService, type InternalThreadControlAuthority } from "../thread-control-service.js";
+import { ThreadControlService } from "../thread-control-service.js";
+
+vi.mock("../../transport/push.js", () => ({ broadcast: vi.fn() }));
 
 describe("internal thread-control MCP workflow", () => {
-  it("searches Projects, creates across a partial batch, and controls the usable worktree thread", async () => {
-    const sourceWorkspace = {
-      id: "workspace-source",
-      name: "Coordinator Project",
-      path: "C:/private/coordinator",
-      is_git_repo: true,
-    };
-    const destinationWorkspace = {
-      id: "workspace-destination",
-      name: "Child Project",
-      path: "C:/private/child",
-      is_git_repo: true,
-    };
-    const sourceThread = {
-      id: "source-thread",
-      workspace_id: sourceWorkspace.id,
-      title: "Coordinator",
-      status: "active",
-      mode: "direct",
-      branch: "main",
-      permission_mode: "full",
-      interaction_mode: "build",
-      model: "gpt-default",
-      provider: "codex",
-      created_at: "2026-07-29T00:00:00.000Z",
-      updated_at: "2026-07-29T00:00:00.000Z",
-      deleted_at: null,
-    };
-    const threadsById = new Map<string, Record<string, unknown>>([[sourceThread.id, sourceThread]]);
-    const messagesByThread = new Map<string, Array<Record<string, unknown>>>();
-    let createdCount = 0;
+  let db: ReturnType<typeof openMemoryDatabase> | undefined;
 
-    const workspaces = {
-      search: vi.fn().mockReturnValue([sourceWorkspace, destinationWorkspace]),
-      findById: vi.fn((id: string) => id === sourceWorkspace.id ? sourceWorkspace : id === destinationWorkspace.id ? destinationWorkspace : null),
-      findByIdIncludeDeleted: vi.fn((id: string) => id === sourceWorkspace.id ? sourceWorkspace : id === destinationWorkspace.id ? destinationWorkspace : null),
-    };
+  afterEach(() => {
+    db?.close();
+    db = undefined;
+  });
+
+  it("persists a cross-Project worktree workflow and keeps the child usable after partial failure", async () => {
+    db = openMemoryDatabase();
+    const workspaces = new WorkspaceRepo(db);
+    const threads = new ThreadRepo(db);
+    const messages = new MessageRepo(db);
+    const approvals = new ThreadControlApprovalRepo(db);
+    const audit = new ThreadControlAuditRepo(db);
+    const sourceWorkspace = workspaces.create("Coordinator Project", "C:/private/coordinator");
+    const destinationWorkspace = workspaces.create("Child Project", "C:/private/child");
+    const sourceThread = threads.create(sourceWorkspace.id, "Coordinator", "direct", "main", true, "codex");
+    threads.updateModel(sourceThread.id, "gpt-default");
+    threads.updateSettings(sourceThread.id, { permission_mode: "full", interaction_mode: "build" });
+    const sequenceByThread = new Map<string, number>();
+
     const worktrees = {
       reconcile: vi.fn().mockReturnValue([{ worktreeId: "worktree-main", label: "main", branch: "main" }]),
       findCurrentById: vi.fn(),
@@ -55,43 +44,9 @@ describe("internal thread-control MCP workflow", () => {
       listWorktrees: vi.fn().mockResolvedValue([{ path: "C:/private/child", name: "main", branch: "main", managed: false }]),
       getCurrentBranch: vi.fn().mockResolvedValue("main"),
     };
-    const threads = {
-      create: vi.fn((workspaceId: string, title: string, mode: string, branch: string, _managed: boolean, provider: string) => {
-        createdCount += 1;
-        const thread = {
-          id: `destination-thread-${createdCount}`,
-          workspace_id: workspaceId,
-          title,
-          status: "active",
-          mode,
-          branch,
-          permission_mode: null,
-          interaction_mode: null,
-          model: null,
-          provider,
-          created_at: `2026-07-29T00:00:0${createdCount}.000Z`,
-          updated_at: `2026-07-29T00:00:0${createdCount}.000Z`,
-          deleted_at: null,
-        };
-        threadsById.set(thread.id, thread);
-        return thread;
-      }),
-      findById: vi.fn((id: string) => threadsById.get(id) ?? null),
-      search: vi.fn(() => ({ threads: [...threadsById.values()], workspaces: [] })),
-      updateModel: vi.fn((id: string, model: string) => { const thread = threadsById.get(id); if (thread) thread.model = model; return true; }),
-      updateSettings: vi.fn((id: string, settings: { permission_mode: string; interaction_mode: string }) => { const thread = threadsById.get(id); if (thread) Object.assign(thread, settings); return true; }),
-      updateDelegationLineage: vi.fn().mockReturnValue(true),
-      updateStatus: vi.fn((id: string, status: string) => { const thread = threadsById.get(id); if (thread) thread.status = status; return true; }),
-      updateWorktreePath: vi.fn().mockReturnValue(true),
-      clearWorktreePath: vi.fn().mockReturnValue(true),
-      updateExternalCreator: vi.fn().mockReturnValue(true),
-      countActiveByIntegration: vi.fn().mockReturnValue(0),
-      findDelegationLineage: vi.fn().mockReturnValue(null),
-      listDelegationChildren: vi.fn().mockReturnValue([]),
-    };
     const threadService = {
       provisionWorktree: vi.fn().mockImplementation(async (threadId: string) => ({
-        ...(threadsById.get(threadId) ?? {}),
+        ...threads.findById(threadId),
         mode: "worktree",
         worktree_path: "C:/private/child/.worktrees/feature-workflow-proof",
       })),
@@ -99,49 +54,61 @@ describe("internal thread-control MCP workflow", () => {
     };
     const agentService = {
       activeThreadIds: vi.fn().mockReturnValue([]),
-      sendMessage: vi.fn().mockImplementation(async (input: { threadId: string; content: string; sourceThreadId?: string; originSourceTurnId?: string; sourceProviderId?: string }) => {
-        const thread = threadsById.get(input.threadId);
-        if (thread) thread.status = "paused";
-        const messages = messagesByThread.get(input.threadId) ?? [];
-        messages.push({
-          id: `message-${messages.length + 1}`,
-          role: "user",
-          content: input.content,
-          timestamp: `2026-07-29T00:01:0${messages.length}.000Z`,
-          provider: null,
-          model: null,
-          originType: input.sourceThreadId ? "thread" : "composer",
-          sourceThreadId: input.sourceThreadId ?? null,
-          sourceTurnId: input.originSourceTurnId ?? null,
-          sourceProviderId: input.sourceProviderId ?? null,
-        });
-        messagesByThread.set(input.threadId, messages);
+      sendMessage: vi.fn().mockImplementation(async (input: {
+        threadId: string;
+        content: string;
+        sourceThreadId?: string;
+        originSourceTurnId?: string;
+        sourceProviderId?: string;
+      }) => {
+        const sequence = (sequenceByThread.get(input.threadId) ?? 0) + 1;
+        sequenceByThread.set(input.threadId, sequence);
+        messages.create(
+          input.threadId,
+          "user",
+          input.content,
+          sequence,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          input.sourceThreadId && input.originSourceTurnId && input.sourceProviderId
+            ? {
+                type: "thread",
+                sourceThreadId: input.sourceThreadId,
+                sourceTurnId: input.originSourceTurnId,
+                sourceProviderId: input.sourceProviderId,
+              }
+            : { type: "composer" },
+        );
+        threads.updateStatus(input.threadId, "paused");
       }),
       stopSession: vi.fn().mockResolvedValue(undefined),
     };
-    const approvals = {
-      create: vi.fn(), createSend: vi.fn(), createStop: vi.fn(), claim: vi.fn(), settle: vi.fn(),
-      setOperationPhase: vi.fn().mockReturnValue(true), listPending: vi.fn().mockReturnValue([]),
-      listProcessing: vi.fn().mockReturnValue([]), requeue: vi.fn(), requeueDispatch: vi.fn(),
-      requeueRecoveredProvisioning: vi.fn(), listPendingByThread: vi.fn().mockReturnValue([]),
-      listPendingBySourceThread: vi.fn().mockReturnValue([]),
+    const settings = {
+      get: () => ({
+        model: { defaults: { provider: "codex", id: "gpt-default" } },
+        agent: { defaults: { permission: "full" } },
+      }),
     };
-    const messages = {
-      listByThreadForThreadControl: vi.fn((threadId: string) => ({ messages: messagesByThread.get(threadId) ?? [], hasMore: false })),
-    };
+    const providers = { resolve: vi.fn(() => ({ id: "codex" })) };
+    const models = { listModels: vi.fn().mockResolvedValue([{ id: "gpt-default" }]) };
     const service = new ThreadControlService(
-      workspaces as never,
+      workspaces,
       worktrees as never,
       git as never,
-      threads as never,
+      threads,
       threadService as never,
       agentService as never,
-      { get: () => ({ model: { defaults: { provider: "codex", id: "gpt-default" } }, agent: { defaults: { permission: "full" } } }) } as never,
-      { resolve: vi.fn(() => ({ id: "codex" })) } as never,
-      { listModels: vi.fn().mockResolvedValue([{ id: "gpt-default" }]) } as never,
-      approvals as never,
-      { write: vi.fn() } as never,
-      messages as never,
+      settings as never,
+      providers as never,
+      models as never,
+      approvals,
+      audit,
+      messages,
       new ThreadControlMutationReservationService(),
     );
 
@@ -161,9 +128,10 @@ describe("internal thread-control MCP workflow", () => {
       arguments: args,
     });
 
-    await expect(call("search-projects", "workspace_search", { query: "Project" })).resolves.toMatchObject({
-      workspaces: [{ workspaceId: sourceWorkspace.id }, { workspaceId: destinationWorkspace.id }],
-    });
+    const projectSearch = await call("search-projects", "workspace_search", { query: "Project" }) as { workspaces: Array<{ workspaceId: string }> };
+    expect(projectSearch.workspaces.map((workspace) => workspace.workspaceId)).toEqual(
+      expect.arrayContaining([sourceWorkspace.id, destinationWorkspace.id]),
+    );
     await expect(call("list-destination-worktrees", "worktree_list", { workspaceId: destinationWorkspace.id })).resolves.toMatchObject({
       status: "found",
       worktrees: [{ worktreeId: "worktree-main" }],
@@ -189,6 +157,13 @@ describe("internal thread-control MCP workflow", () => {
       { index: 1, status: "rejected", error: { code: "not_found" } },
     ]);
     const destinationThreadId = (batch.results[0] as { threadId: string }).threadId;
+    expect(threads.findById(destinationThreadId)).toMatchObject({ workspace_id: destinationWorkspace.id, title: "Issue 965 child" });
+    expect(threads.findDelegationLineage(destinationThreadId)).toEqual({
+      coordinatorThreadId: sourceThread.id,
+      creatorTurnId: "source-turn",
+      creatorToolCallId: "create-batch",
+      creationKind: "thread_delegation",
+    });
 
     await expect(call("search-created", "thread_search", { workspaceIds: [destinationWorkspace.id] })).resolves.toMatchObject({
       threads: [{ threadId: destinationThreadId, workspaceId: destinationWorkspace.id }],
@@ -196,15 +171,23 @@ describe("internal thread-control MCP workflow", () => {
     await expect(call("read-created", "thread_get", { threadId: destinationThreadId })).resolves.toMatchObject({
       status: "found",
       workspaceId: destinationWorkspace.id,
-      messages: [{ content: "Implement the workflow proof." }],
+      messages: [{ content: "Implement the workflow proof.", origin: { type: "composer" } }],
     });
     await expect(call("follow-up", "thread_send", { threadId: destinationThreadId, message: "Continue with the regression." })).resolves.toMatchObject({
       status: "accepted",
       threadId: destinationThreadId,
     });
-    await expect(call("wait-for-attention", "thread_wait", { threadIds: [destinationThreadId], timeoutSeconds: 1 })).resolves.toMatchObject({
+    const waitAbort = new AbortController();
+    waitAbort.abort();
+    await expect(session.dispatch({
+      bearerCredential: lease.credential,
+      requestId: "wait-for-attention",
+      toolName: "thread_wait",
+      arguments: { threadIds: [destinationThreadId], timeoutSeconds: 1 },
+      signal: waitAbort.signal,
+    })).resolves.toMatchObject({
       status: "success",
-      timedOut: false,
+      timedOut: true,
       results: [{ threadId: destinationThreadId, state: { status: "waiting_for_user" } }],
     });
     await expect(call("stop-created", "thread_stop", { threadId: destinationThreadId })).resolves.toMatchObject({
@@ -217,15 +200,24 @@ describe("internal thread-control MCP workflow", () => {
       thread: { state: { status: "stopped" } },
       messages: [
         { content: "Implement the workflow proof." },
-        { content: "Continue with the regression.", origin: { type: "thread", sourceThreadId: sourceThread.id } },
+        { content: "Continue with the regression.", origin: { type: "thread", sourceThreadId: sourceThread.id, sourceProviderId: "codex" } },
       ],
     });
-    expect(threads.create).toHaveBeenCalledTimes(1);
-    expect(threadService.provisionWorktree).toHaveBeenCalledWith(destinationThreadId, destinationWorkspace.id, {
-      type: "new_worktree",
-      baseRef: "main",
-      branchName: "feature/workflow-proof",
+
+    const restartedThreads = new ThreadRepo(db);
+    const restartedMessages = new MessageRepo(db);
+    expect(restartedThreads.findDelegationLineage(destinationThreadId)).toEqual({
+      coordinatorThreadId: sourceThread.id,
+      creatorTurnId: "source-turn",
+      creatorToolCallId: "create-batch",
+      creationKind: "thread_delegation",
     });
+    expect(restartedMessages.listByThreadForThreadControl(destinationThreadId, 10, 100_000).messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ content: "Continue with the regression.", sourceThreadId: sourceThread.id, sourceProviderId: "codex" }),
+      ]),
+    );
+    expect(threads.listDelegationChildren(sourceThread.id).map(({ thread }) => thread.id)).toContain(destinationThreadId);
     expect(agentService.stopSession).toHaveBeenCalledWith(destinationThreadId);
   });
 });

--- a/apps/server/src/services/__tests__/thread-control-workflow.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-workflow.test.ts
@@ -156,7 +156,7 @@ describe("internal thread-control MCP workflow", () => {
       { index: 0, status: "created", workspaceId: destinationWorkspace.id, placement: { type: "new_worktree", worktreeId: "worktree-created" } },
       { index: 1, status: "rejected", error: { code: "not_found" } },
     ]);
-    const destinationThreadId = (batch.results[0] as { threadId: string }).threadId;
+    const destinationThreadId = (batch.results as Array<{ threadId: string }>)[0].threadId;
     expect(threads.findById(destinationThreadId)).toMatchObject({ workspace_id: destinationWorkspace.id, title: "Issue 965 child" });
     expect(threads.findDelegationLineage(destinationThreadId)).toEqual({
       coordinatorThreadId: sourceThread.id,

--- a/apps/server/src/services/__tests__/thread-control-workflow.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-workflow.test.ts
@@ -1,0 +1,231 @@
+import "reflect-metadata";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../transport/push.js", () => ({ broadcast: vi.fn() }));
+
+import { InternalThreadControlMcpAuthority } from "../thread-control-mcp-authority.js";
+import { createInternalThreadControlMcpSession } from "../thread-control-mcp-transport.js";
+import { ThreadControlMutationReservationService } from "../thread-control-mutation-reservation-service.js";
+import { ThreadControlService, type InternalThreadControlAuthority } from "../thread-control-service.js";
+
+describe("internal thread-control MCP workflow", () => {
+  it("searches Projects, creates across a partial batch, and controls the usable worktree thread", async () => {
+    const sourceWorkspace = {
+      id: "workspace-source",
+      name: "Coordinator Project",
+      path: "C:/private/coordinator",
+      is_git_repo: true,
+    };
+    const destinationWorkspace = {
+      id: "workspace-destination",
+      name: "Child Project",
+      path: "C:/private/child",
+      is_git_repo: true,
+    };
+    const sourceThread = {
+      id: "source-thread",
+      workspace_id: sourceWorkspace.id,
+      title: "Coordinator",
+      status: "active",
+      mode: "direct",
+      branch: "main",
+      permission_mode: "full",
+      interaction_mode: "build",
+      model: "gpt-default",
+      provider: "codex",
+      created_at: "2026-07-29T00:00:00.000Z",
+      updated_at: "2026-07-29T00:00:00.000Z",
+      deleted_at: null,
+    };
+    const threadsById = new Map<string, Record<string, unknown>>([[sourceThread.id, sourceThread]]);
+    const messagesByThread = new Map<string, Array<Record<string, unknown>>>();
+    let createdCount = 0;
+
+    const workspaces = {
+      search: vi.fn().mockReturnValue([sourceWorkspace, destinationWorkspace]),
+      findById: vi.fn((id: string) => id === sourceWorkspace.id ? sourceWorkspace : id === destinationWorkspace.id ? destinationWorkspace : null),
+      findByIdIncludeDeleted: vi.fn((id: string) => id === sourceWorkspace.id ? sourceWorkspace : id === destinationWorkspace.id ? destinationWorkspace : null),
+    };
+    const worktrees = {
+      reconcile: vi.fn().mockReturnValue([{ worktreeId: "worktree-main", label: "main", branch: "main" }]),
+      findCurrentById: vi.fn(),
+      register: vi.fn().mockReturnValue({ worktreeId: "worktree-created", label: "feature/workflow-proof" }),
+    };
+    const git = {
+      listWorktrees: vi.fn().mockResolvedValue([{ path: "C:/private/child", name: "main", branch: "main", managed: false }]),
+      getCurrentBranch: vi.fn().mockResolvedValue("main"),
+    };
+    const threads = {
+      create: vi.fn((workspaceId: string, title: string, mode: string, branch: string, _managed: boolean, provider: string) => {
+        createdCount += 1;
+        const thread = {
+          id: `destination-thread-${createdCount}`,
+          workspace_id: workspaceId,
+          title,
+          status: "active",
+          mode,
+          branch,
+          permission_mode: null,
+          interaction_mode: null,
+          model: null,
+          provider,
+          created_at: `2026-07-29T00:00:0${createdCount}.000Z`,
+          updated_at: `2026-07-29T00:00:0${createdCount}.000Z`,
+          deleted_at: null,
+        };
+        threadsById.set(thread.id, thread);
+        return thread;
+      }),
+      findById: vi.fn((id: string) => threadsById.get(id) ?? null),
+      search: vi.fn(() => ({ threads: [...threadsById.values()], workspaces: [] })),
+      updateModel: vi.fn((id: string, model: string) => { const thread = threadsById.get(id); if (thread) thread.model = model; return true; }),
+      updateSettings: vi.fn((id: string, settings: { permission_mode: string; interaction_mode: string }) => { const thread = threadsById.get(id); if (thread) Object.assign(thread, settings); return true; }),
+      updateDelegationLineage: vi.fn().mockReturnValue(true),
+      updateStatus: vi.fn((id: string, status: string) => { const thread = threadsById.get(id); if (thread) thread.status = status; return true; }),
+      updateWorktreePath: vi.fn().mockReturnValue(true),
+      clearWorktreePath: vi.fn().mockReturnValue(true),
+      updateExternalCreator: vi.fn().mockReturnValue(true),
+      countActiveByIntegration: vi.fn().mockReturnValue(0),
+      findDelegationLineage: vi.fn().mockReturnValue(null),
+      listDelegationChildren: vi.fn().mockReturnValue([]),
+    };
+    const threadService = {
+      provisionWorktree: vi.fn().mockImplementation(async (threadId: string) => ({
+        ...(threadsById.get(threadId) ?? {}),
+        mode: "worktree",
+        worktree_path: "C:/private/child/.worktrees/feature-workflow-proof",
+      })),
+      cleanupInterruptedProvisioning: vi.fn().mockResolvedValue(true),
+    };
+    const agentService = {
+      activeThreadIds: vi.fn().mockReturnValue([]),
+      sendMessage: vi.fn().mockImplementation(async (input: { threadId: string; content: string; sourceThreadId?: string; originSourceTurnId?: string; sourceProviderId?: string }) => {
+        const thread = threadsById.get(input.threadId);
+        if (thread) thread.status = "paused";
+        const messages = messagesByThread.get(input.threadId) ?? [];
+        messages.push({
+          id: `message-${messages.length + 1}`,
+          role: "user",
+          content: input.content,
+          timestamp: `2026-07-29T00:01:0${messages.length}.000Z`,
+          provider: null,
+          model: null,
+          originType: input.sourceThreadId ? "thread" : "composer",
+          sourceThreadId: input.sourceThreadId ?? null,
+          sourceTurnId: input.originSourceTurnId ?? null,
+          sourceProviderId: input.sourceProviderId ?? null,
+        });
+        messagesByThread.set(input.threadId, messages);
+      }),
+      stopSession: vi.fn().mockResolvedValue(undefined),
+    };
+    const approvals = {
+      create: vi.fn(), createSend: vi.fn(), createStop: vi.fn(), claim: vi.fn(), settle: vi.fn(),
+      setOperationPhase: vi.fn().mockReturnValue(true), listPending: vi.fn().mockReturnValue([]),
+      listProcessing: vi.fn().mockReturnValue([]), requeue: vi.fn(), requeueDispatch: vi.fn(),
+      requeueRecoveredProvisioning: vi.fn(), listPendingByThread: vi.fn().mockReturnValue([]),
+      listPendingBySourceThread: vi.fn().mockReturnValue([]),
+    };
+    const messages = {
+      listByThreadForThreadControl: vi.fn((threadId: string) => ({ messages: messagesByThread.get(threadId) ?? [], hasMore: false })),
+    };
+    const service = new ThreadControlService(
+      workspaces as never,
+      worktrees as never,
+      git as never,
+      threads as never,
+      threadService as never,
+      agentService as never,
+      { get: () => ({ model: { defaults: { provider: "codex", id: "gpt-default" } }, agent: { defaults: { permission: "full" } } }) } as never,
+      { resolve: vi.fn(() => ({ id: "codex" })) } as never,
+      { listModels: vi.fn().mockResolvedValue([{ id: "gpt-default" }]) } as never,
+      approvals as never,
+      { write: vi.fn() } as never,
+      messages as never,
+      new ThreadControlMutationReservationService(),
+    );
+
+    const authority = new InternalThreadControlMcpAuthority();
+    const lease = authority.activate({
+      sessionId: "workflow-session",
+      sourceThreadId: sourceThread.id,
+      sourceTurnId: "source-turn",
+      sourceProviderId: "codex",
+      permissionMode: "full",
+    });
+    const session = createInternalThreadControlMcpSession({ authority, service });
+    const call = (requestId: string, toolName: string, args: unknown) => session.dispatch({
+      bearerCredential: lease.credential,
+      requestId,
+      toolName,
+      arguments: args,
+    });
+
+    await expect(call("search-projects", "workspace_search", { query: "Project" })).resolves.toMatchObject({
+      workspaces: [{ workspaceId: sourceWorkspace.id }, { workspaceId: destinationWorkspace.id }],
+    });
+    await expect(call("list-destination-worktrees", "worktree_list", { workspaceId: destinationWorkspace.id })).resolves.toMatchObject({
+      status: "found",
+      worktrees: [{ worktreeId: "worktree-main" }],
+    });
+    const batch = await call("create-batch", "thread_create_batch", {
+      items: [
+        {
+          workspaceId: destinationWorkspace.id,
+          title: "Issue 965 child",
+          prompt: "Implement the workflow proof.",
+          placement: { type: "new_worktree", baseRef: "main", branchName: "feature/workflow-proof" },
+        },
+        {
+          workspaceId: "unknown-workspace",
+          title: "Rejected child",
+          prompt: "Must not persist.",
+          placement: { type: "direct" },
+        },
+      ],
+    });
+    expect(batch.results).toMatchObject([
+      { index: 0, status: "created", workspaceId: destinationWorkspace.id, placement: { type: "new_worktree", worktreeId: "worktree-created" } },
+      { index: 1, status: "rejected", error: { code: "not_found" } },
+    ]);
+    const destinationThreadId = (batch.results[0] as { threadId: string }).threadId;
+
+    await expect(call("search-created", "thread_search", { workspaceIds: [destinationWorkspace.id] })).resolves.toMatchObject({
+      threads: [{ threadId: destinationThreadId, workspaceId: destinationWorkspace.id }],
+    });
+    await expect(call("read-created", "thread_get", { threadId: destinationThreadId })).resolves.toMatchObject({
+      status: "found",
+      workspaceId: destinationWorkspace.id,
+      messages: [{ content: "Implement the workflow proof." }],
+    });
+    await expect(call("follow-up", "thread_send", { threadId: destinationThreadId, message: "Continue with the regression." })).resolves.toMatchObject({
+      status: "accepted",
+      threadId: destinationThreadId,
+    });
+    await expect(call("wait-for-attention", "thread_wait", { threadIds: [destinationThreadId], timeoutSeconds: 1 })).resolves.toMatchObject({
+      status: "success",
+      timedOut: false,
+      results: [{ threadId: destinationThreadId, state: { status: "waiting_for_user" } }],
+    });
+    await expect(call("stop-created", "thread_stop", { threadId: destinationThreadId })).resolves.toMatchObject({
+      status: "accepted",
+      threadId: destinationThreadId,
+      state: { status: "stopped" },
+    });
+    await expect(call("read-after-stop", "thread_get", { threadId: destinationThreadId })).resolves.toMatchObject({
+      status: "found",
+      thread: { state: { status: "stopped" } },
+      messages: [
+        { content: "Implement the workflow proof." },
+        { content: "Continue with the regression.", origin: { type: "thread", sourceThreadId: sourceThread.id } },
+      ],
+    });
+    expect(threads.create).toHaveBeenCalledTimes(1);
+    expect(threadService.provisionWorktree).toHaveBeenCalledWith(destinationThreadId, destinationWorkspace.id, {
+      type: "new_worktree",
+      baseRef: "main",
+      branchName: "feature/workflow-proof",
+    });
+    expect(agentService.stopSession).toHaveBeenCalledWith(destinationThreadId);
+  });
+});

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -962,7 +962,7 @@ export class AgentService {
       resumeFrom: attemptResumeFrom,
       providerOptions,
     } as TurnRequest;
-    if (effectiveProvider === "claude" || effectiveProvider === "codex") {
+    if (["claude", "codex", "cursor", "copilot"].includes(effectiveProvider)) {
       this.threadControlMcp?.activate({
         sessionId: sessionName,
         sourceThreadId: threadId,
@@ -2209,7 +2209,7 @@ export class AgentService {
         });
       }
       if (!this.getCurrentRetryDispatch(threadId, identity)) return false;
-      if (dispatch.effectiveProvider === "claude" || dispatch.effectiveProvider === "codex") {
+      if (["claude", "codex", "cursor", "copilot"].includes(dispatch.effectiveProvider)) {
         this.threadControlMcp?.activate({
           sessionId: dispatch.sessionName,
           sourceThreadId: threadId,

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -90,6 +90,11 @@ function escapeXml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/** Reports whether a provider receives the internal thread-control MCP lease. */
+export function usesInternalThreadControlMcp(provider: string): provider is ProviderId {
+  return ["claude", "codex", "cursor", "copilot"].includes(provider);
+}
+
 const FILE_INJECTION_SEPARATOR = "\n\n---\n";
 
 type RetryDispatchIdentity = Readonly<{
@@ -962,7 +967,7 @@ export class AgentService {
       resumeFrom: attemptResumeFrom,
       providerOptions,
     } as TurnRequest;
-    if (["claude", "codex", "cursor", "copilot"].includes(effectiveProvider)) {
+    if (usesInternalThreadControlMcp(effectiveProvider)) {
       this.threadControlMcp?.activate({
         sessionId: sessionName,
         sourceThreadId: threadId,
@@ -2209,7 +2214,7 @@ export class AgentService {
         });
       }
       if (!this.getCurrentRetryDispatch(threadId, identity)) return false;
-      if (["claude", "codex", "cursor", "copilot"].includes(dispatch.effectiveProvider)) {
+      if (usesInternalThreadControlMcp(dispatch.effectiveProvider)) {
         this.threadControlMcp?.activate({
           sessionId: dispatch.sessionName,
           sourceThreadId: threadId,

--- a/apps/server/src/services/thread-control-mcp-runtime.ts
+++ b/apps/server/src/services/thread-control-mcp-runtime.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { PassThrough } from "node:stream";
 import { inject, injectable } from "tsyringe";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,6 +15,10 @@ import { ThreadControlService } from "./thread-control-service.js";
 const CODEX_MCP_TOKEN_ENV = "MCODE_INTERNAL_THREAD_CONTROL_TOKEN";
 const CODEX_MCP_NAME = "mcode_internal_thread_control";
 const MAX_HTTP_CLIENT_SESSIONS = 4;
+/** Maximum bytes accepted for one loopback MCP request body. */
+export const MAX_INTERNAL_MCP_REQUEST_BODY_BYTES = 1_048_576;
+/** Socket and request deadline for loopback MCP traffic. */
+export const INTERNAL_MCP_REQUEST_TIMEOUT_MS = 15_000;
 
 type HttpClientSession = { server: McpServer; transport: StreamableHTTPServerTransport };
 
@@ -168,6 +173,10 @@ export class InternalThreadControlMcpRuntime {
 
   private async startHttpServer(): Promise<void> {
     const server = createServer((request, response) => {
+      request.setTimeout(INTERNAL_MCP_REQUEST_TIMEOUT_MS, () => {
+        if (!response.headersSent) response.writeHead(408).end();
+        request.destroy();
+      });
       const encodedSessionId = request.url?.split("?", 1)[0]?.slice(1);
       if (!encodedSessionId) {
         response.writeHead(404).end();
@@ -196,7 +205,8 @@ export class InternalThreadControlMcpRuntime {
         return;
       }
       if (request.method === "POST" && !clientSession.value) {
-        void this.handleHttpInitialize(sessionId, entry, request, response);
+        void this.handleBoundedRequest(request, response, (boundedRequest) =>
+          this.handleHttpInitialize(sessionId, entry, boundedRequest, response));
         return;
       }
       if (request.method !== "POST" && request.method !== "GET" && request.method !== "DELETE") {
@@ -212,11 +222,12 @@ export class InternalThreadControlMcpRuntime {
         response.writeHead(404).end();
         return;
       }
-      void client.transport.handleRequest(request, response).catch(() => {
-        if (!response.headersSent) response.writeHead(500);
-        response.end();
-      });
+      void this.handleBoundedRequest(request, response, (boundedRequest) =>
+        client.transport.handleRequest(boundedRequest, response));
     });
+    server.requestTimeout = INTERNAL_MCP_REQUEST_TIMEOUT_MS;
+    server.headersTimeout = INTERNAL_MCP_REQUEST_TIMEOUT_MS;
+    server.timeout = INTERNAL_MCP_REQUEST_TIMEOUT_MS;
     await new Promise<void>((resolve, reject) => {
       server.once("error", reject);
       server.listen(0, "127.0.0.1", () => {
@@ -275,6 +286,81 @@ export class InternalThreadControlMcpRuntime {
       if (!registered) await transport.close().catch(() => undefined);
     }
   }
+
+  private async handleBoundedRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+    handler: (boundedRequest: IncomingMessage) => Promise<void>,
+  ): Promise<void> {
+    const declaredLength = parseContentLength(request);
+    if (declaredLength === "invalid") {
+      response.writeHead(400, { Connection: "close" }).end();
+      request.pause();
+      return;
+    }
+    if (declaredLength !== undefined && declaredLength > MAX_INTERNAL_MCP_REQUEST_BODY_BYTES) {
+      response.writeHead(413, { Connection: "close" }).end();
+      request.pause();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    let received = 0;
+    let rejected = false;
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = (): void => {
+        request.off("data", onData);
+        request.off("end", onEnd);
+        request.off("error", onError);
+      };
+      const onData = (chunk: Buffer): void => {
+        received += chunk.length;
+        if (received > MAX_INTERNAL_MCP_REQUEST_BODY_BYTES) {
+          rejected = true;
+          cleanup();
+          request.pause();
+          resolve();
+          return;
+        }
+        chunks.push(Buffer.from(chunk));
+      };
+      const onEnd = (): void => {
+        cleanup();
+        resolve();
+      };
+      const onError = (error: Error): void => {
+        cleanup();
+        reject(error);
+      };
+      request.on("data", onData);
+      request.once("end", onEnd);
+      request.once("error", onError);
+    });
+    if (rejected) {
+      response.writeHead(413, { Connection: "close" }).end();
+      return;
+    }
+    const body = new PassThrough();
+    const boundedRequest = Object.assign(body, {
+      method: request.method,
+      headers: request.headers,
+      url: request.url,
+      httpVersion: request.httpVersion,
+      httpVersionMajor: request.httpVersionMajor,
+      httpVersionMinor: request.httpVersionMinor,
+      socket: request.socket,
+      rawHeaders: request.rawHeaders,
+      rawTrailers: request.rawTrailers,
+    }) as unknown as IncomingMessage;
+    body.end(Buffer.concat(chunks));
+    try {
+      await handler(boundedRequest);
+    } catch {
+      if (!response.headersSent && !rejected) response.writeHead(500).end();
+    } finally {
+      body.destroy();
+    }
+  }
 }
 
 function readClientSessionHeader(request: IncomingMessage): { value?: string; invalid: boolean } {
@@ -282,4 +368,12 @@ function readClientSessionHeader(request: IncomingMessage): { value?: string; in
   if (header === undefined) return { invalid: false };
   if (typeof header !== "string" || header.length === 0 || header.length > 256) return { invalid: true };
   return { value: header, invalid: false };
+}
+
+function parseContentLength(request: IncomingMessage): number | "invalid" | undefined {
+  const raw = request.headers["content-length"];
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) return "invalid";
+  const length = Number(raw);
+  return Number.isSafeInteger(length) ? length : "invalid";
 }

--- a/apps/server/src/services/thread-control-mcp-runtime.ts
+++ b/apps/server/src/services/thread-control-mcp-runtime.ts
@@ -78,7 +78,7 @@ export class InternalThreadControlMcpRuntime {
       }
       if (!this.httpSessions.has(sessionId)) {
         const server = this.transport.createServer(credential);
-        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => sessionId });
         await server.connect(transport);
         if (credential !== this.authority.credential(sessionId)) {
           await transport.close().catch(() => undefined);

--- a/apps/server/src/services/thread-control-mcp-runtime.ts
+++ b/apps/server/src/services/thread-control-mcp-runtime.ts
@@ -151,8 +151,12 @@ export class InternalThreadControlMcpRuntime {
   private async startHttpServer(): Promise<void> {
     const server = createServer((request, response) => {
       const encodedSessionId = request.url?.slice(1);
-      if (!encodedSessionId || request.method !== "POST") {
+      if (!encodedSessionId) {
         response.writeHead(404).end();
+        return;
+      }
+      if (request.method !== "POST") {
+        response.writeHead(request.method === "GET" ? 405 : 404).end();
         return;
       }
       let sessionId: string;

--- a/apps/server/src/services/thread-control-mcp-runtime.ts
+++ b/apps/server/src/services/thread-control-mcp-runtime.ts
@@ -1,4 +1,5 @@
-import { createServer, type Server } from "node:http";
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { inject, injectable } from "tsyringe";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -12,6 +13,16 @@ import { ThreadControlService } from "./thread-control-service.js";
 
 const CODEX_MCP_TOKEN_ENV = "MCODE_INTERNAL_THREAD_CONTROL_TOKEN";
 const CODEX_MCP_NAME = "mcode_internal_thread_control";
+const MAX_HTTP_CLIENT_SESSIONS = 4;
+
+type HttpClientSession = { server: McpServer; transport: StreamableHTTPServerTransport };
+
+type HttpProviderSession = {
+  credential: string;
+  clients: Map<string, HttpClientSession>;
+  pending: Set<StreamableHTTPServerTransport>;
+  closed: boolean;
+};
 
 /** Authenticated HTTP MCP connection details for one pooled provider session. */
 export interface InternalThreadControlMcpHttpConnection {
@@ -24,7 +35,7 @@ export interface InternalThreadControlMcpHttpConnection {
 @injectable()
 export class InternalThreadControlMcpRuntime {
   private readonly transport;
-  private readonly httpSessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
+  private readonly httpSessions = new Map<string, HttpProviderSession>();
   private httpServer: Server | undefined;
   private httpPort: number | undefined;
   private httpServerStartup: Promise<void> | undefined;
@@ -54,7 +65,13 @@ export class InternalThreadControlMcpRuntime {
       const entry = this.httpSessions.get(sessionId);
       this.httpSessions.delete(sessionId);
       if (entry) {
-        await entry.transport.close().catch(() => undefined);
+        entry.closed = true;
+        await Promise.all([
+          ...Array.from(entry.clients.values(), ({ transport }) => transport.close().catch(() => undefined)),
+          ...Array.from(entry.pending, (transport) => transport.close().catch(() => undefined)),
+        ]);
+        entry.clients.clear();
+        entry.pending.clear();
       }
       await this.closeHttpServerWhenIdle();
     });
@@ -76,16 +93,17 @@ export class InternalThreadControlMcpRuntime {
         await this.closeHttpServerWhenIdle();
         return undefined;
       }
-      if (!this.httpSessions.has(sessionId)) {
-        const server = this.transport.createServer(credential);
-        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => sessionId });
-        await server.connect(transport);
-        if (credential !== this.authority.credential(sessionId)) {
-          await transport.close().catch(() => undefined);
-          await this.closeHttpServerWhenIdle();
-          return undefined;
-        }
-        this.httpSessions.set(sessionId, { server, transport });
+      const entry = this.httpSessions.get(sessionId);
+      if (entry && entry.credential !== credential) {
+        return undefined;
+      }
+      if (!entry) {
+        this.httpSessions.set(sessionId, {
+          credential,
+          clients: new Map(),
+          pending: new Set(),
+          closed: false,
+        });
       }
       return {
         name: CODEX_MCP_NAME,
@@ -150,13 +168,9 @@ export class InternalThreadControlMcpRuntime {
 
   private async startHttpServer(): Promise<void> {
     const server = createServer((request, response) => {
-      const encodedSessionId = request.url?.slice(1);
+      const encodedSessionId = request.url?.split("?", 1)[0]?.slice(1);
       if (!encodedSessionId) {
         response.writeHead(404).end();
-        return;
-      }
-      if (request.method !== "POST") {
-        response.writeHead(request.method === "GET" ? 405 : 404).end();
         return;
       }
       let sessionId: string;
@@ -168,11 +182,37 @@ export class InternalThreadControlMcpRuntime {
       }
       const entry = this.httpSessions.get(sessionId);
       const credential = entry && this.authority.credential(sessionId);
-      if (!entry || !credential || !constantTimeCredentialEqual(request.headers.authorization ?? "", `Bearer ${credential}`)) {
+      if (!entry || entry.closed || !credential || !constantTimeCredentialEqual(request.headers.authorization ?? "", `Bearer ${credential}`)) {
         response.writeHead(401).end();
         return;
       }
-      void entry.transport.handleRequest(request, response).catch(() => {
+      const clientSession = readClientSessionHeader(request);
+      if (clientSession.invalid) {
+        response.writeHead(404).end();
+        return;
+      }
+      if (request.method === "GET" && !clientSession.value) {
+        response.writeHead(405).end();
+        return;
+      }
+      if (request.method === "POST" && !clientSession.value) {
+        void this.handleHttpInitialize(sessionId, entry, request, response);
+        return;
+      }
+      if (request.method !== "POST" && request.method !== "GET" && request.method !== "DELETE") {
+        response.writeHead(404).end();
+        return;
+      }
+      if (!clientSession.value) {
+        response.writeHead(404).end();
+        return;
+      }
+      const client = entry.clients.get(clientSession.value);
+      if (!client) {
+        response.writeHead(404).end();
+        return;
+      }
+      void client.transport.handleRequest(request, response).catch(() => {
         if (!response.headersSent) response.writeHead(500);
         response.end();
       });
@@ -192,4 +232,54 @@ export class InternalThreadControlMcpRuntime {
     this.httpServer = server;
     this.httpPort = address.port;
   }
+
+  private async handleHttpInitialize(
+    sessionId: string,
+    entry: HttpProviderSession,
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    if (entry.clients.size + entry.pending.size >= MAX_HTTP_CLIENT_SESSIONS) {
+      response.writeHead(429).end();
+      return;
+    }
+    const server = this.transport.createServer(entry.credential);
+    let transport!: StreamableHTTPServerTransport;
+    let registered = false;
+    transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (clientSessionId) => {
+        entry.pending.delete(transport);
+        if (entry.closed || this.httpSessions.get(sessionId) !== entry) {
+          void transport.close().catch(() => undefined);
+          return;
+        }
+        entry.clients.set(clientSessionId, { server, transport });
+        registered = true;
+      },
+      onsessionclosed: (clientSessionId) => {
+        if (entry.clients.get(clientSessionId)?.transport === transport) {
+          entry.clients.delete(clientSessionId);
+        }
+      },
+    });
+    entry.pending.add(transport);
+    try {
+      await server.connect(transport);
+      await transport.handleRequest(request, response);
+    } catch {
+      if (!response.headersSent) response.writeHead(500);
+      response.end();
+    } finally {
+      entry.pending.delete(transport);
+      if (!registered) await transport.close().catch(() => undefined);
+    }
+  }
+}
+
+function readClientSessionHeader(request: IncomingMessage): { value?: string; invalid: boolean } {
+  const header = request.headers["mcp-session-id"];
+  if (header === undefined) return { invalid: false };
+  if (typeof header !== "string" || header.length === 0 || header.length > 256) return { invalid: true };
+  return { value: header, invalid: false };
 }

--- a/apps/server/src/services/thread-control-mcp-runtime.ts
+++ b/apps/server/src/services/thread-control-mcp-runtime.ts
@@ -13,6 +13,13 @@ import { ThreadControlService } from "./thread-control-service.js";
 const CODEX_MCP_TOKEN_ENV = "MCODE_INTERNAL_THREAD_CONTROL_TOKEN";
 const CODEX_MCP_NAME = "mcode_internal_thread_control";
 
+/** Authenticated HTTP MCP connection details for one pooled provider session. */
+export interface InternalThreadControlMcpHttpConnection {
+  name: string;
+  url: string;
+  headers: Record<string, string>;
+}
+
 /** Server-only lifecycle bridge for provider-injected thread-control MCP sessions. */
 @injectable()
 export class InternalThreadControlMcpRuntime {
@@ -59,8 +66,8 @@ export class InternalThreadControlMcpRuntime {
     return credential ? this.transport.createServer(credential) : undefined;
   }
 
-  /** Creates bounded loopback configuration for one Codex app-server session. */
-  async createCodexConfiguration(sessionId: string): Promise<{ configOverrides: string[]; env: Record<string, string> } | undefined> {
+  /** Creates one authenticated loopback HTTP connection for a pooled provider session. */
+  async createHttpConnection(sessionId: string): Promise<InternalThreadControlMcpHttpConnection | undefined> {
     const credential = this.authority.credential(sessionId);
     if (!credential) return undefined;
     return this.inLifecycle(async () => {
@@ -80,15 +87,28 @@ export class InternalThreadControlMcpRuntime {
         }
         this.httpSessions.set(sessionId, { server, transport });
       }
-      const url = `http://127.0.0.1:${this.httpPort}/${encodeURIComponent(sessionId)}`;
       return {
-        configOverrides: [
-          `mcp_servers.${CODEX_MCP_NAME}.url=\"${url}\"`,
-          `mcp_servers.${CODEX_MCP_NAME}.bearer_token_env_var=\"${CODEX_MCP_TOKEN_ENV}\"`,
-        ],
-        env: { [CODEX_MCP_TOKEN_ENV]: credential },
+        name: CODEX_MCP_NAME,
+        url: `http://127.0.0.1:${this.httpPort}/${encodeURIComponent(sessionId)}`,
+        headers: { Authorization: `Bearer ${credential}` },
       };
     });
+  }
+
+  /** Creates bounded loopback configuration for one Codex app-server session. */
+  async createCodexConfiguration(sessionId: string): Promise<{ configOverrides: string[]; env: Record<string, string> } | undefined> {
+    const connection = await this.createHttpConnection(sessionId);
+    if (!connection) return undefined;
+    const authorization = connection.headers.Authorization;
+    const credential = authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined;
+    if (!credential) return undefined;
+    return {
+      configOverrides: [
+        `mcp_servers.${connection.name}.url=\"${connection.url}\"`,
+        `mcp_servers.${connection.name}.bearer_token_env_var=\"${CODEX_MCP_TOKEN_ENV}\"`,
+      ],
+      env: { [CODEX_MCP_TOKEN_ENV]: credential },
+    };
   }
 
   private async inLifecycle<T>(operation: () => Promise<T>): Promise<T> {

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -51,6 +51,7 @@ import {
 } from "@mcode/contracts";
 import type {
   ExternalThreadControlAuthority,
+  InternalThreadControlAuthority,
   ThreadControlAuthority,
 } from "@mcode/thread-orchestration";
 export type {

--- a/scripts/build-server-dev-bundle.mjs
+++ b/scripts/build-server-dev-bundle.mjs
@@ -9,7 +9,7 @@
 
 import { build } from "esbuild";
 import { execFileSync } from "node:child_process";
-import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, realpathSync, rmSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -294,6 +294,80 @@ export function copyClaudeSdkCliNextTo(
   }
 }
 
+/** Return the platform-specific optional package name shipped with Copilot CLI. */
+export function copilotSdkPlatformPackageName(platform, arch) {
+  return `@github/copilot-${platform}-${arch}`;
+}
+
+/**
+ * Resolve the Copilot SDK package and its bundled CLI dependencies from the SDK's own
+ * dependency graph. This avoids relying on the workspace's hoisted or global packages.
+ */
+export function resolveCopilotSdkSources(serverPackageRoot, platform, arch) {
+  const platformPkg = copilotSdkPlatformPackageName(platform, arch);
+  try {
+    const serverRequire = createRequire(resolve(serverPackageRoot, "package.json"));
+    const sdkEntry = serverRequire.resolve("@github/copilot-sdk");
+    const sdkRequire = createRequire(sdkEntry);
+    const copilotPackageDir = realpathSync(resolve(dirname(sdkEntry), "..", "..", "..", "copilot"));
+    const platformEntry = sdkRequire.resolve(platformPkg);
+    const platformPackageDir = realpathSync(dirname(platformEntry));
+    return { platformPkg, copilotPackageDir, platformPackageDir };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `${platformPkg} not installed - run 'bun install' (Copilot SDK dependencies are out of sync): ${detail}`,
+    );
+  }
+}
+
+/** Copy the complete Copilot CLI package tree and target platform package into a server tree. */
+export function copyCopilotSdkToDir({ destServerDir, serverPackageRoot, platform, arch }) {
+  const { platformPkg, copilotPackageDir, platformPackageDir } = resolveCopilotSdkSources(
+    serverPackageRoot,
+    platform,
+    arch,
+  );
+  const githubDir = resolve(destServerDir, "node_modules", "@github");
+  const copilotDst = resolve(githubDir, "copilot");
+  const platformDst = resolve(githubDir, platformPkg.slice("@github/".length));
+  mkdirSync(githubDir, { recursive: true });
+  rmSync(copilotDst, { recursive: true, force: true });
+  rmSync(platformDst, { recursive: true, force: true });
+  cpSync(copilotPackageDir, copilotDst, { recursive: true });
+  cpSync(platformPackageDir, platformDst, { recursive: true });
+  return { platformPkg, copilotDst, platformDst };
+}
+
+/** Stage Copilot's bundled CLI packages beside a bundled `server.cjs` for development. */
+export function copyCopilotSdkNextTo(
+  serverCjsOut,
+  serverPackageRoot,
+  platform = process.platform,
+  arch = process.arch,
+) {
+  return copyCopilotSdkToDir({
+    destServerDir: dirname(serverCjsOut),
+    serverPackageRoot,
+    platform,
+    arch,
+  });
+}
+
+/** Detect a complete staged Copilot package tree beside a bundled server entry. */
+export function findCopilotSdkPath(serverCjsOut, platform, arch) {
+  const serverDir = dirname(serverCjsOut);
+  const platformPkg = copilotSdkPlatformPackageName(platform, arch);
+  const copilotIndex = resolve(serverDir, "node_modules", "@github", "copilot", "index.js");
+  const platformEntry = resolve(
+    serverDir,
+    "node_modules",
+    "@github",
+    platformPkg.slice("@github/".length),
+  );
+  return existsSync(copilotIndex) && existsSync(platformEntry) ? copilotIndex : undefined;
+}
+
 /**
  * Produce `apps/desktop/dist/server/server.cjs` from current server sources.
  *
@@ -328,6 +402,7 @@ export async function rebuildServerDevBundle(options = {}) {
   });
 
   copyClaudeSdkCliNextTo(serverOutFile, serverRoot);
+  copyCopilotSdkNextTo(serverOutFile, serverRoot);
 
   const drizzleSrc = resolve(serverRoot, "drizzle");
   const drizzleDst = resolve(desktopRoot, "dist/server/drizzle");


### PR DESCRIPTION
## What

Expose Mcode's authenticated thread-control MCP to Codex, Cursor, and GitHub Copilot.

## Why

Allow provider prompts to search workspaces and create Mcode tasks while preserving workspace authority, provider lifecycle cleanup, and side-channel isolation.

## Key Changes

- Start bounded loopback MCP sessions and inject them into main provider sessions.
- Isolate provider side channels from thread-control authority.
- Use and package the Copilot CLI version compatible with the bundled SDK.
- Cover authentication, lifecycle, multiplexing, request bounds, and provider wiring with focused tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787932176&installation_model_id=20477&pr_number=1004&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1004&signature=7189053815420cc47bab5aa378a3ab59dc78f737252c1f46d5969f4b8d034254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal thread-control MCP support across Codex, Copilot, and Cursor sessions.
  * Improved session handoffs by using isolated side-channel sessions with conversation context.
  * Added safer session recovery, cleanup, and startup monitoring.
  * Added authenticated connection pooling with request size and timeout protections.

* **Bug Fixes**
  * Improved handling of failed MCP startup, session resume errors, and unavailable provider capabilities.
  * Enhanced diagnostic previews with secret redaction and length limits.

* **Chores**
  * Added Copilot SDK packaging for development and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->