### PR TITLE
feat(web): align subagent details with chat turns

### DIFF
--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -269,6 +269,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 interface MessageBubbleProps {
   /** The message object to render. */
   message: Message;
+  /** Controls whether user-message actions such as copy, reply, or fork are available. */
+  interactive?: boolean;
   /** Called when the user clicks the branch icon on this message. */
   onBranch?: (messageId: string) => void;
   /** Called when the user clicks the reply button on this message. */
@@ -465,6 +467,7 @@ function QuoteBlock({
 /** Renders a single chat message (system, user, or assistant). Memoized to prevent re-renders when the message ref is unchanged. */
 export const MessageBubble = memo(function MessageBubble({
   message,
+  interactive = true,
   onBranch,
   onReply,
   onScrollToMessage,
@@ -623,9 +626,9 @@ export const MessageBubble = memo(function MessageBubble({
                       src={src}
                       name={img.name}
                       single={imageAttachments.length === 1}
-                      onOpenPreview={() =>
-                        setImagePreview({ items: imageSlides, initialIndex: idx })
-                      }
+                      onOpenPreview={interactive
+                        ? () => setImagePreview({ items: imageSlides, initialIndex: idx })
+                        : undefined}
                     />
                   );
                 })}
@@ -671,7 +674,7 @@ export const MessageBubble = memo(function MessageBubble({
 
           <div className="flex flex-col items-end gap-0.5 pr-1">
             <div className="flex items-center gap-1.5">
-              {onReply && <ReplyButton onClick={() => {
+              {interactive && onReply && <ReplyButton onClick={() => {
                 let fallback = "[Attachment]";
                 if (!userDisplayText.trim()) {
                   const firstAtt = message.attachments?.[0];
@@ -683,8 +686,8 @@ export const MessageBubble = memo(function MessageBubble({
                 }
                 onReply(message.id, userDisplayText.trim() || fallback, "user");
               }} />}
-              {onBranch && <BranchButton onClick={() => onBranch(message.id)} />}
-              {userDisplayText.trim() && <CopyButton content={userDisplayText} />}
+              {interactive && onBranch && <BranchButton onClick={() => onBranch(message.id)} />}
+              {interactive && userDisplayText.trim() && <CopyButton content={userDisplayText} />}
             </div>
             <div className="flex items-center gap-2 font-mono text-xs tabular-nums text-muted-foreground/55">
               {userGoal && <GoalReceipt label="Sent as goal" tone="muted" />}

--- a/apps/web/src/components/panels/SubagentsPanel.tsx
+++ b/apps/web/src/components/panels/SubagentsPanel.tsx
@@ -24,8 +24,9 @@ import { useDiffStore, type SubagentRosterTab } from "@/stores/diffStore";
 import { useThreadRecord } from "@/stores/thread-selectors";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { showRightPanelAdaptive } from "@/lib/right-panel-layout";
-import { getTransport } from "@/transport";
+import { getTransport, type Message } from "@/transport";
 import { resolveModelDisplayLabel } from "@/lib/format-model-label";
+import { MessageBubble } from "@/components/chat/MessageBubble";
 import { SubagentChangeSummary } from "./SubagentChangeSummary";
 
 const FINISHED_STATUS: Record<FinishedSubagentStatus, string> = {
@@ -109,6 +110,10 @@ function DetailView({ threadId, row, onBack }: { readonly threadId: string; read
   const status = finished ? FINISHED_STATUS[row.status] : "Running";
   const showLifecycleDot = !finished || row.status !== "completed";
   const duration = formatDuration(row.elapsedSeconds);
+  const metadata = [
+    row.detail.model ? resolveModelDisplayLabel(row.detail.model) : null,
+    row.detail.reasoningEffort ? formatReasoningLevel(row.detail.reasoningEffort) : null,
+  ].filter(Boolean).join(" · ");
   const statusDescription = finished
     ? `${status}, ran for ${duration}`
     : `${status}, ${duration} elapsed`;
@@ -123,6 +128,19 @@ function DetailView({ threadId, row, onBack }: { readonly threadId: string; read
     outputTotalBytes: row.detail.outputTotalBytes,
     outputArtifactPath: row.detail.outputArtifactPath,
   };
+  const taskMessage = useMemo<Message>(() => ({
+    id: `subagent-task-${row.id}`,
+    thread_id: threadId,
+    role: "user",
+    content: row.task,
+    tool_calls: null,
+    files_changed: null,
+    cost_usd: null,
+    tokens_used: null,
+    timestamp: new Date(row.startedAt).toISOString(),
+    sequence: 0,
+    attachments: null,
+  }), [row.id, row.startedAt, row.task, threadId]);
   const handleViewAllDiffs = useCallback((paths: readonly string[], additions: number, deletions: number) => {
     const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
     if (!workspaceId) return;
@@ -152,23 +170,30 @@ function DetailView({ threadId, row, onBack }: { readonly threadId: string; read
             size={15}
           />
           <h2 className="min-w-0 flex-1 truncate text-sm font-semibold">{row.identity}</h2>
-          <span
-            role="group"
-            aria-label={statusDescription}
-            className="flex shrink-0 items-center gap-2"
-          >
-            {showLifecycleDot && (
-              <SubagentLifecycleStatus
-                label=""
-                tone={finished ? FINISHED_TONE[row.status] : "running"}
-              />
+          <div className="flex min-w-0 shrink-0 items-center gap-2">
+            {metadata && (
+              <span
+                data-testid="subagent-header-metadata"
+                className="min-w-0 max-w-40 truncate font-mono text-xs tabular-nums text-muted-foreground"
+                title={metadata}
+              >
+                {metadata}
+              </span>
             )}
-            <time aria-hidden className="font-mono text-xs tabular-nums text-muted-foreground">{duration}</time>
-          </span>
+            <span role="group" aria-label={statusDescription} className="flex shrink-0 items-center gap-2">
+              {showLifecycleDot && (
+                <SubagentLifecycleStatus
+                  label=""
+                  tone={finished ? FINISHED_TONE[row.status] : "running"}
+                />
+              )}
+            </span>
+          </div>
         </div>
       </header>
       <ScrollArea className="min-h-0 flex-1">
         <div className={`${PRIMARY_CONTENT_RAIL_CLASS} px-6 py-8 sm:px-10`}>
+          <MessageBubble message={taskMessage} interactive={false} />
           {row.detail.transcript.length > 0 && (
             <NarrativeFlow
               toolCalls={row.detail.transcript}
@@ -197,17 +222,6 @@ function DetailView({ threadId, row, onBack }: { readonly threadId: string; read
           {row.detail.transcript.length === 0 && !row.detail.output && (
             <p role="status" className="text-sm text-muted-foreground">
               {finished ? FINISHED_STATUS[row.status] : "Working"}
-            </p>
-          )}
-          {(row.detail.model || row.detail.reasoningEffort) && (
-            <p
-              data-testid="subagent-response-byline"
-              className="mt-3 text-right font-mono text-xs tabular-nums text-muted-foreground/55"
-            >
-              {[
-                row.detail.model ? resolveModelDisplayLabel(row.detail.model) : null,
-                row.detail.reasoningEffort ? formatReasoningLevel(row.detail.reasoningEffort) : null,
-              ].filter(Boolean).join(" · ")}
             </p>
           )}
           <TurnFooter

--- a/apps/web/src/components/panels/__tests__/SubagentsPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/SubagentsPanel.test.tsx
@@ -14,9 +14,14 @@ const state = vi.hoisted(() => ({
 }));
 
 vi.mock("@/stores/thread-selectors", () => ({
-  useThreadRecord: (threadId: string, selector: (record: unknown) => unknown) => selector(
-    state.records[threadId] ?? { toolCalls: [], narrativeByMessage: {} },
-  ),
+  useThreadRecord: (threadId: string, selector: (record: unknown) => unknown) => selector({
+    answeredPlanMessageIds: new Set(),
+    ...(state.records[threadId] ?? { toolCalls: [], narrativeByMessage: {} }),
+  }),
+}));
+
+vi.mock("../../chat/MarkdownContent", () => ({
+  default: ({ content }: { content: string }) => <span>{content}</span>,
 }));
 
 import { SubagentsPanel } from "../SubagentsPanel";
@@ -147,7 +152,8 @@ describe("SubagentsPanel", () => {
     const row = screen.getByRole("button", { name: /Open Implementation worker details/ });
     fireEvent.click(row);
     expect(screen.getByRole("region", { name: /Implementation worker subagent details/ })).toBeInTheDocument();
-    expect(screen.queryByText("Build the roster")).not.toBeInTheDocument();
+    const callerTask = await screen.findByText("Build the roster");
+    expect(callerTask.closest("[data-message-role='user']")).toBeInTheDocument();
     expect(screen.queryByText("Delegated task")).not.toBeInTheDocument();
     expect(screen.queryByText("Activity")).not.toBeInTheDocument();
     expect(screen.queryByText("Result")).not.toBeInTheDocument();
@@ -156,6 +162,10 @@ describe("SubagentsPanel", () => {
     expect(screen.queryByTestId("subagent-lifecycle-dot")).not.toBeInTheDocument();
     expect(screen.getByText("**Done**")).toBeInTheDocument();
     expect(screen.getByTestId("subagent-response-text")).toHaveClass("text-sm", "text-foreground");
+    expect(screen.queryByRole("button", { name: "Reply to this message" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Fork from this message" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy message" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Back to subagents" }));
     await waitFor(() => {
@@ -189,8 +199,9 @@ describe("SubagentsPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: /Open Implementation worker details/ }));
 
     expect(screen.getByRole("group", { name: /Running, \d+s elapsed/ })).toBeInTheDocument();
-    expect(screen.getByTestId("subagent-response-byline")).toHaveTextContent("GPT-5.6 Sol · High");
+    expect(screen.getByTestId("subagent-header-metadata")).toHaveTextContent("GPT-5.6 Sol · High");
     expect(screen.queryByTestId("subagent-response-text")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("subagent-response-byline")).not.toBeInTheDocument();
   });
 
   it("shows explicit metadata, exact footer counts, and opens attributed workspace diffs", () => {
@@ -229,12 +240,13 @@ describe("SubagentsPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: /Open Implementation worker details/ }));
 
     const response = screen.getByTestId("subagent-response-text");
-    const byline = screen.getByTestId("subagent-response-byline");
+    const headerMetadata = screen.getByTestId("subagent-header-metadata");
     const footer = screen.getByText("1 step").closest("div")!;
-    expect(byline).toHaveTextContent("GPT-5.6 Sol · High");
-    expect(byline).toHaveClass("text-right", "font-mono", "tabular-nums");
-    expect(response.compareDocumentPosition(byline) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(byline.compareDocumentPosition(footer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(headerMetadata).toHaveTextContent("GPT-5.6 Sol · High");
+    expect(headerMetadata.compareDocumentPosition(response) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.queryByTestId("subagent-response-byline")).not.toBeInTheDocument();
+    expect(screen.getByText("7.0s")).toBeInTheDocument();
+    expect(footer).toContainElement(screen.getByText("7.0s"));
     expect(screen.getByText("1 step")).toBeInTheDocument();
     expect(screen.getByText("1 file changed")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "View all diffs" }));

--- a/apps/web/src/components/subagents/__tests__/subagent-projection.test.ts
+++ b/apps/web/src/components/subagents/__tests__/subagent-projection.test.ts
@@ -288,6 +288,7 @@ describe("projectSubagents", () => {
     expect(roster.finished).toEqual([expect.objectContaining({
       id: "latest",
       memberCallIds: ["first", "latest"],
+      startedAt: Date.parse("2026-07-22T10:00:00.000Z"),
       detail: expect.objectContaining({
         output: "Latest result",
         subtreeIds: ["first", "first-child", "latest", "latest-child"],
@@ -324,6 +325,7 @@ describe("projectSubagents", () => {
         identity: "Security reviewer",
         hasExplicitIdentity: true,
         task: "Review auth changes",
+        startedAt: 1_000,
         activity: "Read file: auth.ts",
         activityAt: 8_000,
         elapsedSeconds: 10,

--- a/apps/web/src/components/subagents/subagent-projection.ts
+++ b/apps/web/src/components/subagents/subagent-projection.ts
@@ -67,6 +67,8 @@ interface SubagentRow {
   readonly hasExplicitIdentity: boolean;
   /** Stable delegated-task description. */
   readonly task: string;
+  /** Epoch milliseconds when the delegated Agent started. */
+  readonly startedAt: number;
   /** Latest provider-supplied activity or terminal result summary. */
   readonly activity: string;
   /** Epoch milliseconds for stable row ordering. */
@@ -308,6 +310,7 @@ export function projectSubagents(
           providerAgentKey,
           ...subagentIdentity(agent),
           task: boundedDisplayText(extractSubagentDescription(agent), MAX_TASK_LENGTH),
+          startedAt,
           activity: latestActivity,
           activityAt: activityTimestamp(latestCall),
           elapsedSeconds: Math.max(0, Math.floor(agent.elapsedSeconds ?? (now - startedAt) / 1_000)),
@@ -326,6 +329,7 @@ export function projectSubagents(
         providerAgentKey,
         ...subagentIdentity(agent),
         task: boundedDisplayText(extractSubagentDescription(agent), MAX_TASK_LENGTH),
+        startedAt,
         activity: terminalLiveActivity(agent, latestActivity),
         activityAt: completedAt,
         elapsedSeconds: Math.max(0, Math.floor(agent.elapsedSeconds ?? (agent.durationMs ?? completedAt - startedAt) / 1_000)),
@@ -392,6 +396,7 @@ export function projectSubagents(
         providerAgentKey: nonEmptyString(record.provider_agent_key),
         ...hydratedIdentity(record),
         task,
+        startedAt,
         activity: boundedDisplayText(nonEmptyString(record.output_summary) ?? task, MAX_ACTIVITY_LENGTH),
         activityAt: record.status === "running" ? startedAt : completedAt,
         elapsedSeconds: elapsedSeconds(startedAt, record.status === "running" ? now : completedAt),
@@ -473,6 +478,7 @@ export function projectSubagents(
       identity: representative.row.identity,
       hasExplicitIdentity: representative.row.hasExplicitIdentity,
       task: representative.row.task,
+      startedAt: representative.row.startedAt,
       activity: representative.row.activity,
       activityAt: representative.row.activityAt,
       elapsedSeconds: members.reduce((total, { row }) => total + row.elapsedSeconds, 0),


### PR DESCRIPTION
## What
Make the sub-agent detail view follow the chat turn presentation while remaining read-only.

## Why
Sub-agent details used a separate layout that duplicated timing metadata and omitted the caller task from the conversation flow.

## Key Changes
- Render the caller task with the shared user-message component and disable message actions.
- Keep sub-agent steps and duration in the turn footer.
- Show model and reasoning metadata in the detail header.
- Preserve the delegated agent start time for accurate message timestamps.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787936111&installation_model_id=20477&pr_number=1005&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1005&signature=8fe841f6491de4f1ce0a38515a86382bc05bdea23e57b4fbea177665f66ffa87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subagent header metadata showing the selected model and reasoning level.
  * Added start-time tracking for subagent activity and grouped subagent rows.
  * Added support for non-interactive message displays, hiding reply, branch, copy, and image-preview actions when disabled.

* **UI Improvements**
  * Simplified subagent detail layouts by removing redundant response bylines.
  * Improved status and elapsed-time presentation in subagent details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->