### PR TITLE
feat: make thread switching responsive

### DIFF
--- a/apps/server/src/services/__tests__/conversation-page.test.ts
+++ b/apps/server/src/services/__tests__/conversation-page.test.ts
@@ -8,7 +8,7 @@ import { ThoughtSegmentRepo } from "../../repositories/thought-segment-repo";
 import { HookExecutionRepo } from "../../repositories/hook-execution-repo";
 import { PlanQuestionAnswersRepo } from "../../repositories/plan-question-answers-repo";
 import { NarrativeStore } from "../narrative-store";
-import { loadConversationPage } from "../conversation-page";
+import { loadConversationPage, loadConversationTail } from "../conversation-page";
 
 function seedThread(db: Database.Database): void {
   const now = new Date().toISOString();
@@ -140,5 +140,35 @@ describe("loadConversationPage", () => {
     expect(page.messages.map((m) => m.sequence)).toEqual([3, 4]);
     expect(page.hasMore).toBe(true);
     expect(page.narrativeByMessage.m4).toEqual({ tools: [], thoughts: [], hooks: [] });
+  });
+});
+
+describe("loadConversationTail", () => {
+  it("returns the newest visible messages and bypasses narrative and plan queries", () => {
+    const db = openMemoryDatabase();
+    seedThread(db);
+    insertMessage(db, "u1", "user", "start", 1);
+    insertMessage(db, "a1", "assistant", "answer", 2);
+    insertMessage(db, "internal", "assistant", "hidden", 3, true);
+    insertMessage(db, "u2", "user", "latest", 4);
+    const deps = createDeps(db);
+    const narrativeSpy = vi.spyOn(deps.narrativeStore, "loadForMessages");
+    const planSpy = vi.spyOn(deps.planQuestionAnswersRepo, "listAnsweredForThread");
+
+    const tail = loadConversationTail(deps, {
+      threadId: "thread-1",
+      limit: 2,
+    });
+
+    expect(tail).toEqual({
+      messages: [
+        expect.objectContaining({ id: "a1", sequence: 2 }),
+        expect.objectContaining({ id: "u2", sequence: 4 }),
+      ],
+      hasMore: true,
+      nextBefore: 2,
+    });
+    expect(narrativeSpy).not.toHaveBeenCalled();
+    expect(planSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/services/conversation-page.ts
+++ b/apps/server/src/services/conversation-page.ts
@@ -1,8 +1,10 @@
 import type {
   ConversationNarrativeBatch,
   ConversationPage,
+  ConversationTail,
   NarrativeEntry,
 } from "@mcode/contracts";
+import { CONVERSATION_TAIL_MAX_MESSAGES } from "@mcode/contracts";
 import type { MessageRepo } from "../repositories/message-repo.js";
 import type { NarrativeStore } from "./narrative-store.js";
 import type { PlanQuestionAnswersRepo } from "../repositories/plan-question-answers-repo.js";
@@ -12,6 +14,11 @@ export interface ConversationPageDeps {
   messageRepo: MessageRepo;
   narrativeStore: NarrativeStore;
   planQuestionAnswersRepo: PlanQuestionAnswersRepo;
+}
+
+/** Dependencies needed to load a bounded conversation tail. */
+export interface ConversationTailDeps {
+  messageRepo: MessageRepo;
 }
 
 /** Groups flat narrative entries into the legacy per-message payload shape. */
@@ -61,5 +68,31 @@ export function loadConversationPage(
     answeredPlanMessageIds:
       deps.planQuestionAnswersRepo.listAnsweredForThread(input.threadId),
     narrativeByMessage: groupNarrativeEntriesByMessage(entries),
+  };
+}
+
+/** Loads the newest visible messages without narrative or plan-answer queries. */
+export function loadConversationTail(
+  deps: ConversationTailDeps,
+  input: { threadId: string; limit: number },
+): ConversationTail {
+  const page = deps.messageRepo.listByThread(
+    input.threadId,
+    Math.min(CONVERSATION_TAIL_MAX_MESSAGES, input.limit),
+  );
+  const messages = page.messages.map((message) => ({
+    id: message.id,
+    thread_id: message.thread_id,
+    role: message.role,
+    content: message.content,
+    timestamp: message.timestamp,
+    sequence: message.sequence,
+  }));
+  return {
+    messages,
+    hasMore: page.hasMore,
+    ...(page.hasMore && messages.length > 0
+      ? { nextBefore: messages[0].sequence }
+      : {}),
   };
 }

--- a/apps/server/src/transport/push.test.ts
+++ b/apps/server/src/transport/push.test.ts
@@ -4,6 +4,7 @@ import {
   addClient,
   broadcast,
   broadcastTerminalData,
+  setClientThreadSubscriptions,
   subscribeClientToThread,
   unsubscribeClientFromThread,
   _resetForTest,
@@ -129,6 +130,45 @@ describe("broadcast", () => {
       type: "textDelta",
       threadId: "thread-a",
       delta: "hello",
+    });
+
+    expect(received).toHaveLength(0);
+  });
+
+  it("atomically replaces all thread subscriptions", () => {
+    const received: Array<{ buf: Buffer; binary: boolean }> = [];
+    const ws = fakeOpenSocket(received);
+    addClient(ws);
+    subscribeClientToThread(ws, "thread-old");
+
+    setClientThreadSubscriptions(ws, ["thread-new"]);
+
+    broadcast("agent.event", {
+      type: "textDelta",
+      threadId: "thread-old",
+      delta: "old",
+    });
+    broadcast("agent.event", {
+      type: "textDelta",
+      threadId: "thread-new",
+      delta: "new",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(JSON.parse(received[0].buf.toString("utf-8")).data.threadId).toBe("thread-new");
+  });
+
+  it("clears all thread subscriptions when replacing with an empty set", () => {
+    const received: Array<{ buf: Buffer; binary: boolean }> = [];
+    const ws = fakeOpenSocket(received);
+    addClient(ws);
+    subscribeClientToThread(ws, "thread-a");
+
+    setClientThreadSubscriptions(ws, []);
+    broadcast("agent.event", {
+      type: "textDelta",
+      threadId: "thread-a",
+      delta: "ignored",
     });
 
     expect(received).toHaveLength(0);

--- a/apps/server/src/transport/push.ts
+++ b/apps/server/src/transport/push.ts
@@ -71,6 +71,15 @@ export function unsubscribeClientFromThread(ws: WebSocket, threadId: string): vo
   threadSubscriptions.get(ws)?.delete(threadId);
 }
 
+/** Atomically replace a connected client's complete desired subscription set. */
+export function setClientThreadSubscriptions(
+  ws: WebSocket,
+  threadIds: readonly string[],
+): void {
+  if (!clients.has(ws)) return;
+  threadSubscriptions.set(ws, new Set(threadIds));
+}
+
 /** Get the current number of connected clients. */
 export function clientCount(): number {
   return clients.size;

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -59,7 +59,12 @@ import type { ThreadRepo } from "../repositories/thread-repo";
 import type { WorkspaceRepo } from "../repositories/workspace-repo";
 import type { WorkspaceEnricher } from "../services/workspace-enricher";
 import type { FilesystemBrowser } from "../services/filesystem-browser";
-import { broadcast, subscribeClientToThread, unsubscribeClientFromThread } from "./push";
+import {
+  broadcast,
+  setClientThreadSubscriptions,
+  subscribeClientToThread,
+  unsubscribeClientFromThread,
+} from "./push";
 import { getTransportPayloadValidator } from "./payload-validation.js";
 import {
   ProviderCliMissingError,
@@ -92,7 +97,7 @@ import type { ModelCacheService } from "../services/model-cache-service.js";
 import type { DiffSummaryService } from "../services/diff-summary-service.js";
 import type { RecapService } from "../services/recap-service.js";
 import type { HandoffStorage } from "../services/handoff/handoff-storage.js";
-import { loadConversationPage } from "../services/conversation-page.js";
+import { loadConversationPage, loadConversationTail } from "../services/conversation-page.js";
 import type { ThreadTeardownService } from "../services/thread-teardown-service.js";
 import type { PullRequestService } from "../services/pull-requests/pull-request-service.js";
 import type { PullRequestMutationService } from "../services/pull-requests/pull-request-mutation-service.js";
@@ -423,6 +428,11 @@ async function dispatch(
     case "push.unsubscribeThread":
       if (context.client) {
         unsubscribeClientFromThread(context.client, params.threadId);
+      }
+      return;
+    case "push.setThreadSubscriptions":
+      if (context.client) {
+        setClientThreadSubscriptions(context.client, params.threadIds);
       }
       return;
 
@@ -851,6 +861,11 @@ async function dispatch(
         threadId: params.threadId,
         limit: params.limit,
         before: params.before,
+      });
+    case "conversation.tail":
+      return loadConversationTail(deps, {
+        threadId: params.threadId,
+        limit: params.limit,
       });
 
     // Files

--- a/apps/web/src/__tests__/prefetch.test.ts
+++ b/apps/web/src/__tests__/prefetch.test.ts
@@ -165,4 +165,43 @@ describe("prefetch", () => {
     expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
     expect(mockTransport.loadConversationPage).toHaveBeenCalledWith("t3", 100);
   });
+
+  it("keeps rapid unique pointer prefetches within two shared slots", async () => {
+    const resolvers = new Map<string, (value: {
+      messages: ReturnType<typeof createMockMessage>[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void>();
+    vi.mocked(mockTransport.loadConversationPage).mockImplementation(
+      (threadId) =>
+        new Promise((resolve) => {
+          resolvers.set(threadId, resolve);
+        }),
+    );
+
+    prefetchOnPointerDown("t1");
+    prefetchOnPointerDown("t2");
+    prefetchOnPointerDown("t3");
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(2);
+
+    const page = (threadId: string) => ({
+      messages: [
+        createMockMessage({
+          id: `${threadId}-message`,
+          thread_id: threadId,
+          sequence: 1,
+        }),
+      ],
+      hasMore: false,
+      narrativeByMessage: {},
+    });
+    resolvers.get("t1")?.(page("t1"));
+    await vi.runAllTimersAsync();
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(3);
+
+    resolvers.get("t2")?.(page("t2"));
+    resolvers.get("t3")?.(page("t3"));
+    await vi.runAllTimersAsync();
+  });
 });

--- a/apps/web/src/__tests__/prefetch.test.ts
+++ b/apps/web/src/__tests__/prefetch.test.ts
@@ -33,6 +33,7 @@ function cacheRecord(threadId: string, record: ThreadRecord): void {
 describe("prefetch", () => {
   let schedulePrefetch: typeof import("@/lib/thread-hydrator/prefetch-scheduler").schedulePrefetch;
   let cancelPrefetch: typeof import("@/lib/thread-hydrator/prefetch-scheduler").cancelPrefetch;
+  let prefetchOnPointerDown: typeof import("@/lib/thread-hydrator/prefetch-scheduler").prefetchOnPointerDown;
   let resetPrefetch: typeof import("@/lib/thread-hydrator/prefetch-scheduler").__resetPrefetchForTests;
 
   beforeEach(async () => {
@@ -55,6 +56,7 @@ describe("prefetch", () => {
     const mod = await import("@/lib/thread-hydrator/prefetch-scheduler");
     schedulePrefetch = mod.schedulePrefetch;
     cancelPrefetch = mod.cancelPrefetch;
+    prefetchOnPointerDown = mod.prefetchOnPointerDown;
     resetPrefetch = mod.__resetPrefetchForTests;
   });
 
@@ -63,14 +65,14 @@ describe("prefetch", () => {
     vi.useRealTimers();
   });
 
-  it("fires prefetch after 150ms debounce", async () => {
+  it("fires prefetch after 50ms debounce", async () => {
     schedulePrefetch("t1");
 
     // Not yet fired
     expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
 
     // Advance past debounce
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(50);
     expect(mockTransport.loadConversationPage).toHaveBeenCalledWith("t1", 100);
     expect(mockTransport.getMessages).not.toHaveBeenCalled();
 
@@ -83,7 +85,7 @@ describe("prefetch", () => {
     schedulePrefetch("t1");
     cancelPrefetch();
 
-    vi.advanceTimersByTime(200);
+    vi.advanceTimersByTime(100);
     expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
   });
 
@@ -91,7 +93,7 @@ describe("prefetch", () => {
     cacheRecord("t1", makeRecord("t1"));
 
     schedulePrefetch("t1");
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(50);
 
     expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
   });
@@ -105,12 +107,12 @@ describe("prefetch", () => {
     );
 
     schedulePrefetch("t1");
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(50);
     expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
 
     // Schedule a second prefetch for the same thread while the first is in flight
     schedulePrefetch("t1");
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(50);
     // Should not fire a second RPC
     expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
 
@@ -129,7 +131,7 @@ describe("prefetch", () => {
     );
 
     schedulePrefetch("t1");
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(50);
 
     // Should not throw; the error is swallowed
     await vi.runAllTimersAsync();
@@ -138,15 +140,28 @@ describe("prefetch", () => {
     expect(getCachedRecord("t1")).toBeUndefined();
   });
 
+  it("prefetches immediately on pointer-down and cancels pending hover work", () => {
+    schedulePrefetch("t1");
+    vi.advanceTimersByTime(25);
+
+    prefetchOnPointerDown("t1");
+
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith("t1", 100);
+
+    vi.advanceTimersByTime(100);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+  });
+
   it("debounces rapid successive calls", () => {
     schedulePrefetch("t1");
-    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(20);
     schedulePrefetch("t2");
-    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(20);
     schedulePrefetch("t3");
 
     // Only the last one should fire after full debounce
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(50);
     expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
     expect(mockTransport.loadConversationPage).toHaveBeenCalledWith("t3", 100);
   });

--- a/apps/web/src/__tests__/thread-switching.test.ts
+++ b/apps/web/src/__tests__/thread-switching.test.ts
@@ -31,7 +31,7 @@ describe("Thread Switching", () => {
     vi.clearAllMocks();
   });
 
-  it("clears stale messages immediately when switching to a non-running thread", async () => {
+  it("keeps outgoing messages out of the target while switching to a non-running thread", async () => {
     // Arrange: Thread A has messages loaded
     const threadAMsg = createMockMessage({
       id: "a-1",
@@ -63,7 +63,7 @@ describe("Thread Switching", () => {
     // Act: switch to Thread B (don't await yet)
 const loadPromise = activateTestConversation("thread-b");
 
-    // Assert: messages cleared synchronously BEFORE fetch resolves
+    // Assert: target record owns the surface; outgoing messages never leak.
     const midState = useThreadStore.getState();
     expect(midState.currentThreadId).toBe("thread-b");
     expect(getTestActiveMessages()).toEqual([]);
@@ -84,7 +84,7 @@ const loadPromise = activateTestConversation("thread-b");
     expect(getTestActiveLoading()).toBe(false);
   });
 
-  it("clears stale messages immediately when switching to a running thread", async () => {
+  it("keeps outgoing messages out of the target while switching to a running thread", async () => {
     // Arrange: Thread A has messages, Thread B has a running agent
     const threadAMsg = createMockMessage({
       id: "a-1",
@@ -116,7 +116,7 @@ const loadPromise = activateTestConversation("thread-b");
     // Act: switch to running Thread B
     const loadPromise = activateTestConversation("thread-b");
 
-    // Assert: messages cleared even for a running thread
+    // Assert: target record owns the surface; outgoing messages never leak.
     const midState = useThreadStore.getState();
     expect(midState.currentThreadId).toBe("thread-b");
     expect(getTestActiveMessages()).toEqual([]);

--- a/apps/web/src/__tests__/threadStore-equality-guards.test.ts
+++ b/apps/web/src/__tests__/threadStore-equality-guards.test.ts
@@ -15,7 +15,11 @@ import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-reco
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useTaskStore } from "@/stores/taskStore";
-import { clearRecordCache, getCachedRecord } from "@/lib/thread-hydrator/record-cache";
+import {
+  cacheRecord,
+  clearRecordCache,
+  getCachedRecord,
+} from "@/lib/thread-hydrator/record-cache";
 import { mockTransport, createMockMessage } from "./mocks/transport";
 
 vi.mock("@/transport", async () => ({
@@ -96,6 +100,13 @@ function resetState() {
   });
 
   useTaskStore.setState({ tasksByThread: {} });
+}
+
+/** Age the cache-owned freshness marker so cache-hit equality guards run their RPC handlers. */
+function ageCachedHydration(): void {
+  const cached = getCachedRecord(THREAD_ID);
+  expect(cached).toBeDefined();
+  cacheRecord(THREAD_ID, { ...cached!, lastHydratedAt: Date.now() - 5000 });
 }
 
 // ---------------------------------------------------------------------------
@@ -253,10 +264,8 @@ describe("loadMessages (cache-hit) - listPendingPermissions equality guard", () 
       expect(getCachedRecord(THREAD_ID)).toBeDefined();
     });
     // Switch away so that the next call to loadMessages(THREAD_ID) hits the cache.
-    // Clear `lastHydratedByThread` so the cache-hit staleness gate does not skip
-    // the side-effect refresh under test - these tests exercise the equality
-    // guards inside the RPC handlers, not the gate itself.
     resetThreadStoreForTests({ currentThreadId: "other-thread" });
+    ageCachedHydration();
     vi.clearAllMocks();
     // Re-set mock defaults so the cache-hit refresh calls are controlled.
     (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([]);
@@ -335,8 +344,8 @@ describe("loadMessages (cache-hit) - getThreadTasks equality guard", () => {
     await vi.waitFor(() => {
       expect(getCachedRecord(THREAD_ID)).toBeDefined();
     });
-    // See note in the sibling warmCache about clearing `lastHydratedByThread`.
     resetThreadStoreForTests({ currentThreadId: "other-thread" });
+    ageCachedHydration();
     vi.clearAllMocks();
     (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   }

--- a/apps/web/src/__tests__/threadStore-skip-rpc.test.ts
+++ b/apps/web/src/__tests__/threadStore-skip-rpc.test.ts
@@ -9,7 +9,11 @@ import { createEmptyThreadRecord, type ThreadRecord } from "@/stores/thread-reco
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useThreadStore, MESSAGE_FETCH_SIZE } from "@/stores/threadStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { clearRecordCache } from "@/lib/thread-hydrator/record-cache";
+import {
+  cacheRecord,
+  clearRecordCache,
+  getCachedRecord,
+} from "@/lib/thread-hydrator/record-cache";
 import { mockTransport, createMockMessage, createMockThread } from "./mocks/transport";
 
 vi.mock("@/transport", async () => ({
@@ -144,6 +148,9 @@ describe("loadMessages (cache-hit) - hydration staleness gate", () => {
         [THREAD_ID, { ...createEmptyThreadRecord(), lastHydratedAt: Date.now() - 5000 }],
       ]),
     });
+    const cached = getCachedRecord(THREAD_ID);
+    expect(cached).toBeDefined();
+    cacheRecord(THREAD_ID, { ...cached!, lastHydratedAt: Date.now() - 5000 });
     vi.clearAllMocks();
 
     await activateTestConversation(THREAD_ID);

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -10,11 +10,13 @@ const {
   chatViewWorkspaceMockRef,
   chatViewThreadMockRef,
   chatViewConnectionStatusRef,
+  chatViewGetTransportMock,
   chatViewTransportMock,
 } = vi.hoisted(() => ({
   chatViewWorkspaceMockRef: { current: null as Record<string, unknown> | null },
   chatViewThreadMockRef: { current: null as Record<string, unknown> | null },
   chatViewConnectionStatusRef: { current: "connected" as "connected" | "reconnecting" | "authFailed" },
+  chatViewGetTransportMock: vi.fn(),
   chatViewTransportMock: {
     subscribeThread: vi.fn(),
     unsubscribeThread: vi.fn(),
@@ -78,7 +80,7 @@ vi.mock("@/stores/composerDraftStore", () => ({
 }));
 
 vi.mock("@/transport", () => ({
-  getTransport: () => chatViewTransportMock,
+  getTransport: chatViewGetTransportMock,
 }));
 
 // Composer and MessageList have deep dependencies; stub them out.
@@ -167,7 +169,7 @@ function defaultWorkspaceState(overrides: Partial<{
   return {
     workspaces: [WORKSPACE],
     activeWorkspaceId: "ws-1",
-    activeThreadId: overrides.activeThreadId ?? thread.id,
+    activeThreadId: overrides.activeThreadId !== undefined ? overrides.activeThreadId : thread.id,
     pendingNewThread: false,
     threads: overrides.threads ?? [thread],
     loadWorkspaces: vi.fn(),
@@ -244,6 +246,8 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     chatViewTransportMock.unsubscribeThread.mockResolvedValue(undefined);
     chatViewTransportMock.subscribeThread.mockClear();
     chatViewTransportMock.unsubscribeThread.mockClear();
+    chatViewGetTransportMock.mockReset();
+    chatViewGetTransportMock.mockReturnValue(chatViewTransportMock);
     disableAtomicSubscriptionTransport();
     setupWorkspaceMock(defaultWorkspaceState());
     chatViewThreadMockRef.current = defaultThreadState();
@@ -666,5 +670,16 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
       expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
       expect(setThreadSubscriptions).toHaveBeenLastCalledWith({ threadIds: ["thread-1"] });
     });
+  });
+
+  it("does not resolve transport while unmounting without subscriptions", () => {
+    chatViewConnectionStatusRef.current = "reconnecting";
+    setupWorkspaceMock({ ...defaultWorkspaceState(), activeThreadId: null, threads: [] });
+    chatViewThreadMockRef.current = defaultThreadState();
+
+    const { unmount } = render(<ChatView />);
+    unmount();
+
+    expect(chatViewGetTransportMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -6,12 +6,19 @@ import type { Thread } from "@/transport/types";
 // Store mocks must be declared before importing the component under test.
 
 /** Holds the store snapshot backing both the hook selector and `getState()` (real Zustand API). */
-const { chatViewWorkspaceMockRef, chatViewThreadMockRef, chatViewTransportMock } = vi.hoisted(() => ({
+const {
+  chatViewWorkspaceMockRef,
+  chatViewThreadMockRef,
+  chatViewConnectionStatusRef,
+  chatViewTransportMock,
+} = vi.hoisted(() => ({
   chatViewWorkspaceMockRef: { current: null as Record<string, unknown> | null },
   chatViewThreadMockRef: { current: null as Record<string, unknown> | null },
+  chatViewConnectionStatusRef: { current: "connected" as "connected" | "reconnecting" | "authFailed" },
   chatViewTransportMock: {
     subscribeThread: vi.fn(),
     unsubscribeThread: vi.fn(),
+    setThreadSubscriptions: vi.fn(),
   },
 }));
 
@@ -47,7 +54,7 @@ vi.mock("@/stores/threadStore", () => ({
 
 vi.mock("@/stores/connectionStore", () => ({
   useConnectionStore: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ status: "connected" }),
+    selector({ status: chatViewConnectionStatusRef.current }),
   ),
 }));
 
@@ -192,6 +199,26 @@ function setupWorkspaceMock(state: ReturnType<typeof defaultWorkspaceState>) {
   );
 }
 
+/** Keep the legacy per-thread transport path covered by the existing tests. */
+function disableAtomicSubscriptionTransport() {
+  Object.defineProperty(chatViewTransportMock, "setThreadSubscriptions", {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  });
+}
+
+/** Enable the atomic transport path and return its caller-boundary spy. */
+function enableAtomicSubscriptionTransport() {
+  const setThreadSubscriptions = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(chatViewTransportMock, "setThreadSubscriptions", {
+    configurable: true,
+    writable: true,
+    value: setThreadSubscriptions,
+  });
+  return setThreadSubscriptions;
+}
+
 /** Produces the thread-store fields consumed by ChatView. */
 function defaultThreadState(overrides: Partial<{
   currentThreadId: string | null;
@@ -212,10 +239,12 @@ function defaultThreadState(overrides: Partial<{
 
 describe("ChatView - Thread Title Double-Click Rename", () => {
   beforeEach(() => {
+    chatViewConnectionStatusRef.current = "connected";
     chatViewTransportMock.subscribeThread.mockResolvedValue(undefined);
     chatViewTransportMock.unsubscribeThread.mockResolvedValue(undefined);
     chatViewTransportMock.subscribeThread.mockClear();
     chatViewTransportMock.unsubscribeThread.mockClear();
+    disableAtomicSubscriptionTransport();
     setupWorkspaceMock(defaultWorkspaceState());
     chatViewThreadMockRef.current = defaultThreadState();
   });
@@ -455,5 +484,98 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
       expect(chatViewTransportMock.unsubscribeThread).toHaveBeenCalledTimes(2);
       expect(chatViewTransportMock.unsubscribeThread).toHaveBeenLastCalledWith(thread1.id);
     }, { timeout: 3000 });
+  });
+
+  it("replaces the full active and running thread set through the atomic transport", async () => {
+    const setThreadSubscriptions = enableAtomicSubscriptionTransport();
+    const thread1 = makeThread({ id: "thread-1", title: "Thread 1" });
+    const thread2 = makeThread({ id: "thread-2", title: "Thread 2", status: "active" });
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread1.id,
+      threads: [thread1, thread2],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread1.id,
+      runningThreadIds: new Set([thread2.id]),
+    });
+
+    const { rerender } = render(<ChatView />);
+
+    await waitFor(() => {
+      expect(setThreadSubscriptions).toHaveBeenCalledWith({ threadIds: ["thread-1", "thread-2"] });
+    });
+    expect(chatViewTransportMock.subscribeThread).not.toHaveBeenCalled();
+    expect(chatViewTransportMock.unsubscribeThread).not.toHaveBeenCalled();
+
+    chatViewThreadMockRef.current = defaultThreadState({ currentThreadId: thread1.id });
+    rerender(<ChatView />);
+
+    await waitFor(() => {
+      expect(setThreadSubscriptions).toHaveBeenCalledWith({ threadIds: ["thread-1"] });
+    });
+    expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces repeated reconciliation while an atomic request is pending", async () => {
+    const requestResolvers: Array<() => void> = [];
+    const setThreadSubscriptions = vi.fn(() => new Promise<void>((resolve) => {
+      requestResolvers.push(resolve);
+    }));
+    Object.defineProperty(chatViewTransportMock, "setThreadSubscriptions", {
+      configurable: true,
+      writable: true,
+      value: setThreadSubscriptions,
+    });
+    const { rerender } = render(<ChatView />);
+
+    await waitFor(() => {
+      expect(setThreadSubscriptions).toHaveBeenCalledTimes(1);
+    });
+
+    chatViewThreadMockRef.current = defaultThreadState();
+    rerender(<ChatView />);
+    chatViewThreadMockRef.current = defaultThreadState();
+    rerender(<ChatView />);
+
+    expect(setThreadSubscriptions).toHaveBeenCalledTimes(1);
+    requestResolvers[0]?.();
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(1));
+  });
+
+  it("retries a failed atomic replacement at the caller boundary", async () => {
+    const setThreadSubscriptions = enableAtomicSubscriptionTransport();
+    setThreadSubscriptions
+      .mockRejectedValueOnce(new Error("temporary atomic subscribe failure"))
+      .mockResolvedValue(undefined);
+
+    render(<ChatView />);
+
+    await waitFor(() => {
+      expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
+      expect(setThreadSubscriptions).toHaveBeenNthCalledWith(1, { threadIds: ["thread-1"] });
+      expect(setThreadSubscriptions).toHaveBeenNthCalledWith(2, { threadIds: ["thread-1"] });
+    }, { timeout: 3000 });
+  });
+
+  it("reconciles the complete atomic set after reconnecting", async () => {
+    const setThreadSubscriptions = enableAtomicSubscriptionTransport();
+    const { rerender } = render(<ChatView />);
+
+    await waitFor(() => {
+      expect(setThreadSubscriptions).toHaveBeenCalledTimes(1);
+      expect(setThreadSubscriptions).toHaveBeenLastCalledWith({ threadIds: ["thread-1"] });
+    });
+
+    chatViewConnectionStatusRef.current = "reconnecting";
+    rerender(<ChatView />);
+    expect(setThreadSubscriptions).toHaveBeenCalledTimes(1);
+
+    chatViewConnectionStatusRef.current = "connected";
+    rerender(<ChatView />);
+
+    await waitFor(() => {
+      expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
+      expect(setThreadSubscriptions).toHaveBeenLastCalledWith({ threadIds: ["thread-1"] });
+    });
   });
 });

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -542,6 +542,48 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(1));
   });
 
+  it("reconciles a newer atomic target after an older response and failed replacement", async () => {
+    const requests: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
+    const setThreadSubscriptions = vi.fn(() => new Promise<void>((resolve, reject) => {
+      requests.push({ resolve, reject });
+    }));
+    Object.defineProperty(chatViewTransportMock, "setThreadSubscriptions", {
+      configurable: true,
+      writable: true,
+      value: setThreadSubscriptions,
+    });
+    const thread2 = makeThread({ id: "thread-2", title: "Thread 2", status: "active" });
+    const { rerender } = render(<ChatView />);
+
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(1));
+
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: "thread-1",
+      threads: [makeThread(), thread2],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      runningThreadIds: new Set([thread2.id]),
+    });
+    rerender(<ChatView />);
+
+    await waitFor(() => {
+      expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
+      expect(setThreadSubscriptions).toHaveBeenNthCalledWith(2, {
+        threadIds: ["thread-1", "thread-2"],
+      });
+    });
+
+    requests[0]?.resolve();
+    requests[1]?.reject(new Error("temporary atomic subscribe failure"));
+
+    await waitFor(() => {
+      expect(setThreadSubscriptions).toHaveBeenCalledTimes(3);
+      expect(setThreadSubscriptions).toHaveBeenNthCalledWith(3, {
+        threadIds: ["thread-1", "thread-2"],
+      });
+    }, { timeout: 3000 });
+  });
+
   it("retries a failed atomic replacement at the caller boundary", async () => {
     const setThreadSubscriptions = enableAtomicSubscriptionTransport();
     setThreadSubscriptions

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -308,13 +308,20 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     expect(screen.queryByTestId("chat-header-title-input")).not.toBeInTheDocument();
   });
 
-  it("swaps the thread shell before persisted history resolves", () => {
-    chatViewThreadMockRef.current = defaultThreadState({ currentThreadId: "thread-2" });
+  it("shows the selected thread shell before persisted history resolves", () => {
+    const selectedThread = makeThread({ id: "thread-2", title: "Thread 2" });
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: selectedThread.id,
+      threads: [selectedThread],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({ currentThreadId: "thread-1" });
 
     render(<ChatView />);
 
-    expect(screen.getByTestId("chat-header-title")).toHaveTextContent("My Thread");
-    expect(screen.getByTestId("conversation-loading")).toBeVisible();
+    expect(screen.getByTestId("chat-header-title")).toHaveTextContent("Thread 2");
+    expect(screen.getByTestId("conversation-transition-shell")).toHaveTextContent("Thread 2");
+    expect(screen.getByTestId("conversation-transition-shell")).toHaveAttribute("data-thread-id", "thread-2");
+    expect(screen.queryByTestId("conversation-loading")).not.toBeInTheDocument();
     expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -599,6 +599,53 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     }, { timeout: 3000 });
   });
 
+  it("does not let stale atomic failures consume the current target retry budget", async () => {
+    const requests: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
+    const setThreadSubscriptions = vi.fn(() => new Promise<void>((resolve, reject) => {
+      requests.push({ resolve, reject });
+    }));
+    Object.defineProperty(chatViewTransportMock, "setThreadSubscriptions", {
+      configurable: true,
+      writable: true,
+      value: setThreadSubscriptions,
+    });
+    const thread2 = makeThread({ id: "thread-2", title: "Thread 2", status: "active" });
+    const thread3 = makeThread({ id: "thread-3", title: "Thread 3", status: "active" });
+    const { rerender } = render(<ChatView />);
+
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(1));
+
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: "thread-1",
+      threads: [makeThread(), thread2, thread3],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      runningThreadIds: new Set([thread2.id]),
+    });
+    rerender(<ChatView />);
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(2));
+
+    chatViewThreadMockRef.current = defaultThreadState({
+      runningThreadIds: new Set([thread3.id]),
+    });
+    rerender(<ChatView />);
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(3));
+
+    requests[0]?.reject(new Error("stale D1 failure"));
+    requests[1]?.reject(new Error("stale D2 failure"));
+    requests[2]?.reject(new Error("current D3 failure"));
+
+    for (let requestIndex = 3; requestIndex < 7; requestIndex += 1) {
+      await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(requestIndex + 1), {
+        timeout: 3000,
+      });
+      requests[requestIndex]?.reject(new Error(`current retry ${requestIndex - 2} failure`));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1_700));
+    expect(setThreadSubscriptions).toHaveBeenCalledTimes(7);
+  }, 10_000);
+
   it("reconciles the complete atomic set after reconnecting", async () => {
     const setThreadSubscriptions = enableAtomicSubscriptionTransport();
     const { rerender } = render(<ChatView />);

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -546,6 +546,32 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(1));
   });
 
+  it("clears a pending atomic set on unmount without retrying after it settles", async () => {
+    const requests: Array<{ resolve: () => void }> = [];
+    const setThreadSubscriptions = vi.fn(() => new Promise<void>((resolve) => {
+      requests.push({ resolve });
+    }));
+    Object.defineProperty(chatViewTransportMock, "setThreadSubscriptions", {
+      configurable: true,
+      writable: true,
+      value: setThreadSubscriptions,
+    });
+    const { rerender, unmount } = render(<ChatView />);
+
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledWith({ threadIds: ["thread-1"] }));
+
+    setupWorkspaceMock({ ...defaultWorkspaceState(), activeThreadId: null, threads: [] });
+    rerender(<ChatView />);
+    unmount();
+
+    expect(setThreadSubscriptions).toHaveBeenCalledWith({ threadIds: [] });
+    expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
+
+    requests[0]?.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
+  });
+
   it("reconciles a newer atomic target after an older response and failed replacement", async () => {
     const requests: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
     const setThreadSubscriptions = vi.fn(() => new Promise<void>((resolve, reject) => {

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -526,6 +526,7 @@ export function ChatView() {
     const setThreadSubscriptions = getTransport().setThreadSubscriptions;
     if (setThreadSubscriptions) {
       const sortedThreadIds = Array.from(desired).sort();
+      const sentThreadIds = new Set(sortedThreadIds);
       const confirmed = confirmedThreadIdsRef.current;
       const alreadyApplied = confirmed.size === desired.size
         && Array.from(confirmed).every((threadId) => desired.has(threadId));
@@ -534,10 +535,14 @@ export function ChatView() {
       atomicSubscriptionRequestRef.current = { epoch, signature: targetSignature };
       void setThreadSubscriptions({ threadIds: sortedThreadIds }).then(() => {
         if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
-        confirmedThreadIdsRef.current = new Set(desiredThreadIdsRef.current);
+        confirmedThreadIdsRef.current = sentThreadIds;
         subscriptionRetryAttemptRef.current = 0;
         subscriptionRetryExhaustedRef.current = false;
-        if (subscriptionTargetSignatureRef.current !== targetSignature) {
+        const latestDesired = desiredThreadIdsRef.current;
+        const responseIsCurrent = subscriptionTargetSignatureRef.current === targetSignature
+          && latestDesired.size === sentThreadIds.size
+          && Array.from(latestDesired).every((threadId) => sentThreadIds.has(threadId));
+        if (!responseIsCurrent) {
           setSubscriptionReconcileVersion((version) => version + 1);
         }
       }).catch(() => {

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -489,7 +489,8 @@ export function ChatView() {
   const subscriptionRetryAttemptRef = useRef(0);
   const subscriptionRetryExhaustedRef = useRef(false);
   const subscriptionTargetSignatureRef = useRef("");
-  const atomicSubscriptionRequestRef = useRef<{ epoch: number; signature: string } | null>(null);
+  const atomicSubscriptionRequestIdRef = useRef(0);
+  const atomicSubscriptionRequestRef = useRef<{ epoch: number; signature: string; id: number } | null>(null);
   const subscriptionMountedRef = useRef(true);
   const [subscriptionReconcileVersion, setSubscriptionReconcileVersion] = useState(0);
 
@@ -532,21 +533,28 @@ export function ChatView() {
         && Array.from(confirmed).every((threadId) => desired.has(threadId));
       const pending = atomicSubscriptionRequestRef.current;
       if (alreadyApplied || (pending?.epoch === epoch && pending.signature === targetSignature)) return;
-      atomicSubscriptionRequestRef.current = { epoch, signature: targetSignature };
+      const requestId = atomicSubscriptionRequestIdRef.current + 1;
+      atomicSubscriptionRequestIdRef.current = requestId;
+      atomicSubscriptionRequestRef.current = { epoch, signature: targetSignature, id: requestId };
       void setThreadSubscriptions({ threadIds: sortedThreadIds }).then(() => {
         if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
         confirmedThreadIdsRef.current = sentThreadIds;
-        subscriptionRetryAttemptRef.current = 0;
-        subscriptionRetryExhaustedRef.current = false;
         const latestDesired = desiredThreadIdsRef.current;
         const responseIsCurrent = subscriptionTargetSignatureRef.current === targetSignature
           && latestDesired.size === sentThreadIds.size
           && Array.from(latestDesired).every((threadId) => sentThreadIds.has(threadId));
+        if (responseIsCurrent) {
+          subscriptionRetryAttemptRef.current = 0;
+          subscriptionRetryExhaustedRef.current = false;
+        }
         if (!responseIsCurrent) {
           setSubscriptionReconcileVersion((version) => version + 1);
         }
       }).catch(() => {
         if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
+        const currentRequest = atomicSubscriptionRequestRef.current;
+        if (currentRequest?.epoch !== epoch || currentRequest.id !== requestId) return;
+        if (subscriptionTargetSignatureRef.current !== targetSignature) return;
         if (subscriptionRetryAttemptRef.current >= THREAD_SUBSCRIPTION_MAX_RETRIES) {
           subscriptionRetryExhaustedRef.current = true;
           return;
@@ -564,7 +572,7 @@ export function ChatView() {
         }, delay);
       }).finally(() => {
         if (atomicSubscriptionRequestRef.current?.epoch === epoch
-          && atomicSubscriptionRequestRef.current.signature === targetSignature) {
+          && atomicSubscriptionRequestRef.current.id === requestId) {
           atomicSubscriptionRequestRef.current = null;
         }
       });

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -13,7 +13,6 @@ import { useComposerDraftStore } from "@/stores/composerDraftStore";
 import { useOverviewStore } from "@/stores/overviewStore";
 import { Badge } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { MessageList } from "./MessageList";
 import { Composer } from "./Composer";
@@ -35,7 +34,6 @@ import { overviewResponsivePaddingRight } from "@/lib/composer-layout";
 import { Button } from "@/components/ui/button";
 import { McodeLogo } from "@/components/brand/McodeLogo";
 import { NewThreadProjectPicker } from "./NewThreadProjectPicker";
-import { PRIMARY_CONTENT_RAIL_CLASS } from "@/lib/layout-rails";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
 const ENTRY_POINTS = [
@@ -274,25 +272,25 @@ const THREAD_SUBSCRIPTION_MAX_RETRIES = 4;
 
 type ThreadSubscriptionAction = "subscribe" | "unsubscribe";
 
-/** Keeps the conversation surface occupied while the latest persisted tail loads. */
-function ConversationLoadingState() {
+/** Keeps a cold switch target visible without rendering stale transcript content. */
+function ConversationTransitionState({
+  threadId,
+  threadTitle,
+}: {
+  threadId: string;
+  threadTitle: string;
+}) {
   return (
     <div
-      data-testid="conversation-loading"
+      data-testid="conversation-transition-shell"
+      data-thread-id={threadId}
       role="status"
-      aria-label="Loading conversation"
-      className="flex h-full items-end px-4 pb-6 sm:px-8"
+      aria-label={`Loading ${threadTitle}`}
+      className="flex h-full items-center justify-center px-4"
     >
-      <div className={`${PRIMARY_CONTENT_RAIL_CLASS} w-full space-y-5 motion-safe:animate-pulse`}>
-        <div className="ml-auto space-y-2">
-          <Skeleton className="ml-auto h-3 w-2/5 rounded bg-muted/55" />
-          <Skeleton className="ml-auto h-3 w-3/5 rounded bg-muted/40" />
-        </div>
-        <div className="space-y-2">
-          <Skeleton className="h-3 w-1/4 rounded bg-muted/55" />
-          <Skeleton className="h-3 w-4/5 rounded bg-muted/40" />
-          <Skeleton className="h-3 w-3/5 rounded bg-muted/40" />
-        </div>
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner size={16} />
+        <span>{threadTitle}</span>
       </div>
     </div>
   );
@@ -789,7 +787,10 @@ export function ChatView() {
         style={{ paddingRight: overviewPaddingRight }}
       >
         {conversationLoading && !hasMessages && !isAgentRunning ? (
-          <ConversationLoadingState />
+          <ConversationTransitionState
+            threadId={activeThread.id}
+            threadTitle={activeThread.title || "Conversation"}
+          />
         ) : showFullConversationError ? (
           <ConversationErrorState error={sessionError ?? ""} />
         ) : showEmptyState ? (

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -271,6 +271,11 @@ const THREAD_SUBSCRIPTION_RETRY_MAX_MS = 1_600;
 const THREAD_SUBSCRIPTION_MAX_RETRIES = 4;
 
 type ThreadSubscriptionAction = "subscribe" | "unsubscribe";
+type AtomicSubscriptionRequest = {
+  epoch: number;
+  signature: string;
+  id: number;
+};
 
 /** Keeps a cold switch target visible without rendering stale transcript content. */
 function ConversationTransitionState({
@@ -490,7 +495,8 @@ export function ChatView() {
   const subscriptionRetryExhaustedRef = useRef(false);
   const subscriptionTargetSignatureRef = useRef("");
   const atomicSubscriptionRequestIdRef = useRef(0);
-  const atomicSubscriptionRequestRef = useRef<{ epoch: number; signature: string; id: number } | null>(null);
+  const atomicSubscriptionRequestRef = useRef<AtomicSubscriptionRequest | null>(null);
+  const pendingAtomicThreadIdsRef = useRef<Map<number, string[]>>(new Map());
   const subscriptionMountedRef = useRef(true);
   const [subscriptionReconcileVersion, setSubscriptionReconcileVersion] = useState(0);
 
@@ -535,7 +541,12 @@ export function ChatView() {
       if (alreadyApplied || (pending?.epoch === epoch && pending.signature === targetSignature)) return;
       const requestId = atomicSubscriptionRequestIdRef.current + 1;
       atomicSubscriptionRequestIdRef.current = requestId;
-      atomicSubscriptionRequestRef.current = { epoch, signature: targetSignature, id: requestId };
+      atomicSubscriptionRequestRef.current = {
+        epoch,
+        signature: targetSignature,
+        id: requestId,
+      };
+      pendingAtomicThreadIdsRef.current.set(requestId, sortedThreadIds);
       void setThreadSubscriptions({ threadIds: sortedThreadIds }).then(() => {
         if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
         confirmedThreadIdsRef.current = sentThreadIds;
@@ -571,6 +582,7 @@ export function ChatView() {
           }
         }, delay);
       }).finally(() => {
+        pendingAtomicThreadIdsRef.current.delete(requestId);
         if (atomicSubscriptionRequestRef.current?.epoch === epoch
           && atomicSubscriptionRequestRef.current.id === requestId) {
           atomicSubscriptionRequestRef.current = null;
@@ -656,6 +668,7 @@ export function ChatView() {
     subscriptionMountedRef.current = true;
     return () => {
       subscriptionMountedRef.current = false;
+      const pendingAtomicThreadIds = Array.from(pendingAtomicThreadIdsRef.current.values()).flat();
       subscriptionEpochRef.current += 1;
       if (subscriptionRetryTimerRef.current !== null) {
         clearTimeout(subscriptionRetryTimerRef.current);
@@ -664,6 +677,7 @@ export function ChatView() {
       const threadIds = new Set([
         ...confirmedThreadIdsRef.current,
         ...desiredThreadIdsRef.current,
+        ...pendingAtomicThreadIds,
       ]);
       if (threadIds.size > 0) {
         const setThreadSubscriptions = getTransport().setThreadSubscriptions;
@@ -678,6 +692,7 @@ export function ChatView() {
       confirmedThreadIdsRef.current.clear();
       desiredThreadIdsRef.current.clear();
       pendingThreadChangesRef.current.clear();
+      pendingAtomicThreadIdsRef.current.clear();
     };
   }, []);
 

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -489,6 +489,7 @@ export function ChatView() {
   const subscriptionRetryAttemptRef = useRef(0);
   const subscriptionRetryExhaustedRef = useRef(false);
   const subscriptionTargetSignatureRef = useRef("");
+  const atomicSubscriptionRequestRef = useRef<{ epoch: number; signature: string } | null>(null);
   const subscriptionMountedRef = useRef(true);
   const [subscriptionReconcileVersion, setSubscriptionReconcileVersion] = useState(0);
 
@@ -522,6 +523,49 @@ export function ChatView() {
     if (connectionStatus !== "connected" || subscriptionRetryExhaustedRef.current) return;
 
     const epoch = subscriptionEpochRef.current;
+    const setThreadSubscriptions = getTransport().setThreadSubscriptions;
+    if (setThreadSubscriptions) {
+      const sortedThreadIds = Array.from(desired).sort();
+      const confirmed = confirmedThreadIdsRef.current;
+      const alreadyApplied = confirmed.size === desired.size
+        && Array.from(confirmed).every((threadId) => desired.has(threadId));
+      const pending = atomicSubscriptionRequestRef.current;
+      if (alreadyApplied || (pending?.epoch === epoch && pending.signature === targetSignature)) return;
+      atomicSubscriptionRequestRef.current = { epoch, signature: targetSignature };
+      void setThreadSubscriptions({ threadIds: sortedThreadIds }).then(() => {
+        if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
+        confirmedThreadIdsRef.current = new Set(desiredThreadIdsRef.current);
+        subscriptionRetryAttemptRef.current = 0;
+        subscriptionRetryExhaustedRef.current = false;
+        if (subscriptionTargetSignatureRef.current !== targetSignature) {
+          setSubscriptionReconcileVersion((version) => version + 1);
+        }
+      }).catch(() => {
+        if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
+        if (subscriptionRetryAttemptRef.current >= THREAD_SUBSCRIPTION_MAX_RETRIES) {
+          subscriptionRetryExhaustedRef.current = true;
+          return;
+        }
+        const delay = Math.min(
+          THREAD_SUBSCRIPTION_RETRY_BASE_MS * (2 ** subscriptionRetryAttemptRef.current),
+          THREAD_SUBSCRIPTION_RETRY_MAX_MS,
+        );
+        subscriptionRetryAttemptRef.current += 1;
+        subscriptionRetryTimerRef.current = setTimeout(() => {
+          subscriptionRetryTimerRef.current = null;
+          if (subscriptionMountedRef.current) {
+            setSubscriptionReconcileVersion((version) => version + 1);
+          }
+        }, delay);
+      }).finally(() => {
+        if (atomicSubscriptionRequestRef.current?.epoch === epoch
+          && atomicSubscriptionRequestRef.current.signature === targetSignature) {
+          atomicSubscriptionRequestRef.current = null;
+        }
+      });
+      return;
+    }
+
     const operations: Promise<boolean>[] = [];
     const startChange = (threadId: string, action: ThreadSubscriptionAction) => {
       const change = Symbol();
@@ -608,8 +652,13 @@ export function ChatView() {
         ...confirmedThreadIdsRef.current,
         ...desiredThreadIdsRef.current,
       ]);
-      for (const threadId of threadIds) {
-        void getTransport().unsubscribeThread(threadId).catch(() => {});
+      const setThreadSubscriptions = getTransport().setThreadSubscriptions;
+      if (setThreadSubscriptions) {
+        void setThreadSubscriptions({ threadIds: [] }).catch(() => {});
+      } else {
+        for (const threadId of threadIds) {
+          void getTransport().unsubscribeThread(threadId).catch(() => {});
+        }
       }
       confirmedThreadIdsRef.current.clear();
       desiredThreadIdsRef.current.clear();

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -665,12 +665,14 @@ export function ChatView() {
         ...confirmedThreadIdsRef.current,
         ...desiredThreadIdsRef.current,
       ]);
-      const setThreadSubscriptions = getTransport().setThreadSubscriptions;
-      if (setThreadSubscriptions) {
-        void setThreadSubscriptions({ threadIds: [] }).catch(() => {});
-      } else {
-        for (const threadId of threadIds) {
-          void getTransport().unsubscribeThread(threadId).catch(() => {});
+      if (threadIds.size > 0) {
+        const setThreadSubscriptions = getTransport().setThreadSubscriptions;
+        if (setThreadSubscriptions) {
+          void setThreadSubscriptions({ threadIds: [] }).catch(() => {});
+        } else {
+          for (const threadId of threadIds) {
+            void getTransport().unsubscribeThread(threadId).catch(() => {});
+          }
         }
       }
       confirmedThreadIdsRef.current.clear();

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useShallow } from "zustand/shallow";
 import { defaultRangeExtractor, useVirtualizer, type Range } from "@tanstack/react-virtual";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { recordThreadPositioned } from "@/lib/thread-switch-telemetry";
 import { useThreadStore } from "@/stores/threadStore";
 import { useActiveThreadRecord } from "@/stores/thread-selectors";
 import { getThreadRecord, getHandoffStatus } from "@/stores/thread-record";
@@ -367,6 +368,12 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   useLayoutEffect(() => {
     isPositionedRef.current = isPositioned;
   }, [isPositioned]);
+
+  useLayoutEffect(() => {
+    if (!isPositioned || !activeThreadId) return;
+    if (renderedThreadId && renderedThreadId !== activeThreadId) return;
+    recordThreadPositioned(activeThreadId);
+  }, [activeThreadId, isPositioned, renderedThreadId]);
 
   /** Syncs sticky preview visibility with the current scroll position. */
   const syncStickyUserMessageVisibility = useCallback(() => {

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -33,6 +33,12 @@ vi.mock("@/stores/workspaceStore", () => ({
   ),
 }));
 
+vi.mock("@/lib/thread-hydrator/prefetch-scheduler", () => ({
+  schedulePrefetch: vi.fn(),
+  cancelPrefetch: vi.fn(),
+  prefetchOnPointerDown: vi.fn(),
+}));
+
 // Mutable holder so individual tests can inject unsettled permission requests
 // and running-thread state into the mocked thread store without re-registering
 // the mock.
@@ -104,6 +110,7 @@ vi.mock("@tanstack/react-virtual", () => ({
 // Import after mocks are registered.
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useUiStore } from "@/stores/uiStore";
+import { prefetchOnPointerDown } from "@/lib/thread-hydrator/prefetch-scheduler";
 import { ProjectTree } from "./ProjectTree";
 
 /** Build a minimal Thread fixture. */
@@ -367,6 +374,20 @@ describe("ProjectTree thread interactions", () => {
     // Navigation must fire on the first click — no debounce.
     expect(setActiveThread).toHaveBeenCalledWith("thread-1");
     expect(setActiveThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefetches on pointerdown before click navigation", () => {
+    const setActiveThread = vi.fn();
+    setupStoreMocks({ setActiveThread });
+
+    render(<ProjectTree />);
+
+    const threadButton = screen.getByRole("button", { name: /My Thread/i });
+    fireEvent.pointerDown(threadButton);
+    expect(prefetchOnPointerDown).toHaveBeenCalledWith("thread-1");
+
+    fireEvent.click(threadButton);
+    expect(setActiveThread).toHaveBeenCalledWith("thread-1");
   });
 
   it("double click enters edit mode after first-click navigation", () => {

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -630,7 +630,6 @@ export function ProjectTree() {
                     workspace={ws}
                     isExpanded={expanded[ws.id] ?? false}
                     isActive={activeWorkspaceId === ws.id}
-                    activeThreadId={activeThreadId}
                     threads={wsThreads}
                     runningThreadIds={runningThreadIds}
                     pendingPermissionThreadIds={pendingPermissionThreadIds}
@@ -905,7 +904,6 @@ interface VirtualizedThreadListProps {
   treeItems: ThreadTreeItem[];
   /** Maximum number of tree rows to render. Used by the parent to enforce the THREAD_LIST_CAP. */
   maxVisible: number;
-  activeThreadId: string | null;
   runningThreadIds: Set<string>;
   /** Thread IDs with at least one unsettled permission request. */
   pendingPermissionThreadIds: Set<string>;
@@ -921,6 +919,260 @@ interface VirtualizedThreadListProps {
   onSelectThread: (id: string) => void;
   onThreadContextMenu: (e: React.MouseEvent, thread: Thread) => void;
 }
+
+interface ThreadRowProps {
+  workspaceName: string;
+  thread: WorkspaceThread;
+  depth: number;
+  isRunning: boolean;
+  hasPendingPermission: boolean;
+  checks?: ChecksStatus;
+  isEditing: boolean;
+  inlineEdit: InlineEditState | null;
+  worktreesLoadedFor: string | null;
+  validWorktreePaths: Set<string>;
+  availableProviders: Array<{
+    id: string;
+    enabled: boolean;
+    cli: { status: string };
+  }>;
+  onInlineEditChange: (title: string) => void;
+  onInlineEditCommit: () => void;
+  onInlineEditCancel: () => void;
+  onThreadClick: (threadId: string, title: string) => void;
+  onThreadDoubleClick: (threadId: string, title: string) => void;
+  onSelectThread: (id: string) => void;
+  onThreadContextMenu: (e: React.MouseEvent, thread: Thread) => void;
+}
+
+/** Renders one sidebar thread row and subscribes only to its own active state. */
+const ThreadRow = memo(function ThreadRow({
+  workspaceName,
+  thread,
+  depth,
+  isRunning,
+  hasPendingPermission,
+  checks,
+  isEditing,
+  inlineEdit,
+  worktreesLoadedFor,
+  validWorktreePaths,
+  availableProviders,
+  onInlineEditChange,
+  onInlineEditCommit,
+  onInlineEditCancel,
+  onThreadClick,
+  onThreadDoubleClick,
+  onSelectThread,
+  onThreadContextMenu,
+}: ThreadRowProps) {
+  const isActive = useWorkspaceStore((s) => s.activeThreadId === thread.id);
+  const marker = getThreadStateMarker({
+    thread,
+    checks,
+    isRunning,
+    hasPendingPermission,
+  });
+  const prable = isPrable(thread);
+  const showPrCi = Boolean(
+    prable &&
+      thread.pr_number != null &&
+      checks &&
+      checks.aggregate !== "no_checks" &&
+      marker.kind !== "action" &&
+      marker.kind !== "running",
+  );
+  const showEndMarker = !showPrCi;
+  const isStaleWorktree =
+    worktreesLoadedFor === thread.workspace_id &&
+    thread.mode === "worktree" &&
+    !!thread.worktree_path &&
+    !validWorktreePaths.has(
+      thread.worktree_path
+        .replace(/\\/g, "/")
+        .replace(/\/$/, "")
+        .toLowerCase(),
+    );
+  const providerRow = availableProviders.find((p) => p.id === thread.provider);
+  const unusable = providerRow
+    ? !providerRow.enabled || providerRow.cli.status === "not_found"
+    : false;
+  const unusableReason = !providerRow
+    ? ""
+    : !providerRow.enabled
+      ? "Provider disabled"
+      : "CLI not found";
+  const scaffoldDim =
+    (thread.clientPreparing || thread.clientError) && "opacity-[0.72]";
+  const providerMeta = getProviderMeta(thread.provider);
+  const RowProviderIcon = providerMeta.icon;
+  const row = (
+    <div
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (isEditing) return;
+        // Keyboard navigation fires immediately — no double-click semantics for keyboard users.
+        // Enter/Space always navigates; rename must be triggered via mouse double-click.
+        if (
+          (e.key === "Enter" || e.key === " ") &&
+          e.target === e.currentTarget
+        ) {
+          e.preventDefault();
+          onSelectThread(thread.id);
+        }
+      }}
+      onClick={() => onThreadClick(thread.id, thread.title)}
+      onDoubleClick={() => onThreadDoubleClick(thread.id, thread.title)}
+      onContextMenu={(e) => onThreadContextMenu(e, thread)}
+      onMouseEnter={() => {
+        if (!thread.clientPreparing && !thread.clientError) {
+          schedulePrefetch(thread.id);
+        }
+      }}
+      onMouseLeave={cancelPrefetch}
+      className={cn(
+        "group/row relative flex min-h-8 items-center gap-2 rounded-md pr-2 text-[13px] cursor-pointer transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
+        isActive
+          ? "bg-accent text-foreground"
+          : "text-muted-foreground/85 hover:bg-accent/40 hover:text-foreground",
+      )}
+      style={{ paddingLeft: `${42 + depth * 12}px` }}
+    >
+      <span
+        className="absolute left-0.5 top-1/2 flex -translate-y-1/2 items-center justify-end gap-1"
+        style={{ width: `${36 + depth * 12}px` }}
+      >
+        {prable && thread.pr_number != null ? (
+          <ThreadPrIndicator
+            threadId={thread.id}
+            prNumber={thread.pr_number}
+            prStatus={thread.pr_status}
+            checks={checks}
+            showCi={showPrCi}
+          />
+        ) : null}
+        <span
+          aria-label={`Provider, ${providerMeta.label}`}
+          className={cn(
+            "-mt-px flex h-4 w-4 items-center justify-center",
+            providerMeta.color,
+            scaffoldDim,
+          )}
+        >
+          <RowProviderIcon size={12} />
+        </span>
+      </span>
+      <div
+        className={cn(
+          "flex min-w-0 flex-1 items-center gap-2",
+          scaffoldDim,
+        )}
+      >
+        {isEditing ? (
+          <Input
+            type="text"
+            size="xs"
+            value={inlineEdit?.title ?? ""}
+            onChange={(e) => onInlineEditChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (!e.nativeEvent.isComposing) {
+                if (e.key === "Enter") onInlineEditCommit();
+                if (e.key === "Escape") onInlineEditCancel();
+              }
+              e.stopPropagation();
+            }}
+            onBlur={onInlineEditCommit}
+            autoFocus
+            onClick={(e) => e.stopPropagation()}
+            className="flex-1 border-ring"
+          />
+        ) : (
+          <>
+            <span
+              className={cn(
+                "truncate flex-1",
+                isStaleWorktree &&
+                  "text-[var(--diff-remove-strong)]/85 line-through",
+              )}
+              data-testid="thread-title"
+            >
+              {isStaleWorktree && (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <AlertTriangle
+                        size={11}
+                        className="inline mr-1 align-text-bottom text-[var(--diff-remove-strong)]/80"
+                      />
+                    }
+                  />
+                  <TooltipContent side="right" className="text-xs">
+                    Worktree directory no longer exists
+                  </TooltipContent>
+                </Tooltip>
+              )}
+              {thread.title}
+            </span>
+            {thread.mode === "worktree" && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <WorktreeModeIcon
+                      size={12}
+                      data-testid={`thread-worktree-indicator-${thread.id}`}
+                      aria-label="Worktree mode"
+                      className="text-muted-foreground/65"
+                    />
+                  }
+                />
+                <TooltipContent side="right" className="text-xs">
+                  Worktree
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </>
+        )}
+        {!isEditing && unusable && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span
+                  data-testid={`sidebar-unusable-${thread.id}`}
+                  className="ml-1 shrink-0 inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/60"
+                  aria-label={unusableReason}
+                />
+              }
+            />
+            <TooltipContent side="right" className="text-xs">
+              {unusableReason}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+      {!isEditing && showEndMarker && (
+        <ThreadStateMarker marker={marker} dim={Boolean(scaffoldDim)} />
+      )}
+    </div>
+  );
+
+  return isEditing ? (
+    row
+  ) : (
+    <Tooltip>
+      <TooltipTrigger render={row} />
+      <TooltipContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        variant="surface"
+        className="max-w-none p-3"
+      >
+        <SidebarThreadPreview workspaceName={workspaceName} thread={thread} />
+      </TooltipContent>
+    </Tooltip>
+  );
+});
 
 /**
  * Workspace-row CI roll-up chip.
@@ -1103,7 +1355,6 @@ function VirtualizedThreadList({
   workspaceName,
   treeItems: allTreeItems,
   maxVisible,
-  activeThreadId,
   runningThreadIds,
   pendingPermissionThreadIds,
   checksById,
@@ -1188,7 +1439,7 @@ function VirtualizedThreadList({
       const next = containerRef.current?.offsetTop ?? 0;
       return prev === next ? prev : next;
     });
-  });
+  }, [allTreeItems, maxVisible, scrollElementRef]);
 
   const virtualizer = useVirtualizer({
     count: treeItems.length,
@@ -1210,213 +1461,7 @@ function VirtualizedThreadList({
     >
       {virtualizer.getVirtualItems().map((virtualItem) => {
         const { thread, depth } = treeItems[virtualItem.index];
-        const isRunning = runningThreadIds.has(thread.id);
-        const hasPendingPermission = pendingPermissionThreadIds.has(thread.id);
-        const checks = checksById[thread.id];
-        const marker = getThreadStateMarker({
-          thread,
-          checks,
-          isRunning,
-          hasPendingPermission,
-        });
         const isEditing = inlineEdit?.threadId === thread.id;
-        // Only PR-able (worktree) threads surface PR affordances. A direct-mode
-        // thread shows its branch/agent status, never a PR icon, even if a PR
-        // number happens to be attached.
-        const prable = isPrable(thread);
-        const showPrCi = Boolean(
-          prable &&
-            thread.pr_number != null &&
-            checks &&
-            checks.aggregate !== "no_checks" &&
-            marker.kind !== "action" &&
-            marker.kind !== "running",
-        );
-        const showEndMarker = !showPrCi;
-        // Worktree thread whose directory no longer exists on disk.
-        // Only check threads from the workspace whose worktrees are loaded — comparing
-        // against a different workspace's worktree list would produce false positives.
-        const isStaleWorktree =
-          worktreesLoadedFor === thread.workspace_id &&
-          thread.mode === "worktree" &&
-          !!thread.worktree_path &&
-          !validWorktreePaths.has(
-            thread.worktree_path
-              .replace(/\\/g, "/")
-              .replace(/\/$/, "")
-              .toLowerCase(),
-          );
-        // Unusable when the provider is disabled or its CLI binary is missing.
-        // "unchecked" is not treated as unusable — the server may not have verified yet.
-        const providerRow = availableProviders.find(
-          (p) => p.id === thread.provider,
-        );
-        const unusable = providerRow
-          ? !providerRow.enabled || providerRow.cli.status === "not_found"
-          : false;
-        // Only compute a reason when the thread is actually unusable. A missing
-        // providerRow means availability hasn't arrived yet — don't label those as "disabled".
-        const unusableReason = !providerRow
-          ? ""
-          : !providerRow.enabled
-            ? "Provider disabled"
-            : "CLI not found";
-        // Opacity on the row would compound onto status markers; dim only the title cluster and timestamp.
-        const scaffoldDim =
-          (thread.clientPreparing || thread.clientError) && "opacity-[0.72]";
-        const providerMeta = getProviderMeta(thread.provider);
-        const RowProviderIcon = providerMeta.icon;
-        const row = (
-          <div
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => {
-              if (isEditing) return;
-              // Keyboard navigation fires immediately — no double-click semantics for keyboard users.
-              // Enter/Space always navigates; rename must be triggered via mouse double-click.
-              if (
-                (e.key === "Enter" || e.key === " ") &&
-                e.target === e.currentTarget
-              ) {
-                e.preventDefault();
-                onSelectThread(thread.id);
-              }
-            }}
-            onClick={() => handleThreadClick(thread.id, thread.title)}
-            onDoubleClick={() =>
-              handleThreadDoubleClick(thread.id, thread.title)
-            }
-            onContextMenu={(e) => onThreadContextMenu(e, thread)}
-            onMouseEnter={() => {
-              if (!thread.clientPreparing && !thread.clientError) {
-                schedulePrefetch(thread.id);
-              }
-            }}
-            onMouseLeave={cancelPrefetch}
-            className={cn(
-              "group/row relative flex min-h-8 items-center gap-2 rounded-md pr-2 text-[13px] cursor-pointer transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
-              activeThreadId === thread.id
-                ? "bg-accent text-foreground"
-                : "text-muted-foreground/85 hover:bg-accent/40 hover:text-foreground",
-            )}
-            style={{ paddingLeft: `${42 + depth * 12}px` }}
-          >
-            <span
-              className="absolute left-0.5 top-1/2 flex -translate-y-1/2 items-center justify-end gap-1"
-              style={{ width: `${36 + depth * 12}px` }}
-            >
-              {prable && thread.pr_number != null ? (
-                <ThreadPrIndicator
-                  threadId={thread.id}
-                  prNumber={thread.pr_number}
-                  prStatus={thread.pr_status}
-                  checks={checks}
-                  showCi={showPrCi}
-                />
-              ) : null}
-              <span
-                aria-label={`Provider, ${providerMeta.label}`}
-                className={cn(
-                  "-mt-px flex h-4 w-4 items-center justify-center",
-                  providerMeta.color,
-                  scaffoldDim,
-                )}
-              >
-                <RowProviderIcon size={12} />
-              </span>
-            </span>
-            <div
-              className={cn(
-                "flex min-w-0 flex-1 items-center gap-2",
-                scaffoldDim,
-              )}
-            >
-              {isEditing ? (
-                <Input
-                  type="text"
-                  size="xs"
-                  value={inlineEdit.title}
-                  onChange={(e) => onInlineEditChange(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (!e.nativeEvent.isComposing) {
-                      if (e.key === "Enter") onInlineEditCommit();
-                      if (e.key === "Escape") onInlineEditCancel();
-                    }
-                    e.stopPropagation();
-                  }}
-                  onBlur={onInlineEditCommit}
-                  autoFocus
-                  onClick={(e) => e.stopPropagation()}
-                  className="flex-1 border-ring"
-                />
-              ) : (
-                <>
-                  <span
-                    className={cn(
-                      "truncate flex-1",
-                      isStaleWorktree &&
-                        "text-[var(--diff-remove-strong)]/85 line-through",
-                    )}
-                    data-testid="thread-title"
-                  >
-                    {isStaleWorktree && (
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <AlertTriangle
-                              size={11}
-                              className="inline mr-1 align-text-bottom text-[var(--diff-remove-strong)]/80"
-                            />
-                          }
-                        />
-                        <TooltipContent side="right" className="text-xs">
-                          Worktree directory no longer exists
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                    {thread.title}
-                  </span>
-                  {thread.mode === "worktree" && (
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <WorktreeModeIcon
-                            size={12}
-                            data-testid={`thread-worktree-indicator-${thread.id}`}
-                            aria-label="Worktree mode"
-                            className="text-muted-foreground/65"
-                          />
-                        }
-                      />
-                      <TooltipContent side="right" className="text-xs">
-                        Worktree
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </>
-              )}
-              {!isEditing && unusable && (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <span
-                        data-testid={`sidebar-unusable-${thread.id}`}
-                        className="ml-1 shrink-0 inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/60"
-                        aria-label={unusableReason}
-                      />
-                    }
-                  />
-                  <TooltipContent side="right" className="text-xs">
-                    {unusableReason}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
-            {!isEditing && showEndMarker && (
-              <ThreadStateMarker marker={marker} dim={Boolean(scaffoldDim)} />
-            )}
-          </div>
-        );
         return (
           <div
             key={thread.id}
@@ -1431,25 +1476,26 @@ function VirtualizedThreadList({
               transform: `translateY(${virtualItem.start - scrollMargin}px)`,
             }}
           >
-            {isEditing ? (
-              row
-            ) : (
-              <Tooltip>
-                <TooltipTrigger render={row} />
-                <TooltipContent
-                  side="right"
-                  align="start"
-                  sideOffset={8}
-                  variant="surface"
-                  className="max-w-none p-3"
-                >
-                  <SidebarThreadPreview
-                    workspaceName={workspaceName}
-                    thread={thread}
-                  />
-                </TooltipContent>
-              </Tooltip>
-            )}
+            <ThreadRow
+              workspaceName={workspaceName}
+              thread={thread}
+              depth={depth}
+              isRunning={runningThreadIds.has(thread.id)}
+              hasPendingPermission={pendingPermissionThreadIds.has(thread.id)}
+              checks={checksById[thread.id]}
+              isEditing={isEditing}
+              inlineEdit={isEditing ? inlineEdit : null}
+              worktreesLoadedFor={worktreesLoadedFor}
+              validWorktreePaths={validWorktreePaths}
+              availableProviders={availableProviders}
+              onInlineEditChange={onInlineEditChange}
+              onInlineEditCommit={onInlineEditCommit}
+              onInlineEditCancel={onInlineEditCancel}
+              onThreadClick={handleThreadClick}
+              onThreadDoubleClick={handleThreadDoubleClick}
+              onSelectThread={onSelectThread}
+              onThreadContextMenu={onThreadContextMenu}
+            />
           </div>
         );
       })}
@@ -1464,7 +1510,6 @@ interface ProjectNodeProps {
   workspace: Workspace;
   isExpanded: boolean;
   isActive: boolean;
-  activeThreadId: string | null;
   threads: WorkspaceThread[];
   runningThreadIds: Set<string>;
   /** Thread IDs with at least one unsettled permission request. */
@@ -1503,7 +1548,6 @@ const ProjectNode = memo(function ProjectNode({
   workspace,
   isExpanded,
   isActive,
-  activeThreadId,
   threads,
   runningThreadIds,
   pendingPermissionThreadIds,
@@ -1535,10 +1579,13 @@ const ProjectNode = memo(function ProjectNode({
   // Use the flattened tree order (same order VirtualizedThreadList renders) for cap decisions.
   const treeItems = useMemo(() => buildThreadTree(threads), [threads]);
   const needsCap = treeItems.length > THREAD_LIST_CAP;
-  const activeIndex = activeThreadId
-    ? treeItems.findIndex((item) => item.thread.id === activeThreadId)
-    : -1;
-  const forceExpand = activeIndex >= THREAD_LIST_CAP;
+  const forceExpand = useWorkspaceStore((s) => {
+    if (!s.activeThreadId) return false;
+    const activeIndex = treeItems.findIndex(
+      (item) => item.thread.id === s.activeThreadId,
+    );
+    return activeIndex >= THREAD_LIST_CAP;
+  });
   const maxVisible =
     !needsCap || isThreadListExpanded || forceExpand
       ? Infinity
@@ -1763,7 +1810,6 @@ const ProjectNode = memo(function ProjectNode({
             workspaceName={workspace.name}
             treeItems={treeItems}
             maxVisible={maxVisible}
-            activeThreadId={activeThreadId}
             runningThreadIds={runningThreadIds}
             pendingPermissionThreadIds={pendingPermissionThreadIds}
             checksById={checksById}

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -70,6 +70,7 @@ import {
 import {
   schedulePrefetch,
   cancelPrefetch,
+  prefetchOnPointerDown,
 } from "@/lib/thread-hydrator/prefetch-scheduler";
 import { isPrable } from "@/lib/is-prable";
 import { getCiVisual, CI_ICON_STROKE } from "@/lib/ci-status";
@@ -1023,6 +1024,17 @@ const ThreadRow = memo(function ThreadRow({
         }
       }}
       onClick={() => onThreadClick(thread.id, thread.title)}
+      onPointerDown={(event) => {
+        if (
+          event.button !== 0 ||
+          isEditing ||
+          thread.clientPreparing ||
+          thread.clientError
+        ) {
+          return;
+        }
+        prefetchOnPointerDown(thread.id);
+      }}
       onDoubleClick={() => onThreadDoubleClick(thread.id, thread.title)}
       onContextMenu={(e) => onThreadContextMenu(e, thread)}
       onMouseEnter={() => {

--- a/apps/web/src/lib/__tests__/thread-switch-telemetry.test.ts
+++ b/apps/web/src/lib/__tests__/thread-switch-telemetry.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetThreadSwitchTelemetryForTests,
+  recordThreadCommit,
+  recordThreadPositioned,
+  recordThreadSelection,
+} from "../thread-switch-telemetry";
+
+function names(prefix: string): string[] {
+  return performance.getEntriesByType("mark")
+    .map((entry) => entry.name)
+    .filter((name) => name.startsWith(prefix));
+}
+
+beforeEach(() => {
+  __resetThreadSwitchTelemetryForTests();
+});
+
+afterEach(() => {
+  __resetThreadSwitchTelemetryForTests();
+});
+
+describe("thread switch telemetry", () => {
+  it("records selection, cache commit, and positioned completion", () => {
+    recordThreadSelection("thread-a");
+    recordThreadCommit("thread-a", "cache-restore");
+    recordThreadPositioned("thread-a");
+
+    expect(names("mcode:thread-switch:selection:")).toHaveLength(1);
+    expect(names("mcode:thread-switch:commit:cache-restore:")).toHaveLength(1);
+    expect(names("mcode:thread-switch:positioned:")).toHaveLength(1);
+    expect(performance.getEntriesByName("mcode:thread-switch:selection-to-positioned:1")).toHaveLength(1);
+  });
+
+  it("keeps cache and network commits distinguishable and bounds retained entries", () => {
+    for (let index = 0; index < 40; index++) {
+      const threadId = `thread-${index}`;
+      recordThreadSelection(threadId);
+      recordThreadCommit(threadId, index % 2 === 0 ? "cache-restore" : "network-fetch");
+    }
+
+    expect(performance.getEntriesByType("mark").filter((entry) => entry.name.startsWith("mcode:thread-switch")).length)
+      .toBeLessThanOrEqual(64);
+    expect(names("mcode:thread-switch:commit:cache-restore:").length).toBeGreaterThan(0);
+    expect(names("mcode:thread-switch:commit:network-fetch:").length).toBeGreaterThan(0);
+  });
+
+  it("does not position a superseded thread", () => {
+    recordThreadSelection("thread-a");
+    recordThreadSelection("thread-b");
+    recordThreadPositioned("thread-a");
+    recordThreadPositioned("thread-b");
+
+    expect(names("mcode:thread-switch:positioned:")).toHaveLength(1);
+    expect(performance.getEntriesByType("mark").some((entry) => entry.name.includes(":positioned:2"))).toBe(true);
+  });
+});

--- a/apps/web/src/lib/thread-hydrator/__tests__/adjacent-prefetch.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/adjacent-prefetch.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAdjacentPrefetchScheduler,
+  type AdjacentPrefetchThread,
+} from "../adjacent-prefetch";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function thread(id: string, overrides: Partial<AdjacentPrefetchThread> = {}) {
+  return { id, ...overrides };
+}
+
+describe("adjacent prefetch scheduler", () => {
+  it("warms only the previous and next eligible neighbors", async () => {
+    const prefetch = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createAdjacentPrefetchScheduler({ prefetch });
+
+    scheduler.activate("t2", [
+      thread("t1"),
+      thread("t2"),
+      thread("preparing", { clientPreparing: true }),
+      thread("t4"),
+    ]);
+    await Promise.resolve();
+
+    expect(prefetch).toHaveBeenCalledTimes(2);
+    expect(prefetch).toHaveBeenNthCalledWith(1, "t1");
+    expect(prefetch).toHaveBeenNthCalledWith(2, "t4");
+  });
+
+  it("does nothing for an unknown selection or unavailable neighbors", () => {
+    const prefetch = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createAdjacentPrefetchScheduler({ prefetch });
+
+    scheduler.activate("missing", [thread("t1")]);
+    scheduler.activate("t2", [
+      thread("t1", { clientError: "failed" }),
+      thread("t2"),
+      thread("t3", { clientPreparing: true }),
+    ]);
+
+    expect(prefetch).not.toHaveBeenCalled();
+  });
+
+  it("cancels queued work from the previous activation while in-flight work settles", async () => {
+    const first = deferred();
+    const second = deferred();
+    const prefetch = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise)
+      .mockResolvedValue(undefined);
+    const scheduler = createAdjacentPrefetchScheduler({ prefetch });
+
+    scheduler.activate("t2", [thread("t1"), thread("t2"), thread("t3")]);
+    scheduler.activate("t3", [thread("t1"), thread("t2"), thread("t3"), thread("t4")]);
+    scheduler.activate("t1", [thread("t1"), thread("t2"), thread("t3"), thread("t4")]);
+    expect(prefetch.mock.calls.map(([id]) => id)).toEqual(["t1", "t3"]);
+    first.resolve();
+    second.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(prefetch.mock.calls.map(([id]) => id)).toEqual(["t1", "t3", "t2"]);
+  });
+
+  it("releases a slot when an old request settles", async () => {
+    const first = deferred();
+    const second = deferred();
+    const third = deferred();
+    const fourth = deferred();
+    const prefetch = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise)
+      .mockImplementationOnce(() => third.promise)
+      .mockImplementationOnce(() => fourth.promise);
+    const scheduler = createAdjacentPrefetchScheduler({ prefetch });
+
+    scheduler.activate("t2", [thread("t1"), thread("t2"), thread("t3")]);
+    first.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    scheduler.activate("t3", [thread("t1"), thread("t2"), thread("t3"), thread("t4")]);
+    expect(prefetch.mock.calls.map(([id]) => id)).toEqual(["t1", "t3", "t2"]);
+
+    second.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(prefetch.mock.calls.map(([id]) => id)).toEqual(["t1", "t3", "t2", "t4"]);
+
+    third.resolve();
+    fourth.resolve();
+  });
+});

--- a/apps/web/src/lib/thread-hydrator/__tests__/adjacent-prefetch.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/adjacent-prefetch.test.ts
@@ -3,6 +3,7 @@ import {
   createAdjacentPrefetchScheduler,
   type AdjacentPrefetchThread,
 } from "../adjacent-prefetch";
+import { enqueueBackgroundPrefetch } from "../prefetch-scheduler";
 
 function deferred() {
   let resolve!: () => void;
@@ -97,5 +98,32 @@ describe("adjacent prefetch scheduler", () => {
 
     third.resolve();
     fourth.resolve();
+  });
+
+  it("shares its two slots with pointer and hover prefetch work", async () => {
+    const hover = deferred();
+    const firstAdjacent = deferred();
+    const secondAdjacent = deferred();
+    const prefetch = vi
+      .fn()
+      .mockImplementationOnce(() => firstAdjacent.promise)
+      .mockImplementationOnce(() => secondAdjacent.promise);
+    enqueueBackgroundPrefetch("hover", () => hover.promise);
+    const scheduler = createAdjacentPrefetchScheduler({ prefetch });
+
+    scheduler.activate("t2", [thread("t1"), thread("t2"), thread("t3")]);
+    expect(prefetch).toHaveBeenCalledTimes(1);
+    expect(prefetch).toHaveBeenCalledWith("t1");
+
+    hover.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(prefetch).toHaveBeenCalledTimes(2);
+    expect(prefetch).toHaveBeenLastCalledWith("t3");
+
+    firstAdjacent.resolve();
+    secondAdjacent.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
   });
 });

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -576,6 +576,24 @@ describe("ThreadHydrator", () => {
     expect(mockTransport.getThreadTasks).not.toHaveBeenCalled();
   });
 
+  it("retains auxiliary freshness when an inactive thread is restored from cache", async () => {
+    await hydrator.hydrate(THREAD_A, "active");
+    await vi.waitFor(() => {
+      expect(mockTransport.listPendingPermissions).toHaveBeenCalledWith(THREAD_A);
+    });
+    expect(getCachedRecord(THREAD_A)?.lastHydratedAt).toBeGreaterThan(0);
+
+    vi.clearAllMocks();
+    await hydrator.hydrate(THREAD_B, "active");
+    vi.clearAllMocks();
+
+    await hydrator.hydrate(THREAD_A, "active");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(mockTransport.listPendingPermissions).not.toHaveBeenCalled();
+    expect(mockTransport.getThreadTasks).not.toHaveBeenCalled();
+  });
+
   it("re-fans out auxiliary data once the TTL window elapses", async () => {
     await hydrator.hydrate(THREAD_A, "active");
     useThreadStore.setState((s) => ({

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -1161,6 +1161,53 @@ describe("ThreadHydrator", () => {
     }
   });
 
+  it("does not let an invalidated tail follow-up overwrite newer cached messages", async () => {
+    const staleTail = createMockMessage({
+      id: "stale-tail-message",
+      thread_id: THREAD_A,
+      content: "stale tail",
+      sequence: 1,
+    });
+    const freshCachedMessage = createMockMessage({
+      id: "fresh-cached-message",
+      thread_id: THREAD_A,
+      content: "fresh cached message",
+      sequence: 2,
+    });
+    let resolveFollowup!: (value: {
+      messages: typeof staleTail[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    const tailLoader = vi.fn().mockResolvedValue({
+      messages: [staleTail],
+      hasMore: false,
+    });
+    mockTransport.loadConversationTail = tailLoader;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveFollowup = resolve;
+      }),
+    );
+
+    try {
+      const hydration = hydrator.hydrate(THREAD_A, "active");
+      await vi.waitFor(() => expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(
+        THREAD_A,
+        MESSAGE_FETCH_SIZE,
+      ));
+
+      hydrator.invalidateConversation(THREAD_A);
+      cacheRecord(THREAD_A, makeCachedRecord([freshCachedMessage]));
+      resolveFollowup({ messages: [staleTail], hasMore: false, narrativeByMessage: {} });
+      await hydration;
+
+      expect(getCachedRecord(THREAD_A)?.messages).toEqual([freshCachedMessage]);
+    } finally {
+      mockTransport.loadConversationTail = undefined;
+    }
+  });
+
   it("does not let a background prefetch replace an inactive WebSocket update", async () => {
     const staleMessage = createMockMessage({
       id: "stale-prefetch-message",

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -1124,6 +1124,43 @@ describe("ThreadHydrator", () => {
     expect(getTestActiveMessages()).toEqual([msgB]);
   });
 
+  it("uses the bounded tail loader only for active first-paint fetches", async () => {
+    const tailLoader = vi.fn().mockResolvedValue({ messages: [msgA], hasMore: false });
+    mockTransport.loadConversationTail = tailLoader;
+
+    try {
+      resetThreadStoreForTests({
+        currentThreadId: THREAD_B,
+        records: new Map<string, ThreadRecord>([
+          [THREAD_B, { ...createEmptyThreadRecord(), messages: [msgB] }],
+        ]),
+      });
+
+      await hydrator.hydrate(THREAD_A, "background");
+
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(
+        THREAD_A,
+        BACKGROUND_PREFETCH_LIMIT,
+      );
+      expect(tailLoader).not.toHaveBeenCalled();
+
+      clearRecordCache();
+      resetThreadStoreForTests({ currentThreadId: null, records: new Map() });
+      hydrator = createStoreHydrator();
+
+      await hydrator.hydrate(THREAD_A, "active");
+
+      expect(tailLoader).toHaveBeenCalledWith(THREAD_A, MESSAGE_FETCH_SIZE);
+      expect(mockTransport.loadConversationPage).toHaveBeenNthCalledWith(
+        2,
+        THREAD_A,
+        MESSAGE_FETCH_SIZE,
+      );
+    } finally {
+      mockTransport.loadConversationTail = undefined;
+    }
+  });
+
   it("does not let a background prefetch replace an inactive WebSocket update", async () => {
     const staleMessage = createMockMessage({
       id: "stale-prefetch-message",

--- a/apps/web/src/lib/thread-hydrator/adjacent-prefetch.ts
+++ b/apps/web/src/lib/thread-hydrator/adjacent-prefetch.ts
@@ -1,0 +1,86 @@
+/** A thread row supplied in the sorted sidebar order. */
+export interface AdjacentPrefetchThread {
+  id: string;
+  clientPreparing?: boolean;
+  clientError?: string | null;
+}
+
+/** Shared background operation used to warm one thread. */
+export interface AdjacentPrefetchDeps {
+  prefetch: (threadId: string) => Promise<void>;
+}
+
+/** Lifecycle controller for bounded adjacent-thread warming. */
+export interface AdjacentPrefetchController {
+  activate(
+    selectedThreadId: string,
+    threads: readonly AdjacentPrefetchThread[],
+  ): void;
+  cancel(): void;
+}
+
+const MAX_CONCURRENT_PREFETCHES = 2;
+
+function isEligible(thread: AdjacentPrefetchThread): boolean {
+  return !thread.clientPreparing && !thread.clientError;
+}
+
+/**
+ * Creates a bounded scheduler for the previous and next eligible sidebar rows.
+ * In-flight work is allowed to settle, while queued work from an old activation
+ * is discarded before the next activation can claim a slot.
+ */
+export function createAdjacentPrefetchScheduler(
+  deps: AdjacentPrefetchDeps,
+): AdjacentPrefetchController {
+  let queue: string[] = [];
+  const active = new Set<string>();
+
+  const pump = () => {
+    while (active.size < MAX_CONCURRENT_PREFETCHES && queue.length > 0) {
+      const threadId = queue.shift();
+      if (!threadId || active.has(threadId)) continue;
+      active.add(threadId);
+      void deps.prefetch(threadId)
+        .catch(() => undefined)
+        .finally(() => {
+          active.delete(threadId);
+          pump();
+        });
+    }
+  };
+
+  const cancel = () => {
+    queue = [];
+  };
+
+  return {
+    activate(selectedThreadId, threads) {
+      cancel();
+      const selectedIndex = threads.findIndex(
+        (thread) => thread.id === selectedThreadId,
+      );
+      if (selectedIndex < 0) return;
+
+      const neighbors: string[] = [];
+      for (let index = selectedIndex - 1; index >= 0; index -= 1) {
+        if (isEligible(threads[index])) {
+          neighbors.push(threads[index].id);
+          break;
+        }
+      }
+      for (let index = selectedIndex + 1; index < threads.length; index += 1) {
+        if (isEligible(threads[index])) {
+          neighbors.push(threads[index].id);
+          break;
+        }
+      }
+      queue = neighbors.filter(
+        (threadId, index) =>
+          threadId !== selectedThreadId && neighbors.indexOf(threadId) === index,
+      );
+      pump();
+    },
+    cancel,
+  };
+}

--- a/apps/web/src/lib/thread-hydrator/adjacent-prefetch.ts
+++ b/apps/web/src/lib/thread-hydrator/adjacent-prefetch.ts
@@ -1,3 +1,5 @@
+import { enqueueBackgroundPrefetch } from "./prefetch-scheduler";
+
 /** A thread row supplied in the sorted sidebar order. */
 export interface AdjacentPrefetchThread {
   id: string;
@@ -19,39 +21,24 @@ export interface AdjacentPrefetchController {
   cancel(): void;
 }
 
-const MAX_CONCURRENT_PREFETCHES = 2;
-
 function isEligible(thread: AdjacentPrefetchThread): boolean {
   return !thread.clientPreparing && !thread.clientError;
 }
 
 /**
- * Creates a bounded scheduler for the previous and next eligible sidebar rows.
+ * Creates a scheduler for the previous and next eligible sidebar rows using
+ * the shared two-request speculative prefetch budget.
  * In-flight work is allowed to settle, while queued work from an old activation
  * is discarded before the next activation can claim a slot.
  */
 export function createAdjacentPrefetchScheduler(
   deps: AdjacentPrefetchDeps,
 ): AdjacentPrefetchController {
-  let queue: string[] = [];
-  const active = new Set<string>();
-
-  const pump = () => {
-    while (active.size < MAX_CONCURRENT_PREFETCHES && queue.length > 0) {
-      const threadId = queue.shift();
-      if (!threadId || active.has(threadId)) continue;
-      active.add(threadId);
-      void deps.prefetch(threadId)
-        .catch(() => undefined)
-        .finally(() => {
-          active.delete(threadId);
-          pump();
-        });
-    }
-  };
+  let queuedCancels: Array<() => void> = [];
 
   const cancel = () => {
-    queue = [];
+    queuedCancels.forEach((cancelRequest) => cancelRequest());
+    queuedCancels = [];
   };
 
   return {
@@ -75,11 +62,17 @@ export function createAdjacentPrefetchScheduler(
           break;
         }
       }
-      queue = neighbors.filter(
+      const uniqueNeighbors = neighbors.filter(
         (threadId, index) =>
           threadId !== selectedThreadId && neighbors.indexOf(threadId) === index,
       );
-      pump();
+      queuedCancels = uniqueNeighbors.map((threadId) =>
+        enqueueBackgroundPrefetch(
+          threadId,
+          () => deps.prefetch(threadId),
+          "background",
+        ),
+      );
     },
     cancel,
   };

--- a/apps/web/src/lib/thread-hydrator/deferred-work.ts
+++ b/apps/web/src/lib/thread-hydrator/deferred-work.ts
@@ -22,7 +22,6 @@ export function scheduleDeferredWork(
   let cancelled = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let frame: number | undefined;
-  let deadline: ReturnType<typeof setTimeout> | undefined;
   const run = () => {
     if (cancelled) return;
     cancelled = true;
@@ -40,7 +39,7 @@ export function scheduleDeferredWork(
     : undefined;
   if (delayMs === 0 && raf) frame = raf(run);
   else timer = setTimeout(run, delayMs);
-  deadline = setTimeout(run, maxDelayMs);
+  const deadline: ReturnType<typeof setTimeout> = setTimeout(run, maxDelayMs);
   return {
     cancel() {
       if (cancelled) return;

--- a/apps/web/src/lib/thread-hydrator/deferred-work.ts
+++ b/apps/web/src/lib/thread-hydrator/deferred-work.ts
@@ -1,0 +1,58 @@
+/** Options controlling a bounded deferred task. */
+export interface DeferredWorkOptions {
+  /** Delay before running the task. Defaults to the next available frame. */
+  delayMs?: number;
+  /** Maximum delay before the task runs even when frames are unavailable. */
+  maxDelayMs?: number;
+}
+
+/** Handle returned by {@link scheduleDeferredWork}. */
+export interface DeferredWorkHandle {
+  /** Cancel the task when the owning selection is superseded. */
+  cancel(): void;
+  /** Whether cancellation has already been requested. */
+  readonly cancelled: boolean;
+}
+
+/** Schedule non-critical hydration work with a bounded, cancellable delay. */
+export function scheduleDeferredWork(
+  work: () => void,
+  options: DeferredWorkOptions = {},
+): DeferredWorkHandle {
+  let cancelled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let frame: number | undefined;
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  const run = () => {
+    if (cancelled) return;
+    cancelled = true;
+    if (timer !== undefined) clearTimeout(timer);
+    if (frame !== undefined && typeof globalThis.cancelAnimationFrame === "function") {
+      globalThis.cancelAnimationFrame(frame);
+    }
+    if (deadline !== undefined) clearTimeout(deadline);
+    work();
+  };
+  const delayMs = Math.max(0, options.delayMs ?? 0);
+  const maxDelayMs = Math.max(delayMs, options.maxDelayMs ?? 100);
+  const raf = typeof globalThis.requestAnimationFrame === "function"
+    ? globalThis.requestAnimationFrame
+    : undefined;
+  if (delayMs === 0 && raf) frame = raf(run);
+  else timer = setTimeout(run, delayMs);
+  deadline = setTimeout(run, maxDelayMs);
+  return {
+    cancel() {
+      if (cancelled) return;
+      cancelled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      if (frame !== undefined && typeof globalThis.cancelAnimationFrame === "function") {
+        globalThis.cancelAnimationFrame(frame);
+      }
+      clearTimeout(deadline);
+    },
+    get cancelled() {
+      return cancelled;
+    },
+  };
+}

--- a/apps/web/src/lib/thread-hydrator/index.ts
+++ b/apps/web/src/lib/thread-hydrator/index.ts
@@ -28,6 +28,8 @@ export {
 export type { ConversationCacheState } from "./record-cache";
 export { AuxiliaryHydrator } from "./auxiliary-hydrator";
 export type { AuxiliaryHydratorOptions, AuxiliaryHydratorDeps } from "./auxiliary-hydrator";
+export { scheduleDeferredWork } from "./deferred-work";
+export type { DeferredWorkHandle, DeferredWorkOptions } from "./deferred-work";
 export type {
   HydrateMode,
   ThreadHydratorOptions,

--- a/apps/web/src/lib/thread-hydrator/prefetch-scheduler.ts
+++ b/apps/web/src/lib/thread-hydrator/prefetch-scheduler.ts
@@ -1,14 +1,113 @@
 import { hasCachedRecord } from "./record-cache";
 import { getConversationResidency } from "@/stores/conversation-residency";
 
-/** Threads currently being prefetched, to avoid duplicate requests. */
-const inflight = new Set<string>();
+const MAX_CONCURRENT_PREFETCHES = 2;
+
+/** Ordering class used by the shared speculative prefetch queue. */
+export type PrefetchPriority = "interactive" | "background";
+
+interface PrefetchRequest {
+  threadId: string;
+  run: () => Promise<void>;
+  priority: PrefetchPriority;
+  sequence: number;
+  consumers: number;
+  active: boolean;
+}
+
+/** Shared queue that bounds all speculative conversation work to two requests. */
+const requests = new Map<string, PrefetchRequest>();
+const queue: PrefetchRequest[] = [];
+let activeCount = 0;
+let nextSequence = 0;
 
 /** Debounce timer for hover prefetch. */
 let hoverTimer: ReturnType<typeof setTimeout> | null = null;
 
+/** Cancellation handle for a hover request that is queued behind other work. */
+let hoverRequestCancel: (() => void) | null = null;
+
 /** Debounce delay before triggering prefetch on hover (ms). */
 const HOVER_DEBOUNCE_MS = 50;
+
+/** Enqueue one shared background prefetch, deduplicating requests by thread. */
+export function enqueueBackgroundPrefetch(
+  threadId: string,
+  run: () => Promise<void>,
+  priority: PrefetchPriority = "background",
+): () => void {
+  const existing = requests.get(threadId);
+  if (existing) {
+    existing.consumers += 1;
+    if (!existing.active && priority === "interactive") {
+      existing.priority = priority;
+    }
+    return createCancellation(existing);
+  }
+
+  const request: PrefetchRequest = {
+    threadId,
+    run,
+    priority,
+    sequence: nextSequence++,
+    consumers: 1,
+    active: false,
+  };
+  requests.set(threadId, request);
+  queue.push(request);
+  pumpPrefetchQueue();
+  return createCancellation(request);
+}
+
+function createCancellation(request: PrefetchRequest): () => void {
+  let cancelled = false;
+  return () => {
+    if (cancelled) return;
+    cancelled = true;
+    request.consumers = Math.max(0, request.consumers - 1);
+    if (!request.active && request.consumers === 0) {
+      requests.delete(request.threadId);
+      pumpPrefetchQueue();
+    }
+  };
+}
+
+function pumpPrefetchQueue(): void {
+  while (activeCount < MAX_CONCURRENT_PREFETCHES) {
+    const nextIndex = queue.reduce((bestIndex, request, index) => {
+      if (request.consumers === 0) return bestIndex;
+      if (bestIndex < 0) return index;
+      const best = queue[bestIndex];
+      if (!best) return index;
+      if (request.priority !== best.priority) {
+        return request.priority === "interactive" ? index : bestIndex;
+      }
+      return request.sequence < best.sequence ? index : bestIndex;
+    }, -1);
+    if (nextIndex < 0) {
+      queue.length = 0;
+      return;
+    }
+    const [request] = queue.splice(nextIndex, 1);
+    if (!request || request.consumers === 0) continue;
+
+    request.active = true;
+    activeCount += 1;
+    let operation: Promise<void>;
+    try {
+      operation = request.run();
+    } catch {
+      operation = Promise.resolve();
+    }
+    void operation
+      .catch(() => undefined)
+      .finally(() => {
+        activeCount -= 1;
+        requests.delete(request.threadId);
+        pumpPrefetchQueue();
+      });
+  }
+}
 
 /**
  * Schedule a background prefetch of messages for a thread.
@@ -17,10 +116,11 @@ const HOVER_DEBOUNCE_MS = 50;
  * or a prefetch is in flight.
  */
 export function schedulePrefetch(threadId: string): void {
+  cancelPrefetch();
   if (hoverTimer) clearTimeout(hoverTimer);
   hoverTimer = setTimeout(() => {
     hoverTimer = null;
-    void prefetchThread(threadId);
+    hoverRequestCancel = prefetchThread(threadId, "background");
   }, HOVER_DEBOUNCE_MS);
 }
 
@@ -30,12 +130,14 @@ export function cancelPrefetch(): void {
     clearTimeout(hoverTimer);
     hoverTimer = null;
   }
+  hoverRequestCancel?.();
+  hoverRequestCancel = null;
 }
 
 /** Start a speculative prefetch immediately when a thread receives pointer-down. */
 export function prefetchOnPointerDown(threadId: string): void {
   cancelPrefetch();
-  void prefetchThread(threadId);
+  prefetchThread(threadId, "interactive");
 }
 
 /**
@@ -43,20 +145,26 @@ export function prefetchOnPointerDown(threadId: string): void {
  * Skips if already cached or in flight. Failures are silent
  * since this is a speculative optimisation.
  */
-async function prefetchThread(threadId: string): Promise<void> {
-  if (hasCachedRecord(threadId) || inflight.has(threadId)) return;
-  inflight.add(threadId);
-  try {
-    await getConversationResidency().prefetch(threadId);
-  } catch {
-    // Prefetch is speculative; swallow errors silently
-  } finally {
-    inflight.delete(threadId);
-  }
+function prefetchThread(
+  threadId: string,
+  priority: PrefetchPriority,
+): () => void {
+  if (hasCachedRecord(threadId)) return () => undefined;
+  return enqueueBackgroundPrefetch(
+    threadId,
+    async () => {
+      if (hasCachedRecord(threadId)) return;
+      await getConversationResidency().prefetch(threadId);
+    },
+    priority,
+  );
 }
 
-/** Clear inflight tracking. Used by tests. */
+/** Clear queued prefetch tracking while allowing active requests to settle. */
 export function __resetPrefetchForTests(): void {
-  inflight.clear();
   cancelPrefetch();
+  queue.length = 0;
+  for (const [threadId, request] of requests) {
+    if (!request.active) requests.delete(threadId);
+  }
 }

--- a/apps/web/src/lib/thread-hydrator/prefetch-scheduler.ts
+++ b/apps/web/src/lib/thread-hydrator/prefetch-scheduler.ts
@@ -8,7 +8,7 @@ const inflight = new Set<string>();
 let hoverTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** Debounce delay before triggering prefetch on hover (ms). */
-const HOVER_DEBOUNCE_MS = 150;
+const HOVER_DEBOUNCE_MS = 50;
 
 /**
  * Schedule a background prefetch of messages for a thread.
@@ -30,6 +30,12 @@ export function cancelPrefetch(): void {
     clearTimeout(hoverTimer);
     hoverTimer = null;
   }
+}
+
+/** Start a speculative prefetch immediately when a thread receives pointer-down. */
+export function prefetchOnPointerDown(threadId: string): void {
+  cancelPrefetch();
+  void prefetchThread(threadId);
 }
 
 /**

--- a/apps/web/src/lib/thread-hydrator/record-cache.ts
+++ b/apps/web/src/lib/thread-hydrator/record-cache.ts
@@ -32,6 +32,8 @@ export interface ConversationCacheState {
   narrativeByMessage: ThreadRecord["narrativeByMessage"];
   answeredPlanMessageIds: ThreadRecord["answeredPlanMessageIds"];
   assistantResponseKeys: ThreadRecord["assistantResponseKeys"];
+  /** Auxiliary hydration freshness retained with the inactive conversation. */
+  lastHydratedAt?: ThreadRecord["lastHydratedAt"];
   /** Latest settled snapshot projection. Never populated from a live turn. */
   settledFileEffectSummary: ThreadRecord["fileEffectSummary"] | null;
 }
@@ -49,6 +51,7 @@ export function projectConversationCacheState(record: ThreadRecord): Conversatio
     narrativeByMessage: record.narrativeByMessage,
     answeredPlanMessageIds: record.answeredPlanMessageIds,
     assistantResponseKeys: record.assistantResponseKeys,
+    lastHydratedAt: record.lastHydratedAt,
     settledFileEffectSummary: record.fileEffectTurnId.length === 0
       ? record.fileEffectSummary
       : null,

--- a/apps/web/src/lib/thread-hydrator/record-cache.ts
+++ b/apps/web/src/lib/thread-hydrator/record-cache.ts
@@ -10,7 +10,7 @@ import type { ConversationPage } from "@mcode/contracts";
  * Initial default thread cache capacity.
  * Overridden by the `performance.threadCacheSize` user setting at runtime.
  */
-export const RECORD_CACHE_SIZE = 15;
+export const RECORD_CACHE_SIZE = 25;
 
 /** Maximum messages retained across one thread's record and warm history page. */
 export const RECORD_MESSAGE_CACHE_SIZE = 100;

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -960,6 +960,9 @@ export class ThreadHydrator {
                 : {}),
             loading: false,
             isLoadingMore: false,
+            // Reserve the auxiliary freshness window with the conversation commit.
+            // The fanout itself is deferred so the first paint is not blocked.
+            lastHydratedAt: Date.now(),
             settings: this.deps.getWorkspaceThreadSettings(threadId),
           }),
         };

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -866,7 +866,7 @@ export class ThreadHydrator {
       const tailLoader = this.transport().loadConversationTail;
       const usedTail = tailLoader != null && requestedLimit <= MESSAGE_FETCH_SIZE;
       let pageResult: ConversationPage;
-      if (tailLoader) {
+      if (usedTail && tailLoader) {
         const tail = await tailLoader(threadId, Math.min(requestedLimit, MESSAGE_FETCH_SIZE));
         pageResult = {
           messages: normalizeTailMessages(tail),

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -229,6 +229,7 @@ export class ThreadHydrator {
   private readonly backgroundHydrates = new Map<string, Promise<void>>();
   private readonly pendingHistoryPrefetches = new Map<string, PendingHistoryPrefetch>();
   private readonly deferredWork = new Map<string, DeferredWorkHandle>();
+  private readonly invalidationGenerations = new Map<string, number>();
 
   constructor(private readonly deps: ThreadHydratorDeps) {
     this.auxiliaryHydrator = new AuxiliaryHydrator({
@@ -282,7 +283,19 @@ export class ThreadHydrator {
 
   /** Discard a stale cached conversation before an authoritative mutation. */
   invalidateConversation(threadId: string): void {
+    if (this.activeHydrates.has(threadId) || this.backgroundHydrates.has(threadId)) {
+      this.invalidationGenerations.set(
+        threadId,
+        (this.invalidationGenerations.get(threadId) ?? 0) + 1,
+      );
+    }
     evictCachedRecord(threadId);
+  }
+
+  private pruneInvalidationGeneration(threadId: string): void {
+    if (!this.activeHydrates.has(threadId) && !this.backgroundHydrates.has(threadId)) {
+      this.invalidationGenerations.delete(threadId);
+    }
   }
 
   /** Synchronize the current resident conversation into its bounded cache entry. */
@@ -352,6 +365,7 @@ export class ThreadHydrator {
       if (this.backgroundHydrates.get(threadId) === hydrate) {
         this.backgroundHydrates.delete(threadId);
       }
+      this.pruneInvalidationGeneration(threadId);
     });
     this.backgroundHydrates.set(threadId, hydrate);
     await hydrate;
@@ -470,6 +484,7 @@ export class ThreadHydrator {
         this.activeHydrates.delete(threadId);
         this.discardInactiveLoadingRecord(threadId);
       }
+      this.pruneInvalidationGeneration(threadId);
     });
     this.activeHydrates.set(threadId, hydrate);
     await hydrate;
@@ -850,6 +865,7 @@ export class ThreadHydrator {
       this.prepareActiveLoad(threadId);
     }
     const expectedEpoch = getThreadRecord(getState().records, threadId).loadEpoch;
+    const expectedInvalidationGeneration = this.invalidationGenerations.get(threadId) ?? 0;
     const expectedConversationRevision = conversationRevision(
       getThreadRecord(getState().records, threadId),
     );
@@ -879,7 +895,26 @@ export class ThreadHydrator {
 
       const stateAtCommit = getState();
       const recordAtCommit = getThreadRecord(stateAtCommit.records, threadId);
-      if (stateAtCommit.currentThreadId !== threadId || recordAtCommit.loadEpoch !== expectedEpoch) {
+      if (
+        stateAtCommit.currentThreadId !== threadId
+        || recordAtCommit.loadEpoch !== expectedEpoch
+        || (this.invalidationGenerations.get(threadId) ?? 0) !== expectedInvalidationGeneration
+      ) {
+        if (
+          stateAtCommit.currentThreadId === threadId
+          && recordAtCommit.loadEpoch === expectedEpoch
+        ) {
+          setState((state: ThreadHydratorWriteState) => {
+            const current = getThreadRecord(state.records, threadId);
+            if (state.currentThreadId !== threadId || current.loadEpoch !== expectedEpoch) return {};
+            return {
+              records: patchThreadRecord(state.records, threadId, {
+                loading: false,
+                isLoadingMore: false,
+              }),
+            };
+          });
+        }
         return;
       }
       if (conversationRevision(recordAtCommit) !== expectedConversationRevision) {
@@ -939,20 +974,40 @@ export class ThreadHydrator {
         skipFileChangeSnapshots: true,
       });
 
+      let tailFollowupInvalidated = false;
       if (usedTail) {
         const postTailState = getState();
         if (
           postTailState.currentThreadId !== threadId
           || getThreadRecord(postTailState.records, threadId).loadEpoch !== expectedEpoch
+          || (this.invalidationGenerations.get(threadId) ?? 0) !== expectedInvalidationGeneration
         ) return;
+        const tailRevision = conversationRevision(getThreadRecord(postTailState.records, threadId));
+        const tailGeneration = this.invalidationGenerations.get(threadId) ?? 0;
         try {
           const narrativePage = await this.transport().loadConversationPage(
             threadId,
             MESSAGE_FETCH_SIZE,
           );
+          const stateAtTailFollowup = getState();
+          const recordAtTailFollowup = getThreadRecord(stateAtTailFollowup.records, threadId);
+          if (
+            stateAtTailFollowup.currentThreadId !== threadId
+            || recordAtTailFollowup.loadEpoch !== expectedEpoch
+            || (this.invalidationGenerations.get(threadId) ?? 0) !== tailGeneration
+            || conversationRevision(recordAtTailFollowup) !== tailRevision
+          ) {
+            tailFollowupInvalidated = true;
+          }
           setState((state: ThreadHydratorWriteState) => {
             const current = getThreadRecord(state.records, threadId);
-            if (state.currentThreadId !== threadId || current.loadEpoch !== expectedEpoch) return {};
+            if (
+              tailFollowupInvalidated
+              || state.currentThreadId !== threadId
+              || current.loadEpoch !== expectedEpoch
+              || (this.invalidationGenerations.get(threadId) ?? 0) !== tailGeneration
+              || conversationRevision(current) !== tailRevision
+            ) return {};
             const retained = new Set(current.messages.map((message) => message.id));
             return {
               records: patchThreadRecord(state.records, threadId, {
@@ -966,6 +1021,13 @@ export class ThreadHydrator {
             };
           });
         } catch {
+          const stateAtTailFailure = getState();
+          const recordAtTailFailure = getThreadRecord(stateAtTailFailure.records, threadId);
+          tailFollowupInvalidated =
+            stateAtTailFailure.currentThreadId !== threadId
+            || recordAtTailFailure.loadEpoch !== expectedEpoch
+            || (this.invalidationGenerations.get(threadId) ?? 0) !== tailGeneration
+            || conversationRevision(recordAtTailFailure) !== tailRevision;
           // First-paint tail remains usable when the narrative follow-up fails.
         }
       }
@@ -981,10 +1043,16 @@ export class ThreadHydrator {
         }
       }
 
-      cacheRecord(
-        threadId,
-        projectConversationCacheState(getThreadRecord(getState().records, threadId)),
-      );
+      const stateBeforeCache = getState();
+      const recordBeforeCache = getThreadRecord(stateBeforeCache.records, threadId);
+      if (
+        !tailFollowupInvalidated
+        && stateBeforeCache.currentThreadId === threadId
+        && recordBeforeCache.loadEpoch === expectedEpoch
+        && (this.invalidationGenerations.get(threadId) ?? 0) === expectedInvalidationGeneration
+      ) {
+        cacheRecord(threadId, projectConversationCacheState(recordBeforeCache));
+      }
       void snapshotsPromise.then((snapshots) => {
         this.applySnapshots(threadId, snapshots, expectedEpoch);
       });

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -27,9 +27,11 @@ import type {
 } from "./types";
 import { SnapshotBuilder, snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
-import type { ConversationPage } from "@mcode/contracts";
+import type { ConversationPage, ConversationTail } from "@mcode/contracts";
 import { hasRememberedHistoryPosition } from "@/components/chat/scrollPositionMemory";
 import { recordThreadCommit } from "@/lib/thread-switch-telemetry";
+import { scheduleDeferredWork } from "./deferred-work";
+import type { DeferredWorkHandle } from "./deferred-work";
 
 interface PendingHistoryPrefetch {
   expectedEpoch: number;
@@ -194,6 +196,17 @@ function buildConversationPageSubset(
   };
 }
 
+function normalizeTailMessages(tail: ConversationTail): ConversationPage["messages"] {
+  return tail.messages.map((message) => ({
+    ...message,
+    cost_usd: null,
+    tokens_used: null,
+    tool_calls: null,
+    files_changed: null,
+    attachments: null,
+  }));
+}
+
 /** Latest messages fetched before the selected thread first paints. */
 export const MESSAGE_FETCH_SIZE = 2;
 
@@ -215,6 +228,7 @@ export class ThreadHydrator {
   private readonly activeHydrates = new Map<string, Promise<void>>();
   private readonly backgroundHydrates = new Map<string, Promise<void>>();
   private readonly pendingHistoryPrefetches = new Map<string, PendingHistoryPrefetch>();
+  private readonly deferredWork = new Map<string, DeferredWorkHandle>();
 
   constructor(private readonly deps: ThreadHydratorDeps) {
     this.auxiliaryHydrator = new AuxiliaryHydrator({
@@ -248,6 +262,15 @@ export class ThreadHydrator {
       return;
     }
     await this.hydrateActive(threadId, opts);
+  }
+
+  private cancelDeferredForThread(threadId: string): void {
+    for (const [key, handle] of this.deferredWork) {
+      if (key === threadId || key.startsWith(`${threadId}:`)) {
+        handle.cancel();
+        this.deferredWork.delete(key);
+      }
+    }
   }
 
   /** Retain an inactive resident transcript through the bounded conversation cache. */
@@ -391,6 +414,9 @@ export class ThreadHydrator {
   /** Active-thread load invoked from ChatView and workspaceStore. */
   private async hydrateActive(threadId: string, opts?: ThreadHydratorOptions): Promise<void> {
     const outgoingThreadId = this.deps.getState().currentThreadId;
+    if (outgoingThreadId && outgoingThreadId !== threadId) {
+      this.cancelDeferredForThread(outgoingThreadId);
+    }
     const outgoingHydrate = outgoingThreadId
       ? this.activeHydrates.get(outgoingThreadId)
       : undefined;
@@ -569,7 +595,7 @@ export class ThreadHydrator {
     recordThreadCommit(threadId, "cache-restore");
     const expectedEpoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
     void this.refreshThreadGoal(threadId, expectedEpoch);
-    this.auxiliaryHydrator.hydrate(threadId, {
+    this.scheduleAuxiliaryHydration(threadId, expectedEpoch, {
       freshnessTtlMs: HYDRATION_TTL_MS,
       force: opts?.force,
       commitFileChangesToStore: true,
@@ -581,6 +607,26 @@ export class ThreadHydrator {
     ) {
       this.scheduleEarlierHistoryPrefetch(threadId, renderableCachedRecord);
     }
+  }
+
+  /** Run auxiliary fanout after the first paint, unless this selection is superseded. */
+  private scheduleAuxiliaryHydration(
+    threadId: string,
+    expectedEpoch: number,
+    options: Parameters<AuxiliaryHydrator["hydrate"]>[1],
+  ): void {
+    this.deferredWork.get(threadId)?.cancel();
+    const handle = scheduleDeferredWork(() => {
+      const state = this.deps.getState();
+      const record = getThreadRecord(state.records, threadId);
+      if (state.currentThreadId !== threadId || record.loadEpoch !== expectedEpoch) {
+        this.deferredWork.delete(threadId);
+        return;
+      }
+      this.auxiliaryHydrator.hydrate(threadId, options);
+      this.deferredWork.delete(threadId);
+    }, { maxDelayMs: 100 });
+    this.deferredWork.set(threadId, handle);
   }
 
   /** Keep cache-hit reconciliation bounded while retaining loaded history for upward pagination. */
@@ -735,6 +781,8 @@ export class ThreadHydrator {
   /** Prepare the live record for an active-thread load before the RPC settles. */
   private prepareActiveLoad(threadId: string): void {
     const { getState, setState } = this.deps;
+    this.deferredWork.get(threadId)?.cancel();
+    this.deferredWork.delete(threadId);
     const isRunning = getState().runningThreadIds.has(threadId);
 
     if (!isRunning) {
@@ -814,10 +862,20 @@ export class ThreadHydrator {
       const snapshotsPromise = shouldFetchSnapshots
         ? this.transport().listSnapshots(threadId).catch(() => [] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>)
         : Promise.resolve([] as Awaited<ReturnType<ThreadHydratorTransport["listSnapshots"]>>);
-      const pageResult = await this.transport().loadConversationPage(
-        threadId,
-        commitOpts?.fetchLimit ?? MESSAGE_FETCH_SIZE,
-      );
+      const requestedLimit = commitOpts?.fetchLimit ?? MESSAGE_FETCH_SIZE;
+      const tailLoader = this.transport().loadConversationTail;
+      const usedTail = tailLoader != null && requestedLimit <= MESSAGE_FETCH_SIZE;
+      let pageResult: ConversationPage;
+      if (tailLoader) {
+        const tail = await tailLoader(threadId, Math.min(requestedLimit, MESSAGE_FETCH_SIZE));
+        pageResult = {
+          messages: normalizeTailMessages(tail),
+          hasMore: tail.hasMore,
+          narrativeByMessage: {},
+        };
+      } else {
+        pageResult = await this.transport().loadConversationPage(threadId, requestedLimit);
+      }
 
       const stateAtCommit = getState();
       const recordAtCommit = getThreadRecord(stateAtCommit.records, threadId);
@@ -873,13 +931,44 @@ export class ThreadHydrator {
       });
       recordThreadCommit(threadId, "network-fetch");
 
-      this.auxiliaryHydrator.hydrate(threadId, {
+      this.scheduleAuxiliaryHydration(threadId, expectedEpoch, {
         freshnessTtlMs: HYDRATION_TTL_MS,
         force: opts?.force ?? true,
         commitFileChangesToStore: true,
         expectedLoadEpoch: expectedEpoch,
         skipFileChangeSnapshots: true,
       });
+
+      if (usedTail) {
+        const postTailState = getState();
+        if (
+          postTailState.currentThreadId !== threadId
+          || getThreadRecord(postTailState.records, threadId).loadEpoch !== expectedEpoch
+        ) return;
+        try {
+          const narrativePage = await this.transport().loadConversationPage(
+            threadId,
+            MESSAGE_FETCH_SIZE,
+          );
+          setState((state: ThreadHydratorWriteState) => {
+            const current = getThreadRecord(state.records, threadId);
+            if (state.currentThreadId !== threadId || current.loadEpoch !== expectedEpoch) return {};
+            const retained = new Set(current.messages.map((message) => message.id));
+            return {
+              records: patchThreadRecord(state.records, threadId, {
+                narrativeByMessage: Object.fromEntries(
+                  Object.entries(narrativePage.narrativeByMessage).filter(([id]) => retained.has(id)),
+                ),
+                answeredPlanMessageIds: new Set(
+                  (narrativePage.answeredPlanMessageIds ?? []).filter((id) => retained.has(id)),
+                ),
+              }),
+            };
+          });
+        } catch {
+          // First-paint tail remains usable when the narrative follow-up fails.
+        }
+      }
 
       const committed = getThreadRecord(getState().records, threadId);
       if (committed.planQuestionsStatus !== "pending") {
@@ -928,7 +1017,7 @@ export class ThreadHydrator {
     if (hasPrefetchedHistoryPage(threadId, before)) return;
     const epoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
     const prefetchKey = `${threadId}:${before}`;
-    setTimeout(() => {
+    const deferred = scheduleDeferredWork(() => {
       const state = this.deps.getState();
       if (state.currentThreadId !== threadId) return;
       if (getThreadRecord(state.records, threadId).loadEpoch !== epoch) return;
@@ -949,9 +1038,11 @@ export class ThreadHydrator {
         if (this.pendingHistoryPrefetches.get(prefetchKey) === prefetch) {
           this.pendingHistoryPrefetches.delete(prefetchKey);
         }
+        this.deferredWork.delete(prefetchKey);
       });
       this.pendingHistoryPrefetches.set(prefetchKey, prefetch);
-    }, 0);
+    }, { maxDelayMs: 100 });
+    this.deferredWork.set(prefetchKey, deferred);
   }
 
   /** Cache the older history window without attaching it to live React state. */

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -29,6 +29,7 @@ import { SnapshotBuilder, snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
 import type { ConversationPage } from "@mcode/contracts";
 import { hasRememberedHistoryPosition } from "@/components/chat/scrollPositionMemory";
+import { recordThreadCommit } from "@/lib/thread-switch-telemetry";
 
 interface PendingHistoryPrefetch {
   expectedEpoch: number;
@@ -565,6 +566,7 @@ export class ThreadHydrator {
   ): void {
     const renderableCachedRecord = this.compactCachedRecordForRestore(threadId, cached);
     this.restoreFromCache(threadId, renderableCachedRecord, restoreOpts);
+    recordThreadCommit(threadId, "cache-restore");
     const expectedEpoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
     void this.refreshThreadGoal(threadId, expectedEpoch);
     this.auxiliaryHydrator.hydrate(threadId, {
@@ -869,6 +871,7 @@ export class ThreadHydrator {
           }),
         };
       });
+      recordThreadCommit(threadId, "network-fetch");
 
       this.auxiliaryHydrator.hydrate(threadId, {
         freshnessTtlMs: HYDRATION_TTL_MS,

--- a/apps/web/src/lib/thread-hydrator/types.ts
+++ b/apps/web/src/lib/thread-hydrator/types.ts
@@ -1,5 +1,5 @@
 import type { Message, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord } from "@/transport";
-import type { TurnSnapshot, PermissionRequest, PlanRecord, NarrativeEntry, ConversationPage, GoalLookupResult } from "@mcode/contracts";
+import type { TurnSnapshot, PermissionRequest, PlanRecord, NarrativeEntry, ConversationPage, ConversationTail, GoalLookupResult } from "@mcode/contracts";
 import type { TaskItem } from "@/stores/taskStore";
 import type { PlanQuestion } from "@mcode/contracts";
 import type { ThreadRecord } from "@/stores/thread-record";
@@ -34,6 +34,8 @@ export type NarrativeBatchResult = Record<
 export interface ThreadHydratorTransport {
   getMessages(threadId: string, limit: number, before?: number): Promise<PaginatedMessages>;
   loadConversationPage(threadId: string, limit: number, before?: number): Promise<ConversationPage>;
+  /** Fetch only the bounded tail needed for first paint when supported. */
+  loadConversationTail?: (threadId: string, limit: number) => Promise<ConversationTail>;
   listSnapshots(threadId: string): Promise<TurnSnapshot[]>;
   listNarrative(messageId: string): Promise<NarrativeBatchResult[string]>;
   loadTurn(threadId: string): Promise<NarrativeEntry[]>;

--- a/apps/web/src/lib/thread-switch-telemetry.ts
+++ b/apps/web/src/lib/thread-switch-telemetry.ts
@@ -1,0 +1,106 @@
+/** Dev-only performance marks for the thread switch critical path. */
+
+const MARK_PREFIX = "mcode:thread-switch";
+const MAX_RETAINED_SWITCHES = 32;
+
+type ThreadSwitchPath = "cache-restore" | "network-fetch";
+
+interface ThreadSwitchRecord {
+  id: number;
+  threadId: string;
+  selectionMark: string;
+  commitMark?: string;
+  positionedMark?: string;
+}
+
+const records = new Map<number, ThreadSwitchRecord>();
+const latestByThread = new Map<string, number>();
+let nextSwitchId = 0;
+let latestSelectionId: number | null = null;
+
+function isEnabled(): boolean {
+  return import.meta.env.DEV && typeof performance !== "undefined";
+}
+
+function clearRecord(record: ThreadSwitchRecord): void {
+  performance.clearMarks(record.selectionMark);
+  if (record.commitMark) performance.clearMarks(record.commitMark);
+  if (record.positionedMark) performance.clearMarks(record.positionedMark);
+  performance.clearMeasures(`${MARK_PREFIX}:selection-to-commit:${record.id}`);
+  performance.clearMeasures(`${MARK_PREFIX}:selection-to-positioned:${record.id}`);
+  records.delete(record.id);
+  if (latestByThread.get(record.threadId) === record.id) {
+    latestByThread.delete(record.threadId);
+  }
+}
+
+function retain(record: ThreadSwitchRecord): void {
+  records.set(record.id, record);
+  while (records.size > MAX_RETAINED_SWITCHES) {
+    const oldest = records.values().next().value as ThreadSwitchRecord | undefined;
+    if (!oldest) return;
+    clearRecord(oldest);
+  }
+}
+
+function mark(name: string, detail: Record<string, string | number>): void {
+  performance.mark(name, { detail });
+}
+
+/** Record a user's thread selection and return its switch identity. */
+export function recordThreadSelection(threadId: string): number | null {
+  if (!isEnabled()) return null;
+  const id = ++nextSwitchId;
+  const selectionMark = `${MARK_PREFIX}:selection:${id}`;
+  mark(selectionMark, { threadId, switchId: id });
+  const record: ThreadSwitchRecord = { id, threadId, selectionMark };
+  latestSelectionId = id;
+  latestByThread.set(threadId, id);
+  retain(record);
+  return id;
+}
+
+/** Record the cache or network commit for the latest selection of a thread. */
+export function recordThreadCommit(threadId: string, path: ThreadSwitchPath): void {
+  if (!isEnabled()) return;
+  const id = latestByThread.get(threadId);
+  if (id == null || id !== latestSelectionId) return;
+  const record = records.get(id);
+  if (!record || record.commitMark) return;
+  const commitMark = `${MARK_PREFIX}:commit:${path}:${id}`;
+  mark(commitMark, { threadId, switchId: id, path });
+  record.commitMark = commitMark;
+  performance.measure(`${MARK_PREFIX}:selection-to-commit:${id}`, {
+    start: record.selectionMark,
+    end: commitMark,
+    detail: { threadId, switchId: id, path },
+  });
+}
+
+/** Record the first positioned paint for the latest selection of a thread. */
+export function recordThreadPositioned(threadId: string): void {
+  if (!isEnabled()) return;
+  const id = latestByThread.get(threadId);
+  if (id == null || id !== latestSelectionId) return;
+  const record = records.get(id);
+  if (!record || record.positionedMark) return;
+  const positionedMark = `${MARK_PREFIX}:positioned:${id}`;
+  mark(positionedMark, { threadId, switchId: id });
+  record.positionedMark = positionedMark;
+  performance.measure(`${MARK_PREFIX}:selection-to-positioned:${id}`, {
+    start: record.selectionMark,
+    end: positionedMark,
+    detail: { threadId, switchId: id },
+  });
+}
+
+/** Clear telemetry state and browser entries. Intended for unit tests only. */
+export function __resetThreadSwitchTelemetryForTests(): void {
+  if (isEnabled()) {
+    for (const record of records.values()) clearRecord(record);
+  }
+  records.clear();
+  latestByThread.clear();
+  nextSwitchId = 0;
+  latestSelectionId = null;
+}

--- a/apps/web/src/stores/__tests__/conversation-residency.test.ts
+++ b/apps/web/src/stores/__tests__/conversation-residency.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { createConversationResidency } from "../conversation-residency";
+
+function deps() {
+  return {
+    restoreConversation: vi.fn().mockResolvedValue(undefined),
+    refreshConversation: vi.fn().mockResolvedValue(undefined),
+    deactivateConversation: vi.fn(),
+    retainInactiveConversation: vi.fn(),
+    invalidateConversation: vi.fn(),
+    synchronizeConversation: vi.fn(),
+    mergeCachedFileChanges: vi.fn(),
+    takePrefetchedHistoryPage: vi.fn(),
+    prefetchConversation: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("ConversationResidency adjacent prefetch", () => {
+  it("prefetches sorted neighbors only after valid activation", async () => {
+    const dependencies = deps();
+    const residency = createConversationResidency(dependencies);
+
+    await residency.activate("t2", [
+      { id: "t1" },
+      { id: "t2" },
+      { id: "t3" },
+    ]);
+
+    expect(
+      dependencies.prefetchConversation.mock.calls.map(([id]) => id),
+    ).toEqual(["t1", "t3"]);
+  });
+
+  it.each([
+    [null, []],
+    ["missing", [{ id: "t1" }]],
+    ["preparing", [{ id: "preparing", clientPreparing: true }, { id: "t2" }]],
+    ["failed", [{ id: "failed", clientError: "failed" }, { id: "t2" }]],
+  ])(
+    "does not prefetch neighbors for unavailable activation %s",
+    async (selected, threads) => {
+      const dependencies = deps();
+      const residency = createConversationResidency(dependencies);
+
+      await residency.activate(selected, threads);
+
+      expect(dependencies.prefetchConversation).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not schedule stale neighbors when a newer activation wins", async () => {
+    const dependencies = deps();
+    let resolveFirst!: () => void;
+    dependencies.restoreConversation
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(undefined);
+    const residency = createConversationResidency(dependencies);
+    const threads = [{ id: "t1" }, { id: "t2" }, { id: "t3" }];
+
+    const firstActivation = residency.activate("t2", threads);
+    await residency.activate("t3", threads);
+    resolveFirst();
+    await firstActivation;
+
+    expect(
+      dependencies.prefetchConversation.mock.calls.map(([id]) => id),
+    ).toEqual(["t2"]);
+  });
+});

--- a/apps/web/src/stores/conversation-residency.ts
+++ b/apps/web/src/stores/conversation-residency.ts
@@ -1,11 +1,11 @@
 import type { ConversationPage } from "@mcode/contracts";
+import {
+  createAdjacentPrefetchScheduler,
+  type AdjacentPrefetchThread,
+} from "@/lib/thread-hydrator/adjacent-prefetch";
 
 /** A sidebar row that can be activated as a persisted conversation. */
-export interface ConversationResidencyThread {
-  id: string;
-  clientPreparing?: boolean;
-  clientError?: string | null;
-}
+export type ConversationResidencyThread = AdjacentPrefetchThread;
 
 /** Dependency contract for conversation residency behavior. */
 export interface ConversationResidencyDeps {
@@ -25,16 +25,29 @@ export interface ConversationResidencyDeps {
  * Transport, cache freshness, and live-record precedence stay in ThreadHydrator.
  */
 export class ConversationResidency {
-  constructor(private readonly deps: ConversationResidencyDeps) {}
+  private activationGeneration = 0;
+  private readonly adjacentPrefetch;
+
+  constructor(private readonly deps: ConversationResidencyDeps) {
+    this.adjacentPrefetch = createAdjacentPrefetchScheduler({
+      prefetch: deps.prefetchConversation,
+    });
+  }
 
   /** Activate the selected thread when it has a persisted conversation identity. */
   activate(threadId: string | null, threads: readonly ConversationResidencyThread[]): Promise<void> {
+    const activationGeneration = ++this.activationGeneration;
+    this.adjacentPrefetch.cancel();
     const thread = threadId ? threads.find((candidate) => candidate.id === threadId) : undefined;
     if (!thread || thread.clientPreparing || thread.clientError) {
       this.deps.deactivateConversation();
       return Promise.resolve();
     }
-    return this.deps.restoreConversation(thread.id);
+    return this.deps.restoreConversation(thread.id).then(() => {
+      if (activationGeneration === this.activationGeneration) {
+        this.adjacentPrefetch.activate(thread.id, threads);
+      }
+    });
   }
 
   /** Revalidate the selected transcript without clearing its resident rendering. */

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -351,8 +351,15 @@ interface WorkspaceState {
 
 /** Zustand store for workspace, thread, branch, and PR state management. */
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
+  let activationQueued = false;
   const reconcileSelectedConversation = () => {
-    void getConversationResidency().activate(get().activeThreadId, get().threads);
+    if (activationQueued) return;
+    activationQueued = true;
+    queueMicrotask(() => {
+      activationQueued = false;
+      const { activeThreadId, threads } = get();
+      void getConversationResidency().activate(activeThreadId, threads);
+    });
   };
 
   const applyOptimisticSuccess = (

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -27,6 +27,7 @@ import type { ContextWindowMode, NamingMode, ReasoningLevel, InteractionMode, Or
 import { sanitizeCustomBranchInput } from "@/lib/branch-name";
 import { isDetachedWorktree, normalizeWorktreePath } from "@/lib/worktree";
 import { readRememberedComposerMode } from "@/lib/composer-mode-preference";
+import { recordThreadSelection } from "@/lib/thread-switch-telemetry";
 
 /** Generate a short random branch name for auto-mode worktrees (e.g. `mcode-a1b2c3d4`). */
 function generateBranchId(): string {
@@ -1183,6 +1184,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
    * so it stays cleared across workspace switches and app restarts.
    */
   setActiveThread: (id) => {
+    if (id) recordThreadSelection(id);
     const thread = id ? get().threads.find((t) => t.id === id) : null;
     const isCompleted = thread?.status === "completed";
 

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -38,6 +38,8 @@ import type {
   PermissionRequest,
   CreateAndSendResult,
   ConversationPage,
+  ConversationTail,
+  SetThreadSubscriptionsInput,
   GoalLookupResult,
   PullRequestCapabilitiesRequest,
   PullRequestCapabilitiesResult,
@@ -127,7 +129,7 @@ export type {
   CreateAndSendInput,
 } from "@mcode/contracts";
 
-export type { PaginatedMessages, ConversationPage, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord, TurnSnapshot, CopilotSubagent } from "@mcode/contracts";
+export type { PaginatedMessages, ConversationPage, ConversationTail, ToolCallRecord, ThoughtSegmentRecord, HookExecutionRecord, TurnSnapshot, CopilotSubagent } from "@mcode/contracts";
 
 export { PERMISSION_MODES, INTERACTION_MODES } from "@mcode/contracts";
 
@@ -291,6 +293,8 @@ export interface McodeTransport {
   subscribeThread(threadId: string): Promise<void>;
   /** Remove this client connection's push subscription for a thread. */
   unsubscribeThread(threadId: string): Promise<void>;
+  /** Replace this connection's complete push subscription set atomically. */
+  setThreadSubscriptions?(input: SetThreadSubscriptionsInput): Promise<void>;
   /** Fetch the current active goal for a thread without starting provider work. */
   getThreadGoal(threadId: string): Promise<GoalLookupResult>;
   /** Clear the current active goal for a thread without sending a chat message. */
@@ -341,6 +345,8 @@ export interface McodeTransport {
   getMessages(threadId: string, limit: number, before?: number): Promise<PaginatedMessages>;
   /** Fetch persisted messages and grouped narrative for one thread page. */
   loadConversationPage(threadId: string, limit: number, before?: number): Promise<ConversationPage>;
+  /** Fetch only the bounded tail needed for first paint. */
+  loadConversationTail?(threadId: string, limit: number): Promise<ConversationTail>;
 
   // Config
   discoverConfig(workspacePath: string): Promise<Record<string, unknown>>;

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -54,7 +54,7 @@ import type {
   CreateAndSendInput,
 } from "@mcode/contracts";
 import { emitPtyReconnectGap } from "@/components/terminal/ptyDataRegistry";
-import type { PaginatedMessages, ConversationPage, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability, GoalLookupResult } from "@mcode/contracts";
+import type { PaginatedMessages, ConversationPage, ConversationTail, SetThreadSubscriptionsInput, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability, GoalLookupResult } from "@mcode/contracts";
 import {
   TERMINAL_DATA_TAG,
   decodeTerminalDataFrame,
@@ -637,6 +637,8 @@ export function createWsTransport(
     listRunning: () => rpc<string[]>("agent.listRunning", {}),
     subscribeThread: (threadId) => rpc<void>("push.subscribeThread", { threadId }),
     unsubscribeThread: (threadId) => rpc<void>("push.unsubscribeThread", { threadId }),
+    setThreadSubscriptions: (input: SetThreadSubscriptionsInput) =>
+      rpc<void>("push.setThreadSubscriptions", input),
     getThreadGoal: (threadId) =>
       rpc<GoalLookupResult>("thread.goal.get", { threadId }),
     clearThreadGoal: (threadId) =>
@@ -656,6 +658,8 @@ export function createWsTransport(
       rpc<PaginatedMessages>("message.list", { threadId, limit, ...(before != null ? { before } : {}) }),
     loadConversationPage: (threadId, limit, before?) =>
       rpc<ConversationPage>("conversation.page", { threadId, limit, ...(before != null ? { before } : {}) }),
+    loadConversationTail: (threadId, limit) =>
+      rpc<ConversationTail>("conversation.tail", { threadId, limit }),
 
     // Config
     discoverConfig: (workspacePath) =>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -186,6 +186,21 @@ export type {
 } from "./models/conversation-page.js";
 
 export {
+  CONVERSATION_TAIL_MAX_MESSAGES,
+  CONVERSATION_TAIL_THREAD_ID_MAX_LENGTH,
+  ConversationTailMessageSchema,
+  ConversationTailParamsSchema,
+  ConversationTailSchema,
+  ConversationTailResultSchema,
+} from "./models/conversation-tail.js";
+export type {
+  ConversationTailMessage,
+  ConversationTailParams,
+  ConversationTail,
+  ConversationTailResult,
+} from "./models/conversation-tail.js";
+
+export {
   ToolCallRecordSchema,
   ToolCallStatusSchema,
   PROVIDER_AGENT_KEY_MAX_LENGTH,
@@ -688,12 +703,15 @@ export {
   RECAP_MAX_MESSAGES,
   RECAP_MAX_MESSAGE_CONTENT_CHARS,
   RECAP_MAX_PREVIOUS_RECAP_CHARS,
+  MAX_THREAD_SUBSCRIPTIONS,
+  SetThreadSubscriptionsSchema,
 } from "./ws/methods.js";
 export type {
   WsMethodName,
   SendMessageInput,
   CreateAndSendInput,
   CreateAndSendResult,
+  SetThreadSubscriptionsInput,
 } from "./ws/methods.js";
 
 export { WS_CHANNELS } from "./ws/channels.js";

--- a/packages/contracts/src/models/__tests__/conversation-tail.test.ts
+++ b/packages/contracts/src/models/__tests__/conversation-tail.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONVERSATION_TAIL_MAX_MESSAGES,
+  ConversationTailMessageSchema,
+  ConversationTailParamsSchema,
+  ConversationTailSchema,
+} from "../conversation-tail.js";
+
+const message = {
+  id: "message-2",
+  thread_id: "thread-1",
+  role: "assistant" as const,
+  content: "Done",
+  timestamp: "2026-07-29T12:00:00.000Z",
+  sequence: 2,
+};
+
+describe("ConversationTailSchema", () => {
+  it("accepts a bounded tail without narrative payload", () => {
+    const result = ConversationTailSchema().safeParse({
+      messages: [message],
+      hasMore: true,
+      nextBefore: 2,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.messages).toEqual([message]);
+      expect("narrativeByMessage" in result.data).toBe(false);
+    }
+  });
+
+  it("rejects more than two messages", () => {
+    const result = ConversationTailSchema().safeParse({
+      messages: [message, { ...message, id: "message-1", sequence: 1 }, { ...message, id: "message-0", sequence: 0 }],
+      hasMore: false,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("bounds the request limit to the first-paint tail size", () => {
+    expect(ConversationTailParamsSchema().safeParse({ threadId: "thread-1", limit: CONVERSATION_TAIL_MAX_MESSAGES }).success).toBe(true);
+    expect(ConversationTailParamsSchema().safeParse({ threadId: "thread-1", limit: CONVERSATION_TAIL_MAX_MESSAGES + 1 }).success).toBe(false);
+    expect(ConversationTailParamsSchema().safeParse({ threadId: "thread-1", limit: 0 }).success).toBe(false);
+  });
+
+  it("does not accept narrative fields on a tail message", () => {
+    const result = ConversationTailMessageSchema().safeParse({
+      ...message,
+      tool_calls: [],
+      narrativeByMessage: {},
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).not.toHaveProperty("tool_calls");
+      expect(result.data).not.toHaveProperty("narrativeByMessage");
+    }
+  });
+});

--- a/packages/contracts/src/models/__tests__/settings.test.ts
+++ b/packages/contracts/src/models/__tests__/settings.test.ts
@@ -18,6 +18,22 @@ describe("settings.provider.enabled", () => {
   });
 });
 
+describe("settings.performance.threadCacheSize", () => {
+  it("defaults the thread cache to 25 entries", () => {
+    expect(getDefaultSettings().performance.threadCacheSize).toBe(25);
+    expect(SettingsSchema().parse({}).performance.threadCacheSize).toBe(25);
+  });
+
+  it("accepts bounded user overrides", () => {
+    expect(
+      SettingsSchema().parse({ performance: { threadCacheSize: 50 } }).performance.threadCacheSize,
+    ).toBe(50);
+    expect(
+      PartialSettingsSchema().parse({ performance: { threadCacheSize: 12 } }).performance?.threadCacheSize,
+    ).toBe(12);
+  });
+});
+
 describe("preview.memorySaver", () => {
   it("applies ADR 0002 defaults", () => {
     const s = SettingsSchema().parse({});

--- a/packages/contracts/src/models/conversation-tail.ts
+++ b/packages/contracts/src/models/conversation-tail.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { MessageRoleSchema } from "./enums.js";
+import { lazySchema } from "../utils/lazySchema.js";
+
+/** Maximum number of messages returned by the first-paint conversation tail. */
+export const CONVERSATION_TAIL_MAX_MESSAGES = 2;
+
+/** Maximum characters accepted for a thread identifier in conversation reads. */
+export const CONVERSATION_TAIL_THREAD_ID_MAX_LENGTH = 128;
+
+/** Minimal persisted message shape used for first-paint conversation content. */
+export const ConversationTailMessageSchema = lazySchema(() =>
+  z.object({
+    id: z.string().min(1),
+    thread_id: z.string().min(1),
+    role: MessageRoleSchema,
+    content: z.string(),
+    timestamp: z.string(),
+    sequence: z.number().int().nonnegative(),
+  }),
+);
+
+/** Parameters for loading a bounded conversation tail. */
+export const ConversationTailParamsSchema = lazySchema(() =>
+  z.object({
+    threadId: z.string().trim().min(1).max(CONVERSATION_TAIL_THREAD_ID_MAX_LENGTH),
+    limit: z.number().int().min(1).max(CONVERSATION_TAIL_MAX_MESSAGES),
+  }),
+);
+
+/** Minimal conversation tail with cursor facts for a follow-up page request. */
+export const ConversationTailSchema = lazySchema(() =>
+  z.object({
+    messages: z.array(ConversationTailMessageSchema()).max(CONVERSATION_TAIL_MAX_MESSAGES),
+    hasMore: z.boolean(),
+    nextBefore: z.number().int().nonnegative().optional(),
+  }),
+);
+
+/** Result returned by `conversation.tail`. */
+export const ConversationTailResultSchema = ConversationTailSchema;
+
+/** Parameters accepted by `conversation.tail`. */
+export type ConversationTailParams = z.infer<ReturnType<typeof ConversationTailParamsSchema>>;
+
+/** Minimal message returned by `conversation.tail`. */
+export type ConversationTailMessage = z.infer<ReturnType<typeof ConversationTailMessageSchema>>;
+
+/** Result returned by `conversation.tail`. */
+export type ConversationTail = z.infer<ReturnType<typeof ConversationTailSchema>>;
+
+/** Result returned by `conversation.tail`. */
+export type ConversationTailResult = ConversationTail;

--- a/packages/contracts/src/models/settings.ts
+++ b/packages/contracts/src/models/settings.ts
@@ -439,7 +439,7 @@ export const SettingsSchema = lazySchema(() =>
          * Higher values reduce thread-switch latency at the cost of memory;
          * lower values free memory at the cost of more getMessages round-trips.
          */
-        threadCacheSize: z.number().int().min(1).max(50).default(15),
+        threadCacheSize: z.number().int().min(1).max(50).default(25),
       })
       .default({}),
 

--- a/packages/contracts/src/ws/__tests__/methods.test.ts
+++ b/packages/contracts/src/ws/__tests__/methods.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { MAX_THREAD_SUBSCRIPTIONS, WS_METHODS } from "../methods.js";
+
+describe("thread switching WebSocket contracts", () => {
+  it("registers bounded conversation.tail params and result", () => {
+    const method = WS_METHODS()["conversation.tail"];
+
+    expect(method.params.safeParse({ threadId: "thread-1", limit: 2 }).success).toBe(true);
+    expect(method.params.safeParse({ threadId: "thread-1", limit: 3 }).success).toBe(false);
+    expect(method.result.safeParse({ messages: [], hasMore: false }).success).toBe(true);
+  });
+
+  it("replaces the complete desired subscription set atomically", () => {
+    const method = WS_METHODS()["push.setThreadSubscriptions"];
+
+    expect(method.params.safeParse({ threadIds: ["thread-1", "thread-2"] }).success).toBe(true);
+    expect(method.params.safeParse({ threadIds: ["thread-1", "thread-1"] }).success).toBe(false);
+    expect(method.params.safeParse({ threadIds: Array.from({ length: MAX_THREAD_SUBSCRIPTIONS + 1 }, (_, index) => `thread-${index}`) }).success).toBe(false);
+    expect(method.params.safeParse({ threadIds: [""] }).success).toBe(false);
+  });
+
+  it("keeps legacy single-thread subscription methods available", () => {
+    expect(WS_METHODS()["push.subscribeThread"]).toBeDefined();
+    expect(WS_METHODS()["push.unsubscribeThread"]).toBeDefined();
+  });
+});

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -5,6 +5,11 @@ import { ThreadModeSchema, PermissionModeSchema, InteractionModeSchema, Orchestr
 import { PaginatedMessagesSchema } from "../models/message.js";
 import { MessageMentionsSchema } from "../models/mention.js";
 import { ConversationPageSchema } from "../models/conversation-page.js";
+import {
+  CONVERSATION_TAIL_THREAD_ID_MAX_LENGTH,
+  ConversationTailParamsSchema,
+  ConversationTailSchema,
+} from "../models/conversation-tail.js";
 import { AttachmentMetaSchema } from "../models/attachment.js";
 import { MAX_ATTACHMENTS } from "../models/file-types.js";
 import { ToolCallRecordSchema } from "../models/tool-call-record.js";
@@ -122,6 +127,26 @@ export const RECAP_MAX_MESSAGES = 80;
 export const RECAP_MAX_MESSAGE_CONTENT_CHARS = 4_000;
 /** Maximum characters accepted for the previous recap hint. */
 export const RECAP_MAX_PREVIOUS_RECAP_CHARS = 500;
+
+/** Maximum number of thread subscriptions replaced in one atomic request. */
+export const MAX_THREAD_SUBSCRIPTIONS = 100;
+
+/** Thread identifier schema shared by atomic push subscription updates. */
+const ThreadSubscriptionIdSchema = z.string().trim().min(1).max(CONVERSATION_TAIL_THREAD_ID_MAX_LENGTH);
+
+/** Complete desired push subscription set for one WebSocket connection. */
+export const SetThreadSubscriptionsSchema = lazySchema(() =>
+  z.object({
+    threadIds: z.array(ThreadSubscriptionIdSchema).max(MAX_THREAD_SUBSCRIPTIONS).superRefine((threadIds, context) => {
+      if (new Set(threadIds).size !== threadIds.length) {
+        context.addIssue({ code: z.ZodIssueCode.custom, message: "threadIds must be unique" });
+      }
+    }),
+  }),
+);
+
+/** Input accepted by `push.setThreadSubscriptions`. */
+export type SetThreadSubscriptionsInput = z.infer<ReturnType<typeof SetThreadSubscriptionsSchema>>;
 
 /** Schema for creating a new thread. */
 export const CreateThreadSchema = lazySchema(() =>
@@ -639,6 +664,10 @@ export const WS_METHODS = lazySchema(() => ({
     params: z.object({ threadId: z.string() }),
     result: z.void(),
   },
+  "push.setThreadSubscriptions": {
+    params: SetThreadSubscriptionsSchema(),
+    result: z.void(),
+  },
   "agent.answerQuestions": {
     params: z.object({
       threadId: z.string(),
@@ -701,6 +730,10 @@ export const WS_METHODS = lazySchema(() => ({
       before: z.number().int().optional(),
     }),
     result: ConversationPageSchema(),
+  },
+  "conversation.tail": {
+    params: ConversationTailParamsSchema(),
+    result: ConversationTailSchema(),
   },
   "file.list": {
     params: z.object({


### PR DESCRIPTION
## What
Make rapid thread switching responsive across the web client, WebSocket transport, and conversation service.

## Why
Cold and sequential thread selections could show a generic loading state, start overlapping work, and delay the target conversation. The new flow prioritizes the latest selection, restores bounded cached content, and fetches a minimal conversation tail before deferred narrative work.

## Key Changes
- Add latest-selection coalescing, a target-scoped transition shell, bounded telemetry, and isolated sidebar row updates.
- Share a two-job prefetch budget across hover, pointer-down, and adjacent-thread prefetch paths.
- Add the bounded `conversation.tail` RPC and guard deferred narrative cache writes against stale generations.
- Replace per-thread push subscription churn with atomic active-and-running subscription reconciliation.
- Add coverage for hydration races, prefetch concurrency, retry ordering, reconnects, and stale subscription responses.

## Verification
- Independent high-risk review passed after all findings were fixed.
- In-app browser verification selected five synthetic Codex threads and ended on the correct conversation without stale transcript content or a generic loading shell.
- Focused affected suites passed, including the final 19-test ChatView suite. Web typecheck passed.
- `bun run verify` lint passed. The repository-wide gate remains blocked by pre-existing `InternalThreadControlAuthority` type errors and a Windows Electron `EPERM` server-test launcher failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787936266&installation_model_id=20477&pr_number=1006&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1006&signature=fb708f585f49298cd01dab4c538465989c896429d71731acfd15b58614013ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->