### PR TITLE
fix(runtime): repair Windows verification baseline

### DIFF
--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -18,6 +18,7 @@ import type { GitBranch, WorktreeInfo, GitCommit, BranchComparison, GitRemoteUrl
 const MAX_REVIEW_COMPARISON_FILES = 10_000;
 import { WorkspaceRepo } from "../repositories/workspace-repo";
 import type { GitExecutor } from "./git-executor/index.js";
+import { normalizePathForComparison } from "./path-identity.js";
 
 /** Normalized configured remote used for repository-identity matching. */
 export interface NormalizedGitRemote {
@@ -341,13 +342,8 @@ function assertSafeReviewBranch(value: string, label: string): void {
   }
 }
 
-function normalizePathForComparison(value: string): string {
-  const normalized = resolve(value).replace(/\\/g, "/").replace(/\/+$/, "");
-  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
-}
-
 function isPathWithin(basePath: string, candidatePath: string): boolean {
-  const rel = relative(resolve(basePath), resolve(candidatePath));
+  const rel = relative(normalizePathForComparison(basePath), normalizePathForComparison(candidatePath));
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 

--- a/apps/server/src/services/git-service.ts
+++ b/apps/server/src/services/git-service.ts
@@ -10,7 +10,7 @@ import { injectable, inject } from "tsyringe";
 import { createHash } from "crypto";
 import { AsyncLocalStorage } from "async_hooks";
 import { rm, rmdir, realpath } from "fs/promises";
-import { existsSync, mkdirSync } from "fs";
+import { existsSync, mkdirSync, realpathSync } from "fs";
 import { join, basename, dirname, resolve, relative, isAbsolute } from "path";
 import { getMcodeDir, validateBranchName, validateWorktreeName, logger } from "@mcode/shared";
 import type { GitBranch, WorktreeInfo, GitCommit, BranchComparison, GitRemoteUrl, ReviewComparison, ReviewFileChange } from "@mcode/contracts";
@@ -1717,7 +1717,7 @@ export class GitService {
     if (!branch.worktreePath || !existsSync(branch.worktreePath)) return null;
     let canonicalPath: string;
     try {
-      canonicalPath = await realpath(branch.worktreePath);
+      canonicalPath = realpathSync(branch.worktreePath);
     } catch {
       return null;
     }

--- a/apps/server/src/services/path-identity.ts
+++ b/apps/server/src/services/path-identity.ts
@@ -1,4 +1,5 @@
-import { resolve } from "node:path";
+import { basename, dirname, resolve } from "node:path";
+import { realpathSync } from "node:fs";
 
 /** Remove the Windows extended-length namespace while preserving the filesystem path. */
 export function stripWindowsPathNamespace(value: string): string {
@@ -10,10 +11,30 @@ export function stripWindowsPathNamespace(value: string): string {
 
 /** Normalize a path for identity comparisons across Windows path spellings. */
 export function normalizePathForComparison(value: string): string {
-  const normalized = resolve(stripWindowsPathNamespace(value))
+  const normalized = canonicalizePathForComparison(value)
     .replace(/\\/g, "/")
     .replace(/\/+$/, "");
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+/** Resolve existing Windows path segments so short and long aliases share one identity. */
+function canonicalizePathForComparison(value: string): string {
+  const lexical = resolve(stripWindowsPathNamespace(value));
+  if (process.platform !== "win32") return lexical;
+
+  let cursor = lexical;
+  const missing: string[] = [];
+  for (let depth = 0; depth < 64; depth += 1) {
+    try {
+      return resolve(stripWindowsPathNamespace(realpathSync.native(cursor)), ...missing);
+    } catch {
+      const parent = dirname(cursor);
+      if (parent === cursor) return lexical;
+      missing.unshift(basename(cursor));
+      cursor = parent;
+    }
+  }
+  return lexical;
 }
 
 /** Normalize a canonical path for filesystem operations without changing its casing. */

--- a/apps/server/src/services/path-identity.ts
+++ b/apps/server/src/services/path-identity.ts
@@ -1,0 +1,22 @@
+import { resolve } from "node:path";
+
+/** Remove the Windows extended-length namespace while preserving the filesystem path. */
+export function stripWindowsPathNamespace(value: string): string {
+  if (process.platform !== "win32") return value;
+  if (/^\\\\\?\\UNC\\/i.test(value)) return `\\\\${value.slice(8)}`;
+  if (/^\\\\\?\\[A-Za-z]:\\/i.test(value)) return value.slice(4);
+  return value;
+}
+
+/** Normalize a path for identity comparisons across Windows path spellings. */
+export function normalizePathForComparison(value: string): string {
+  const normalized = resolve(stripWindowsPathNamespace(value))
+    .replace(/\\/g, "/")
+    .replace(/\/+$/, "");
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+/** Normalize a canonical path for filesystem operations without changing its casing. */
+export function normalizeFilesystemPath(value: string): string {
+  return resolve(stripWindowsPathNamespace(value));
+}

--- a/apps/server/src/services/turn-file-tracker.ts
+++ b/apps/server/src/services/turn-file-tracker.ts
@@ -4,6 +4,7 @@ import { lstat, readFile, realpath } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import type { FileEffect, TurnFileEffectSummary } from "@mcode/contracts";
 import { MAX_TURN_FILE_EFFECTS } from "@mcode/contracts";
+import { normalizeFilesystemPath } from "./path-identity.js";
 
 const MAX_FILE_BYTES = 1_048_576;
 const MAX_EVIDENCE_TEXT_BYTES = 1_048_576;
@@ -109,7 +110,7 @@ export class TurnFileTracker {
 
   /** Start a fresh tracker scope for an agent turn. */
   beginTurn(threadId: string, cwd: string, baselineRef: string | null): number {
-    const canonicalRoot = realpathSync.native(cwd);
+    const canonicalRoot = normalizeFilesystemPath(realpathSync.native(cwd));
     const generation = this.nextGeneration++;
     const generations = this.turns.get(threadId) ?? new Map<number, TurnState>();
     generations.set(generation, {
@@ -570,7 +571,7 @@ function resolveCandidatePathSynchronously(
     : "external";
   return {
     path: canonical,
-    displayPath: scope === "workspace" ? relativePath : canonical,
+    displayPath: scope === "workspace" ? relativePath : absolute,
     scope,
   };
 }
@@ -581,7 +582,7 @@ function canonicalizePotentialPathSynchronously(absolutePath: string): string | 
   for (let depth = 0; depth < 64; depth += 1) {
     try {
       const existing = realpathSync.native(cursor);
-      return resolve(existing, ...missing);
+      return normalizeFilesystemPath(resolve(existing, ...missing));
     } catch {
       const parent = dirname(cursor);
       if (parent === cursor) return null;
@@ -606,7 +607,7 @@ async function resolveCandidatePath(
     : "external";
   return {
     path: canonical,
-    displayPath: scope === "workspace" ? relativePath : canonical,
+    displayPath: scope === "workspace" ? relativePath : absolute,
     scope,
   };
 }
@@ -617,7 +618,7 @@ async function canonicalizePotentialPath(absolutePath: string): Promise<string |
   for (let depth = 0; depth < 64; depth += 1) {
     try {
       const existing = await realpath(cursor);
-      return resolve(existing, ...missing);
+      return normalizeFilesystemPath(resolve(existing, ...missing));
     } catch {
       const parent = dirname(cursor);
       if (parent === cursor) return null;

--- a/scripts/agent/__tests__/runtime-contract.test.mjs
+++ b/scripts/agent/__tests__/runtime-contract.test.mjs
@@ -14,7 +14,7 @@ import {
 } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, resolve, win32 } from "node:path";
 
 import {
   buildPortsContract,
@@ -82,6 +82,9 @@ test("deterministic ports derive from canonical lowercase realpath modulo 1000",
     const first = computeDeterministicPort(repo);
     const second = computeDeterministicPort(canonical.toUpperCase());
     assert.equal(first, second);
+    if (process.platform === "win32") {
+      assert.equal(first, computeDeterministicPort(win32.toNamespacedPath(canonical)));
+    }
     assert.ok(first >= 41_000 && first < 42_000);
   } finally {
     rmSync(repo, { recursive: true, force: true });

--- a/scripts/agent/runtime-contract.mjs
+++ b/scripts/agent/runtime-contract.mjs
@@ -124,7 +124,7 @@ export function ensureRuntimeRoot(repoRoot = resolveRepoRoot()) {
  * @returns {number}
  */
 export function computeDeterministicPort(worktreePath, basePort = DEFAULT_PORT_BASE) {
-  const canonical = realpathSync(worktreePath).toLowerCase();
+  const canonical = realpathSync.native(worktreePath).toLowerCase();
   const digest = createHash("sha1").update(canonical).digest("hex");
   const bucket = Number.parseInt(digest.slice(0, 8), 16) % PORT_BUCKET_SIZE;
   return basePort + bucket;

--- a/scripts/run-electron-node.mjs
+++ b/scripts/run-electron-node.mjs
@@ -56,8 +56,9 @@ function resolveWorkspaceCli(args) {
 }
 
 /**
- * Runs Electron asynchronously so Bun can drain both child output pipes while the
- * Electron process starts and exits.
+ * Runs Electron asynchronously while inheriting the caller's output handles.
+ * Inherited handles prevent Electron descendants from keeping adapter-owned
+ * stdio pipes open after the root process exits.
  *
  * @param {string} electronPath
  * @param {string[]} args
@@ -73,7 +74,7 @@ export function runElectronProcess(electronPath, args, { cwd, env, timeoutMs = E
       shell: false,
       detached: !isWindows,
       windowsHide: true,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", "inherit", "inherit"],
     });
     let settled = false;
     let timeoutHandle;
@@ -82,9 +83,6 @@ export function runElectronProcess(electronPath, args, { cwd, env, timeoutMs = E
     let timedOut = false;
     let exitStatus;
     let exitSignal;
-
-    child.stdout.pipe(process.stdout, { end: false });
-    child.stderr.pipe(process.stderr, { end: false });
 
     const signalHandlers = new Map();
     const removeSignalHandlers = () => {

--- a/scripts/run-electron-node.mjs
+++ b/scripts/run-electron-node.mjs
@@ -1,11 +1,10 @@
 /** Runs a JavaScript CLI with the workspace Electron runtime and SQLite binding. */
 
 import { spawn } from "child_process";
-import { closeSync, existsSync, mkdtempSync, openSync, readFileSync, rmSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { createRequire } from "module";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "path";
 import { fileURLToPath } from "url";
-import { tmpdir } from "os";
 import { killPidTree, killProcessTree } from "./kill-process-tree.mjs";
 
 /** Maximum time one Electron CLI invocation may run before its owned process tree is killed. */
@@ -57,8 +56,9 @@ function resolveWorkspaceCli(args) {
 }
 
 /**
- * Runs Electron asynchronously and forwards captured output after the child exits.
- * Detached Windows runs use files so descendants cannot keep the wrapper open.
+ * Runs Electron asynchronously while inheriting the caller's output handles.
+ * Keeping Windows children attached preserves ownership until their descendants
+ * have been terminated by the wrapper's scoped process-tree kill.
  *
  * @param {string} electronPath
  * @param {string[]} args
@@ -68,44 +68,22 @@ function resolveWorkspaceCli(args) {
 export function runElectronProcess(electronPath, args, { cwd, env, timeoutMs = ELECTRON_PROCESS_TIMEOUT_MS }) {
   return new Promise((resolveProcess) => {
     const isWindows = process.platform === "win32";
-    const useDetachedFiles = isWindows && args[0] !== "--workspace-cli";
-    const outputDir = useDetachedFiles ? mkdtempSync(join(tmpdir(), "mcode-electron-node-")) : null;
-    const stdoutFd = outputDir ? openSync(join(outputDir, "stdout"), "w") : null;
-    const stderrFd = outputDir ? openSync(join(outputDir, "stderr"), "w") : null;
     const child = spawn(electronPath, args, {
       cwd,
       env,
       shell: false,
-      detached: useDetachedFiles || !isWindows,
+      detached: !isWindows,
       windowsHide: true,
-      stdio: ["ignore", stdoutFd ?? "inherit", stderrFd ?? "inherit"],
+      stdio: ["ignore", "inherit", "inherit"],
     });
-    if (useDetachedFiles) child.unref();
     let settled = false;
     let timeoutHandle;
     let forcedSettlementHandle;
     let spawnError;
     let timedOut = false;
-    let outputClosed = false;
 
     const recordError = (error) => {
       spawnError ??= error instanceof Error ? error : new Error(String(error));
-    };
-
-    const flushOutput = () => {
-      if (!outputDir || stdoutFd === null || stderrFd === null || outputClosed) return;
-      outputClosed = true;
-      try { closeSync(stdoutFd); } catch (error) { recordError(error); }
-      try { closeSync(stderrFd); } catch (error) { recordError(error); }
-      try {
-        const stdout = readFileSync(join(outputDir, "stdout"));
-        if (stdout.length > 0) process.stdout.write(stdout);
-      } catch (error) { recordError(error); }
-      try {
-        const stderr = readFileSync(join(outputDir, "stderr"));
-        if (stderr.length > 0) process.stderr.write(stderr);
-      } catch (error) { recordError(error); }
-      try { rmSync(outputDir, { recursive: true, force: true }); } catch (error) { recordError(error); }
     };
 
     const signalHandlers = new Map();
@@ -117,7 +95,6 @@ export function runElectronProcess(electronPath, args, { cwd, env, timeoutMs = E
     const settle = (status, signal) => {
       if (settled) return;
       settled = true;
-      flushOutput();
       removeSignalHandlers();
       clearTimeout(timeoutHandle);
       clearTimeout(forcedSettlementHandle);

--- a/scripts/run-electron-node.mjs
+++ b/scripts/run-electron-node.mjs
@@ -1,10 +1,11 @@
 /** Runs a JavaScript CLI with the workspace Electron runtime and SQLite binding. */
 
 import { spawn } from "child_process";
-import { existsSync } from "fs";
+import { closeSync, existsSync, mkdtempSync, openSync, readFileSync, rmSync } from "fs";
 import { createRequire } from "module";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "path";
 import { fileURLToPath } from "url";
+import { tmpdir } from "os";
 import { killPidTree, killProcessTree } from "./kill-process-tree.mjs";
 
 /** Maximum time one Electron CLI invocation may run before its owned process tree is killed. */
@@ -56,9 +57,8 @@ function resolveWorkspaceCli(args) {
 }
 
 /**
- * Runs Electron asynchronously while inheriting the caller's output handles.
- * Inherited handles prevent Electron descendants from keeping adapter-owned
- * stdio pipes open after the root process exits.
+ * Runs Electron asynchronously and forwards captured output after the child exits.
+ * Detached Windows runs use files so descendants cannot keep the wrapper open.
  *
  * @param {string} electronPath
  * @param {string[]} args
@@ -68,21 +68,45 @@ function resolveWorkspaceCli(args) {
 export function runElectronProcess(electronPath, args, { cwd, env, timeoutMs = ELECTRON_PROCESS_TIMEOUT_MS }) {
   return new Promise((resolveProcess) => {
     const isWindows = process.platform === "win32";
+    const useDetachedFiles = isWindows && args[0] !== "--workspace-cli";
+    const outputDir = useDetachedFiles ? mkdtempSync(join(tmpdir(), "mcode-electron-node-")) : null;
+    const stdoutFd = outputDir ? openSync(join(outputDir, "stdout"), "w") : null;
+    const stderrFd = outputDir ? openSync(join(outputDir, "stderr"), "w") : null;
     const child = spawn(electronPath, args, {
       cwd,
       env,
       shell: false,
-      detached: !isWindows,
+      detached: useDetachedFiles || !isWindows,
       windowsHide: true,
-      stdio: ["ignore", "inherit", "inherit"],
+      stdio: ["ignore", stdoutFd ?? "inherit", stderrFd ?? "inherit"],
     });
+    if (useDetachedFiles) child.unref();
     let settled = false;
     let timeoutHandle;
     let forcedSettlementHandle;
     let spawnError;
     let timedOut = false;
-    let exitStatus;
-    let exitSignal;
+    let outputClosed = false;
+
+    const recordError = (error) => {
+      spawnError ??= error instanceof Error ? error : new Error(String(error));
+    };
+
+    const flushOutput = () => {
+      if (!outputDir || stdoutFd === null || stderrFd === null || outputClosed) return;
+      outputClosed = true;
+      try { closeSync(stdoutFd); } catch (error) { recordError(error); }
+      try { closeSync(stderrFd); } catch (error) { recordError(error); }
+      try {
+        const stdout = readFileSync(join(outputDir, "stdout"));
+        if (stdout.length > 0) process.stdout.write(stdout);
+      } catch (error) { recordError(error); }
+      try {
+        const stderr = readFileSync(join(outputDir, "stderr"));
+        if (stderr.length > 0) process.stderr.write(stderr);
+      } catch (error) { recordError(error); }
+      try { rmSync(outputDir, { recursive: true, force: true }); } catch (error) { recordError(error); }
+    };
 
     const signalHandlers = new Map();
     const removeSignalHandlers = () => {
@@ -93,6 +117,7 @@ export function runElectronProcess(electronPath, args, { cwd, env, timeoutMs = E
     const settle = (status, signal) => {
       if (settled) return;
       settled = true;
+      flushOutput();
       removeSignalHandlers();
       clearTimeout(timeoutHandle);
       clearTimeout(forcedSettlementHandle);
@@ -128,20 +153,16 @@ export function runElectronProcess(electronPath, args, { cwd, env, timeoutMs = E
       settle(1, null);
     });
     child.once("exit", (status, signal) => {
-      exitStatus = status;
-      exitSignal = signal;
-    });
-    child.once("close", (status, signal) => {
       settle(
-        timedOut ? 1 : exitStatus ?? status,
-        timedOut ? "SIGTERM" : exitSignal ?? signal,
+        timedOut ? 1 : status,
+        timedOut ? "SIGTERM" : signal,
       );
     });
 
     timeoutHandle = setTimeout(() => {
       timedOut = true;
       Promise.resolve(killProcessTree(child, { useProcessGroup: !isWindows }))
-        .catch(() => undefined)
+        .catch(recordError)
         .finally(() => {
           if (settled) return;
           try {
@@ -155,13 +176,17 @@ export function runElectronProcess(electronPath, args, { cwd, env, timeoutMs = E
           }
           try {
             child.kill();
-          } catch {
-            // The forced settlement below still closes the adapter if the child race is unusual.
-          }
+          } catch (error) { recordError(error); }
           forcedSettlementHandle = setTimeout(() => settle(1, "SIGTERM"), 1_000);
         });
     }, timeoutMs);
   });
+}
+
+function resolveElectronBinary() {
+  const electronDir = dirname(electronRequire.resolve("electron/package.json"));
+  const executable = readFileSync(join(electronDir, "path.txt"), "utf8").trim();
+  return resolve(electronDir, "dist", executable);
 }
 
 const invokedScript = process.argv[1] ? resolve(process.argv[1]) : null;
@@ -178,7 +203,7 @@ if (isMain) {
     throw new Error("Expected a JavaScript CLI entry and its arguments.");
   }
 
-  const result = await runElectronProcess(electronRequire("electron"), resolveWorkspaceCli(cliArgs), {
+  const result = await runElectronProcess(resolveElectronBinary(), resolveWorkspaceCli(cliArgs), {
     cwd: process.cwd(),
     env: {
       ...process.env,


### PR DESCRIPTION
## What
Repair Windows path identity comparisons and Electron process ownership used by repository verification.

## Why
Equivalent short, long, case-varied, and extended Windows paths produced different identities. The Electron CLI wrapper also retained process handles or lost signal ownership in verification flows.

## Key Changes
- Separate comparison identity from operational and display path spelling.
- Canonicalize deterministic runtime port hashing with the native filesystem identity.
- Keep Windows Electron children attached with inherited output and scoped process-tree termination.
- Add focused Windows namespace coverage for deterministic ports.

Related to #980

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787938243&installation_model_id=20477&pr_number=1007&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1007&signature=daf85a048327e4b45f9d0475415bc5ad929fbcfa985d4d4b6256754948a7c091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->