### PR TITLE
feat(web): eliminate blank cold thread switches

### DIFF
--- a/apps/web/src/__tests__/prefetch.test.ts
+++ b/apps/web/src/__tests__/prefetch.test.ts
@@ -34,6 +34,7 @@ describe("prefetch", () => {
   let schedulePrefetch: typeof import("@/lib/thread-hydrator/prefetch-scheduler").schedulePrefetch;
   let cancelPrefetch: typeof import("@/lib/thread-hydrator/prefetch-scheduler").cancelPrefetch;
   let prefetchOnPointerDown: typeof import("@/lib/thread-hydrator/prefetch-scheduler").prefetchOnPointerDown;
+  let isPrefetchPending: typeof import("@/lib/thread-hydrator/prefetch-scheduler").isPrefetchPending;
   let resetPrefetch: typeof import("@/lib/thread-hydrator/prefetch-scheduler").__resetPrefetchForTests;
 
   beforeEach(async () => {
@@ -57,6 +58,7 @@ describe("prefetch", () => {
     schedulePrefetch = mod.schedulePrefetch;
     cancelPrefetch = mod.cancelPrefetch;
     prefetchOnPointerDown = mod.prefetchOnPointerDown;
+    isPrefetchPending = mod.isPrefetchPending;
     resetPrefetch = mod.__resetPrefetchForTests;
   });
 
@@ -151,6 +153,24 @@ describe("prefetch", () => {
 
     vi.advanceTimersByTime(100);
     expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports pointer-down prefetch work until it settles", async () => {
+    let resolvePage!: (value: {
+      messages: ReturnType<typeof createMockMessage>[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    vi.mocked(mockTransport.loadConversationPage).mockImplementationOnce(
+      () => new Promise((resolve) => { resolvePage = resolve; }),
+    );
+
+    prefetchOnPointerDown("t1");
+    expect(isPrefetchPending("t1")).toBe(true);
+
+    resolvePage({ messages: [], hasMore: false, narrativeByMessage: {} });
+    await vi.runAllTimersAsync();
+    expect(isPrefetchPending("t1")).toBe(false);
   });
 
   it("debounces rapid successive calls", () => {

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { Thread } from "@/transport/types";
@@ -66,10 +66,14 @@ vi.mock("@/stores/thread-selectors", async () => {
   return {
     useActiveThreadRecord: (selector: (r: typeof emptyRecord) => unknown) =>
       selector((chatViewThreadMockRef.current?.activeRecord as typeof emptyRecord | undefined) ?? emptyRecord),
-    useThreadRecord: (_threadId: string, selector: (r: typeof emptyRecord) => unknown) =>
-      selector((chatViewThreadMockRef.current?.activeRecord as typeof emptyRecord | undefined) ?? emptyRecord),
-    readThreadRecord: () =>
-      (chatViewThreadMockRef.current?.activeRecord as typeof emptyRecord | undefined) ?? emptyRecord,
+    useThreadRecord: (threadId: string, selector: (r: typeof emptyRecord) => unknown) =>
+      selector((chatViewThreadMockRef.current?.records as Map<string, typeof emptyRecord> | undefined)?.get(threadId)
+        ?? (chatViewThreadMockRef.current?.activeRecord as typeof emptyRecord | undefined)
+        ?? emptyRecord),
+    readThreadRecord: (threadId: string) =>
+      (chatViewThreadMockRef.current?.records as Map<string, typeof emptyRecord> | undefined)?.get(threadId)
+        ?? (chatViewThreadMockRef.current?.activeRecord as typeof emptyRecord | undefined)
+        ?? emptyRecord,
   };
 });
 
@@ -89,7 +93,9 @@ vi.mock("./Composer", () => ({
 }));
 
 vi.mock("./MessageList", () => ({
-  MessageList: () => <div data-testid="message-list" />,
+  MessageList: ({ displayThreadId }: { displayThreadId?: string }) => (
+    <div data-testid="message-list" data-display-thread-id={displayThreadId} />
+  ),
 }));
 
 vi.mock("./HeaderActions", () => ({
@@ -226,9 +232,10 @@ function defaultThreadState(overrides: Partial<{
   currentThreadId: string | null;
   runningThreadIds: Set<string>;
   activeRecord: ReturnType<typeof createEmptyThreadRecord>;
+  records: Map<string, ReturnType<typeof createEmptyThreadRecord>>;
 }> = {}) {
   return {
-    records: new Map(),
+    records: overrides.records ?? new Map(),
     currentThreadId: overrides.currentThreadId ?? "thread-1",
     runningThreadIds: overrides.runningThreadIds ?? new Set<string>(),
     activeRecord: overrides.activeRecord ?? createEmptyThreadRecord(),
@@ -356,6 +363,102 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     expect(screen.getByTestId("conversation-transition-shell")).toHaveAttribute("data-thread-id", "thread-2");
     expect(screen.queryByTestId("conversation-loading")).not.toBeInTheDocument();
     expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
+  });
+
+  it("holds the outgoing transcript while a selected cold thread hydrates", () => {
+    const thread1 = makeThread({ id: "thread-1", title: "Thread 1" });
+    const thread2 = makeThread({ id: "thread-2", title: "Thread 2" });
+    const outgoingRecord = {
+      ...createEmptyThreadRecord(),
+      messages: [createMockMessage({ id: "thread-1-message", thread_id: thread1.id })],
+    };
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread1.id,
+      threads: [thread1, thread2],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread1.id,
+      activeRecord: outgoingRecord,
+      records: new Map([[thread1.id, outgoingRecord]]),
+    });
+
+    const { rerender } = render(<ChatView />);
+
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread2.id,
+      threads: [thread1, thread2],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread2.id,
+      activeRecord: createEmptyThreadRecord(),
+      records: new Map([[thread1.id, outgoingRecord]]),
+    });
+    act(() => rerender(<ChatView />));
+
+    expect(screen.getByTestId("chat-header-title")).toHaveTextContent("Thread 2");
+    expect(screen.getByTestId("message-list")).toHaveAttribute("data-display-thread-id", thread1.id);
+    expect(screen.getByTestId("message-list").parentElement).toHaveAttribute("inert");
+    expect(screen.getByTestId("conversation-hold-overlay")).toHaveTextContent("Thread 2");
+
+    const targetRecord = {
+      ...createEmptyThreadRecord(),
+      messages: [createMockMessage({ id: "thread-2-message", thread_id: thread2.id })],
+    };
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread2.id,
+      activeRecord: targetRecord,
+      records: new Map([[thread1.id, outgoingRecord], [thread2.id, targetRecord]]),
+    });
+    act(() => rerender(<ChatView />));
+
+    expect(screen.queryByTestId("conversation-hold-overlay")).not.toBeInTheDocument();
+    expect(screen.getByTestId("message-list")).not.toHaveAttribute("data-display-thread-id");
+  });
+
+  it("drops a stale hold when rapid switching reaches another cold thread", () => {
+    const thread1 = makeThread({ id: "thread-1", title: "Thread 1" });
+    const thread2 = makeThread({ id: "thread-2", title: "Thread 2" });
+    const thread3 = makeThread({ id: "thread-3", title: "Thread 3" });
+    const outgoingRecord = {
+      ...createEmptyThreadRecord(),
+      messages: [createMockMessage({ id: "thread-1-message", thread_id: thread1.id })],
+    };
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread1.id,
+      threads: [thread1, thread2, thread3],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread1.id,
+      activeRecord: outgoingRecord,
+      records: new Map([[thread1.id, outgoingRecord]]),
+    });
+    const { rerender } = render(<ChatView />);
+
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread2.id,
+      threads: [thread1, thread2, thread3],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread2.id,
+      activeRecord: createEmptyThreadRecord(),
+      records: new Map([[thread1.id, outgoingRecord]]),
+    });
+    act(() => rerender(<ChatView />));
+
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread3.id,
+      threads: [thread1, thread2, thread3],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread2.id,
+      activeRecord: createEmptyThreadRecord(),
+      records: new Map([[thread1.id, outgoingRecord]]),
+    });
+    act(() => rerender(<ChatView />));
+
+    expect(screen.queryByTestId("conversation-hold-overlay")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
+    expect(screen.getByTestId("conversation-transition-shell")).toHaveAttribute("data-thread-id", thread3.id);
   });
 
   it("renders a full-stage hydration error when no transcript is available", () => {

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { MessageList } from "./MessageList";
+import { ConversationHoldOverlay } from "./ConversationHoldOverlay";
 import { Composer } from "./Composer";
 import { PlanQuestionWizard } from "@/components/chat/PlanQuestionWizard";
 import { HeaderActions } from "./HeaderActions";
@@ -34,6 +35,11 @@ import { overviewResponsivePaddingRight } from "@/lib/composer-layout";
 import { Button } from "@/components/ui/button";
 import { McodeLogo } from "@/components/brand/McodeLogo";
 import { NewThreadProjectPicker } from "./NewThreadProjectPicker";
+import {
+  recordFirstMessageVisible,
+  recordThreadHoldEnd,
+  recordThreadHoldStart,
+} from "@/lib/thread-switch-telemetry";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
 const ENTRY_POINTS = [
@@ -336,6 +342,52 @@ export function ChatView() {
   const setPendingPrefill = useComposerDraftStore((s) => s.setPendingPrefill);
 
   const isAgentRunning = activeThreadId ? runningThreadIds.has(activeThreadId) : false;
+  const targetPaintable = hydratedThreadId === activeThreadId
+    && (messageCount > 0 || isAgentRunning);
+  const previousActiveThreadIdRef = useRef<string | null>(activeThreadId);
+  const [heldOutgoingThreadId, setHeldOutgoingThreadId] = useState<string | null>(null);
+  const previousThreadId = previousActiveThreadIdRef.current;
+  const immediateHeldOutgoingThreadId =
+    !targetPaintable
+    && previousThreadId
+    && previousThreadId !== activeThreadId
+    && readThreadRecord(previousThreadId).messages.length > 0
+      ? previousThreadId
+      : null;
+  const displayHoldThreadId = targetPaintable
+    ? null
+    : immediateHeldOutgoingThreadId ?? heldOutgoingThreadId;
+
+  useEffect(() => {
+    const outgoingThreadId = previousActiveThreadIdRef.current;
+    previousActiveThreadIdRef.current = activeThreadId;
+    if (
+      targetPaintable
+      || !activeThreadId
+      || !outgoingThreadId
+      || outgoingThreadId === activeThreadId
+      || readThreadRecord(outgoingThreadId).messages.length === 0
+    ) {
+      setHeldOutgoingThreadId(null);
+      return;
+    }
+
+    setHeldOutgoingThreadId(outgoingThreadId);
+    recordThreadHoldStart(activeThreadId);
+    const timeout = setTimeout(() => {
+      setHeldOutgoingThreadId((heldThreadId) => {
+        if (heldThreadId === outgoingThreadId) recordThreadHoldEnd(activeThreadId);
+        return heldThreadId === outgoingThreadId ? null : heldThreadId;
+      });
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, [activeThreadId, targetPaintable]);
+
+  useEffect(() => {
+    if (!activeThreadId || !targetPaintable) return;
+    if (heldOutgoingThreadId) recordThreadHoldEnd(activeThreadId);
+    recordFirstMessageVisible(activeThreadId);
+  }, [activeThreadId, heldOutgoingThreadId, targetPaintable]);
 
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const activeThread = useActiveWorkspaceThread((t) => t);
@@ -774,7 +826,9 @@ export function ChatView() {
 
   const hasMessages = messageCount > 0;
   const conversationLoading = hydratedThreadId !== activeThreadId || historyLoading;
-  const showEmptyState = !hasMessages && !isAgentRunning && !conversationLoading;
+  const showHold = displayHoldThreadId !== null && !targetPaintable;
+  const showTransition = conversationLoading && !targetPaintable && !showHold && !isAgentRunning;
+  const showEmptyState = !hasMessages && !isAgentRunning && !conversationLoading && !showHold;
   const showFullConversationError = showConversationError && !hasMessages && !isAgentRunning;
   const showConversationErrorBanner = showConversationError && (hasMessages || isAgentRunning);
 
@@ -865,7 +919,18 @@ export function ChatView() {
         className="animate-fade-up-in flex-1 min-h-0 transition-[padding] duration-200"
         style={{ paddingRight: overviewPaddingRight }}
       >
-        {conversationLoading && !hasMessages && !isAgentRunning ? (
+        {showHold ? (
+          <div className="relative h-full" aria-busy="true">
+            <div className="pointer-events-none h-full" inert>
+              <MessageList
+                displayThreadId={displayHoldThreadId}
+                onBranch={handleBranch}
+                onReply={handleReply}
+              />
+            </div>
+            <ConversationHoldOverlay targetTitle={activeThread.title || "Conversation"} />
+          </div>
+        ) : showTransition ? (
           <ConversationTransitionState
             threadId={activeThread.id}
             threadTitle={activeThread.title || "Conversation"}

--- a/apps/web/src/components/chat/ConversationHoldOverlay.tsx
+++ b/apps/web/src/components/chat/ConversationHoldOverlay.tsx
@@ -1,0 +1,24 @@
+import { Spinner } from "@/components/ui/spinner";
+
+/** Props for {@link ConversationHoldOverlay}. */
+interface ConversationHoldOverlayProps {
+  /** Title of the selected thread that is loading behind the preserved transcript. */
+  targetTitle: string;
+}
+
+/** Identifies a temporarily preserved outgoing transcript while the selected thread loads. */
+export function ConversationHoldOverlay({ targetTitle }: ConversationHoldOverlayProps) {
+  return (
+    <div
+      data-testid="conversation-hold-overlay"
+      role="status"
+      aria-live="polite"
+      className="absolute inset-0 z-10 flex items-center justify-center bg-background/45 backdrop-blur-[1px]"
+    >
+      <div className="flex items-center gap-2 rounded-full border border-border/60 bg-background/90 px-3 py-1.5 text-xs text-muted-foreground shadow-sm">
+        <Spinner size={14} />
+        <span>Switching to {targetTitle}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -10,7 +10,7 @@ import { defaultRangeExtractor, useVirtualizer, type Range } from "@tanstack/rea
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { recordThreadPositioned } from "@/lib/thread-switch-telemetry";
 import { useThreadStore } from "@/stores/threadStore";
-import { useActiveThreadRecord } from "@/stores/thread-selectors";
+import { useThreadRecord } from "@/stores/thread-selectors";
 import { getThreadRecord, getHandoffStatus } from "@/stores/thread-record";
 import { MessageBubble } from "./MessageBubble";
 import { ToolCallCard } from "./ToolCallCard";
@@ -227,6 +227,8 @@ export function ScrollToBottomButton({ hasNewContent, onScrollToBottom }: Scroll
 
 /** Props for {@link MessageList}. */
 interface MessageListProps {
+  /** Thread whose resident transcript is rendered while the selected thread hydrates. */
+  displayThreadId?: string;
   /** Called when the user clicks the branch icon on a message. */
   onBranch?: (messageId: string) => void;
   /** Called when the user clicks the reply button or selects text in a message. */
@@ -234,7 +236,7 @@ interface MessageListProps {
 }
 
 /** Virtualized list of chat messages, tool calls, and streaming indicators. */
-export function MessageList({ onBranch, onReply }: MessageListProps) {
+export function MessageList({ displayThreadId, onBranch, onReply }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   /** Survives virtualizer remounts: remembers manual expand/collapse toggles by messageId. */
   const turnExpandRef = useRef<Map<string, boolean>>(new Map());
@@ -316,21 +318,20 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   /** Latest virtualizer instance for scroll-time sticky visibility checks. */
   const virtualizerRef = useRef<StickyVisibilityVirtualizer | null>(null);
 
-  const messages = useActiveThreadRecord((r) => r.messages);
-  const loading = useActiveThreadRecord((r) => r.loading);
   const activeThreadId = useWorkspaceStore((s) => s.activeThreadId);
-  const currentThreadId = useThreadStore((s) => s.currentThreadId);
+  const renderedThreadId = displayThreadId ?? activeThreadId;
+  const messages = useThreadRecord(renderedThreadId, (r) => r.messages);
+  const loading = useThreadRecord(renderedThreadId, (r) => r.loading);
   const isAgentRunning = useThreadStore((s) =>
-    currentThreadId ? s.runningThreadIds.has(currentThreadId) : false,
+    renderedThreadId ? s.runningThreadIds.has(renderedThreadId) : false,
   );
-  const agentStartTime = useActiveThreadRecord((r) => r.agentStartTime);
-  const streamingText = useActiveThreadRecord((r) => r.streaming);
-  const toolCallsRaw = useActiveThreadRecord((r) => r.toolCalls);
+  const agentStartTime = useThreadRecord(renderedThreadId, (r) => r.agentStartTime);
+  const streamingText = useThreadRecord(renderedThreadId, (r) => r.streaming);
+  const toolCallsRaw = useThreadRecord(renderedThreadId, (r) => r.toolCalls);
   const persistedFilesChanged = useThreadStore(
     useShallow((s) => {
-      const id = s.currentThreadId;
-      if (!id) return EMPTY_FILES_CHANGED;
-      const rec = getThreadRecord(s.records, id);
+      if (!renderedThreadId) return EMPTY_FILES_CHANGED;
+      const rec = getThreadRecord(s.records, renderedThreadId);
       if (rec.messages.length === 0) return EMPTY_FILES_CHANGED;
       const out: Record<string, string[]> = {};
       for (const m of rec.messages) {
@@ -340,27 +341,27 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       return out;
     }),
   );
-  const latestTurnWithChanges = useActiveThreadRecord((r) => r.latestTurnWithChanges);
-  const hasMore = useActiveThreadRecord((r) => r.hasMoreMessages);
+  const latestTurnWithChanges = useThreadRecord(renderedThreadId, (r) => r.latestTurnWithChanges);
+  const hasMore = useThreadRecord(renderedThreadId, (r) => r.hasMoreMessages);
   const handoffStatus = useThreadStore((s) =>
-    currentThreadId ? getHandoffStatus(getThreadRecord(s.records, currentThreadId)) : undefined,
+    renderedThreadId ? getHandoffStatus(getThreadRecord(s.records, renderedThreadId)) : undefined,
   );
-  const isLoadingMore = useActiveThreadRecord((r) => r.isLoadingMore);
+  const isLoadingMore = useThreadRecord(renderedThreadId, (r) => r.isLoadingMore);
   const loadOlderMessages = useThreadStore((s) => s.loadOlderMessages);
-  const renderedThreadId = messages[0]?.thread_id ?? null;
-  const permissions = useActiveThreadRecord((r) => r.permissions);
-  const hooks = useActiveThreadRecord((r) => r.hooks);
-  const thoughtSegments = useActiveThreadRecord((r) => r.thoughtSegments);
-  const persistedNarrativeByMessage = useActiveThreadRecord((r) => r.narrativeByMessage);
+  const transcriptThreadId = messages[0]?.thread_id ?? null;
+  const permissions = useThreadRecord(renderedThreadId, (r) => r.permissions);
+  const hooks = useThreadRecord(renderedThreadId, (r) => r.hooks);
+  const thoughtSegments = useThreadRecord(renderedThreadId, (r) => r.thoughtSegments);
+  const persistedNarrativeByMessage = useThreadRecord(renderedThreadId, (r) => r.narrativeByMessage);
   const loadNarrativeForMessage = useThreadStore((s) => s.loadNarrativeForMessage);
-  const currentTurnMessageId = useActiveThreadRecord((r) => r.currentTurnMessageId);
-  const currentTurnResponseKey = useActiveThreadRecord((r) => r.currentTurnResponseKey);
-  const assistantResponseKeys = useActiveThreadRecord((r) => r.assistantResponseKeys);
+  const currentTurnMessageId = useThreadRecord(renderedThreadId, (r) => r.currentTurnMessageId);
+  const currentTurnResponseKey = useThreadRecord(renderedThreadId, (r) => r.currentTurnResponseKey);
+  const assistantResponseKeys = useThreadRecord(renderedThreadId, (r) => r.assistantResponseKeys);
   const currentTurnMessageIdByThread = useMemo(
-    () => (currentThreadId && currentTurnMessageId
-      ? { [currentThreadId]: currentTurnMessageId }
+    () => (renderedThreadId && currentTurnMessageId
+      ? { [renderedThreadId]: currentTurnMessageId }
       : EMPTY_TURN_MAP),
-    [currentThreadId, currentTurnMessageId],
+    [renderedThreadId, currentTurnMessageId],
   );
 
   const toolCalls = toolCallsRaw ?? EMPTY_TOOL_CALLS;
@@ -370,10 +371,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   }, [isPositioned]);
 
   useLayoutEffect(() => {
-    if (!isPositioned || !activeThreadId) return;
-    if (renderedThreadId && renderedThreadId !== activeThreadId) return;
+    if (!isPositioned || !activeThreadId || renderedThreadId !== activeThreadId) return;
+    if (transcriptThreadId && transcriptThreadId !== activeThreadId) return;
     recordThreadPositioned(activeThreadId);
-  }, [activeThreadId, isPositioned, renderedThreadId]);
+  }, [activeThreadId, isPositioned, renderedThreadId, transcriptThreadId]);
 
   /** Syncs sticky preview visibility with the current scroll position. */
   const syncStickyUserMessageVisibility = useCallback(() => {
@@ -439,7 +440,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       !olderHistoryRequestedRef.current ||
       !el ||
       el.scrollTop >= PAGINATION_THRESHOLD ||
-      !activeThreadId ||
+      !renderedThreadId ||
+      renderedThreadId !== activeThreadId ||
       !hasMore ||
       isLoadingMore
     ) {
@@ -461,8 +463,8 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     } else {
       pendingHistoryAnchorRef.current = null;
     }
-    void loadOlderMessages(activeThreadId);
-  }, [activeThreadId, hasMore, isLoadingMore, loadOlderMessages]);
+    void loadOlderMessages(renderedThreadId);
+  }, [activeThreadId, renderedThreadId, hasMore, isLoadingMore, loadOlderMessages]);
 
   /** Clears tail pin when the user scrolls content upward (wheel / trackpad). */
   const handleWheel = useCallback((e: WheelEvent<HTMLDivElement>) => {
@@ -530,15 +532,15 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     isScrolledUpRef.current = scrolledUp;
     setShowScrollBtn(scrolledUp);
     if (
-      activeThreadId
-      && renderedThreadId === activeThreadId
+      renderedThreadId
+      && transcriptThreadId === renderedThreadId
       && !suppressPassiveAutoBottomScrollRef.current
     ) {
       const viewportTop = el.getBoundingClientRect().top;
       const anchor = [...el.querySelectorAll<HTMLElement>("[data-message-id]")]
         .find((node) => node.getBoundingClientRect().bottom > viewportTop + 2);
       rememberScrollTop(
-        activeThreadId,
+        renderedThreadId,
         el.scrollTop,
         !awayFromTail,
         anchor
@@ -560,7 +562,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     loadOlderHistoryWhenRequested();
 
     prevScrollTopRef.current = el.scrollTop;
-  }, [activeThreadId, loadOlderHistoryWhenRequested, renderedThreadId, syncStickyUserMessageVisibility]);
+  }, [renderedThreadId, loadOlderHistoryWhenRequested, transcriptThreadId, syncStickyUserMessageVisibility]);
 
   useEffect(() => {
     for (const message of messages) {
@@ -572,7 +574,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
 
   const stableItems = useMemo(
     () => buildStableItems(messages, persistedFilesChanged, latestTurnWithChanges, {
-      threadId: currentThreadId ?? "",
+      threadId: renderedThreadId ?? "",
       messageId: currentTurnMessageId || undefined,
       responseKey: currentTurnResponseKey || undefined,
       responseKeysByMessageId: assistantResponseKeys,
@@ -581,7 +583,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       messages,
       persistedFilesChanged,
       latestTurnWithChanges,
-      currentThreadId,
+      renderedThreadId,
       currentTurnMessageId,
       currentTurnResponseKey,
       assistantResponseKeys,
@@ -603,7 +605,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       .reverse()
       .find((message) => message.role === "assistant" && !isGoalStatusNotice(message.content));
     const committedAssistantBody =
-      currentThreadId && !isAgentRunning && lastAssistantAnswer
+      renderedThreadId && !isAgentRunning && lastAssistantAnswer
         ? lastAssistantAnswer.content
         : undefined;
     return volatileItemsBuilderRef.current!(
@@ -614,9 +616,9 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       permissions,
       hooks,
       thoughtSegments,
-      currentThreadId
+      renderedThreadId
         ? {
-            threadId: currentThreadId,
+            threadId: renderedThreadId,
             messageId: currentTurnMessageId || undefined,
             responseKey: currentTurnResponseKey || undefined,
             responseKeysByMessageId: assistantResponseKeys,
@@ -633,7 +635,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     hooks,
     thoughtSegments,
     messages,
-    currentThreadId,
+    renderedThreadId,
     currentTurnMessageId,
     currentTurnResponseKey,
     assistantResponseKeys,
@@ -1000,10 +1002,10 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
   // restoration useLayoutEffect reads it.
   useLayoutEffect(() => {
     const prevId = prevActiveThreadIdRef.current;
-    const isThreadSwitch = !!prevId && prevId !== activeThreadId;
-    prevActiveThreadIdRef.current = activeThreadId ?? null;
+    const isThreadSwitch = !!prevId && prevId !== renderedThreadId;
+    prevActiveThreadIdRef.current = renderedThreadId ?? null;
 
-    if (!activeThreadId) return;
+    if (!renderedThreadId) return;
 
     if (isThreadSwitch) {
       // Reset thread-scoped refs and affordance state so the prepend-detection
@@ -1033,7 +1035,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       prevStickyTopInsetRef.current = MESSAGE_LIST_TOP_PADDING_PX;
     }
 
-    if (loading) {
+    if (loading && messages.length === 0) {
       // Cache miss: full reset path. Hide until messages are positioned at bottom,
       // and clear stale measurements so previous-thread heights don't bleed in.
       isInitialLoadRef.current = true;
@@ -1045,6 +1047,11 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       return;
     }
 
+    if (loading && messages.length > 0) {
+      // A tail commit is already paintable even while background history continues.
+      setIsPositioned(true);
+    }
+
     // Cache hit: keep the virtualizer's measurement cache (those rows have the
     // same item keys and dimensions — re-estimating would defeat the optimization).
     // With a remembered offset, restore it in a later effect. On thread switch
@@ -1053,7 +1060,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     // still runs when `loading` flips true→false on the same thread; the
     // `isThreadSwitch` guard on the bottom branch avoids clobbering initial load.
     const rememberedPosition = isThreadSwitch || prevId === null
-      ? recallScrollPosition(activeThreadId)
+      ? recallScrollPosition(renderedThreadId)
       : undefined;
     if (rememberedPosition) {
       isInitialLoadRef.current = false;
@@ -1072,7 +1079,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       pendingScrollRestoreRef.current = null;
       positionAtBottom({ measureFirst: true, revealEarly: true });
     }
-  }, [activeThreadId, loading, virtualizer, positionAtBottom, items.length]);
+  }, [renderedThreadId, loading, messages.length, virtualizer, positionAtBottom, items.length]);
 
   // Stabilize scroll position when older messages are prepended.
   // Detects real prepends by comparing the first message ID before and after
@@ -1190,7 +1197,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     // to be briefly visible. When items load, items.length will change and trigger
     // another effect pass where loading is false.
     if (loading) return;
-    if (renderedThreadId && activeThreadId && renderedThreadId !== activeThreadId) return;
+    if (transcriptThreadId && transcriptThreadId !== renderedThreadId) return;
     beginSuppressPassiveAutoBottomScroll();
     const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
     const withinTail =
@@ -1256,7 +1263,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       requestAnimationFrame(settleReadingAnchor);
     };
     requestAnimationFrame(settleReadingAnchor);
-  }, [activeThreadId, items.length, loading, renderedThreadId, beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
+  }, [renderedThreadId, items.length, loading, transcriptThreadId, beginSuppressPassiveAutoBottomScroll, scheduleEndSuppressPassiveAutoBottomScroll]);
 
   // Discrete events (new message, tool call) -> scroll if at bottom, else highlight button
   useLayoutEffect(() => {
@@ -1276,7 +1283,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       return;
     }
     scrollToBottom(false);
-  }, [activeThreadId, messages.length, toolCalls.length, isAgentRunning, scrollToBottom]);
+  }, [renderedThreadId, messages.length, toolCalls.length, isAgentRunning, scrollToBottom]);
 
   // Streaming deltas -> scroll before paint when following the tail, else highlight button.
   useLayoutEffect(() => {
@@ -1296,7 +1303,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
       return;
     }
     scrollToBottom(false);
-  }, [streamingText, activeThreadId, scrollToBottom]);
+  }, [streamingText, renderedThreadId, scrollToBottom]);
 
   // Capture text selections in message bubbles and activate reply mode for the selected text.
   // Only triggers when Ctrl (or Cmd on Mac) is held during mouseup so casual
@@ -1354,7 +1361,7 @@ export function MessageList({ onBranch, onReply }: MessageListProps) {
     });
     ro.observe(inner);
     return () => ro.disconnect();
-  }, [activeThreadId, loading]);
+  }, [renderedThreadId, loading]);
 
   const stickyReservedTop =
     showStickyUserMessage && isPositioned

--- a/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
+++ b/apps/web/src/components/chat/__tests__/MessageList.thread-switch.test.tsx
@@ -110,8 +110,8 @@ vi.mock("@/stores/threadStore", () => ({
 }));
 
 vi.mock("@/stores/thread-selectors", () => ({
-  useActiveThreadRecord: vi.fn((selector: (r: ReturnType<typeof buildMockRecord>) => unknown) =>
-    selector(buildMockRecord()),
+  useThreadRecord: vi.fn((threadId: string, selector: (r: ReturnType<typeof buildMockRecord>) => unknown) =>
+    selector(buildMockRecord(threadId)),
   ),
 }));
 
@@ -174,7 +174,7 @@ describe("MessageList thread switch", () => {
       role: "assistant",
       content: "Thread A final response",
     }];
-    const { queryByText, rerender } = render(<MessageList />);
+    const { queryByText, rerender } = render(<MessageList displayThreadId="thread-A" />);
 
     expect(queryByText("Thread A final response")).not.toBeNull();
     expect(queryByText("Thinking")).toBeNull();
@@ -203,7 +203,7 @@ describe("MessageList thread switch", () => {
       role: "user",
       content: "Thread A request",
     }];
-    const { container, rerender } = render(<MessageList />);
+    const { container, rerender } = render(<MessageList displayThreadId="thread-A" />);
 
     expect(container.querySelectorAll(".animate-pulse")).toHaveLength(0);
 
@@ -453,9 +453,28 @@ describe("MessageList thread switch", () => {
     measureSpy.mockClear();
     loadingValue = true;             // cache miss ⇒ loading flips to true
     activeThreadIdValue = "thread-B";
+    messagesValue = [];
     rerender(<MessageList />);
 
     expect(measureSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reveals a committed tail while background history is still loading", () => {
+    loadingValue = false;
+    activeThreadIdValue = "thread-A";
+    messagesValue = [{ id: "m-a", sequence: 1, thread_id: "thread-A" }];
+    const { rerender, container } = render(<MessageList />);
+
+    loadingValue = true;
+    activeThreadIdValue = "thread-B";
+    messagesValue = [];
+    act(() => rerender(<MessageList />));
+
+    messagesValue = [{ id: "m-b", sequence: 1, thread_id: "thread-B" }];
+    act(() => rerender(<MessageList />));
+
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    expect(scrollEl.style.opacity).toBe("1");
   });
 
   it("calls scrollToIndex with auto when cache-miss hydrate completes", () => {

--- a/apps/web/src/lib/__tests__/thread-switch-telemetry.test.ts
+++ b/apps/web/src/lib/__tests__/thread-switch-telemetry.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   __resetThreadSwitchTelemetryForTests,
+  recordFirstMessageVisible,
   recordThreadCommit,
+  recordThreadHoldEnd,
+  recordThreadHoldStart,
   recordThreadPositioned,
   recordThreadSelection,
 } from "../thread-switch-telemetry";
@@ -30,6 +33,18 @@ describe("thread switch telemetry", () => {
     expect(names("mcode:thread-switch:commit:cache-restore:")).toHaveLength(1);
     expect(names("mcode:thread-switch:positioned:")).toHaveLength(1);
     expect(performance.getEntriesByName("mcode:thread-switch:selection-to-positioned:1")).toHaveLength(1);
+  });
+
+  it("records the outgoing transcript hold and target's first visible message", () => {
+    recordThreadSelection("thread-a");
+    recordThreadHoldStart("thread-a");
+    recordThreadHoldEnd("thread-a");
+    recordFirstMessageVisible("thread-a");
+
+    expect(names("mcode:thread-switch:hold-start:")).toHaveLength(1);
+    expect(names("mcode:thread-switch:hold-end:")).toHaveLength(1);
+    expect(names("mcode:thread-switch:first-message-visible:")).toHaveLength(1);
+    expect(performance.getEntriesByName("mcode:thread-switch:selection-to-first-message-visible:1")).toHaveLength(1);
   });
 
   it("keeps cache and network commits distinguishable and bounds retained entries", () => {

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -1470,6 +1470,9 @@ describe("ThreadHydrator", () => {
     await Promise.resolve();
 
     expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+    expect(useThreadStore.getState().currentThreadId).toBe(THREAD_A);
+    expect(readActiveThreadField((record) => record.loading)).toBe(true);
+    expect(getTestThreadLoadEpoch(THREAD_A)).toBe(0);
 
     resolvePage({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
     await Promise.all([background, active]);

--- a/apps/web/src/lib/thread-hydrator/prefetch-scheduler.ts
+++ b/apps/web/src/lib/thread-hydrator/prefetch-scheduler.ts
@@ -30,6 +30,12 @@ let hoverRequestCancel: (() => void) | null = null;
 /** Debounce delay before triggering prefetch on hover (ms). */
 const HOVER_DEBOUNCE_MS = 50;
 
+/** Returns whether speculative prefetch work remains queued or running for a thread. */
+export function isPrefetchPending(threadId: string): boolean {
+  const request = requests.get(threadId);
+  return request !== undefined && request.consumers > 0;
+}
+
 /** Enqueue one shared background prefetch, deduplicating requests by thread. */
 export function enqueueBackgroundPrefetch(
   threadId: string,

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -555,7 +555,7 @@ export class ThreadHydrator {
     const background = this.backgroundHydrates.get(threadId);
     if (background) {
       if (!hasResidentLayer) {
-        this.prepareActiveLoad(threadId);
+        this.selectInFlightLayer(threadId, false);
       }
       await background;
 

--- a/apps/web/src/lib/thread-switch-telemetry.ts
+++ b/apps/web/src/lib/thread-switch-telemetry.ts
@@ -10,6 +10,9 @@ interface ThreadSwitchRecord {
   threadId: string;
   selectionMark: string;
   commitMark?: string;
+  holdStartMark?: string;
+  holdEndMark?: string;
+  firstMessageVisibleMark?: string;
   positionedMark?: string;
 }
 
@@ -25,8 +28,12 @@ function isEnabled(): boolean {
 function clearRecord(record: ThreadSwitchRecord): void {
   performance.clearMarks(record.selectionMark);
   if (record.commitMark) performance.clearMarks(record.commitMark);
+  if (record.holdStartMark) performance.clearMarks(record.holdStartMark);
+  if (record.holdEndMark) performance.clearMarks(record.holdEndMark);
+  if (record.firstMessageVisibleMark) performance.clearMarks(record.firstMessageVisibleMark);
   if (record.positionedMark) performance.clearMarks(record.positionedMark);
   performance.clearMeasures(`${MARK_PREFIX}:selection-to-commit:${record.id}`);
+  performance.clearMeasures(`${MARK_PREFIX}:selection-to-first-message-visible:${record.id}`);
   performance.clearMeasures(`${MARK_PREFIX}:selection-to-positioned:${record.id}`);
   records.delete(record.id);
   if (latestByThread.get(record.threadId) === record.id) {
@@ -74,6 +81,47 @@ export function recordThreadCommit(threadId: string, path: ThreadSwitchPath): vo
     start: record.selectionMark,
     end: commitMark,
     detail: { threadId, switchId: id, path },
+  });
+}
+
+/** Record that the selected thread is temporarily displaying its outgoing transcript. */
+export function recordThreadHoldStart(threadId: string): void {
+  if (!isEnabled()) return;
+  const id = latestByThread.get(threadId);
+  if (id == null || id !== latestSelectionId) return;
+  const record = records.get(id);
+  if (!record || record.holdStartMark) return;
+  const holdStartMark = `${MARK_PREFIX}:hold-start:${id}`;
+  mark(holdStartMark, { threadId, switchId: id });
+  record.holdStartMark = holdStartMark;
+}
+
+/** Record that the selected thread no longer needs its outgoing transcript hold. */
+export function recordThreadHoldEnd(threadId: string): void {
+  if (!isEnabled()) return;
+  const id = latestByThread.get(threadId);
+  if (id == null || id !== latestSelectionId) return;
+  const record = records.get(id);
+  if (!record || !record.holdStartMark || record.holdEndMark) return;
+  const holdEndMark = `${MARK_PREFIX}:hold-end:${id}`;
+  mark(holdEndMark, { threadId, switchId: id });
+  record.holdEndMark = holdEndMark;
+}
+
+/** Record the first time the selected thread has paintable transcript content. */
+export function recordFirstMessageVisible(threadId: string): void {
+  if (!isEnabled()) return;
+  const id = latestByThread.get(threadId);
+  if (id == null || id !== latestSelectionId) return;
+  const record = records.get(id);
+  if (!record || record.firstMessageVisibleMark) return;
+  const firstMessageVisibleMark = `${MARK_PREFIX}:first-message-visible:${id}`;
+  mark(firstMessageVisibleMark, { threadId, switchId: id });
+  record.firstMessageVisibleMark = firstMessageVisibleMark;
+  performance.measure(`${MARK_PREFIX}:selection-to-first-message-visible:${id}`, {
+    start: record.selectionMark,
+    end: firstMessageVisibleMark,
+    detail: { threadId, switchId: id },
   });
 }
 


### PR DESCRIPTION
## What
Preserve the outgoing transcript while a cold selected thread hydrates, then reveal the selected thread as soon as its tail commits.

## Why
Rapid thread changes could clear the message stage while a speculative prefetch or active hydration request was still running.

## Key Changes
- Reuse in-flight background hydration without destructively preparing the selected record.
- Hold the outgoing transcript behind an inert switching overlay for at most 500ms.
- Render MessageList from an explicit display thread and reveal committed tails before background history finishes.
- Add prefetch, telemetry, hydrator, rapid-switch, and accessibility regression coverage.

Related to #1006

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787950660&installation_model_id=20477&pr_number=1010&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1010&signature=befdde346f449f5dc5b1420079e2dc583728cf4f72b711a069fc155163fe8531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a smoother thread-switching experience that keeps the previous conversation visible while the selected thread loads.
  - Added a clear “Switching to…” loading overlay during transitions.
  - Improved transcript rendering, scrolling, and history loading when switching between threads.
  - Added prefetch status tracking for pending thread loads.

- **Bug Fixes**
  - Improved reuse of background-loaded conversations and prevented stale transition states.

- **Tests**
  - Expanded coverage for thread switching, prefetching, scrolling, hydration, and transition telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->