### PR TITLE
feat(web): add browser click type and takeover cancellation

### DIFF
--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -389,6 +389,126 @@ describe("BrowserAutomationBroker", () => {
     expect(broker.status().pending).toBe(0);
   });
 
+  it("preserves an assigned open across an exact target generation transition", async () => {
+    const deliveries: any[] = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        if (channel === "browserAutomation.request") deliveries.push(data);
+        return true;
+      },
+    }));
+    const hostSocket = socket("first");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("first", "workspace-a"),
+      capabilities: [
+        { operation: "open", available: true },
+        { operation: "status", available: true },
+      ],
+    }, authorization("first")).generation;
+    const target = {
+      desktopInstanceId: "desktop-first",
+      windowId: 1,
+      connectionGeneration: generation,
+      threadId: "thread-a",
+      tabId: "tab-thread-a",
+      targetGeneration: 0,
+      active: true,
+      focused: true,
+      lastUsedAt: 10,
+    };
+    broker.updateTargets(hostSocket, "first", generation, [target]);
+    const scope = {
+      ...claims("thread-a", "workspace-a"),
+      allowedOperations: ["open" as const, "status" as const],
+    };
+    const opened = broker.execute(scope, {
+      ...request(scope),
+      operation: "open",
+      args: { url: "https://example.test/" },
+    });
+    const replacement = { ...target, targetGeneration: 1, lastUsedAt: 11 };
+    broker.updateTargets(hostSocket, "first", generation, [replacement]);
+    expect(broker.status().pending).toBe(1);
+
+    broker.respond(hostSocket, "first", generation, {
+      contractVersion: 1,
+      requestId: deliveries[0].dispatch.request.requestId,
+      sequence: deliveries[0].dispatch.request.sequence,
+      ok: true,
+      result: { operation: "open", url: "https://example.test/", title: "Example", controlEpoch: 0 },
+    });
+    await expect(opened).resolves.toMatchObject({ ok: true });
+
+    const status = broker.execute(scope, request(scope, 2));
+    expect(deliveries[1].dispatch.target).toMatchObject({ targetGeneration: 1 });
+    broker.respond(hostSocket, "first", generation, {
+      contractVersion: 1,
+      requestId: deliveries[1].dispatch.request.requestId,
+      sequence: deliveries[1].dispatch.request.sequence,
+      ok: true,
+      result: statusResult(),
+    });
+    await expect(status).resolves.toMatchObject({ ok: true });
+  });
+
+  it("settles non-open work when an assigned target advances generations", async () => {
+    let delivery: any;
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        if (channel === "browserAutomation.request") delivery = data;
+        return true;
+      },
+    }));
+    const hostSocket = socket("first");
+    const generation = register(broker, hostSocket, "first", "workspace-a");
+    updateTargets(broker, hostSocket, "first", generation, ["thread-a"]);
+    const scope = claims("thread-a", "workspace-a");
+    const pending = broker.execute(scope, request(scope));
+    broker.updateTargets(hostSocket, "first", generation, [{
+      ...delivery.dispatch.target,
+      targetGeneration: delivery.dispatch.target.targetGeneration + 1,
+    }]);
+    await expect(pending).resolves.toMatchObject({ ok: false, error: { code: "TAB_UNAVAILABLE" } });
+  });
+
+  it("settles open work for generation jumps and window changes", async () => {
+    const run = async (replacement: (target: any) => any) => {
+      const broker = new BrowserAutomationBroker(options({
+        now: () => 10,
+        send: () => true,
+      }));
+      const hostSocket = socket("first");
+      const generation = broker.registerHost(hostSocket, {
+        ...registration("first", "workspace-a"),
+        capabilities: [{ operation: "open", available: true }],
+      }, authorization("first")).generation;
+      const target = {
+        desktopInstanceId: "desktop-first",
+        windowId: 1,
+        connectionGeneration: generation,
+        threadId: "thread-a",
+        tabId: "tab-thread-a",
+        targetGeneration: 0,
+        active: true,
+        focused: true,
+        lastUsedAt: 10,
+      };
+      broker.updateTargets(hostSocket, "first", generation, [target]);
+      const scope = { ...claims("thread-a", "workspace-a"), allowedOperations: ["open" as const] };
+      const pending = broker.execute(scope, {
+        ...request(scope),
+        operation: "open",
+        args: { url: "https://example.test/" },
+      });
+      broker.updateTargets(hostSocket, "first", generation, [replacement(target)]);
+      await expect(pending).resolves.toMatchObject({ ok: false, error: { code: "TAB_UNAVAILABLE" } });
+    };
+    await run((target) => ({ ...target, targetGeneration: 2 }));
+    await run((target) => ({ ...target, windowId: 2, targetGeneration: 1 }));
+  });
+
   it("settles and decrements when directed delivery throws synchronously", async () => {
     const broker = new BrowserAutomationBroker(options({ now: () => 10, send: () => { throw new Error("socket failed"); } }));
     const hostSocket = socket("first");

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -142,6 +142,16 @@ function targetsMatch(
     left.targetGeneration === right.targetGeneration;
 }
 
+function isExactOpenTargetReplacement(
+  oldTarget: BrowserAutomationHostDispatchTarget,
+  replacement: BrowserAutomationHostDispatchTarget,
+): boolean {
+  return replacement.desktopInstanceId === oldTarget.desktopInstanceId &&
+    replacement.windowId === oldTarget.windowId &&
+    replacement.connectionGeneration === oldTarget.connectionGeneration &&
+    replacement.targetGeneration === oldTarget.targetGeneration + 1;
+}
+
 function incrementBounded(value: number, amount = 1): number {
   return Math.min(Number.MAX_SAFE_INTEGER, value + Math.max(0, amount));
 }
@@ -348,7 +358,7 @@ export class BrowserAutomationBroker {
     for (const [key, oldTarget] of host.targets) {
       const replacement = next.get(key);
       if (replacement && replacement.targetGeneration === oldTarget.targetGeneration && replacement.windowId === oldTarget.windowId) continue;
-      this.invalidateTarget(host, key);
+      this.invalidateTarget(host, key, replacement !== undefined && isExactOpenTargetReplacement(oldTarget, replacement));
     }
     for (const [key, target] of next) {
       host.targetGenerationTombstones.delete(key);
@@ -916,12 +926,17 @@ export class BrowserAutomationBroker {
     return null;
   }
 
-  private invalidateTarget(host: RegisteredHost, removedTargetKey: string): void {
+  private invalidateTarget(
+    host: RegisteredHost,
+    removedTargetKey: string,
+    preserveOpenTransition = false,
+  ): void {
     for (const [key, assignment] of this.assignments) {
       if (assignment.host === host && assignment.targetKey === removedTargetKey) this.assignments.delete(key);
     }
     for (const [key, pending] of this.pending) {
       if (pending.host === host && pending.target && targetKey(pending.target) === removedTargetKey) {
+        if (preserveOpenTransition && pending.request.operation === "open") continue;
         this.settle(
           key,
           pending,

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -354,6 +354,27 @@ interface WebNavigationExpectation {
   acceptedRevision?: number;
 }
 
+function acceptExpectedWebNavigationRevision(
+  dispatch: BrowserAutomationHostDispatch,
+  navigation: WebNavigationExpectation | undefined,
+  target: { readonly revision: number } | undefined,
+): number | undefined {
+  if (!navigation || dispatch.request.operation !== "open") return undefined;
+  if (navigation.acceptedRevision !== undefined) {
+    return navigation.acceptedRevision === target?.revision ? navigation.acceptedRevision : undefined;
+  }
+  const expectedUrl = normalizeWebPreviewUrl(dispatch.request.args.url ?? "");
+  if (
+    navigation.targetKey !== browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId) ||
+    navigation.expectedUrl !== expectedUrl ||
+    dispatch.target.targetGeneration !== navigation.initialRevision ||
+    target?.revision !== navigation.initialRevision + 1 ||
+    !webPreviewIframe(dispatch.target.threadId, dispatch.target.tabId, navigation.expectedUrl)
+  ) return undefined;
+  navigation.acceptedRevision = target.revision;
+  return target.revision;
+}
+
 interface BackgroundBrowserScope {
   readonly threadId: string;
   readonly workspaceId: string;
@@ -680,17 +701,8 @@ export function BrowserAutomationHost() {
       for (const [requestKey, dispatch] of inFlightRef.current) {
         if (browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId) !== key) continue;
         const navigation = webNavigationRef.current.get(requestKey);
-        const expectedNavigation = dispatch.request.operation === "open" &&
-          navigation?.targetKey === key &&
-          navigation.expectedUrl === normalizeWebPreviewUrl(
-            dispatch.request.args.url ?? "",
-          ) &&
-          navigation.loadObserved &&
-          navigation.acceptedRevision === undefined &&
-          dispatch.target.targetGeneration === navigation.initialRevision &&
-          target.revision === navigation.initialRevision + 1;
+        const expectedNavigation = acceptExpectedWebNavigationRevision(dispatch, navigation, target) !== undefined;
         if (expectedNavigation) {
-          navigation.acceptedRevision = target.revision;
           continue;
         }
         webAbortRef.current.get(requestKey)?.abort(new Error("Browser document was replaced"));
@@ -837,11 +849,9 @@ export function BrowserAutomationHost() {
         const latestStore = useBrowserAutomationStore.getState();
         const latestTarget = latestStore.liveTargets.get(targetKey);
         const navigation = webNavigationRef.current.get(key);
-        const expectedRevision = navigation?.acceptedRevision ?? (
-          navigation?.loadObserved && navigation.initialRevision === dispatch.target.targetGeneration
-            ? navigation.initialRevision + 1
-            : dispatch.target.targetGeneration
-        );
+        const expectedRevision = navigation?.acceptedRevision ??
+          acceptExpectedWebNavigationRevision(dispatch, navigation, latestTarget) ??
+          dispatch.target.targetGeneration;
         if (!latestTarget || latestTarget.revision !== expectedRevision) {
           return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
         }
@@ -869,11 +879,9 @@ export function BrowserAutomationHost() {
         if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest)) {
           const latestTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
           const navigation = webNavigationRef.current.get(key);
-          const expectedRevision = navigation?.acceptedRevision ?? (
-            navigation?.loadObserved && navigation.initialRevision === dispatch.target.targetGeneration
-              ? navigation.initialRevision + 1
-              : dispatch.target.targetGeneration
-          );
+          const expectedRevision = navigation?.acceptedRevision ??
+            acceptExpectedWebNavigationRevision(dispatch, navigation, latestTarget) ??
+            dispatch.target.targetGeneration;
           if (!latestTarget || latestTarget.revision !== expectedRevision) {
             return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
           }
@@ -883,11 +891,9 @@ export function BrowserAutomationHost() {
         if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest)) {
           const latestTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
           const navigation = webNavigationRef.current.get(key);
-          const expectedRevision = navigation?.acceptedRevision ?? (
-            navigation?.loadObserved && navigation.initialRevision === dispatch.target.targetGeneration
-              ? navigation.initialRevision + 1
-              : dispatch.target.targetGeneration
-          );
+          const expectedRevision = navigation?.acceptedRevision ??
+            acceptExpectedWebNavigationRevision(dispatch, navigation, latestTarget) ??
+            dispatch.target.targetGeneration;
           if (!latestTarget || latestTarget.revision !== expectedRevision) {
             return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
           }

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -275,10 +275,11 @@ function waitForWebPreviewIframe(
   expectedUrl: string,
   deadline: number,
   signal: AbortSignal,
+  onNavigationLoad?: (iframe: HTMLIFrameElement) => void,
 ): Promise<void> {
   if (signal.aborted) return Promise.reject(signal.reason);
   const ready = webPreviewIframe(threadId, tabId, expectedUrl);
-  if (ready?.contentDocument?.readyState === "complete") return Promise.resolve();
+  if (ready?.contentDocument?.readyState === "complete" && !onNavigationLoad) return Promise.resolve();
   return new Promise((resolve, reject) => {
     let settled = false;
     let observedIframe: HTMLIFrameElement | null = null;
@@ -292,14 +293,17 @@ function waitForWebPreviewIframe(
     const observeReady = () => {
       const iframe = webPreviewIframe(threadId, tabId, expectedUrl);
       if (!iframe) return;
-      if (iframe.contentDocument?.readyState === "complete") {
+      if (iframe.contentDocument?.readyState === "complete" && !onNavigationLoad) {
         finish();
         return;
       }
       if (observedIframe === iframe) return;
       if (observedIframe && onLoad) observedIframe.removeEventListener("load", onLoad);
       observedIframe = iframe;
-      onLoad = () => finish();
+      onLoad = () => {
+        onNavigationLoad?.(iframe);
+        finish();
+      };
       iframe.addEventListener("load", onLoad, { once: true });
     };
     const observer = new MutationObserver(() => {
@@ -340,6 +344,14 @@ interface HostLease {
   readonly generation: number;
   readonly desktopInstanceId: string;
   readonly epoch: number;
+}
+
+interface WebNavigationExpectation {
+  readonly targetKey: string;
+  readonly expectedUrl: string;
+  readonly initialRevision: number;
+  loadObserved: boolean;
+  acceptedRevision?: number;
 }
 
 interface BackgroundBrowserScope {
@@ -452,6 +464,7 @@ export function BrowserAutomationHost() {
   const requestAbortRef = useRef(new Map<string, AbortController>());
   const webAbortRef = useRef(new Map<string, AbortController>());
   const webObserverRef = useRef(new Map<string, () => void>());
+  const webNavigationRef = useRef(new Map<string, WebNavigationExpectation>());
   const bootstrapPendingRef = useRef(new Set<string>());
   const bootstrapAbortRef = useRef(new Map<string, AbortController>());
   const bootstrapRequestRef = useRef(new Map<string, BrowserAutomationRequest>());
@@ -666,6 +679,20 @@ export function BrowserAutomationHost() {
       if (previousRevision === undefined || previousRevision === target.revision) continue;
       for (const [requestKey, dispatch] of inFlightRef.current) {
         if (browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId) !== key) continue;
+        const navigation = webNavigationRef.current.get(requestKey);
+        const expectedNavigation = dispatch.request.operation === "open" &&
+          navigation?.targetKey === key &&
+          navigation.expectedUrl === normalizeWebPreviewUrl(
+            dispatch.request.args.url ?? "",
+          ) &&
+          navigation.loadObserved &&
+          navigation.acceptedRevision === undefined &&
+          dispatch.target.targetGeneration === navigation.initialRevision &&
+          target.revision === navigation.initialRevision + 1;
+        if (expectedNavigation) {
+          navigation.acceptedRevision = target.revision;
+          continue;
+        }
         webAbortRef.current.get(requestKey)?.abort(new Error("Browser document was replaced"));
         requestAbortRef.current.get(requestKey)?.abort(new Error("Browser document was replaced"));
       }
@@ -776,7 +803,20 @@ export function BrowserAutomationHost() {
         if (!requestedUrl || !isSameOriginWebPreviewUrl(requestedUrl)) {
           return executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal);
         }
-        if (!webPreviewIframe(dispatch.target.threadId, dispatch.target.tabId, requestedUrl)) {
+        const currentTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
+        if (!currentTarget || currentTarget.revision !== dispatch.target.targetGeneration) {
+          return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
+        }
+        const currentIframe = webPreviewIframe(dispatch.target.threadId, dispatch.target.tabId, requestedUrl);
+        if (!currentIframe) {
+          webNavigationRef.current.set(key, {
+            targetKey,
+            expectedUrl: requestedUrl,
+            initialRevision: currentTarget.revision,
+            loadObserved: false,
+          });
+        }
+        if (!currentIframe) {
           useDiffStore.getState().setPreviewUrlForThread(dispatch.target.threadId, requestedUrl);
         }
         await waitForWebPreviewIframe(
@@ -785,10 +825,24 @@ export function BrowserAutomationHost() {
           requestedUrl,
           dispatch.request.deadline,
           controller.signal,
+          !currentIframe
+          ? () => {
+              const navigation = webNavigationRef.current.get(key);
+              if (navigation?.targetKey === targetKey && navigation.expectedUrl === requestedUrl) {
+                navigation.loadObserved = true;
+              }
+            }
+            : undefined,
         );
         const latestStore = useBrowserAutomationStore.getState();
         const latestTarget = latestStore.liveTargets.get(targetKey);
-        if (!latestTarget || latestTarget.revision !== dispatch.target.targetGeneration) {
+        const navigation = webNavigationRef.current.get(key);
+        const expectedRevision = navigation?.acceptedRevision ?? (
+          navigation?.loadObserved && navigation.initialRevision === dispatch.target.targetGeneration
+            ? navigation.initialRevision + 1
+            : dispatch.target.targetGeneration
+        );
+        if (!latestTarget || latestTarget.revision !== expectedRevision) {
           return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
         }
         const latestEpoch = latestStore.controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch;
@@ -814,7 +868,13 @@ export function BrowserAutomationHost() {
       const guardedOperation = operation.then((response) => {
         if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest)) {
           const latestTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
-          if (!latestTarget || latestTarget.revision !== dispatch.target.targetGeneration) {
+          const navigation = webNavigationRef.current.get(key);
+          const expectedRevision = navigation?.acceptedRevision ?? (
+            navigation?.loadObserved && navigation.initialRevision === dispatch.target.targetGeneration
+              ? navigation.initialRevision + 1
+              : dispatch.target.targetGeneration
+          );
+          if (!latestTarget || latestTarget.revision !== expectedRevision) {
             return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
           }
         }
@@ -822,7 +882,13 @@ export function BrowserAutomationHost() {
       }).catch((cause: unknown) => {
         if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest)) {
           const latestTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
-          if (!latestTarget || latestTarget.revision !== dispatch.target.targetGeneration) {
+          const navigation = webNavigationRef.current.get(key);
+          const expectedRevision = navigation?.acceptedRevision ?? (
+            navigation?.loadObserved && navigation.initialRevision === dispatch.target.targetGeneration
+              ? navigation.initialRevision + 1
+              : dispatch.target.targetGeneration
+          );
+          if (!latestTarget || latestTarget.revision !== expectedRevision) {
             return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
           }
         }
@@ -846,6 +912,7 @@ export function BrowserAutomationHost() {
         webObserverRef.current.get(key)?.();
         webObserverRef.current.delete(key);
         webAbortRef.current.delete(key);
+        webNavigationRef.current.delete(key);
         if (inFlightRef.current.get(key) === dispatch) inFlightRef.current.delete(key);
         requestAbortRef.current.delete(key);
         cancelledRef.current.delete(key);
@@ -1198,6 +1265,7 @@ export function BrowserAutomationHost() {
     bootstrapPendingRef.current.clear();
     inFlightRef.current.clear();
     cancelledRef.current.clear();
+    webNavigationRef.current.clear();
     recorderRef.current.dispose();
     for (const abort of webAbortRef.current.values()) abort.abort(new Error("Browser host was replaced"));
     for (const dispose of webObserverRef.current.values()) dispose();

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -27,6 +27,11 @@ import {
 import { useDiffStore } from "@/stores/diffStore";
 import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { BrowserAutomationRecorder } from "./browserAutomationRecorder";
+import {
+  executeWebInteraction,
+  observeWebHumanInput,
+  resolveSameOriginFrame,
+} from "./webBrowserInteractionExecutor";
 import { PreviewPanel, WEB_RUNTIME_PREVIEW_TAB_ID } from "./PreviewPanel";
 import type { PreviewAutomationBridge } from "@/transport/desktop-bridge";
 import { isBrowserAutomationWebRuntimeEnabled } from "./browserAutomationRuntime";
@@ -40,6 +45,11 @@ const UNAVAILABLE_OPERATIONS = new Map<BrowserAutomationOperation, string>([
 const WEB_AUTOMATION_UNAVAILABLE_REASON = "Web automation executor is unavailable";
 
 export { isBrowserAutomationWebRuntimeEnabled } from "./browserAutomationRuntime";
+
+function escapeWebSelector(value: string): string {
+  const escape = (globalThis as { CSS?: { escape?: (input: string) => string } }).CSS?.escape;
+  return escape ? escape(value) : value.replace(/[^a-zA-Z0-9_-]/g, (character) => `\\${character}`);
+}
 
 function webTargetIdentity(
   worktreeIdentity: string,
@@ -352,6 +362,8 @@ export function BrowserAutomationHost() {
   const registrationEpochRef = useRef(0);
   const inFlightRef = useRef(new Map<string, BrowserAutomationHostDispatch>());
   const requestAbortRef = useRef(new Map<string, AbortController>());
+  const webAbortRef = useRef(new Map<string, AbortController>());
+  const webObserverRef = useRef(new Map<string, () => void>());
   const bootstrapPendingRef = useRef(new Set<string>());
   const bootstrapAbortRef = useRef(new Map<string, AbortController>());
   const bootstrapRequestRef = useRef(new Map<string, BrowserAutomationRequest>());
@@ -375,6 +387,7 @@ export function BrowserAutomationHost() {
   ): void => {
     if (cancelledRef.current.has(key)) return;
     cancelledRef.current.add(key);
+    webAbortRef.current.get(key)?.abort(new Error(`Browser operation was cancelled: ${reason}`));
     recorderRef.current.cancel(dispatch);
     void window.desktopBridge?.preview?.automation?.cancel(dispatch.request.requestId);
     const lease = leaseOverride ?? leaseRef.current;
@@ -439,7 +452,8 @@ export function BrowserAutomationHost() {
       } : {}),
       capabilities: BROWSER_AUTOMATION_OPERATIONS.map((operation) => {
         if (!desktopAutomation) {
-          const available = operation === "status" || operation === "open" || operation === "navigate" || operation === "snapshot";
+          const available = operation === "click" || operation === "type" ||
+            operation === "status" || operation === "open" || operation === "navigate" || operation === "snapshot";
           return available
             ? { operation, available: true }
             : { operation, available: false, unavailableReason: WEB_AUTOMATION_UNAVAILABLE_REASON };
@@ -585,7 +599,8 @@ export function BrowserAutomationHost() {
 
   useEffect(() => {
     const bridge = window.desktopBridge?.preview?.automation;
-    if (!bridge && !isBrowserAutomationWebRuntimeEnabled()) return;
+    const webAutomationEnabled = isBrowserAutomationWebRuntimeEnabled();
+    if (!bridge && !webAutomationEnabled) return;
     const unsubscribeRequest = pushEmitter.on("browserAutomation.request", (input) => {
       const payload = input as { hostId?: unknown; generation?: unknown; dispatch?: unknown };
       const lease = leaseRef.current;
@@ -604,14 +619,73 @@ export function BrowserAutomationHost() {
       store.setActiveRequest({ dispatch, startedAt: Date.now() });
       const controller = new AbortController();
       requestAbortRef.current.set(key, controller);
-      void executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal).then((response) => {
-        if (leaseRef.current !== lease || cancelledRef.current.has(key)) return;
-        return getTransport().respondToBrowserAutomationRequest(
+      const webDispatch = !bridge && webAutomationEnabled &&
+        (dispatch.request.operation === "click" || dispatch.request.operation === "type");
+      const operationAbort = webDispatch ? new AbortController() : null;
+      if (operationAbort) webAbortRef.current.set(key, operationAbort);
+      const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+      const liveTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
+      const currentEpoch = useBrowserAutomationStore.getState().controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch;
+      const staleAtStart = !liveTarget || liveTarget.revision !== dispatch.target.targetGeneration || currentEpoch !== dispatch.request.expectedControlEpoch;
+      const cancelForHuman = () => {
+        if (!operationAbort || cancelledRef.current.has(key)) return;
+        cancelledRef.current.add(key);
+        operationAbort.abort(new Error("Browser operation was interrupted by human input"));
+        const nextEpoch = (useBrowserAutomationStore.getState().controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch) + 1;
+        useBrowserAutomationStore.getState().setControllerForTarget(
+          dispatch.target.threadId,
+          dispatch.target.tabId,
+          { tabId: dispatch.target.tabId, controller: "human", controlEpoch: nextEpoch },
+        );
+        void getTransport().cancelBrowserAutomationRequest(
           lease.hostId,
           lease.generation,
-          response,
-        );
+          dispatch.request.requestId,
+          dispatch.request.sequence,
+          "human-interrupted",
+        ).catch(() => undefined);
+      };
+      const executeWeb = async (): Promise<BrowserAutomationResponse> => {
+        if (staleAtStart) {
+          return failureResponse(dispatch.request, !liveTarget || liveTarget.revision !== dispatch.target.targetGeneration ? "STALE_TARGET_GENERATION" : "STALE_CONTROL_EPOCH", "Browser operation is stale");
+        }
+        if (!operationAbort) return failureResponse(dispatch.request, "TAB_UNAVAILABLE", "Browser target is unavailable");
+        const selector = `iframe[data-thread-id="${escapeWebSelector(dispatch.target.threadId)}"][data-tab-id="${escapeWebSelector(dispatch.target.tabId)}"]`;
+        const targetDocument = resolveSameOriginFrame(document.querySelector<HTMLIFrameElement>(selector));
+        if (!targetDocument) return failureResponse(dispatch.request, "TAB_UNAVAILABLE", "Browser target is unavailable");
+        webObserverRef.current.set(key, observeWebHumanInput(targetDocument.document, cancelForHuman));
+        return executeWebInteraction(targetDocument.document, dispatch, {
+          signal: operationAbort.signal,
+          deadline: dispatch.request.deadline,
+          expectedControlEpoch: dispatch.request.expectedControlEpoch,
+          targetGeneration: dispatch.target.targetGeneration,
+          getControlEpoch: () => useBrowserAutomationStore.getState().controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch,
+          getTargetGeneration: () => useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision ?? 0,
+        });
+      };
+      const operation = webDispatch
+        ? executeWeb()
+        : bridge
+          ? executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal)
+          : Promise.resolve(failureResponse(dispatch.request, "UNSUPPORTED_OPERATION", WEB_AUTOMATION_UNAVAILABLE_REASON));
+      void operation.then((response) => {
+        if (leaseRef.current !== lease || cancelledRef.current.has(key)) return;
+        return webDispatch
+          ? getTransport().respondToBrowserAutomationRequest(
+            lease.hostId,
+            lease.generation,
+            response,
+            dispatch.target,
+          )
+          : getTransport().respondToBrowserAutomationRequest(
+            lease.hostId,
+            lease.generation,
+            response,
+          );
       }).catch(() => undefined).finally(() => {
+        webObserverRef.current.get(key)?.();
+        webObserverRef.current.delete(key);
+        webAbortRef.current.delete(key);
         if (inFlightRef.current.get(key) === dispatch) inFlightRef.current.delete(key);
         requestAbortRef.current.delete(key);
         cancelledRef.current.delete(key);
@@ -640,6 +714,7 @@ export function BrowserAutomationHost() {
       }
       if (!inFlightRef.current.has(key) || cancelledRef.current.has(key)) return;
       cancelledRef.current.add(key);
+      webAbortRef.current.get(key)?.abort(new Error("Browser operation was cancelled"));
       recorderRef.current.cancel(inFlightRef.current.get(key)!);
       requestAbortRef.current.get(key)?.abort(new Error("Browser operation was cancelled"));
       if (bridge) void bridge.cancel(payload.requestId);
@@ -943,6 +1018,10 @@ export function BrowserAutomationHost() {
     inFlightRef.current.clear();
     cancelledRef.current.clear();
     recorderRef.current.dispose();
+    for (const abort of webAbortRef.current.values()) abort.abort(new Error("Browser host was replaced"));
+    for (const dispose of webObserverRef.current.values()) dispose();
+    webAbortRef.current.clear();
+    webObserverRef.current.clear();
   }, []);
 
   return backgroundScopes.map((scope) => (

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -621,6 +621,7 @@ export function BrowserAutomationHost() {
       requestAbortRef.current.set(key, controller);
       const webDispatch = !bridge && webAutomationEnabled &&
         (dispatch.request.operation === "click" || dispatch.request.operation === "type");
+      const webExecutorDispatch = !bridge && webAutomationEnabled;
       const operationAbort = webDispatch ? new AbortController() : null;
       if (operationAbort) webAbortRef.current.set(key, operationAbort);
       const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
@@ -665,7 +666,7 @@ export function BrowserAutomationHost() {
       };
       const operation = webDispatch
         ? executeWeb()
-        : bridge
+        : bridge || webExecutorDispatch
           ? executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal)
           : Promise.resolve(failureResponse(dispatch.request, "UNSUPPORTED_OPERATION", WEB_AUTOMATION_UNAVAILABLE_REASON));
       void operation.then((response) => {

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -34,7 +34,10 @@ import {
 } from "./webBrowserInteractionExecutor";
 import { PreviewPanel, WEB_RUNTIME_PREVIEW_TAB_ID } from "./PreviewPanel";
 import type { PreviewAutomationBridge } from "@/transport/desktop-bridge";
-import { isBrowserAutomationWebRuntimeEnabled } from "./browserAutomationRuntime";
+import {
+  isBrowserAutomationWebRuntimeEnabled,
+  normalizeWebPreviewUrl,
+} from "./browserAutomationRuntime";
 import { executeWebBrowserDispatch } from "./browserAutomationWebExecutor";
 import { captureVisibleWebLocation, sanitizeWebLocation } from "./web-browser-automation/capture";
 
@@ -244,6 +247,91 @@ function waitForLiveTarget(
       resolve();
     });
     signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function webPreviewIframe(
+  threadId: string,
+  tabId: string,
+  expectedUrl: string,
+): HTMLIFrameElement | null {
+  const selector = `iframe[data-thread-id="${escapeWebSelector(threadId)}"][data-tab-id="${escapeWebSelector(tabId)}"]`;
+  const iframe = document.querySelector<HTMLIFrameElement>(selector);
+  if (!iframe || normalizeWebPreviewUrl(iframe.src) !== expectedUrl) return null;
+  return resolveSameOriginFrame(iframe) ? iframe : null;
+}
+
+function isSameOriginWebPreviewUrl(url: string): boolean {
+  try {
+    return new URL(url, window.location.href).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+function waitForWebPreviewIframe(
+  threadId: string,
+  tabId: string,
+  expectedUrl: string,
+  deadline: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  const ready = webPreviewIframe(threadId, tabId, expectedUrl);
+  if (ready?.contentDocument?.readyState === "complete") return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let observedIframe: HTMLIFrameElement | null = null;
+    let onLoad: (() => void) | null = null;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const observeReady = () => {
+      const iframe = webPreviewIframe(threadId, tabId, expectedUrl);
+      if (!iframe) return;
+      if (iframe.contentDocument?.readyState === "complete") {
+        finish();
+        return;
+      }
+      if (observedIframe === iframe) return;
+      if (observedIframe && onLoad) observedIframe.removeEventListener("load", onLoad);
+      observedIframe = iframe;
+      onLoad = () => finish();
+      iframe.addEventListener("load", onLoad, { once: true });
+    };
+    const observer = new MutationObserver(() => {
+      observeReady();
+    });
+    const timeout = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error("Web Preview iframe did not attach before the request deadline"));
+    }, Math.max(1, Math.min(60_000, deadline - Date.now())));
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(signal.reason);
+    };
+    const cleanup = () => {
+      window.clearTimeout(timeout);
+      signal.removeEventListener("abort", onAbort);
+      if (observedIframe && onLoad) observedIframe.removeEventListener("load", onLoad);
+      observer.disconnect();
+    };
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["src", "data-thread-id", "data-tab-id", "class", "style", "hidden", "aria-hidden"],
+    });
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
+    observeReady();
   });
 }
 
@@ -622,6 +710,8 @@ export function BrowserAutomationHost() {
       const webDispatch = !bridge && webAutomationEnabled &&
         (dispatch.request.operation === "click" || dispatch.request.operation === "type");
       const webExecutorDispatch = !bridge && webAutomationEnabled;
+      const webOpenRequest = !bridge && webAutomationEnabled &&
+        dispatch.request.operation === "open" && Boolean(dispatch.request.args.url);
       const operationAbort = webDispatch ? new AbortController() : null;
       if (operationAbort) webAbortRef.current.set(key, operationAbort);
       const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
@@ -664,8 +754,46 @@ export function BrowserAutomationHost() {
           getTargetGeneration: () => useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision ?? 0,
         });
       };
+      const executeWebOpen = async (): Promise<BrowserAutomationResponse> => {
+        if (!webOpenRequest || dispatch.request.operation !== "open" || !dispatch.request.args.url) {
+          return executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal);
+        }
+        const requestedUrl = normalizeWebPreviewUrl(dispatch.request.args.url);
+        if (!requestedUrl || !isSameOriginWebPreviewUrl(requestedUrl)) {
+          return executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal);
+        }
+        if (!webPreviewIframe(dispatch.target.threadId, dispatch.target.tabId, requestedUrl)) {
+          useDiffStore.getState().setPreviewUrlForThread(dispatch.target.threadId, requestedUrl);
+        }
+        await waitForWebPreviewIframe(
+          dispatch.target.threadId,
+          dispatch.target.tabId,
+          requestedUrl,
+          dispatch.request.deadline,
+          controller.signal,
+        );
+        const latestStore = useBrowserAutomationStore.getState();
+        const latestTarget = latestStore.liveTargets.get(targetKey);
+        if (!latestTarget || latestTarget.revision !== dispatch.target.targetGeneration) {
+          return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
+        }
+        const latestEpoch = latestStore.controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch;
+        if (latestEpoch !== dispatch.request.expectedControlEpoch) {
+          return failureResponse(dispatch.request, "STALE_CONTROL_EPOCH", "Browser operation is stale");
+        }
+        const executionDispatch = {
+          ...dispatch,
+          request: {
+            ...dispatch.request,
+            args: { activate: dispatch.request.args.activate },
+          },
+        };
+        return executeBrowserDispatch(bridge, recorderRef.current, executionDispatch, controller.signal);
+      };
       const operation = webDispatch
         ? executeWeb()
+        : webOpenRequest
+          ? executeWebOpen()
         : bridge || webExecutorDispatch
           ? executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal)
           : Promise.resolve(failureResponse(dispatch.request, "UNSUPPORTED_OPERATION", WEB_AUTOMATION_UNAVAILABLE_REASON));
@@ -837,7 +965,9 @@ export function BrowserAutomationHost() {
         }
         if (!tabId) throw new Error("Browser tab could not be created or restored");
         const selectedTab = existingSet?.tabs.find((tab) => tab.id === tabId);
-        const requestedWebUrl = !bridge ? request.args.url : undefined;
+        const requestedWebUrl = !bridge && request.args.url
+          ? normalizeWebPreviewUrl(request.args.url)
+          : undefined;
         const initialUrl = requestedWebUrl ?? selectedTab?.url ?? "about:blank";
         if (!selectedTab?.url || requestedWebUrl) {
           usePreviewTabsStore.getState().updateTabChrome(request.threadId, tabId, {
@@ -849,6 +979,16 @@ export function BrowserAutomationHost() {
         }
         if (controller.signal.aborted) {
           throw controller.signal.reason;
+        }
+        if (!bridge && requestedWebUrl) {
+          await waitForWebPreviewIframe(
+            request.threadId,
+            tabId,
+            requestedWebUrl,
+            request.deadline,
+            controller.signal,
+          );
+          ensureActive();
         }
         await waitForLiveTarget(request.threadId, tabId, request.deadline, controller.signal);
         ensureActive();
@@ -893,7 +1033,16 @@ export function BrowserAutomationHost() {
         });
         inFlightRef.current.set(key, dispatch);
         requestAbortRef.current.set(key, controller);
-        const response = await executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal);
+        const executionDispatch = !bridge && requestedWebUrl
+          ? {
+              ...dispatch,
+              request: {
+                ...dispatch.request,
+                args: { activate: request.args.activate },
+              },
+            }
+          : dispatch;
+        const response = await executeBrowserDispatch(bridge, recorderRef.current, executionDispatch, controller.signal);
         await restoreBackgroundContext();
         if (leaseRef.current === lease && !cancelledRef.current.has(key)) {
           await getTransport().respondToBrowserAutomationRequest(

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -456,6 +456,7 @@ export function BrowserAutomationHost() {
   const bootstrapAbortRef = useRef(new Map<string, AbortController>());
   const bootstrapRequestRef = useRef(new Map<string, BrowserAutomationRequest>());
   const priorLiveTargetKeysRef = useRef(new Set<string>());
+  const priorLiveTargetRevisionsRef = useRef(new Map<string, number>());
   const cancelledRef = useRef(new Set<string>());
   const stableHostId = useMemo(hostId, []);
   const [backgroundScopes, setBackgroundScopes] = useState<readonly BackgroundBrowserScope[]>([]);
@@ -659,6 +660,16 @@ export function BrowserAutomationHost() {
 
   useEffect(() => {
     const next = new Set(liveTargets.keys());
+    const priorRevisions = priorLiveTargetRevisionsRef.current;
+    for (const [key, target] of liveTargets) {
+      const previousRevision = priorRevisions.get(key);
+      if (previousRevision === undefined || previousRevision === target.revision) continue;
+      for (const [requestKey, dispatch] of inFlightRef.current) {
+        if (browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId) !== key) continue;
+        webAbortRef.current.get(requestKey)?.abort(new Error("Browser document was replaced"));
+        requestAbortRef.current.get(requestKey)?.abort(new Error("Browser document was replaced"));
+      }
+    }
     for (const removed of priorLiveTargetKeysRef.current) {
       if (next.has(removed)) continue;
       const [threadId, tabId] = JSON.parse(removed) as [string, string];
@@ -669,6 +680,9 @@ export function BrowserAutomationHost() {
       }
     }
     priorLiveTargetKeysRef.current = next;
+    priorLiveTargetRevisionsRef.current = new Map(
+      [...liveTargets].map(([key, target]) => [key, target.revision]),
+    );
   }, [cancelHostedRequest, liveTargets]);
 
   useEffect(() => {
@@ -797,7 +811,24 @@ export function BrowserAutomationHost() {
         : bridge || webExecutorDispatch
           ? executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal)
           : Promise.resolve(failureResponse(dispatch.request, "UNSUPPORTED_OPERATION", WEB_AUTOMATION_UNAVAILABLE_REASON));
-      void operation.then((response) => {
+      const guardedOperation = operation.then((response) => {
+        if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest)) {
+          const latestTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
+          if (!latestTarget || latestTarget.revision !== dispatch.target.targetGeneration) {
+            return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
+          }
+        }
+        return response;
+      }).catch((cause: unknown) => {
+        if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest)) {
+          const latestTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
+          if (!latestTarget || latestTarget.revision !== dispatch.target.targetGeneration) {
+            return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
+          }
+        }
+        throw cause;
+      });
+      void guardedOperation.then((response) => {
         if (leaseRef.current !== lease || cancelledRef.current.has(key)) return;
         return webDispatch
           ? getTransport().respondToBrowserAutomationRequest(

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1585,6 +1585,10 @@ function WebRuntimePreview({
   };
 
   const onIframeLoad = (event: React.SyntheticEvent<HTMLIFrameElement>): void => {
+    useBrowserAutomationStore.getState().refreshTarget(
+      threadId,
+      WEB_RUNTIME_PREVIEW_TAB_ID,
+    );
     try {
       const actualOrigin = event.currentTarget.contentWindow?.location.origin;
       setCrossOriginObserved(actualOrigin !== window.location.origin);

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -369,13 +369,97 @@ describe("BrowserAutomationHost", () => {
     iframe.dataset.threadId = "thread-1";
     iframe.dataset.tabId = "web-preview";
     document.body.append(iframe);
-    window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
+    window.setTimeout(() => {
+      iframe.dispatchEvent(new Event("load"));
+      useBrowserAutomationStore.getState().refreshTarget("thread-1", "web-preview");
+    }, 0);
     await waitFor(() => expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(
       expect.objectContaining({ request: expect.objectContaining({ args: { activate: true } }) }),
       expect.any(AbortSignal),
     ));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
     iframe.remove();
+    view.unmount();
+  });
+
+  it("accepts the expected target revision advanced by a same-origin open load", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    webExecutor.executeWebBrowserDispatch.mockResolvedValue(successResponse(dispatch(1, 38).request));
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const openDispatch = dispatch(1, 38, { tabId: "tab-1", targetGeneration: 1 });
+    openDispatch.request = {
+      ...openDispatch.request,
+      operation: "open",
+      args: { url: `${window.location.origin}/revision-open`, activate: true },
+    } as never;
+    const expectedUrl = `${window.location.origin}/revision-open`;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: openDispatch }));
+    await waitFor(() => expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(expectedUrl));
+    expect(webExecutor.executeWebBrowserDispatch).not.toHaveBeenCalled();
+
+    const iframe = document.createElement("iframe");
+    iframe.src = expectedUrl;
+    iframe.dataset.threadId = "thread-1";
+    iframe.dataset.tabId = "tab-1";
+    Object.defineProperty(iframe, "contentWindow", {
+      configurable: true,
+      value: { location: { origin: window.location.origin } },
+    });
+    document.body.append(iframe);
+    window.setTimeout(() => {
+      iframe.dispatchEvent(new Event("load"));
+      useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1");
+    }, 0);
+
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      expect.objectContaining({ ok: true }),
+    );
+    expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ request: expect.objectContaining({ args: { activate: true } }) }),
+      expect.any(AbortSignal),
+    );
+    iframe.remove();
+    view.unmount();
+  });
+
+  it("rejects an unrelated iframe replacement during a same-origin open", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    webExecutor.executeWebBrowserDispatch.mockResolvedValue(successResponse(dispatch(1, 39).request));
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const openDispatch = dispatch(1, 39, { tabId: "tab-1", targetGeneration: 1 });
+    openDispatch.request = {
+      ...openDispatch.request,
+      operation: "open",
+      args: { url: `${window.location.origin}/replacement-open`, activate: true },
+    } as never;
+    const expectedUrl = `${window.location.origin}/replacement-open`;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: openDispatch }));
+    await waitFor(() => expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(expectedUrl));
+
+    const replacement = document.createElement("iframe");
+    replacement.src = `${window.location.origin}/unrelated-replacement`;
+    replacement.dataset.threadId = "thread-1";
+    replacement.dataset.tabId = "tab-1";
+    document.body.append(replacement);
+    act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
+
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      expect.objectContaining({ ok: false, error: expect.objectContaining({ code: "STALE_TARGET_GENERATION" }) }),
+    );
+    expect(webExecutor.executeWebBrowserDispatch).not.toHaveBeenCalled();
+    replacement.remove();
     view.unmount();
   });
 

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -1472,6 +1472,49 @@ describe("BrowserAutomationHost", () => {
     frame.remove();
   });
 
+  it("rejects a pending request after web iframe replacement without mutating the new document", async () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    delete window.desktopBridge;
+    const frame = document.createElement("iframe");
+    frame.dataset.threadId = "thread-1";
+    frame.dataset.tabId = "tab-1";
+    document.body.append(frame);
+    Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
+    const frameDocument = frame.contentDocument!;
+    frameDocument.body.innerHTML = '<input id="name" />';
+    const input = frameDocument.querySelector("input")!;
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const pending: Array<FrameRequestCallback> = [];
+    Object.defineProperty(frameDocument.defaultView, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => {
+        pending.push(callback);
+        return pending.length;
+      },
+    });
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    await waitFor(() => expect(useBrowserAutomationStore.getState().registered).toBe(true));
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const typeDispatch = dispatch(1, 36, { targetGeneration: 1 });
+    typeDispatch.request = { ...typeDispatch.request, operation: "type", args: { target: { cssSelector: "#name" }, text: "typed", clear: true, submit: false, timeoutMs: 1000 } } as never;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: typeDispatch }));
+    await waitFor(() => expect(useBrowserAutomationStore.getState().activeRequests.size).toBe(1));
+    act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
+    pending.shift()?.(performance.now());
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenLastCalledWith(
+      hostId,
+      1,
+      expect.objectContaining({ ok: false, error: expect.objectContaining({ code: "STALE_TARGET_GENERATION" }) }),
+      typeDispatch.target,
+    );
+    expect(input).toHaveValue("");
+    view.unmount();
+    frame.remove();
+    delete (frameDocument.defaultView as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+  });
+
   it("suppresses mutation and response after broker cancellation", async () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     delete window.desktopBridge;

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -271,6 +271,30 @@ describe("BrowserAutomationHost", () => {
     view.unmount();
   });
 
+  it("routes normal web status and open requests through the web executor", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    webExecutor.executeWebBrowserDispatch.mockResolvedValue(successResponse(dispatch(1, 32).request));
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const statusDispatch = dispatch(1, 32);
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: statusDispatch }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    const openDispatch = dispatch(1, 33);
+    openDispatch.request = {
+      ...openDispatch.request,
+      operation: "open",
+      args: { url: `${window.location.origin}/normal-open`, activate: true },
+    } as never;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: openDispatch }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledTimes(2));
+    expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(statusDispatch, expect.any(AbortSignal));
+    expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(openDispatch, expect.any(AbortSignal));
+    expect(harness.transport.respondToBrowserAutomationRequest.mock.calls.every(([, , response]) => response.ok)).toBe(true);
+    view.unmount();
+  });
+
   afterEach(() => {
     delete window.desktopBridge;
     vi.unstubAllEnvs();

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -76,7 +76,7 @@ function deferred<T>() {
 function dispatch(
   generation: number,
   sequence: number,
-  options: { requestId?: string; threadId?: string; tabId?: string } = {},
+  options: { requestId?: string; threadId?: string; tabId?: string; targetGeneration?: number; expectedControlEpoch?: number } = {},
 ): BrowserAutomationHostDispatch {
   const threadId = options.threadId ?? "thread-1";
   const tabId = options.tabId ?? "tab-1";
@@ -91,7 +91,7 @@ function dispatch(
       desktopInstanceId: `desktop-${generation}`,
       windowId: 7,
       connectionGeneration: generation,
-      targetGeneration: 3,
+      targetGeneration: options.targetGeneration ?? 3,
     },
     request: {
       contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
@@ -102,7 +102,7 @@ function dispatch(
       requestId: options.requestId ?? `request-${sequence}`,
       sequence,
       deadline: Date.now() + 60_000,
-      expectedControlEpoch: 0,
+      expectedControlEpoch: options.expectedControlEpoch ?? 0,
       operation: "status",
       args: {},
     },
@@ -112,7 +112,7 @@ function dispatch(
       connectionGeneration: generation,
       threadId,
       tabId,
-      targetGeneration: 3,
+      targetGeneration: options.targetGeneration ?? 3,
       active: true,
       focused: true,
       lastUsedAt: 10,
@@ -1248,6 +1248,134 @@ describe("BrowserAutomationHost", () => {
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalled());
     expect(harness.transport.respondToBrowserAutomationRequest.mock.calls.at(-1)?.[2]).toMatchObject({ ok: false, error: { code: "CROSS_ORIGIN" } });
     view.unmount();
+  it("routes web click and type through the broker for the exact iframe target", async () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    delete window.desktopBridge;
+    const frame = document.createElement("iframe");
+    frame.dataset.threadId = "thread-1";
+    frame.dataset.tabId = "tab-1";
+    document.body.append(frame);
+    Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
+    const frameDocument = frame.contentDocument!;
+    frameDocument.body.innerHTML = '<button id="save">Save</button><input id="name" />';
+    const button = frameDocument.querySelector("button")!;
+    const input = frameDocument.querySelector("input")!;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const clicked = vi.fn();
+    button.addEventListener("click", clicked);
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    await waitFor(() => expect(useBrowserAutomationStore.getState().registered).toBe(true));
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const clickDispatch = dispatch(1, 30, { targetGeneration: 1 });
+    clickDispatch.request = { ...clickDispatch.request, operation: "click", args: { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 } } as never;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: clickDispatch }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(clicked).toHaveBeenCalledOnce();
+    expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(hostId, 1, expect.objectContaining({ ok: true, result: expect.objectContaining({ operation: "click" }) }), clickDispatch.target);
+    expect(harness.transport.cancelBrowserAutomationRequest).not.toHaveBeenCalled();
+    const typeDispatch = dispatch(1, 31, { targetGeneration: 1 });
+    typeDispatch.request = { ...typeDispatch.request, operation: "type", args: { target: { cssSelector: "#name" }, text: "typed", clear: true, submit: false, timeoutMs: 1000 } } as never;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: typeDispatch }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledTimes(2));
+    expect(input.value).toBe("typed");
+    expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenLastCalledWith(hostId, 1, expect.objectContaining({ ok: true, result: expect.objectContaining({ operation: "type" }) }), typeDispatch.target);
+    view.unmount();
+    frame.remove();
+  });
+
+  it("cancels the exact web request on direct pointer takeover before click mutation", async () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    delete window.desktopBridge;
+    const frame = document.createElement("iframe");
+    frame.dataset.threadId = "thread-1";
+    frame.dataset.tabId = "tab-1";
+    document.body.append(frame);
+    Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
+    const frameDocument = frame.contentDocument!;
+    frameDocument.body.innerHTML = '<button id="save">Save</button>';
+    const button = frameDocument.querySelector("button")!;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    const clicked = vi.fn();
+    button.addEventListener("click", clicked);
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const clickDispatch = dispatch(1, 32, { targetGeneration: 1 });
+    clickDispatch.request = { ...clickDispatch.request, operation: "click", args: { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 } } as never;
+    frameDocument.addEventListener("mousedown", () => frameDocument.dispatchEvent(new frameDocument.defaultView!.Event("pointerdown", { bubbles: true })), true);
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: clickDispatch }));
+    await waitFor(() => expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(hostId, 1, clickDispatch.request.requestId, clickDispatch.request.sequence, "human-interrupted"));
+    await waitFor(() => expect(useBrowserAutomationStore.getState().activeRequests.size).toBe(0));
+    expect(clicked).not.toHaveBeenCalled();
+    expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
+    view.unmount();
+    frame.remove();
+  });
+
+  it("rejects stale web generations and control epochs without mutating the iframe", async () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    delete window.desktopBridge;
+    const frame = document.createElement("iframe");
+    frame.dataset.threadId = "thread-1";
+    frame.dataset.tabId = "tab-1";
+    document.body.append(frame);
+    Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
+    const frameDocument = frame.contentDocument!;
+    frameDocument.body.innerHTML = '<button id="save">Save</button><input id="name" />';
+    const button = frameDocument.querySelector("button")!;
+    const input = frameDocument.querySelector("input")!;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const clicked = vi.fn();
+    button.addEventListener("click", clicked);
+    useBrowserAutomationStore.getState().setControllerForTarget("thread-1", "tab-1", { tabId: "tab-1", controller: "agent", controlEpoch: 2 });
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const staleGeneration = dispatch(1, 33, { targetGeneration: 9 });
+    staleGeneration.request = { ...staleGeneration.request, operation: "click", args: { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 } } as never;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: staleGeneration }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenLastCalledWith(hostId, 1, expect.objectContaining({ ok: false, error: expect.objectContaining({ code: "STALE_TARGET_GENERATION" }) }), staleGeneration.target);
+    expect(clicked).not.toHaveBeenCalled();
+    const staleEpoch = dispatch(1, 34, { targetGeneration: 1, expectedControlEpoch: 0 });
+    staleEpoch.request = { ...staleEpoch.request, operation: "type", args: { target: { cssSelector: "#name" }, text: "typed", clear: true, submit: false, timeoutMs: 1000 } } as never;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: staleEpoch }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledTimes(2));
+    expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenLastCalledWith(hostId, 1, expect.objectContaining({ ok: false, error: expect.objectContaining({ code: "STALE_CONTROL_EPOCH" }) }), staleEpoch.target);
+    expect(input.value).toBe("");
+    view.unmount();
+    frame.remove();
+  });
+
+  it("suppresses mutation and response after broker cancellation", async () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    delete window.desktopBridge;
+    const frame = document.createElement("iframe");
+    frame.dataset.threadId = "thread-1";
+    frame.dataset.tabId = "tab-1";
+    document.body.append(frame);
+    Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
+    const frameDocument = frame.contentDocument!;
+    frameDocument.body.innerHTML = '<button id="save">Save</button>';
+    const button = frameDocument.querySelector("button")!;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    const clicked = vi.fn();
+    button.addEventListener("click", clicked);
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const clickDispatch = dispatch(1, 35, { targetGeneration: 1 });
+    clickDispatch.request = { ...clickDispatch.request, operation: "click", args: { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 } } as never;
+    frameDocument.addEventListener("mousedown", () => harness.emit("browserAutomation.cancel", { hostId, generation: 1, requestId: clickDispatch.request.requestId, sequence: clickDispatch.request.sequence }), true);
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: clickDispatch }));
+    await waitFor(() => expect(useBrowserAutomationStore.getState().activeRequests.size).toBe(0));
+    expect(clicked).not.toHaveBeenCalled();
+    expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
+    view.unmount();
+    frame.remove();
   });
 
   it("disposes exact target recording on human takeover even after start settled", async () => {

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -263,11 +263,51 @@ describe("BrowserAutomationHost", () => {
       args: { url: `${window.location.origin}/fixture`, activate: true },
     };
     act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
+    await waitFor(() => expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(openRequest.args.url));
+    expect(webExecutor.executeWebBrowserDispatch).not.toHaveBeenCalled();
+    const iframe = document.createElement("iframe");
+    iframe.src = openRequest.args.url;
+    iframe.dataset.threadId = "thread-1";
+    iframe.dataset.tabId = "web-preview";
+    document.body.append(iframe);
+    window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalled());
     expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(`${window.location.origin}/fixture`);
     expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(expect.objectContaining({
-      request: expect.objectContaining({ operation: "open", args: openRequest.args }),
+      request: expect.objectContaining({ operation: "open", args: { activate: true } }),
     }), expect.any(AbortSignal));
+    iframe.remove();
+    view.unmount();
+  });
+
+  it("waits for the seeded web preview iframe before the first open dispatch", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    useBrowserAutomationStore.getState().registerTarget("workspace-1", "thread-1", "web-preview");
+    webExecutor.executeWebBrowserDispatch.mockResolvedValue(successResponse(dispatch(1, 36).request));
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const openRequest = {
+      ...dispatch(1, 36).request,
+      operation: "open" as const,
+      args: { url: `${window.location.origin}/first-open`, activate: true },
+    };
+    act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
+    await waitFor(() => expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(openRequest.args.url));
+    expect(webExecutor.executeWebBrowserDispatch).not.toHaveBeenCalled();
+    const iframe = document.createElement("iframe");
+    iframe.src = openRequest.args.url;
+    iframe.dataset.threadId = "thread-1";
+    iframe.dataset.tabId = "web-preview";
+    document.body.append(iframe);
+    window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
+    await waitFor(() => expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ request: expect.objectContaining({ args: { activate: true } }) }),
+      expect.any(AbortSignal),
+    ));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    iframe.remove();
     view.unmount();
   });
 
@@ -281,17 +321,61 @@ describe("BrowserAutomationHost", () => {
     const statusDispatch = dispatch(1, 32);
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: statusDispatch }));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
-    const openDispatch = dispatch(1, 33);
+    const openDispatch = dispatch(1, 33, { targetGeneration: 1 });
     openDispatch.request = {
       ...openDispatch.request,
       operation: "open",
       args: { url: `${window.location.origin}/normal-open`, activate: true },
     } as never;
+    const normalOpenUrl = `${window.location.origin}/normal-open`;
+    const existingIframe = document.createElement("iframe");
+    existingIframe.src = normalOpenUrl;
+    existingIframe.dataset.threadId = "thread-1";
+    existingIframe.dataset.tabId = "tab-1";
+    document.body.append(existingIframe);
+    window.setTimeout(() => existingIframe.dispatchEvent(new Event("load")), 0);
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: openDispatch }));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledTimes(2));
     expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(statusDispatch, expect.any(AbortSignal));
-    expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(openDispatch, expect.any(AbortSignal));
+    expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ request: expect.objectContaining({ args: { activate: true } }) }),
+      expect.any(AbortSignal),
+    );
     expect(harness.transport.respondToBrowserAutomationRequest.mock.calls.every(([, , response]) => response.ok)).toBe(true);
+    existingIframe.remove();
+    view.unmount();
+  });
+
+  it("seeds an empty registered web target for normal open requests", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    useBrowserAutomationStore.getState().registerTarget("workspace-1", "thread-1", "web-preview");
+    webExecutor.executeWebBrowserDispatch.mockResolvedValue(successResponse(dispatch(1, 37).request));
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const openDispatch = dispatch(1, 37, { tabId: "web-preview", targetGeneration: 1 });
+    openDispatch.request = {
+      ...openDispatch.request,
+      operation: "open",
+      args: { url: `${window.location.origin}/normal-first-open`, activate: true },
+    } as never;
+    const firstOpenUrl = `${window.location.origin}/normal-first-open`;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: openDispatch }));
+    await waitFor(() => expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(firstOpenUrl));
+    expect(webExecutor.executeWebBrowserDispatch).not.toHaveBeenCalled();
+    const iframe = document.createElement("iframe");
+    iframe.src = firstOpenUrl;
+    iframe.dataset.threadId = "thread-1";
+    iframe.dataset.tabId = "web-preview";
+    document.body.append(iframe);
+    window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
+    await waitFor(() => expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ request: expect.objectContaining({ args: { activate: true } }) }),
+      expect.any(AbortSignal),
+    ));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    iframe.remove();
     view.unmount();
   });
 
@@ -1256,6 +1340,7 @@ describe("BrowserAutomationHost", () => {
     expect(sent.result.url).toMatch(/^https:\/\/example\.com\//);
     expect(sent.result.url).not.toMatch(/user|password|eyJabcdefghijk|secret|fragment/);
     view.unmount();
+    iframe.remove();
   });
 
   it("returns typed cross-origin status failure for an inaccessible mounted web target", async () => {
@@ -1282,6 +1367,9 @@ describe("BrowserAutomationHost", () => {
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalled());
     expect(harness.transport.respondToBrowserAutomationRequest.mock.calls.at(-1)?.[2]).toMatchObject({ ok: false, error: { code: "CROSS_ORIGIN" } });
     view.unmount();
+    iframe.remove();
+  });
+
   it("routes web click and type through the broker for the exact iframe target", async () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     delete window.desktopBridge;

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -61,6 +61,16 @@ vi.mock("../PreviewPanel", () => ({
 }));
 
 vi.mock("../browserAutomationWebExecutor", () => webExecutor);
+vi.mock("../webBrowserInteractionExecutor", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../webBrowserInteractionExecutor")>();
+  return {
+    ...actual,
+    observeWebHumanInput: (
+      ownerDocument: Document,
+      onHumanInput: () => void,
+    ) => actual.observeWebHumanInput(ownerDocument, onHumanInput, () => true),
+  };
+});
 
 import { BrowserAutomationHost, isBrowserAutomationWebRuntimeEnabled } from "../BrowserAutomationHost";
 import { BrowserAutomationRecorder } from "../browserAutomationRecorder";

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -410,8 +410,8 @@ describe("BrowserAutomationHost", () => {
     });
     document.body.append(iframe);
     window.setTimeout(() => {
-      iframe.dispatchEvent(new Event("load"));
       useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1");
+      iframe.dispatchEvent(new Event("load"));
     }, 0);
 
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -308,6 +308,13 @@ describe("PreviewPanel: unavailable state", () => {
     expect(useBrowserAutomationStore.getState().liveTargets.get(
       JSON.stringify(["thread-1", "web-preview"]),
     )).toMatchObject({ workspaceId: "workspace-1", threadId: "thread-1", tabId: "web-preview" });
+    const initialRevision = useBrowserAutomationStore.getState().liveTargets.get(
+      JSON.stringify(["thread-1", "web-preview"]),
+    )!.revision;
+    fireEvent.load(iframe);
+    expect(useBrowserAutomationStore.getState().liveTargets.get(
+      JSON.stringify(["thread-1", "web-preview"]),
+    )!.revision).toBe(initialRevision + 1);
     const page = document.implementation.createHTMLDocument("Fixture");
     page.body.innerHTML = "<main>Visible fixture</main>";
     Object.defineProperty(iframe, "contentDocument", { configurable: true, value: page });

--- a/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
@@ -50,6 +50,52 @@ describe("web browser interaction executor", () => {
     expect(clicked).toHaveBeenCalledOnce();
   });
 
+  it("uses iframe-realm controls and event constructors for click, type, and submit", async () => {
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+    const frameDocument = frame.contentDocument!;
+    frameDocument.body.innerHTML = '<button id="save">Save</button><input id="email" />';
+    const button = frameDocument.querySelector("button")!;
+    const input = frameDocument.querySelector("input")!;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const frameView = frameDocument.defaultView!;
+    const clickEvent = frameView.MouseEvent;
+    const inputEvent = frameView.InputEvent;
+    const keyboardEvent = frameView.KeyboardEvent;
+    const clicked = vi.fn();
+    const typed = vi.fn();
+    const submitted = vi.fn();
+    button.addEventListener("click", (event) => {
+      clicked(event instanceof clickEvent);
+    });
+    input.addEventListener("input", (event) => {
+      typed(event instanceof inputEvent);
+    });
+    input.addEventListener("keydown", (event) => {
+      event.preventDefault();
+      submitted(event instanceof keyboardEvent && (event as KeyboardEvent).key === "Enter");
+    });
+
+    const clickResult = await executeWebInteraction(
+      frameDocument,
+      dispatch("click", { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 }),
+      guard(),
+    );
+    const typeResult = await executeWebInteraction(
+      frameDocument,
+      dispatch("type", { target: { cssSelector: "#email" }, text: "typed", clear: true, submit: true, timeoutMs: 1000 }),
+      guard(),
+    );
+
+    expect(clickResult.ok).toBe(true);
+    expect(typeResult.ok).toBe(true);
+    expect(clicked).toHaveBeenCalledWith(true);
+    expect(typed).toHaveBeenCalledWith(true);
+    expect(submitted).toHaveBeenCalledWith(true);
+    expect(input.value).toBe("typed");
+  });
+
   it("types into editable controls and never echoes typed text in failures", async () => {
     document.body.innerHTML = '<input id="email" />';
     const input = document.querySelector("input") as HTMLInputElement;

--- a/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { BROWSER_AUTOMATION_CONTRACT_VERSION, type BrowserAutomationHostDispatch } from "@mcode/contracts";
+import {
+  executeWebInteraction,
+  observeWebHumanInput,
+  resolveWebTarget,
+} from "../webBrowserInteractionExecutor";
+
+function dispatch(operation: "click" | "type", args: Record<string, unknown>): BrowserAutomationHostDispatch {
+  return {
+    scope: { workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance" },
+    connection: { desktopInstanceId: "desktop", windowId: 1, connectionGeneration: 1, targetGeneration: 1 },
+    target: { desktopInstanceId: "desktop", windowId: 1, connectionGeneration: 1, threadId: "thread", tabId: "tab", targetGeneration: 1, active: true, focused: true, lastUsedAt: 1 },
+    request: {
+      contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+      workspaceId: "workspace",
+      threadId: "thread",
+      providerSessionId: "session",
+      providerInstanceId: "instance",
+      requestId: `request-${operation}`,
+      sequence: 1,
+      deadline: Date.now() + 10_000,
+      expectedControlEpoch: 0,
+      operation,
+      args,
+    } as never,
+  };
+}
+
+function guard(signal = new AbortController().signal) {
+  return {
+    signal,
+    deadline: Date.now() + 10_000,
+    expectedControlEpoch: 0,
+    targetGeneration: 1,
+    getControlEpoch: () => 0,
+    getTargetGeneration: () => 1,
+  };
+}
+
+describe("web browser interaction executor", () => {
+  it("clicks an eligible visible same-origin target", async () => {
+    document.body.innerHTML = '<button id="save">Save</button>';
+    const button = document.querySelector("button") as HTMLButtonElement;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    const clicked = vi.fn();
+    button.addEventListener("click", clicked);
+    const result = await executeWebInteraction(document, dispatch("click", { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 }), guard());
+    expect(result.ok).toBe(true);
+    expect(clicked).toHaveBeenCalledOnce();
+  });
+
+  it("types into editable controls and never echoes typed text in failures", async () => {
+    document.body.innerHTML = '<input id="email" />';
+    const input = document.querySelector("input") as HTMLInputElement;
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const secret = "sensitive-value";
+    const result = await executeWebInteraction(document, dispatch("type", { target: { cssSelector: "#email" }, text: secret, clear: true, submit: false, timeoutMs: 1000 }), guard());
+    expect(result.ok).toBe(true);
+    expect(input.value).toBe(secret);
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("fails closed for hostile selectors and cancelled work", async () => {
+    document.body.innerHTML = '<button id="save">Save</button>';
+    expect(resolveWebTarget(document, { cssSelector: "[" })).toMatchObject({ ok: false, code: "TARGET_NOT_FOUND" });
+    const controller = new AbortController();
+    controller.abort();
+    const result = await executeWebInteraction(document, dispatch("click", { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 }), guard(controller.signal));
+    expect(result).toMatchObject({ ok: false, error: { code: "OPERATION_CANCELLED" } });
+  });
+
+  it("observes direct human input", () => {
+    const onHumanInput = vi.fn();
+    const dispose = observeWebHumanInput(document, onHumanInput);
+    document.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    expect(onHumanInput).toHaveBeenCalledOnce();
+    dispose();
+  });
+});

--- a/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
@@ -6,6 +6,7 @@ import {
   redactBrowserLocation,
   redactBrowserText,
   resolveWebTarget,
+  isTrustedHumanInputEvent,
 } from "../webBrowserInteractionExecutor";
 
 function dispatch(operation: "click" | "type", args: Record<string, unknown>): BrowserAutomationHostDispatch {
@@ -184,6 +185,25 @@ describe("web browser interaction executor", () => {
     expect(submitted).not.toHaveBeenCalled();
   });
 
+  it("submits at most once when a page Enter handler requests submission", async () => {
+    document.body.innerHTML = '<form id="form"><input id="email" /></form>';
+    const form = document.querySelector("form")!;
+    const input = document.querySelector("input") as HTMLInputElement;
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const submitted = vi.fn((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitted);
+    input.addEventListener("keydown", () => form.requestSubmit());
+
+    const result = await executeWebInteraction(
+      document,
+      dispatch("type", { target: { cssSelector: "#email" }, text: "typed", clear: true, submit: true, timeoutMs: 1000 }),
+      guard(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(submitted).toHaveBeenCalledOnce();
+  });
+
   it("redacts credential-shaped URL and title metadata while preserving useful identity", async () => {
     document.body.innerHTML = '<button id="save">Save</button>';
     const button = document.querySelector("button")!;
@@ -199,6 +219,10 @@ describe("web browser interaction executor", () => {
     expect(result).toMatchObject({ ok: true, result: { title: "Dashboard token: [REDACTED]" } });
     expect(redactBrowserLocation("https://user:pass@example.test/path?view=home&token=secret#next=ok&access_token=hidden")).toBe("https://example.test/path?view=home&token=%5BREDACTED%5D#next=ok&access_token=%5BREDACTED%5D");
     expect(redactBrowserText("Bearer abc.def password: secret")).toBe("Bearer [REDACTED] password: [REDACTED]");
+    expect(redactBrowserText("password: my secret")).toBe("password: [REDACTED]");
+    const fragmentToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMifQ.signature-value";
+    expect(redactBrowserLocation(`https://example.test/callback#${fragmentToken}`)).not.toContain(fragmentToken);
+    expect(redactBrowserLocation("https://example.test/callback#section-1")).toBe("https://example.test/callback#section-1");
     expect(JSON.stringify(result)).not.toContain("eyJheader.payloadxx.signaturexx");
   });
 
@@ -222,11 +246,18 @@ describe("web browser interaction executor", () => {
     expect(result).toMatchObject({ ok: false, error: { code: "OPERATION_CANCELLED" } });
   });
 
-  it("observes direct human input", () => {
+  it("ignores untrusted page events but recognizes trusted human input", () => {
     const onHumanInput = vi.fn();
     const dispose = observeWebHumanInput(document, onHumanInput);
     document.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
-    expect(onHumanInput).toHaveBeenCalledOnce();
+    document.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+    expect(onHumanInput).not.toHaveBeenCalled();
     dispose();
+    const trustedDispose = observeWebHumanInput(document, onHumanInput, () => true);
+    document.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    expect(onHumanInput).toHaveBeenCalledOnce();
+    expect(isTrustedHumanInputEvent({ isTrusted: true } as Event)).toBe(true);
+    expect(isTrustedHumanInputEvent({ isTrusted: false } as Event)).toBe(false);
+    trustedDispose();
   });
 });

--- a/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
@@ -3,6 +3,8 @@ import { BROWSER_AUTOMATION_CONTRACT_VERSION, type BrowserAutomationHostDispatch
 import {
   executeWebInteraction,
   observeWebHumanInput,
+  redactBrowserLocation,
+  redactBrowserText,
   resolveWebTarget,
 } from "../webBrowserInteractionExecutor";
 
@@ -94,6 +96,110 @@ describe("web browser interaction executor", () => {
     expect(typed).toHaveBeenCalledWith(true);
     expect(submitted).toHaveBeenCalledWith(true);
     expect(input.value).toBe("typed");
+  });
+
+  it("submits a native single-line form control once when Enter is not prevented", async () => {
+    document.body.innerHTML = '<form id="form"><input id="email" /></form>';
+    const form = document.querySelector("form")!;
+    const input = document.querySelector("input") as HTMLInputElement;
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const submitted = vi.fn((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitted);
+
+    const result = await executeWebInteraction(
+      document,
+      dispatch("type", { target: { cssSelector: "#email" }, text: "typed", clear: true, submit: true, timeoutMs: 1000 }),
+      guard(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(submitted).toHaveBeenCalledOnce();
+  });
+
+  it("does not submit when Enter is prevented and keeps textarea Enter native", async () => {
+    document.body.innerHTML = '<form id="form"><input id="email" /><textarea id="notes"></textarea></form>';
+    const form = document.querySelector("form")!;
+    const input = document.querySelector("input") as HTMLInputElement;
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    vi.spyOn(textarea, "getBoundingClientRect").mockReturnValue({ width: 120, height: 40 } as DOMRect);
+    const submitted = vi.fn((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitted);
+    input.addEventListener("keydown", (event) => event.preventDefault());
+
+    await executeWebInteraction(
+      document,
+      dispatch("type", { target: { cssSelector: "#email" }, text: "typed", clear: true, submit: true, timeoutMs: 1000 }),
+      guard(),
+    );
+    await executeWebInteraction(
+      document,
+      dispatch("type", { target: { cssSelector: "#notes" }, text: "line", clear: true, submit: true, timeoutMs: 1000 }),
+      guard(),
+    );
+
+    expect(submitted).not.toHaveBeenCalled();
+    expect(textarea.value).toBe("line");
+  });
+
+  it("does not submit when the synthetic keypress is prevented", async () => {
+    document.body.innerHTML = '<form id="form"><input id="email" /></form>';
+    const form = document.querySelector("form")!;
+    const input = document.querySelector("input") as HTMLInputElement;
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const submitted = vi.fn((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitted);
+    input.addEventListener("keypress", (event) => event.preventDefault());
+
+    await executeWebInteraction(
+      document,
+      dispatch("type", { target: { cssSelector: "#email" }, text: "typed", clear: true, submit: true, timeoutMs: 1000 }),
+      guard(),
+    );
+
+    expect(submitted).not.toHaveBeenCalled();
+  });
+
+  it("rechecks target generation after Enter handlers before submitting", async () => {
+    document.body.innerHTML = '<form id="form"><input id="email" /></form>';
+    const form = document.querySelector("form")!;
+    const input = document.querySelector("input") as HTMLInputElement;
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const submitted = vi.fn((event: SubmitEvent) => event.preventDefault());
+    form.addEventListener("submit", submitted);
+    let generation = 1;
+    const operationGuard = guard();
+    operationGuard.getTargetGeneration = () => generation;
+    input.addEventListener("keydown", () => {
+      generation = 2;
+    });
+
+    const result = await executeWebInteraction(
+      document,
+      dispatch("type", { target: { cssSelector: "#email" }, text: "typed", clear: true, submit: true, timeoutMs: 1000 }),
+      operationGuard,
+    );
+
+    expect(result).toMatchObject({ ok: false, error: { code: "STALE_TARGET_GENERATION" } });
+    expect(submitted).not.toHaveBeenCalled();
+  });
+
+  it("redacts credential-shaped URL and title metadata while preserving useful identity", async () => {
+    document.body.innerHTML = '<button id="save">Save</button>';
+    const button = document.querySelector("button")!;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    Object.defineProperty(document, "title", { configurable: true, value: "Dashboard token: eyJheader.payloadxx.signaturexx" });
+
+    const result = await executeWebInteraction(
+      document,
+      dispatch("click", { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 }),
+      guard(),
+    );
+
+    expect(result).toMatchObject({ ok: true, result: { title: "Dashboard token: [REDACTED]" } });
+    expect(redactBrowserLocation("https://user:pass@example.test/path?view=home&token=secret#next=ok&access_token=hidden")).toBe("https://example.test/path?view=home&token=%5BREDACTED%5D#next=ok&access_token=%5BREDACTED%5D");
+    expect(redactBrowserText("Bearer abc.def password: secret")).toBe("Bearer [REDACTED] password: [REDACTED]");
+    expect(JSON.stringify(result)).not.toContain("eyJheader.payloadxx.signaturexx");
   });
 
   it("types into editable controls and never echoes typed text in failures", async () => {

--- a/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
@@ -53,6 +53,129 @@ describe("web browser interaction executor", () => {
     expect(clicked).toHaveBeenCalledOnce();
   });
 
+  it("cancels click during the scheduling frame before dispatching events", async () => {
+    document.body.innerHTML = '<button id="save">Save</button>';
+    const button = document.querySelector("button") as HTMLButtonElement;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    const clicked = vi.fn();
+    button.addEventListener("click", clicked);
+    const pending: Array<FrameRequestCallback> = [];
+    Object.defineProperty(document.defaultView, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => {
+        pending.push(callback);
+        return pending.length;
+      },
+    });
+    const controller = new AbortController();
+    const operation = executeWebInteraction(
+      document,
+      dispatch("click", { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 }),
+      guard(controller.signal),
+    );
+    await Promise.resolve();
+    controller.abort();
+    pending.shift()?.(performance.now());
+    const result = await operation;
+    delete (document.defaultView as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+    expect(result).toMatchObject({ ok: false, error: { code: "OPERATION_CANCELLED" } });
+    expect(clicked).not.toHaveBeenCalled();
+  });
+
+  it("cancels type during the scheduling frame before focus or value mutation", async () => {
+    document.body.innerHTML = '<input id="email" />';
+    const input = document.querySelector("input") as HTMLInputElement;
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const focus = vi.spyOn(input, "focus");
+    const pending: Array<FrameRequestCallback> = [];
+    Object.defineProperty(document.defaultView, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => {
+        pending.push(callback);
+        return pending.length;
+      },
+    });
+    const controller = new AbortController();
+    const operation = executeWebInteraction(
+      document,
+      dispatch("type", { target: { cssSelector: "#email" }, text: "typed", clear: true, submit: false, timeoutMs: 1000 }),
+      guard(controller.signal),
+    );
+    await Promise.resolve();
+    controller.abort();
+    pending.shift()?.(performance.now());
+    const result = await operation;
+    delete (document.defaultView as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+    expect(result).toMatchObject({ ok: false, error: { code: "OPERATION_CANCELLED" } });
+    expect(focus).not.toHaveBeenCalled();
+    expect(input.value).toBe("");
+  });
+
+  it("does not treat executor-generated pointer events as human takeover", async () => {
+    document.body.innerHTML = '<button id="save">Save</button>';
+    const button = document.querySelector("button") as HTMLButtonElement;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    const onHumanInput = vi.fn();
+    const dispose = observeWebHumanInput(document, onHumanInput, () => true);
+    const result = await executeWebInteraction(
+      document,
+      dispatch("click", { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 }),
+      guard(),
+    );
+    dispose();
+    expect(result.ok).toBe(true);
+    expect(onHumanInput).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale work after the scheduling frame without mutating the target", async () => {
+    document.body.innerHTML = '<input id="email" />';
+    const input = document.querySelector("input") as HTMLInputElement;
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
+    const pending: Array<FrameRequestCallback> = [];
+    Object.defineProperty(document.defaultView, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => {
+        pending.push(callback);
+        return pending.length;
+      },
+    });
+    let generation = 1;
+    const operationGuard = guard();
+    operationGuard.getTargetGeneration = () => generation;
+    const operation = executeWebInteraction(
+      document,
+      dispatch("type", { target: { cssSelector: "#email" }, text: "typed", clear: true, submit: false, timeoutMs: 1000 }),
+      operationGuard,
+    );
+    await Promise.resolve();
+    generation = 2;
+    pending.shift()?.(performance.now());
+    const result = await operation;
+    delete (document.defaultView as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+    expect(result).toMatchObject({ ok: false, error: { code: "STALE_TARGET_GENERATION" } });
+    expect(input.value).toBe("");
+  });
+
+  it("fails on the request deadline when the scheduling frame never fires", async () => {
+    document.body.innerHTML = '<button id="save">Save</button>';
+    const button = document.querySelector("button") as HTMLButtonElement;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    Object.defineProperty(document.defaultView, "requestAnimationFrame", {
+      configurable: true,
+      value: () => 1,
+    });
+    const operationGuard = guard();
+    operationGuard.deadline = Date.now() + 20;
+    const operation = executeWebInteraction(
+      document,
+      dispatch("click", { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 20 }),
+      operationGuard,
+    );
+    const result = await operation;
+    delete (document.defaultView as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+    expect(result).toMatchObject({ ok: false, error: { code: "DEADLINE_EXCEEDED" } });
+  });
+
   it("uses iframe-realm controls and event constructors for click, type, and submit", async () => {
     const frame = document.createElement("iframe");
     document.body.append(frame);

--- a/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
+++ b/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
@@ -8,9 +8,11 @@ import type {
 const MAX_TARGET_SCAN = 1_024;
 const MAX_METADATA_CHARS = 2_048;
 const SECRET_KEY = /^(?:access[_-]?token|api[_-]?key|auth|authorization|bearer|client[_-]?secret|code|cookie|credential|id[_-]?token|jwt|password|private[_-]?key|refresh[_-]?token|secret|session|session[_-]?id|signature|token)$/i;
-const SECRET_TEXT = /\b(?:access[_-]?token|api[_-]?key|authorization|bearer|cookie|credential|password|refresh[_-]?token|secret|session[_-]?id|token)\b\s*[:=]\s*([^\s,;]+)/gi;
+const SECRET_TEXT = /\b(access[_-]?token|api[_-]?key|authorization|bearer|cookie|credential|password|refresh[_-]?token|secret|session[_-]?id|token)(\s*[:=]\s*)([^,;!?\r\n]{1,512}?)(?=\s*(?:[,;!?\r\n]|\.\s+|$))/gi;
 const BEARER_TEXT = /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi;
 const JWT_TEXT = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
+const JWT_VALUE_TEXT = /\b(access[_-]?token|api[_-]?key|authorization|bearer|cookie|credential|password|refresh[_-]?token|secret|session[_-]?id|token)\b(\s*[:=]\s*)(eyJ[^\s,;]+)/gi;
+const OPAQUE_CREDENTIAL_FRAGMENT = /^(?:Bearer\s+)?eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$/i;
 const URL_TEXT = /\bhttps?:\/\/[^\s"'<>]+/gi;
 const executorEvents = new WeakSet<Event>();
 
@@ -145,8 +147,9 @@ export function redactBrowserText(value: unknown): string {
   return String(value ?? "")
     .replace(URL_TEXT, (candidate) => redactBrowserLocation(candidate))
     .replace(BEARER_TEXT, "Bearer [REDACTED]")
+    .replace(JWT_VALUE_TEXT, (_match, key: string, separator: string) => `${key}${separator}[REDACTED]`)
     .replace(JWT_TEXT, "[REDACTED]")
-    .replace(SECRET_TEXT, (match, captured: string) => match.replace(captured, "[REDACTED]"))
+    .replace(SECRET_TEXT, (_match, key: string, separator: string) => `${key}${separator}[REDACTED]`)
     .slice(0, MAX_METADATA_CHARS);
 }
 
@@ -162,7 +165,17 @@ export function redactBrowserLocation(value: unknown): string {
         if (SECRET_KEY.test(key)) url.searchParams.set(key, "[REDACTED]");
       }
       if (url.hash.length > 1) {
-        const fragment = new URLSearchParams(url.hash.slice(1));
+        const rawFragment = url.hash.slice(1);
+        let decodedFragment = rawFragment;
+        try {
+          decodedFragment = decodeURIComponent(rawFragment);
+        } catch {
+          // Preserve the opaque fragment when it is not valid URL encoding.
+        }
+        if (OPAQUE_CREDENTIAL_FRAGMENT.test(decodedFragment.trim())) {
+          url.hash = "[REDACTED]";
+        }
+        const fragment = new URLSearchParams(rawFragment);
         let changed = false;
         for (const key of [...fragment.keys()]) {
           if (!SECRET_KEY.test(key)) continue;
@@ -186,23 +199,41 @@ function isNativeSubmitControl(element: HTMLElement, ownerDocument: Document): e
   return !["button", "checkbox", "color", "date", "datetime-local", "file", "hidden", "image", "month", "radio", "range", "reset", "submit", "time", "week"].includes(type);
 }
 
-function dispatchEnter(ownerDocument: Document, element: HTMLElement): boolean {
+function dispatchEnter(ownerDocument: Document, element: HTMLElement): { readonly defaultAllowed: boolean; readonly formSubmitRequested: boolean } {
   const view = ownerDocument.defaultView;
   if (!view || typeof view.KeyboardEvent !== "function") throw new Error("Browser iframe event constructors are unavailable");
   const init = { key: "Enter", code: "Enter", bubbles: true, cancelable: true, composed: true } as const;
-  const keydown = new view.KeyboardEvent("keydown", init);
-  markExecutorEvent(keydown);
-  const keydownAllowed = element.dispatchEvent(keydown);
-  let keypressAllowed = true;
-  if (keydownAllowed && !keydown.defaultPrevented) {
-    const keypress = new view.KeyboardEvent("keypress", init);
-    markExecutorEvent(keypress);
-    keypressAllowed = element.dispatchEvent(keypress);
+  const form = isNativeSubmitControl(element, ownerDocument) ? (element as HTMLInputElement).form : null;
+  const originalRequestSubmit = form?.requestSubmit;
+  let formSubmitRequested = false;
+  let wrappedRequestSubmit: HTMLFormElement["requestSubmit"] | null = null;
+  if (form && typeof originalRequestSubmit === "function") {
+    wrappedRequestSubmit = function(this: HTMLFormElement, submitter?: HTMLElement): void {
+      formSubmitRequested = true;
+      if (submitter === undefined) originalRequestSubmit.call(this);
+      else originalRequestSubmit.call(this, submitter);
+    };
+    form.requestSubmit = wrappedRequestSubmit;
   }
-  const keyup = new view.KeyboardEvent("keyup", init);
-  markExecutorEvent(keyup);
-  element.dispatchEvent(keyup);
-  return keydownAllowed && !keydown.defaultPrevented && keypressAllowed;
+  try {
+    const keydown = new view.KeyboardEvent("keydown", init);
+    markExecutorEvent(keydown);
+    const keydownAllowed = element.dispatchEvent(keydown);
+    let keypressAllowed = true;
+    if (keydownAllowed && !keydown.defaultPrevented) {
+      const keypress = new view.KeyboardEvent("keypress", init);
+      markExecutorEvent(keypress);
+      keypressAllowed = element.dispatchEvent(keypress);
+    }
+    const keyup = new view.KeyboardEvent("keyup", init);
+    markExecutorEvent(keyup);
+    element.dispatchEvent(keyup);
+    return { defaultAllowed: keydownAllowed && !keydown.defaultPrevented && keypressAllowed, formSubmitRequested };
+  } finally {
+    if (form && originalRequestSubmit && form.requestSubmit === wrappedRequestSubmit) {
+      form.requestSubmit = originalRequestSubmit;
+    }
+  }
 }
 
 function errorResponse(dispatch: BrowserAutomationHostDispatch, code: Extract<BrowserAutomationResponse, { ok: false }>["error"]["code"], message: string): BrowserAutomationResponse {
@@ -218,10 +249,19 @@ export function isExecutorGeneratedEvent(event: Event): boolean {
   return executorEvents.has(event);
 }
 
+/** True only for browser events carrying the platform's trusted-user signal. */
+export function isTrustedHumanInputEvent(event: Event): boolean {
+  return event.isTrusted === true;
+}
+
 /** Attach direct-user takeover observers to one same-origin document. */
-export function observeWebHumanInput(ownerDocument: Document, onHumanInput: () => void): () => void {
+export function observeWebHumanInput(
+  ownerDocument: Document,
+  onHumanInput: () => void,
+  isTrustedInput: (event: Event) => boolean = isTrustedHumanInputEvent,
+): () => void {
   const handler = (event: Event) => {
-    if (isExecutorGeneratedEvent(event)) return;
+    if (isExecutorGeneratedEvent(event) || !isTrustedInput(event)) return;
     onHumanInput();
   };
   ownerDocument.addEventListener("pointerdown", handler, true);
@@ -277,8 +317,9 @@ export async function executeWebInteraction(
       element.dispatchEvent(inputEvent);
       if (args.submit) {
         guardMutation(guard);
-        const defaultAllowed = dispatchEnter(ownerDocument, element);
-        if (defaultAllowed && isNativeSubmitControl(element, ownerDocument)) {
+        const enterResult = dispatchEnter(ownerDocument, element);
+        guardMutation(guard);
+        if (enterResult.defaultAllowed && !enterResult.formSubmitRequested && isNativeSubmitControl(element, ownerDocument)) {
           guardMutation(guard);
           const form = (element as HTMLInputElement).form;
           if (form && typeof form.requestSubmit === "function") form.requestSubmit();

--- a/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
+++ b/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
@@ -1,0 +1,228 @@
+import type {
+  BrowserAutomationHostDispatch,
+  BrowserAutomationResult,
+  BrowserAutomationResponse,
+  BrowserAutomationTarget,
+} from "@mcode/contracts";
+
+const MAX_TARGET_SCAN = 1_024;
+const executorEvents = new WeakSet<Event>();
+
+/** Current host-owned identity used to reject stale work before a mutation. */
+export interface WebInteractionGuard {
+  readonly signal: AbortSignal;
+  readonly deadline: number;
+  readonly expectedControlEpoch: number;
+  readonly targetGeneration: number;
+  readonly getControlEpoch: () => number;
+  readonly getTargetGeneration: () => number;
+}
+
+/** Same-origin iframe lookup inputs for the low-level DOM executor. */
+export interface WebInteractionTargetDocument {
+  readonly document: Document;
+  readonly url: string;
+  readonly title: string;
+}
+
+/** Result of resolving one bounded browser target. */
+export type WebTargetResolution =
+  | { readonly ok: true; readonly element: HTMLElement }
+  | { readonly ok: false; readonly code: "TARGET_NOT_FOUND" | "TAB_UNAVAILABLE"; readonly message: string };
+
+function fail(code: "TARGET_NOT_FOUND" | "TAB_UNAVAILABLE", message: string): WebTargetResolution {
+  return { ok: false, code, message };
+}
+
+function escapeSelector(value: string): string {
+  const escape = (globalThis as { CSS?: { escape?: (input: string) => string } }).CSS?.escape;
+  if (escape) return escape(value);
+  return value.replace(/[^a-zA-Z0-9_-]/g, (character) => `\\${character}`);
+}
+
+function isVisible(element: HTMLElement, ownerDocument: Document): boolean {
+  if (!element.isConnected) return false;
+  const view = ownerDocument.defaultView;
+  const style = view?.getComputedStyle(element);
+  if (!style || style.display === "none" || style.visibility === "hidden" || style.opacity === "0") {
+    return false;
+  }
+  const rect = element.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+function isEnabled(element: HTMLElement): boolean {
+  if (element.hasAttribute("disabled") || element.getAttribute("aria-disabled") === "true") return false;
+  return !(element instanceof HTMLButtonElement || element instanceof HTMLInputElement ||
+    element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement) ||
+    !(element as HTMLButtonElement | HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement).disabled;
+}
+
+function accessibleName(element: HTMLElement): string {
+  const labelledBy = element.getAttribute("aria-labelledby");
+  if (labelledBy) {
+    const labels = labelledBy.split(/\s+/).slice(0, 16).map((id) => element.ownerDocument.getElementById(id)?.textContent ?? "");
+    const text = labels.join(" ").trim();
+    if (text) return text;
+  }
+  return element.getAttribute("aria-label")?.trim() || element.textContent?.trim().slice(0, 512) || "";
+}
+
+/** Resolve a target using only bounded, explicit DOM targeting mechanics. */
+export function resolveWebTarget(ownerDocument: Document, target: BrowserAutomationTarget): WebTargetResolution {
+  try {
+    let element: HTMLElement | null = null;
+    if ("cssSelector" in target) {
+      if (target.cssSelector.length > 4_096) return fail("TARGET_NOT_FOUND", "Browser target selector is invalid");
+      element = ownerDocument.querySelector<HTMLElement>(target.cssSelector);
+    } else if ("semanticId" in target) {
+      element = ownerDocument.getElementById(target.semanticId);
+      if (!element) element = ownerDocument.querySelector<HTMLElement>(`[data-automation-id="${escapeSelector(target.semanticId)}"]`);
+    } else if ("role" in target) {
+      let scanned = 0;
+      for (const candidate of ownerDocument.querySelectorAll<HTMLElement>("[role]")) {
+        if (++scanned > MAX_TARGET_SCAN) break;
+        if (candidate.getAttribute("role") === target.role && accessibleName(candidate) === target.accessibleName) {
+          element = candidate;
+          break;
+        }
+      }
+    } else {
+      if (target.x < 0 || target.y < 0 || target.x > ownerDocument.documentElement.clientWidth || target.y > ownerDocument.documentElement.clientHeight) {
+        return fail("TARGET_NOT_FOUND", "Browser coordinate target is outside the visible page");
+      }
+      element = ownerDocument.elementFromPoint(target.x, target.y) as HTMLElement | null;
+    }
+    if (!element) return fail("TARGET_NOT_FOUND", "Browser target was not found");
+    if (!isVisible(element, ownerDocument) || !isEnabled(element)) return fail("TARGET_NOT_FOUND", "Browser target is not eligible");
+    return { ok: true, element };
+  } catch {
+    return fail("TARGET_NOT_FOUND", "Browser target selector is invalid");
+  }
+}
+
+function guardMutation(guard: WebInteractionGuard): void {
+  if (guard.signal.aborted) throw new Error("Browser operation was cancelled");
+  if (Date.now() >= guard.deadline) throw new Error("Browser operation deadline exceeded");
+  if (guard.getTargetGeneration() !== guard.targetGeneration) throw new Error("Browser target generation is stale");
+  if (guard.getControlEpoch() !== guard.expectedControlEpoch) throw new Error("Browser control epoch is stale");
+}
+
+function response(dispatch: BrowserAutomationHostDispatch, result: BrowserAutomationResult): BrowserAutomationResponse {
+  return { contractVersion: dispatch.request.contractVersion, requestId: dispatch.request.requestId, sequence: dispatch.request.sequence, ok: true, result };
+}
+
+function pageMetadata(ownerDocument: Document): { readonly url: string; readonly title: string } {
+  return { url: ownerDocument.location.href.slice(0, 4_096), title: ownerDocument.title.slice(0, 4_096) };
+}
+
+function errorResponse(dispatch: BrowserAutomationHostDispatch, code: Extract<BrowserAutomationResponse, { ok: false }>["error"]["code"], message: string): BrowserAutomationResponse {
+  return { contractVersion: dispatch.request.contractVersion, requestId: dispatch.request.requestId, sequence: dispatch.request.sequence, ok: false, error: { code, message, retryable: code !== "INVALID_REQUEST" } };
+}
+
+function markExecutorEvent(event: Event): void {
+  executorEvents.add(event);
+}
+
+/** True only for an event emitted by this executor instance. */
+export function isExecutorGeneratedEvent(event: Event): boolean {
+  return executorEvents.has(event);
+}
+
+/** Attach direct-user takeover observers to one same-origin document. */
+export function observeWebHumanInput(ownerDocument: Document, onHumanInput: () => void): () => void {
+  const handler = (event: Event) => {
+    if (isExecutorGeneratedEvent(event)) return;
+    onHumanInput();
+  };
+  ownerDocument.addEventListener("pointerdown", handler, true);
+  ownerDocument.addEventListener("keydown", handler, true);
+  return () => {
+    ownerDocument.removeEventListener("pointerdown", handler, true);
+    ownerDocument.removeEventListener("keydown", handler, true);
+  };
+}
+
+/** Execute bounded click/type mechanics against an already-authorized document. */
+export async function executeWebInteraction(
+  ownerDocument: Document,
+  dispatch: BrowserAutomationHostDispatch,
+  guard: WebInteractionGuard,
+): Promise<BrowserAutomationResponse> {
+  if (dispatch.request.operation !== "click" && dispatch.request.operation !== "type") {
+    return errorResponse(dispatch, "UNSUPPORTED_OPERATION", "Web executor supports click and type only");
+  }
+  try {
+    const target = dispatch.request.args.target;
+    if (!target) return errorResponse(dispatch, "TARGET_NOT_FOUND", "Browser target was not specified");
+    guardMutation(guard);
+    const resolved = resolveWebTarget(ownerDocument, target);
+    if (!resolved.ok) return errorResponse(dispatch, resolved.code, resolved.message);
+    const element = resolved.element;
+    if (dispatch.request.operation === "type") {
+      const args = dispatch.request.args;
+      const editable = element.isContentEditable || element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement;
+      if (!editable) return errorResponse(dispatch, "TARGET_NOT_FOUND", "Browser type target is not editable");
+      guardMutation(guard);
+      element.focus();
+      if (args.clear) {
+        if (element.isContentEditable) element.textContent = "";
+        else (element as HTMLInputElement | HTMLTextAreaElement).value = "";
+      }
+      guardMutation(guard);
+      if (element.isContentEditable) element.textContent = `${element.textContent ?? ""}${args.text}`;
+      else {
+        const input = element as HTMLInputElement | HTMLTextAreaElement;
+        const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(input), "value");
+        descriptor?.set?.call(input, `${input.value}${args.text}`);
+        if (!input.value.endsWith(args.text)) input.value = `${input.value}${args.text}`;
+      }
+      const inputEvent = new InputEvent("input", { bubbles: true, composed: true, inputType: "insertText" });
+      markExecutorEvent(inputEvent);
+      element.dispatchEvent(inputEvent);
+      if (args.submit) {
+        guardMutation(guard);
+        const keyEvent = new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, composed: true });
+        markExecutorEvent(keyEvent);
+        element.dispatchEvent(keyEvent);
+      }
+      guardMutation(guard);
+      return response(dispatch, { operation: "type", ...pageMetadata(ownerDocument), controlEpoch: guard.expectedControlEpoch });
+    }
+    const args = dispatch.request.args;
+    guardMutation(guard);
+    const button = args.button === "right" ? 2 : args.button === "middle" ? 1 : 0;
+    for (let clickIndex = 0; clickIndex < args.clickCount; clickIndex += 1) {
+      const mouseDown = new MouseEvent("mousedown", { bubbles: true, cancelable: true, composed: true, button, detail: clickIndex + 1 });
+      const mouseUp = new MouseEvent("mouseup", { bubbles: true, cancelable: true, composed: true, button, detail: clickIndex + 1 });
+      const click = new MouseEvent("click", { bubbles: true, cancelable: true, composed: true, button, detail: clickIndex + 1 });
+      markExecutorEvent(mouseDown); markExecutorEvent(mouseUp); markExecutorEvent(click);
+      element.dispatchEvent(mouseDown);
+      guardMutation(guard);
+      element.dispatchEvent(mouseUp);
+      guardMutation(guard);
+      element.dispatchEvent(click);
+      guardMutation(guard);
+    }
+    return response(dispatch, { operation: "click", ...pageMetadata(ownerDocument), controlEpoch: guard.expectedControlEpoch });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : "Browser operation failed";
+    if (message.includes("deadline")) return errorResponse(dispatch, "DEADLINE_EXCEEDED", message);
+    if (message.includes("generation")) return errorResponse(dispatch, "STALE_TARGET_GENERATION", message);
+    if (message.includes("epoch")) return errorResponse(dispatch, "STALE_CONTROL_EPOCH", message);
+    if (message.includes("cancelled")) return errorResponse(dispatch, "OPERATION_CANCELLED", message);
+    return errorResponse(dispatch, "TAB_UNAVAILABLE", "Browser target is unavailable");
+  }
+}
+
+/** Resolve an iframe's same-origin document without weakening browser policy. */
+export function resolveSameOriginFrame(frame: HTMLIFrameElement | null): WebInteractionTargetDocument | null {
+  if (!frame) return null;
+  try {
+    const document = frame.contentDocument;
+    if (!document || !frame.contentWindow || frame.contentWindow.location.origin !== window.location.origin) return null;
+    return { document, url: document.location.href, title: document.title };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
+++ b/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
@@ -6,6 +6,12 @@ import type {
 } from "@mcode/contracts";
 
 const MAX_TARGET_SCAN = 1_024;
+const MAX_METADATA_CHARS = 2_048;
+const SECRET_KEY = /^(?:access[_-]?token|api[_-]?key|auth|authorization|bearer|client[_-]?secret|code|cookie|credential|id[_-]?token|jwt|password|private[_-]?key|refresh[_-]?token|secret|session|session[_-]?id|signature|token)$/i;
+const SECRET_TEXT = /\b(?:access[_-]?token|api[_-]?key|authorization|bearer|cookie|credential|password|refresh[_-]?token|secret|session[_-]?id|token)\b\s*[:=]\s*([^\s,;]+)/gi;
+const BEARER_TEXT = /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi;
+const JWT_TEXT = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
+const URL_TEXT = /\bhttps?:\/\/[^\s"'<>]+/gi;
 const executorEvents = new WeakSet<Event>();
 
 /** Current host-owned identity used to reject stale work before a mutation. */
@@ -128,7 +134,75 @@ function response(dispatch: BrowserAutomationHostDispatch, result: BrowserAutoma
 }
 
 function pageMetadata(ownerDocument: Document): { readonly url: string; readonly title: string } {
-  return { url: ownerDocument.location.href.slice(0, 4_096), title: ownerDocument.title.slice(0, 4_096) };
+  return {
+    url: redactBrowserLocation(ownerDocument.location.href),
+    title: redactBrowserText(ownerDocument.title),
+  };
+}
+
+/** Redact credential-shaped text before exposing page metadata to the broker. */
+export function redactBrowserText(value: unknown): string {
+  return String(value ?? "")
+    .replace(URL_TEXT, (candidate) => redactBrowserLocation(candidate))
+    .replace(BEARER_TEXT, "Bearer [REDACTED]")
+    .replace(JWT_TEXT, "[REDACTED]")
+    .replace(SECRET_TEXT, (match, captured: string) => match.replace(captured, "[REDACTED]"))
+    .slice(0, MAX_METADATA_CHARS);
+}
+
+/** Redact credentials and secret query values from a bounded page location. */
+export function redactBrowserLocation(value: unknown): string {
+  const raw = String(value ?? "").slice(0, 8_192);
+  try {
+    const url = new URL(raw);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      url.username = "";
+      url.password = "";
+      for (const key of [...url.searchParams.keys()]) {
+        if (SECRET_KEY.test(key)) url.searchParams.set(key, "[REDACTED]");
+      }
+      if (url.hash.length > 1) {
+        const fragment = new URLSearchParams(url.hash.slice(1));
+        let changed = false;
+        for (const key of [...fragment.keys()]) {
+          if (!SECRET_KEY.test(key)) continue;
+          fragment.set(key, "[REDACTED]");
+          changed = true;
+        }
+        if (changed) url.hash = fragment.toString();
+      }
+      return url.toString().slice(0, MAX_METADATA_CHARS);
+    }
+    if (raw === "about:blank") return raw;
+    return `${url.protocol}[REDACTED]`;
+  } catch {
+    return "about:blank";
+  }
+}
+
+function isNativeSubmitControl(element: HTMLElement, ownerDocument: Document): element is HTMLInputElement {
+  if (!isNativeControl(element, ownerDocument) || element.localName.toLowerCase() !== "input") return false;
+  const type = (element.getAttribute("type") ?? "text").toLowerCase();
+  return !["button", "checkbox", "color", "date", "datetime-local", "file", "hidden", "image", "month", "radio", "range", "reset", "submit", "time", "week"].includes(type);
+}
+
+function dispatchEnter(ownerDocument: Document, element: HTMLElement): boolean {
+  const view = ownerDocument.defaultView;
+  if (!view || typeof view.KeyboardEvent !== "function") throw new Error("Browser iframe event constructors are unavailable");
+  const init = { key: "Enter", code: "Enter", bubbles: true, cancelable: true, composed: true } as const;
+  const keydown = new view.KeyboardEvent("keydown", init);
+  markExecutorEvent(keydown);
+  const keydownAllowed = element.dispatchEvent(keydown);
+  let keypressAllowed = true;
+  if (keydownAllowed && !keydown.defaultPrevented) {
+    const keypress = new view.KeyboardEvent("keypress", init);
+    markExecutorEvent(keypress);
+    keypressAllowed = element.dispatchEvent(keypress);
+  }
+  const keyup = new view.KeyboardEvent("keyup", init);
+  markExecutorEvent(keyup);
+  element.dispatchEvent(keyup);
+  return keydownAllowed && !keydown.defaultPrevented && keypressAllowed;
 }
 
 function errorResponse(dispatch: BrowserAutomationHostDispatch, code: Extract<BrowserAutomationResponse, { ok: false }>["error"]["code"], message: string): BrowserAutomationResponse {
@@ -203,9 +277,12 @@ export async function executeWebInteraction(
       element.dispatchEvent(inputEvent);
       if (args.submit) {
         guardMutation(guard);
-        const keyEvent = new view.KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, composed: true });
-        markExecutorEvent(keyEvent);
-        element.dispatchEvent(keyEvent);
+        const defaultAllowed = dispatchEnter(ownerDocument, element);
+        if (defaultAllowed && isNativeSubmitControl(element, ownerDocument)) {
+          guardMutation(guard);
+          const form = (element as HTMLInputElement).form;
+          if (form && typeof form.requestSubmit === "function") form.requestSubmit();
+        }
       }
       guardMutation(guard);
       return response(dispatch, { operation: "type", ...pageMetadata(ownerDocument), controlEpoch: guard.expectedControlEpoch });

--- a/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
+++ b/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
@@ -131,6 +131,46 @@ function guardMutation(guard: WebInteractionGuard): void {
   if (guard.getControlEpoch() !== guard.expectedControlEpoch) throw new Error("Browser control epoch is stale");
 }
 
+function waitForInteractionFrame(ownerDocument: Document, guard: WebInteractionGuard): Promise<void> {
+  guardMutation(guard);
+  const view = ownerDocument.defaultView;
+  if (!view || typeof view.requestAnimationFrame !== "function") {
+    return Promise.resolve().then(() => guardMutation(guard));
+  }
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let frameId: number | null = null;
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+    const finish = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      guard.signal.removeEventListener("abort", onAbort);
+      if (deadlineTimer !== null) clearTimeout(deadlineTimer);
+      if (frameId !== null && typeof view.cancelAnimationFrame === "function") view.cancelAnimationFrame(frameId);
+      if (error === undefined) resolve();
+      else reject(error);
+    };
+    const onAbort = () => finish(new Error("Browser operation was cancelled"));
+    guard.signal.addEventListener("abort", onAbort, { once: true });
+    deadlineTimer = setTimeout(() => finish(new Error("Browser operation deadline exceeded")), Math.max(0, guard.deadline - Date.now()));
+    try {
+      const scheduledFrame = view.requestAnimationFrame(() => {
+        try {
+          guardMutation(guard);
+          finish();
+        } catch (cause) {
+          finish(cause);
+        }
+      });
+      frameId = scheduledFrame;
+      if (settled && typeof view.cancelAnimationFrame === "function") view.cancelAnimationFrame(scheduledFrame);
+    } catch (cause) {
+      finish(cause);
+    }
+    if (guard.signal.aborted) onAbort();
+  });
+}
+
 function response(dispatch: BrowserAutomationHostDispatch, result: BrowserAutomationResult): BrowserAutomationResponse {
   return { contractVersion: dispatch.request.contractVersion, requestId: dispatch.request.requestId, sequence: dispatch.request.sequence, ok: true, result };
 }
@@ -294,6 +334,7 @@ export async function executeWebInteraction(
       const editable = element.isContentEditable ||
         ((tagName === "input" || tagName === "textarea") && isNativeControl(element, ownerDocument));
       if (!editable) return errorResponse(dispatch, "TARGET_NOT_FOUND", "Browser type target is not editable");
+      await waitForInteractionFrame(ownerDocument, guard);
       guardMutation(guard);
       element.focus();
       if (args.clear) {
@@ -329,6 +370,7 @@ export async function executeWebInteraction(
       return response(dispatch, { operation: "type", ...pageMetadata(ownerDocument), controlEpoch: guard.expectedControlEpoch });
     }
     const args = dispatch.request.args;
+    await waitForInteractionFrame(ownerDocument, guard);
     guardMutation(guard);
     const view = ownerDocument.defaultView;
     if (!view || typeof view.MouseEvent !== "function") {

--- a/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
+++ b/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
@@ -51,11 +51,26 @@ function isVisible(element: HTMLElement, ownerDocument: Document): boolean {
   return rect.width > 0 && rect.height > 0;
 }
 
-function isEnabled(element: HTMLElement): boolean {
+function isNativeControl(element: HTMLElement, ownerDocument: Document): boolean {
+  const tagName = element.localName?.toLowerCase();
+  if (tagName !== "button" && tagName !== "input" && tagName !== "select" && tagName !== "textarea") return false;
+  const view = ownerDocument.defaultView;
+  const constructor = tagName === "button"
+    ? view?.HTMLButtonElement
+    : tagName === "input"
+      ? view?.HTMLInputElement
+      : tagName === "select"
+        ? view?.HTMLSelectElement
+        : view?.HTMLTextAreaElement;
+  return typeof constructor === "function" && element instanceof constructor;
+}
+
+function isEnabled(element: HTMLElement, ownerDocument: Document): boolean {
   if (element.hasAttribute("disabled") || element.getAttribute("aria-disabled") === "true") return false;
-  return !(element instanceof HTMLButtonElement || element instanceof HTMLInputElement ||
-    element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement) ||
-    !(element as HTMLButtonElement | HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement).disabled;
+  const tagName = element.localName?.toLowerCase();
+  const nativeTag = tagName === "button" || tagName === "input" || tagName === "select" || tagName === "textarea";
+  if (nativeTag && !isNativeControl(element, ownerDocument)) return false;
+  return !nativeTag || !(element as HTMLElement & { disabled?: boolean }).disabled;
 }
 
 function accessibleName(element: HTMLElement): string {
@@ -94,7 +109,7 @@ export function resolveWebTarget(ownerDocument: Document, target: BrowserAutomat
       element = ownerDocument.elementFromPoint(target.x, target.y) as HTMLElement | null;
     }
     if (!element) return fail("TARGET_NOT_FOUND", "Browser target was not found");
-    if (!isVisible(element, ownerDocument) || !isEnabled(element)) return fail("TARGET_NOT_FOUND", "Browser target is not eligible");
+    if (!isVisible(element, ownerDocument) || !isEnabled(element, ownerDocument)) return fail("TARGET_NOT_FOUND", "Browser target is not eligible");
     return { ok: true, element };
   } catch {
     return fail("TARGET_NOT_FOUND", "Browser target selector is invalid");
@@ -161,7 +176,9 @@ export async function executeWebInteraction(
     const element = resolved.element;
     if (dispatch.request.operation === "type") {
       const args = dispatch.request.args;
-      const editable = element.isContentEditable || element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement;
+      const tagName = element.localName?.toLowerCase();
+      const editable = element.isContentEditable ||
+        ((tagName === "input" || tagName === "textarea") && isNativeControl(element, ownerDocument));
       if (!editable) return errorResponse(dispatch, "TARGET_NOT_FOUND", "Browser type target is not editable");
       guardMutation(guard);
       element.focus();
@@ -177,12 +194,16 @@ export async function executeWebInteraction(
         descriptor?.set?.call(input, `${input.value}${args.text}`);
         if (!input.value.endsWith(args.text)) input.value = `${input.value}${args.text}`;
       }
-      const inputEvent = new InputEvent("input", { bubbles: true, composed: true, inputType: "insertText" });
+      const view = ownerDocument.defaultView;
+      if (!view || typeof view.InputEvent !== "function" || typeof view.KeyboardEvent !== "function") {
+        throw new Error("Browser iframe event constructors are unavailable");
+      }
+      const inputEvent = new view.InputEvent("input", { bubbles: true, composed: true, inputType: "insertText" });
       markExecutorEvent(inputEvent);
       element.dispatchEvent(inputEvent);
       if (args.submit) {
         guardMutation(guard);
-        const keyEvent = new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, composed: true });
+        const keyEvent = new view.KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, composed: true });
         markExecutorEvent(keyEvent);
         element.dispatchEvent(keyEvent);
       }
@@ -191,11 +212,15 @@ export async function executeWebInteraction(
     }
     const args = dispatch.request.args;
     guardMutation(guard);
+    const view = ownerDocument.defaultView;
+    if (!view || typeof view.MouseEvent !== "function") {
+      throw new Error("Browser iframe event constructors are unavailable");
+    }
     const button = args.button === "right" ? 2 : args.button === "middle" ? 1 : 0;
     for (let clickIndex = 0; clickIndex < args.clickCount; clickIndex += 1) {
-      const mouseDown = new MouseEvent("mousedown", { bubbles: true, cancelable: true, composed: true, button, detail: clickIndex + 1 });
-      const mouseUp = new MouseEvent("mouseup", { bubbles: true, cancelable: true, composed: true, button, detail: clickIndex + 1 });
-      const click = new MouseEvent("click", { bubbles: true, cancelable: true, composed: true, button, detail: clickIndex + 1 });
+      const mouseDown = new view.MouseEvent("mousedown", { bubbles: true, cancelable: true, composed: true, button, detail: clickIndex + 1 });
+      const mouseUp = new view.MouseEvent("mouseup", { bubbles: true, cancelable: true, composed: true, button, detail: clickIndex + 1 });
+      const click = new view.MouseEvent("click", { bubbles: true, cancelable: true, composed: true, button, detail: clickIndex + 1 });
       markExecutorEvent(mouseDown); markExecutorEvent(mouseUp); markExecutorEvent(click);
       element.dispatchEvent(mouseDown);
       guardMutation(guard);

--- a/apps/web/src/stores/browserAutomationStore.ts
+++ b/apps/web/src/stores/browserAutomationStore.ts
@@ -213,7 +213,10 @@ export function interruptBrowserAutomationTarget(
   reason: BrowserAutomationInterruptionReason,
 ): void {
   const bridge = window.desktopBridge?.preview?.automation;
-  if (!bridge) return;
+  if (!bridge) {
+    for (const listener of interruptionListeners) listener(threadId, tabId, reason);
+    return;
+  }
   const key = browserAutomationTargetKey(threadId, tabId);
   if (pendingInterruptions.has(key)) return;
   const interruption = bridge.interrupt({ threadId, tabId });


### PR DESCRIPTION
## What

Adds eligible same-origin browser click and type execution with human takeover cancellation and stale-work suppression.

## Why

Web Preview automation could observe and navigate targets but could not safely interact with them or yield control when a user took over.

## Key Changes

- Executes click and type only against visible, eligible same-origin targets.
- Keeps authorization, interaction policy, cancellation, and target-generation ownership in orchestration.
- Ignores executor-generated untrusted events while trusted pointer or keyboard input cancels active work.
- Prevents cancelled, expired, or replaced-document work from mutating later targets.
- Preserves assigned open requests across the exact expected preview generation transition while rejecting unrelated replacement.
- Adds focused coverage for click, type, human takeover seams, cancellation ordering, deadlines, iframe replacement, and broker lifecycle.

## Verification

- Affected web suite: 170/170 passed.
- Browser broker suite: 29/29 passed.
- Typecheck and lint passed.
- Authenticated visible Preview open, status, click, and type passed before the final broker correction; the exact broker failure was reproduced live and locked into focused regression coverage.
- Final fresh provider-driven rerun was blocked before tool dispatch by external provider outages.
- `verify:changed` retains unrelated Windows process permission and Electron EPERM baseline failures.

Closes #982
Continues #883

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787955200&installation_model_id=20477&pr_number=1011&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1011&signature=aa4eb490340ed73de120b4e96f3a1e2918bf6f656870cfeaee3ac46fd6cc1cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->