### PR TITLE
fix(web): harden browser automation transitions

### DIFF
--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -452,6 +452,62 @@ describe("BrowserAutomationBroker", () => {
     await expect(status).resolves.toMatchObject({ ok: true });
   });
 
+  it("preserves an assigned navigate across an exact target generation transition", async () => {
+    let delivery: any;
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        if (channel === "browserAutomation.request") delivery = data;
+        return true;
+      },
+    }));
+    const hostSocket = socket("first");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("first", "workspace-a"),
+      capabilities: [
+        { operation: "navigate", available: true },
+        { operation: "status", available: true },
+      ],
+    }, authorization("first")).generation;
+    const target = {
+      desktopInstanceId: "desktop-first",
+      windowId: 1,
+      connectionGeneration: generation,
+      threadId: "thread-a",
+      tabId: "tab-thread-a",
+      targetGeneration: 0,
+      active: true,
+      focused: true,
+      lastUsedAt: 10,
+    };
+    broker.updateTargets(hostSocket, "first", generation, [target]);
+    const scope = {
+      ...claims("thread-a", "workspace-a"),
+      allowedOperations: ["navigate" as const, "status" as const],
+    };
+    const navigated = broker.execute(scope, {
+      ...request(scope),
+      operation: "navigate",
+      args: { url: "https://example.test/destination" },
+    });
+    broker.updateTargets(hostSocket, "first", generation, [{ ...target, targetGeneration: 1 }]);
+    expect(broker.status().pending).toBe(1);
+
+    broker.respond(hostSocket, "first", generation, {
+      contractVersion: 1,
+      requestId: delivery.dispatch.request.requestId,
+      sequence: delivery.dispatch.request.sequence,
+      ok: true,
+      result: {
+        operation: "navigate",
+        url: "https://example.test/destination",
+        title: "Destination",
+        controlEpoch: 1,
+      },
+    });
+    await expect(navigated).resolves.toMatchObject({ ok: true });
+  });
+
   it("settles non-open work when an assigned target advances generations", async () => {
     let delivery: any;
     const broker = new BrowserAutomationBroker(options({

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -142,7 +142,7 @@ function targetsMatch(
     left.targetGeneration === right.targetGeneration;
 }
 
-function isExactOpenTargetReplacement(
+function isExactTargetReplacement(
   oldTarget: BrowserAutomationHostDispatchTarget,
   replacement: BrowserAutomationHostDispatchTarget,
 ): boolean {
@@ -358,7 +358,7 @@ export class BrowserAutomationBroker {
     for (const [key, oldTarget] of host.targets) {
       const replacement = next.get(key);
       if (replacement && replacement.targetGeneration === oldTarget.targetGeneration && replacement.windowId === oldTarget.windowId) continue;
-      this.invalidateTarget(host, key, replacement !== undefined && isExactOpenTargetReplacement(oldTarget, replacement));
+      this.invalidateTarget(host, key, replacement !== undefined && isExactTargetReplacement(oldTarget, replacement));
     }
     for (const [key, target] of next) {
       host.targetGenerationTombstones.delete(key);
@@ -929,14 +929,17 @@ export class BrowserAutomationBroker {
   private invalidateTarget(
     host: RegisteredHost,
     removedTargetKey: string,
-    preserveOpenTransition = false,
+    preserveTargetTransition = false,
   ): void {
     for (const [key, assignment] of this.assignments) {
       if (assignment.host === host && assignment.targetKey === removedTargetKey) this.assignments.delete(key);
     }
     for (const [key, pending] of this.pending) {
       if (pending.host === host && pending.target && targetKey(pending.target) === removedTargetKey) {
-        if (preserveOpenTransition && pending.request.operation === "open") continue;
+        if (
+          preserveTargetTransition &&
+          (pending.request.operation === "open" || pending.request.operation === "navigate")
+        ) continue;
         this.settle(
           key,
           pending,

--- a/apps/web/public/browser-automation-fixture.html
+++ b/apps/web/public/browser-automation-fixture.html
@@ -10,14 +10,37 @@
       main { max-width: 640px; margin: 0 auto; }
       label { display: block; margin-top: 20px; font-weight: 600; }
       input { display: block; width: 100%; margin-top: 8px; padding: 10px; box-sizing: border-box; }
+      button, a { display: inline-block; margin-top: 20px; padding: 10px 14px; }
+      a { text-decoration: underline; }
+      output { display: block; margin-top: 12px; }
     </style>
   </head>
   <body>
     <main>
       <h1>Mcode browser automation fixture</h1>
       <p>Deterministic same-origin page for visible Browser checks.</p>
+      <label for="fixture-name">Named fixture text</label>
+      <input id="fixture-name" name="fixture-name" type="text" value="demo-name" autocomplete="off">
       <label for="fixture-password">Masked fixture password</label>
       <input id="fixture-password" name="fixture-password" type="password" value="demo-value" autocomplete="off">
+      <button id="fixture-action-button" name="fixture-action" type="button">Run fixture action</button>
+      <output id="fixture-action-status" aria-live="polite">Action status: pending</output>
+      <a id="fixture-navigation-link" href="browser-automation-fixture.html?destination=complete">Go to same-origin destination</a>
+      <output id="fixture-destination-state" aria-live="polite">Destination state: start</output>
+      <a id="fixture-cross-origin-link" href="https://example.com/" rel="noreferrer">Open cross-origin test target</a>
     </main>
+    <script>
+      const actionButton = document.getElementById("fixture-action-button");
+      const actionStatus = document.getElementById("fixture-action-status");
+      actionButton.addEventListener("click", () => {
+        actionStatus.textContent = "Action status: complete";
+      });
+
+      const destinationState = document.getElementById("fixture-destination-state");
+      const destination = new URL(window.location.href).searchParams.get("destination");
+      destinationState.textContent = destination
+        ? `Destination state: ${destination}`
+        : "Destination state: start";
+    </script>
   </body>
 </html>

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -359,7 +359,7 @@ function acceptExpectedWebNavigationRevision(
   navigation: WebNavigationExpectation | undefined,
   target: { readonly revision: number } | undefined,
 ): number | undefined {
-  if (!navigation || dispatch.request.operation !== "open") return undefined;
+  if (!navigation || (dispatch.request.operation !== "open" && dispatch.request.operation !== "navigate")) return undefined;
   if (navigation.acceptedRevision !== undefined) {
     return navigation.acceptedRevision === target?.revision ? navigation.acceptedRevision : undefined;
   }
@@ -766,12 +766,30 @@ export function BrowserAutomationHost() {
       const webExecutorDispatch = !bridge && webAutomationEnabled;
       const webOpenRequest = !bridge && webAutomationEnabled &&
         dispatch.request.operation === "open" && Boolean(dispatch.request.args.url);
+      const webNavigateRequest = !bridge && webAutomationEnabled &&
+        dispatch.request.operation === "navigate" && Boolean(dispatch.request.args.url);
       const operationAbort = webDispatch ? new AbortController() : null;
       if (operationAbort) webAbortRef.current.set(key, operationAbort);
       const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
       const liveTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
       const currentEpoch = useBrowserAutomationStore.getState().controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch;
       const staleAtStart = !liveTarget || liveTarget.revision !== dispatch.target.targetGeneration || currentEpoch !== dispatch.request.expectedControlEpoch;
+      if (webNavigateRequest) {
+        const requestedUrl = normalizeWebPreviewUrl(dispatch.request.args.url ?? "");
+        if (
+          requestedUrl &&
+          isSameOriginWebPreviewUrl(requestedUrl) &&
+          liveTarget &&
+          liveTarget.revision === dispatch.target.targetGeneration
+        ) {
+          webNavigationRef.current.set(key, {
+            targetKey,
+            expectedUrl: requestedUrl,
+            initialRevision: liveTarget.revision,
+            loadObserved: false,
+          });
+        }
+      }
       const cancelForHuman = () => {
         if (!operationAbort || cancelledRef.current.has(key)) return;
         cancelledRef.current.add(key);
@@ -877,7 +895,7 @@ export function BrowserAutomationHost() {
           ? executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal)
           : Promise.resolve(failureResponse(dispatch.request, "UNSUPPORTED_OPERATION", WEB_AUTOMATION_UNAVAILABLE_REASON));
       const guardedOperation = operation.then((response) => {
-        if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest)) {
+        if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest || webNavigateRequest)) {
           const latestTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
           const navigation = webNavigationRef.current.get(key);
           const expectedRevision = navigation?.acceptedRevision ??
@@ -889,7 +907,7 @@ export function BrowserAutomationHost() {
         }
         return response;
       }).catch((cause: unknown) => {
-        if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest)) {
+        if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest || webNavigateRequest)) {
           const latestTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
           const navigation = webNavigationRef.current.get(key);
           const expectedRevision = navigation?.acceptedRevision ??

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -576,7 +576,8 @@ export function BrowserAutomationHost() {
       capabilities: BROWSER_AUTOMATION_OPERATIONS.map((operation) => {
         if (!desktopAutomation) {
           const available = operation === "click" || operation === "type" ||
-            operation === "status" || operation === "open" || operation === "navigate" || operation === "snapshot";
+            operation === "status" || operation === "open" || operation === "navigate" ||
+            operation === "snapshot" || operation === "screenshot";
           return available
             ? { operation, available: true }
             : { operation, available: false, unavailableReason: WEB_AUTOMATION_UNAVAILABLE_REASON };

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -428,6 +428,49 @@ describe("BrowserAutomationHost", () => {
     view.unmount();
   });
 
+  it("accepts the expected target revision advanced by a same-origin navigate load", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    const executing = deferred<BrowserAutomationResponse>();
+    webExecutor.executeWebBrowserDispatch.mockReturnValue(executing.promise);
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const navigateDispatch = dispatch(1, 40, { tabId: "tab-1", targetGeneration: 1 });
+    navigateDispatch.request = {
+      ...navigateDispatch.request,
+      operation: "navigate",
+      args: { url: `${window.location.origin}/revision-navigate` },
+    } as never;
+    const expectedUrl = `${window.location.origin}/revision-navigate`;
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: navigateDispatch }));
+
+    const iframe = document.createElement("iframe");
+    iframe.src = expectedUrl;
+    iframe.dataset.threadId = "thread-1";
+    iframe.dataset.tabId = "tab-1";
+    Object.defineProperty(iframe, "contentWindow", {
+      configurable: true,
+      value: { location: { origin: window.location.origin } },
+    });
+    document.body.append(iframe);
+    act(() => {
+      iframe.dispatchEvent(new Event("load"));
+      useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1");
+    });
+
+    executing.resolve(successResponse(navigateDispatch.request));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      expect.objectContaining({ ok: true }),
+    );
+    expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(navigateDispatch, expect.any(AbortSignal));
+    iframe.remove();
+    view.unmount();
+  });
+
   it("rejects an unrelated iframe replacement during a same-origin open", async () => {
     delete window.desktopBridge;
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
@@ -489,6 +532,7 @@ describe("BrowserAutomationHost", () => {
     expect(registration.capabilities).toContainEqual({ operation: "open", available: true });
     expect(registration.capabilities).toContainEqual({ operation: "resize", available: true });
     expect(registration.capabilities).toContainEqual({ operation: "navigate", available: true });
+    expect(registration.capabilities).toContainEqual({ operation: "screenshot", available: true });
 
     const firstDispatch = dispatch(1, 1);
     act(() => harness.emit("browserAutomation.request", {
@@ -1394,6 +1438,52 @@ describe("BrowserAutomationHost", () => {
     ]));
     view.unmount();
     vi.unstubAllGlobals();
+  });
+
+  it("returns web screenshot responses through transport", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    const screenshotDispatch = dispatch(1, 21);
+    const requestId = screenshotDispatch.request.requestId;
+    const sequence = screenshotDispatch.request.sequence;
+    const expectedControlEpoch = screenshotDispatch.request.expectedControlEpoch;
+    screenshotDispatch.request = {
+      ...screenshotDispatch.request,
+      operation: "screenshot",
+      args: { maxWidth: 320, fullPage: false },
+    } as never;
+    webExecutor.executeWebBrowserDispatch.mockResolvedValue({
+      contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+      requestId,
+      sequence,
+      ok: true,
+      result: {
+        operation: "screenshot",
+        screenshot: {
+          mediaType: "image/png",
+          dataBase64: "AAAA",
+          width: 320,
+          height: 180,
+          truncation: { truncated: false },
+        },
+        controlEpoch: expectedControlEpoch,
+      },
+    });
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: screenshotDispatch }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(
+      screenshotDispatch,
+      expect.any(AbortSignal),
+    );
+    expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      expect.objectContaining({ ok: true, result: expect.objectContaining({ operation: "screenshot" }) }),
+    );
+    view.unmount();
   });
 
   it("sanitizes the mounted web status location before responding", async () => {

--- a/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
@@ -57,6 +57,16 @@ describe("web browser automation executor", () => {
     target.remove();
   });
 
+  it("uses DOM ids as snapshot semantic ids", async () => {
+    const target = iframe();
+    target.contentDocument!.body.innerHTML = `<button id="save-button">Save</button>`;
+    const result = await executeWebBrowserDispatch(dispatch("snapshot", { includeScreenshot: false }), new AbortController().signal);
+    expect(result).toMatchObject({ ok: true, result: { snapshot: {
+      elements: [{ semanticId: "save-button", role: "button", accessibleName: "Save" }],
+    } } });
+    target.remove();
+  });
+
   it("scans hostile oversized DOM without whole-document query materialization", async () => {
     const target = iframe();
     const page = target.contentDocument!;

--- a/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
@@ -208,4 +208,19 @@ describe("web browser automation executor", () => {
     });
     target.remove();
   });
+
+  it("rejects full-page screenshots before capture", async () => {
+    const target = iframe();
+    vi.mocked(captureVisibleWebScreenshot).mockClear();
+    const result = await executeWebBrowserDispatch(
+      dispatch("screenshot", { maxWidth: 320, fullPage: true }),
+      new AbortController().signal,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "UNSUPPORTED_OPERATION" },
+    });
+    expect(captureVisibleWebScreenshot).not.toHaveBeenCalled();
+    target.remove();
+  });
 });

--- a/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { BROWSER_AUTOMATION_CONTRACT_VERSION, type BrowserAutomationHostDispatch } from "@mcode/contracts";
+import { captureVisibleWebScreenshot } from "../web-browser-automation/capture";
 import { executeWebBrowserDispatch } from "../browserAutomationWebExecutor";
+
+vi.mock("../web-browser-automation/capture", () => ({ captureVisibleWebScreenshot: vi.fn() }));
 
 function dispatch(operation: BrowserAutomationHostDispatch["request"]["operation"], args: Record<string, unknown> = {}, deadline = Date.now() + 1_000): BrowserAutomationHostDispatch {
   return {
@@ -166,6 +169,33 @@ describe("web browser automation executor", () => {
     expect(cancelled).toMatchObject({ ok: false, error: { code: "OPERATION_CANCELLED" } });
     const expired = await executeWebBrowserDispatch(dispatch("snapshot", { includeScreenshot: false }, Date.now() - 1), new AbortController().signal);
     expect(expired).toMatchObject({ ok: false, error: { code: "DEADLINE_EXCEEDED" } });
+    target.remove();
+  });
+
+  it("captures a bounded screenshot from the visible iframe", async () => {
+    const target = iframe();
+    vi.mocked(captureVisibleWebScreenshot).mockResolvedValueOnce({
+      ok: true,
+      value: {
+        mediaType: "image/png",
+        dataBase64: "AAAA",
+        width: 320,
+        height: 180,
+        truncation: { truncated: false },
+      },
+    });
+    const request = dispatch("screenshot", { maxWidth: 320 });
+    const result = await executeWebBrowserDispatch(request, new AbortController().signal);
+    expect(result).toMatchObject({
+      ok: true,
+      result: { operation: "screenshot", screenshot: { mediaType: "image/png", width: 320, height: 180 } },
+    });
+    expect(captureVisibleWebScreenshot).toHaveBeenCalledWith({
+      iframe: target,
+      maxWidth: 320,
+      deadline: request.request.deadline,
+      signal: expect.any(AbortSignal),
+    });
     target.remove();
   });
 });

--- a/apps/web/src/components/panels/browserAutomationWebExecutor.ts
+++ b/apps/web/src/components/panels/browserAutomationWebExecutor.ts
@@ -2,12 +2,14 @@ import {
   BROWSER_AUTOMATION_CONTRACT_VERSION,
   BROWSER_AUTOMATION_MAX_ELEMENTS,
   BROWSER_AUTOMATION_MAX_VISIBLE_TEXT_CHARS,
+  BROWSER_AUTOMATION_MAX_SCREENSHOT_WIDTH,
   type BrowserAutomationHostDispatch,
   type BrowserAutomationResult,
   type BrowserAutomationResponse,
 } from "@mcode/contracts";
+import { captureVisibleWebScreenshot } from "./web-browser-automation/capture";
 
-const WEB_CAPABILITIES = ["status", "open", "navigate", "snapshot"] as const;
+const WEB_CAPABILITIES = ["status", "open", "navigate", "snapshot", "screenshot"] as const;
 const WEB_SNAPSHOT_MAX_SCAN_NODES = 8_192;
 const WEB_SNAPSHOT_MAX_ELEMENT_TEXT = 1_024;
 const WEB_SNAPSHOT_MAX_ELEMENT_TEXT_NODES = 256;
@@ -60,7 +62,7 @@ function response(
 
 function failure(
   dispatch: BrowserAutomationHostDispatch,
-  code: "CROSS_ORIGIN" | "DEADLINE_EXCEEDED" | "NAVIGATION_FAILED" | "OPERATION_CANCELLED" | "TAB_UNAVAILABLE" | "UNSUPPORTED_OPERATION",
+  code: "CROSS_ORIGIN" | "DEADLINE_EXCEEDED" | "INTERNAL_ERROR" | "NAVIGATION_FAILED" | "OPERATION_CANCELLED" | "RESULT_TOO_LARGE" | "TAB_UNAVAILABLE" | "UNSUPPORTED_OPERATION",
   message: string,
 ): BrowserAutomationResponse {
   return {
@@ -387,6 +389,22 @@ function snapshot(dispatch: BrowserAutomationHostDispatch, iframe: WebIframe, si
   });
 }
 
+function screenshot(dispatch: BrowserAutomationHostDispatch, iframe: WebIframe, signal: AbortSignal): Promise<BrowserAutomationResponse> {
+  const maxWidth = dispatch.request.operation === "screenshot" && typeof dispatch.request.args.maxWidth === "number"
+    ? dispatch.request.args.maxWidth
+    : BROWSER_AUTOMATION_MAX_SCREENSHOT_WIDTH;
+  return captureVisibleWebScreenshot({ iframe, maxWidth, deadline: dispatch.request.deadline, signal }).then((result) => {
+    if (!result.ok) {
+      const mapped = result.code === "TIMEOUT" ? "DEADLINE_EXCEEDED"
+        : result.code;
+      return failure(dispatch, mapped, `Web Preview screenshot failed: ${result.code}`);
+    }
+    const cancelled = checkAbort(dispatch, signal);
+    if (cancelled) return cancelled;
+    return response(dispatch, { operation: "screenshot", screenshot: result.value, controlEpoch: dispatch.request.expectedControlEpoch });
+  });
+}
+
 /** Executes the bounded same-origin web Preview operations against its visible iframe. */
 export async function executeWebBrowserDispatch(
   dispatch: BrowserAutomationHostDispatch,
@@ -430,5 +448,6 @@ export async function executeWebBrowserDispatch(
     });
   }
   if (request.operation === "snapshot") return snapshot(dispatch, iframe, signal);
-  return failure(dispatch, "UNSUPPORTED_OPERATION", "Web automation supports status, open, navigate, and snapshot");
+  if (request.operation === "screenshot") return screenshot(dispatch, iframe, signal);
+  return failure(dispatch, "UNSUPPORTED_OPERATION", "Web automation supports status, open, navigate, snapshot, and screenshot");
 }

--- a/apps/web/src/components/panels/browserAutomationWebExecutor.ts
+++ b/apps/web/src/components/panels/browserAutomationWebExecutor.ts
@@ -283,7 +283,7 @@ function collectBoundedSnapshot(document: Document): BoundedSnapshotData {
         const accessibleName = element.getAttribute("aria-label")?.slice(0, WEB_SNAPSHOT_MAX_ELEMENT_TEXT) || boundedElementText(element, WEB_SNAPSHOT_MAX_ELEMENT_TEXT, budget);
         if (typeof accessibleName !== "string" && accessibleName.budgetExhausted) scanLimitReached = true;
         elements.push({
-          semanticId: `element-${elements.length + 1}`,
+          semanticId: element.id || `element-${elements.length + 1}`,
           role: element.getAttribute("role")?.slice(0, 128) || element.tagName.toLowerCase(),
           accessibleName: typeof accessibleName === "string" ? accessibleName : accessibleName.text,
           ...(("value" in element && typeof (element as HTMLInputElement).value === "string" &&

--- a/apps/web/src/components/panels/browserAutomationWebExecutor.ts
+++ b/apps/web/src/components/panels/browserAutomationWebExecutor.ts
@@ -448,6 +448,11 @@ export async function executeWebBrowserDispatch(
     });
   }
   if (request.operation === "snapshot") return snapshot(dispatch, iframe, signal);
-  if (request.operation === "screenshot") return screenshot(dispatch, iframe, signal);
+  if (request.operation === "screenshot") {
+    if (request.args.fullPage) {
+      return failure(dispatch, "UNSUPPORTED_OPERATION", "Web automation does not support full-page screenshots");
+    }
+    return screenshot(dispatch, iframe, signal);
+  }
   return failure(dispatch, "UNSUPPORTED_OPERATION", "Web automation supports status, open, navigate, snapshot, and screenshot");
 }


### PR DESCRIPTION
## Summary
- Accept the expected same-origin +1 revision after web navigation loads.
- Reject unsupported full-page web screenshots instead of returning a viewport capture.
- Cover screenshot registration and host request/response routing.

## Verification
- Focused contracts, server, web, and Electron tests: 220 passed.
- Root typecheck passed.
- Risky review: finding-free.

## Known environment limits
- Codex provider was unavailable; the configured Claude OAuth session had expired.
- Full verification has unrelated Windows process-harness baseline failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787965827&installation_model_id=20477&pr_number=1012&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1012&signature=073f63de0d326ed1c39ff4e9fe4f9a5cf66aff8ba68c25ff84423b4439e21d65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->