### PR TITLE
feat(browser): add provider-neutral session lease

### DIFF
--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
@@ -73,10 +73,10 @@ describe("BrowserAutomationSessionLease", () => {
     let now = 100;
     const registry = new BrowserAutomationCredentialRegistry({ idleTtlMs: 10, absoluteTtlMs: 100, now: () => now });
     const lease = configuredLease({ credentials: registry, pendingTtlMs: 5, now: () => now });
+    const grant = lease.issue(scope({ mcodeSessionId: "mcode-live" }))!;
     const pending = lease.stage(scope());
     now = 106;
     expect(lease.issue(pending)).toBeNull();
-    const grant = lease.issue(scope({ mcodeSessionId: "mcode-live" }))!;
     now = 111;
     expect(registry.size()).toBe(0);
     expect(lease.status()).toEqual({ active: 0, pending: 0 });

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  BrowserAutomationSessionLease,
+  type BrowserAutomationSessionLeaseScope,
+} from "./browser-automation-session-lease.js";
+import { BrowserAutomationCredentialRegistry } from "./credential-registry.js";
+
+const scope = (overrides: Partial<BrowserAutomationSessionLeaseScope> = {}) => ({
+  providerId: "codex",
+  providerSessionId: "provider-a",
+  mcodeSessionId: "mcode-a",
+  threadId: "thread-a",
+  workspaceId: "workspace-a",
+  permissionCapability: "interact" as const,
+  ...overrides,
+});
+
+function configuredLease(options: ConstructorParameters<typeof BrowserAutomationSessionLease>[0] = {}) {
+  const lease = new BrowserAutomationSessionLease(options);
+  lease.configure({ mcpUrl: "http://127.0.0.1:19400/mcp", worktreeIdentity: "worktree-a" });
+  return lease;
+}
+
+describe("BrowserAutomationSessionLease", () => {
+  it("stages, issues, refreshes, and releases one lease", () => {
+    const lease = configuredLease();
+    const staged = lease.stage(scope());
+    expect(staged.leaseId).toBeTypeOf("string");
+    const grant = lease.issue(staged)!;
+    expect(grant.leaseId).toBe(staged.leaseId);
+    expect(lease.credentials.authenticate(grant.token)?.threadId).toBe("thread-a");
+
+    const refreshed = lease.refresh(grant.leaseId);
+    expect(refreshed.ok).toBe(true);
+    if (!refreshed.ok) return;
+    expect(refreshed.grant.credentialId).not.toBe(grant.credentialId);
+    expect(lease.credentials.authenticate(grant.token)).toBeNull();
+    expect(lease.credentials.authenticate(refreshed.grant.token)?.workspaceId).toBe("workspace-a");
+
+    expect(lease.release(grant.leaseId)).toMatchObject({ released: true, leaseId: grant.leaseId });
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
+  it("keeps credentials isolated by logical session while rotating one session", () => {
+    const lease = configuredLease();
+    const first = lease.issue(scope())!;
+    const second = lease.issue(scope({
+      providerId: "claude",
+      providerSessionId: "provider-b",
+      mcodeSessionId: "mcode-b",
+      threadId: "thread-b",
+    }))!;
+    const rotated = lease.issue(scope({ permissionCapability: "privileged" }))!;
+
+    expect(lease.credentials.authenticate(first.token)).toBeNull();
+    expect(lease.credentials.authenticate(second.token)?.threadId).toBe("thread-b");
+    expect(lease.credentials.authenticate(rotated.token)?.allowedOperations).toContain("evaluate");
+    expect(lease.status()).toEqual({ active: 2, pending: 0 });
+  });
+
+  it("cleans a staged scope when registry issuance fails", () => {
+    const lease = configuredLease();
+    const staged = lease.stage(scope({
+      permissionCapability: "interact",
+      allowedOperations: ["evaluate"],
+    }));
+
+    expect(() => lease.issue(staged)).toThrow(/Evaluate requires/);
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
+  it("expires pending scopes and releases every credential on shutdown", () => {
+    let now = 100;
+    const registry = new BrowserAutomationCredentialRegistry({ idleTtlMs: 10, absoluteTtlMs: 100, now: () => now });
+    const lease = configuredLease({ credentials: registry, pendingTtlMs: 5, now: () => now });
+    const pending = lease.stage(scope());
+    now = 106;
+    expect(lease.issue(pending)).toBeNull();
+    const grant = lease.issue(scope({ mcodeSessionId: "mcode-live" }))!;
+    now = 111;
+    expect(registry.size()).toBe(0);
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+
+    lease.issue(scope({ mcodeSessionId: "mcode-second" }));
+    lease.shutdown();
+    expect(registry.authenticate(grant.token)).toBeNull();
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+});

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
@@ -1,0 +1,345 @@
+import {
+  BROWSER_AUTOMATION_OPERATIONS,
+  type BrowserAutomationOperation,
+} from "@mcode/contracts";
+import { randomUUID } from "crypto";
+import {
+  BrowserAutomationCredentialRegistry,
+  type BrowserAutomationCredentialScope,
+  type BrowserAutomationPermissionCapability,
+} from "./credential-registry.js";
+
+const OBSERVE_OPERATIONS = new Set<BrowserAutomationOperation>([
+  "status",
+  "snapshot",
+  "screenshot",
+  "waitFor",
+  "console",
+  "network",
+  "accessibility",
+  "performance",
+]);
+const DEFAULT_PENDING_TTL_MS = 30_000;
+const DEFAULT_MAX_PENDING = 256;
+
+/** Provider-neutral browser scope staged before a credential is issued. */
+export interface BrowserAutomationSessionLeaseScope {
+  providerId: string;
+  providerSessionId: string;
+  mcodeSessionId: string;
+  threadId: string;
+  workspaceId: string;
+  permissionCapability: BrowserAutomationPermissionCapability;
+  allowedOperations?: readonly BrowserAutomationOperation[];
+}
+
+/** Input accepted by the lease staging boundary. */
+export type BrowserAutomationSessionLeaseRequest =
+  | BrowserAutomationSessionLeaseScope
+  | { scope: BrowserAutomationSessionLeaseScope };
+
+/** Loopback endpoint used in grants returned by the lease. */
+export interface BrowserAutomationSessionLeaseConfiguration {
+  mcpUrl: string;
+  worktreeIdentity: string;
+}
+
+/** Opaque handle returned while a scope waits for credential issuance. */
+export interface BrowserAutomationSessionLeaseStage {
+  leaseId: string;
+  expiresAt: number;
+}
+
+/** Plaintext credential returned once for a newly issued or refreshed lease. */
+export interface BrowserAutomationSessionLeaseGrant {
+  leaseId: string;
+  mcpUrl: string;
+  token: string;
+  credentialId: string;
+  expiresAt: number;
+  allowedOperations: readonly BrowserAutomationOperation[];
+}
+
+/** Structured result for rotating an active lease credential. */
+export type BrowserAutomationSessionLeaseRefreshResult =
+  | { ok: true; grant: BrowserAutomationSessionLeaseGrant }
+  | { ok: false; leaseId: string; reason: "not-found" | "unconfigured" | "issuance-failed" };
+
+/** Structured result for releasing an active or already released lease. */
+export interface BrowserAutomationSessionLeaseReleaseResult {
+  leaseId: string;
+  released: boolean;
+  credentialId?: string;
+}
+
+/** Options controlling credential sharing and bounded pending scope retention. */
+export interface BrowserAutomationSessionLeaseOptions
+  extends Partial<BrowserAutomationSessionLeaseConfiguration> {
+  credentials?: BrowserAutomationCredentialRegistry;
+  pendingTtlMs?: number;
+  maxPending?: number;
+  now?: () => number;
+}
+
+interface PendingScope {
+  scope: BrowserAutomationSessionLeaseScope;
+  sessionKey: string;
+  expiresAt: number;
+}
+
+interface ActiveLease {
+  scope: BrowserAutomationSessionLeaseScope;
+  sessionKey: string;
+  credentialId: string;
+}
+
+function allowedOperations(
+  capability: BrowserAutomationPermissionCapability,
+): readonly BrowserAutomationOperation[] {
+  if (capability === "observe") {
+    return BROWSER_AUTOMATION_OPERATIONS.filter((operation) => OBSERVE_OPERATIONS.has(operation));
+  }
+  if (capability === "interact") {
+    return BROWSER_AUTOMATION_OPERATIONS.filter((operation) => operation !== "evaluate");
+  }
+  return [...BROWSER_AUTOMATION_OPERATIONS];
+}
+
+function validateConfiguration(configuration: BrowserAutomationSessionLeaseConfiguration): void {
+  let url: URL;
+  try {
+    url = new URL(configuration.mcpUrl);
+  } catch {
+    throw new Error("Browser automation MCP URL is invalid");
+  }
+  const loopbackHosts = new Set(["127.0.0.1", "localhost", "[::1]"]);
+  if (
+    url.protocol !== "http:" ||
+    !loopbackHosts.has(url.hostname) ||
+    url.pathname !== "/mcp" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("Browser automation MCP URL must be an uncredentialed loopback /mcp endpoint");
+  }
+  if (
+    configuration.worktreeIdentity.length < 1 ||
+    configuration.worktreeIdentity.length > 256
+  ) {
+    throw new Error("Browser automation worktree identity is invalid");
+  }
+}
+
+function normalizeRequest(request: BrowserAutomationSessionLeaseRequest): BrowserAutomationSessionLeaseScope {
+  const scope = "scope" in request ? request.scope : request;
+  return {
+    ...scope,
+    allowedOperations: scope.allowedOperations
+      ? [...scope.allowedOperations]
+      : allowedOperations(scope.permissionCapability),
+  };
+}
+
+/** Owns provider-neutral browser credential staging and session lease cleanup. */
+export class BrowserAutomationSessionLease {
+  readonly credentials: BrowserAutomationCredentialRegistry;
+  private configuration: BrowserAutomationSessionLeaseConfiguration | null = null;
+  private readonly pending = new Map<string, PendingScope>();
+  private readonly active = new Map<string, ActiveLease>();
+  private readonly sessionToLease = new Map<string, string>();
+  private readonly pendingTtlMs: number;
+  private readonly maxPending: number;
+  private readonly now: () => number;
+
+  constructor(optionsOrCredentials: BrowserAutomationSessionLeaseOptions | BrowserAutomationCredentialRegistry = {}) {
+    const options = optionsOrCredentials instanceof BrowserAutomationCredentialRegistry
+      ? { credentials: optionsOrCredentials }
+      : optionsOrCredentials;
+    this.credentials = options.credentials ?? new BrowserAutomationCredentialRegistry();
+    this.pendingTtlMs = options.pendingTtlMs ?? DEFAULT_PENDING_TTL_MS;
+    this.maxPending = options.maxPending ?? DEFAULT_MAX_PENDING;
+    this.now = options.now ?? Date.now;
+    if (!Number.isInteger(this.pendingTtlMs) || this.pendingTtlMs < 1 || this.pendingTtlMs > 24 * 60 * 60_000) {
+      throw new Error("Browser automation session lease pending TTL is invalid");
+    }
+    if (!Number.isInteger(this.maxPending) || this.maxPending < 1 || this.maxPending > 4_096) {
+      throw new Error("Browser automation session lease pending capacity is invalid");
+    }
+    this.credentials.onRemoved((claims) => this.releaseCredential(claims.credentialId));
+    if (options.mcpUrl !== undefined || options.worktreeIdentity !== undefined) {
+      if (!options.mcpUrl || !options.worktreeIdentity) {
+        throw new Error("Browser automation session lease configuration is incomplete");
+      }
+      this.configure({ mcpUrl: options.mcpUrl, worktreeIdentity: options.worktreeIdentity });
+    }
+  }
+
+  /** Configures the exact loopback endpoint used by future grants. */
+  configure(configuration: BrowserAutomationSessionLeaseConfiguration): void {
+    validateConfiguration(configuration);
+    if (this.configuration) {
+      if (
+        this.configuration.mcpUrl !== configuration.mcpUrl ||
+        this.configuration.worktreeIdentity !== configuration.worktreeIdentity
+      ) {
+        throw new Error("Browser automation session lease is already configured");
+      }
+      return;
+    }
+    this.configuration = { ...configuration };
+  }
+
+  /** Stages one bounded scope and returns its opaque lease handle. */
+  stage(request: BrowserAutomationSessionLeaseRequest): BrowserAutomationSessionLeaseStage {
+    this.cleanupPending();
+    if (this.pending.size >= this.maxPending) this.evictOldestPending();
+    const scope = normalizeRequest(request);
+    const leaseId = randomUUID();
+    const sessionKey = this.sessionKey(scope.providerId, scope.mcodeSessionId);
+    const expiresAt = this.now() + this.pendingTtlMs;
+    this.pending.set(leaseId, { scope, sessionKey, expiresAt });
+    return { leaseId, expiresAt };
+  }
+
+  /** Issues a credential for a staged handle, cleaning failed stages before rethrowing. */
+  issue(stageOrRequest: string | BrowserAutomationSessionLeaseStage | BrowserAutomationSessionLeaseRequest): BrowserAutomationSessionLeaseGrant | null {
+    const stage = typeof stageOrRequest === "string" || "leaseId" in stageOrRequest
+      ? stageOrRequest
+      : this.stage(stageOrRequest);
+    const leaseId = typeof stage === "string" ? stage : stage.leaseId;
+    const pending = this.pending.get(leaseId);
+    if (!pending || pending.expiresAt <= this.now()) {
+      this.pending.delete(leaseId);
+      return null;
+    }
+    this.pending.delete(leaseId);
+    const configuration = this.configuration;
+    if (!configuration) return null;
+    try {
+      const grant = this.issueCredential(leaseId, pending);
+      const previousLeaseId = this.sessionToLease.get(pending.sessionKey);
+      if (previousLeaseId && previousLeaseId !== leaseId) this.release(previousLeaseId);
+      return grant;
+    } catch (error) {
+      this.active.delete(leaseId);
+      throw error;
+    }
+  }
+
+  /** Rotates a live lease credential and returns a fresh plaintext grant. */
+  refresh(leaseId: string): BrowserAutomationSessionLeaseRefreshResult {
+    const lease = this.active.get(leaseId);
+    if (!lease) return { ok: false, leaseId, reason: "not-found" };
+    if (!this.configuration) return { ok: false, leaseId, reason: "unconfigured" };
+    try {
+      const grant = this.issueCredential(leaseId, {
+        scope: lease.scope,
+        sessionKey: lease.sessionKey,
+        expiresAt: this.now(),
+      });
+      const previousCredentialId = lease.credentialId;
+      lease.credentialId = grant.credentialId;
+      this.credentials.revoke(previousCredentialId);
+      return { ok: true, grant };
+    } catch {
+      return { ok: false, leaseId, reason: "issuance-failed" };
+    }
+  }
+
+  /** Revokes one lease and releases its metadata and pending scope. */
+  release(leaseId: string): BrowserAutomationSessionLeaseReleaseResult {
+    const lease = this.active.get(leaseId);
+    this.pending.delete(leaseId);
+    if (!lease) return { leaseId, released: false };
+    const released = this.credentials.revoke(lease.credentialId);
+    if (!released) this.releaseCredential(lease.credentialId);
+    return { leaseId, released, credentialId: lease.credentialId };
+  }
+
+  /** Revokes every lease belonging to one logical provider session. */
+  releaseSession(providerId: string, mcodeSessionId: string): number {
+    const key = this.sessionKey(providerId, mcodeSessionId);
+    const leaseId = this.sessionToLease.get(key);
+    let released = leaseId && this.release(leaseId).released ? 1 : 0;
+    for (const [pendingLeaseId, pending] of this.pending) {
+      if (pending.sessionKey !== key) continue;
+      this.pending.delete(pendingLeaseId);
+      released++;
+    }
+    return released;
+  }
+
+  /** Revokes a credential by its non-secret registry identifier. */
+  revokeCredential(credentialId: string): boolean {
+    return this.credentials.revoke(credentialId);
+  }
+
+  /** Removes expired staged scopes and returns the number removed. */
+  cleanupPending(): number {
+    const now = this.now();
+    let removed = 0;
+    for (const [leaseId, pending] of this.pending) {
+      if (pending.expiresAt <= now) {
+        this.pending.delete(leaseId);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /** Revokes all active credentials and drops pending work during shutdown. */
+  shutdown(): void {
+    for (const lease of [...this.active.values()]) this.credentials.revoke(lease.credentialId);
+    this.active.clear();
+    this.sessionToLease.clear();
+    this.pending.clear();
+  }
+
+  /** Returns bounded lifecycle counts for diagnostics and tests. */
+  status(): { active: number; pending: number } {
+    this.cleanupPending();
+    this.credentials.size();
+    return { active: this.active.size, pending: this.pending.size };
+  }
+
+  private issueCredential(leaseId: string, pending: PendingScope): BrowserAutomationSessionLeaseGrant {
+    const configuration = this.configuration;
+    if (!configuration) throw new Error("Browser automation session lease is not configured");
+    const scope: BrowserAutomationCredentialScope = {
+      ...pending.scope,
+      worktreeIdentity: configuration.worktreeIdentity,
+      allowedOperations: pending.scope.allowedOperations ?? allowedOperations(pending.scope.permissionCapability),
+    };
+    const issued = this.credentials.issue(scope);
+    const active: ActiveLease = { scope: pending.scope, sessionKey: pending.sessionKey, credentialId: issued.credentialId };
+    this.active.set(leaseId, active);
+    this.sessionToLease.set(pending.sessionKey, leaseId);
+    return {
+      leaseId,
+      mcpUrl: configuration.mcpUrl,
+      token: issued.token,
+      credentialId: issued.credentialId,
+      expiresAt: issued.expiresAt,
+      allowedOperations: scope.allowedOperations,
+    };
+  }
+
+  private releaseCredential(credentialId: string): void {
+    for (const [leaseId, lease] of this.active) {
+      if (lease.credentialId !== credentialId) continue;
+      this.active.delete(leaseId);
+      if (this.sessionToLease.get(lease.sessionKey) === leaseId) this.sessionToLease.delete(lease.sessionKey);
+    }
+  }
+
+  private evictOldestPending(): void {
+    const oldest = this.pending.keys().next().value as string | undefined;
+    if (oldest) this.pending.delete(oldest);
+  }
+
+  private sessionKey(providerId: string, mcodeSessionId: string): string {
+    return JSON.stringify([providerId, mcodeSessionId]);
+  }
+}

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
@@ -218,10 +218,9 @@ export class BrowserAutomationSessionLease {
     const configuration = this.configuration;
     if (!configuration) return null;
     try {
-      const grant = this.issueCredential(leaseId, pending);
       const previousLeaseId = this.sessionToLease.get(pending.sessionKey);
       if (previousLeaseId && previousLeaseId !== leaseId) this.release(previousLeaseId);
-      return grant;
+      return this.issueCredential(leaseId, pending);
     } catch (error) {
       this.active.delete(leaseId);
       throw error;
@@ -233,15 +232,14 @@ export class BrowserAutomationSessionLease {
     const lease = this.active.get(leaseId);
     if (!lease) return { ok: false, leaseId, reason: "not-found" };
     if (!this.configuration) return { ok: false, leaseId, reason: "unconfigured" };
+    const previousCredentialId = lease.credentialId;
     try {
+      this.credentials.revoke(previousCredentialId);
       const grant = this.issueCredential(leaseId, {
         scope: lease.scope,
         sessionKey: lease.sessionKey,
         expiresAt: this.now(),
       });
-      const previousCredentialId = lease.credentialId;
-      lease.credentialId = grant.credentialId;
-      this.credentials.revoke(previousCredentialId);
       return { ok: true, grant };
     } catch {
       return { ok: false, leaseId, reason: "issuance-failed" };

--- a/apps/server/src/services/browser-automation/index.ts
+++ b/apps/server/src/services/browser-automation/index.ts
@@ -33,3 +33,16 @@ export {
   type BrowserAutomationCredentialRevocation,
   type BrowserAutomationCredentialRevokedListener,
 } from "./access-service.js";
+
+/** Provider-neutral browser session lease exports. */
+export {
+  BrowserAutomationSessionLease,
+  type BrowserAutomationSessionLeaseConfiguration,
+  type BrowserAutomationSessionLeaseGrant,
+  type BrowserAutomationSessionLeaseOptions,
+  type BrowserAutomationSessionLeaseRefreshResult,
+  type BrowserAutomationSessionLeaseReleaseResult,
+  type BrowserAutomationSessionLeaseRequest,
+  type BrowserAutomationSessionLeaseScope,
+  type BrowserAutomationSessionLeaseStage,
+} from "./browser-automation-session-lease.js";


### PR DESCRIPTION
## What
Adds a provider-neutral browser automation session lease with explicit lifecycle results and focused tests.

## Why
Stages shared credential lifecycle mechanics before providers migrate, while preserving existing provider behavior.

## Key Changes
- Adds bounded scope staging, issue, refresh, expiry, release, and shutdown cleanup.
- Adds lifecycle, isolation, failure-cleanup, and shutdown coverage.
- Leaves provider callers unchanged.

Closes #987

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787969997&installation_model_id=20477&pr_number=1014&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1014&signature=d4078539f4b9cf1d53587cda1414b027626247fd49cc1827d73872fe46e5af8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->