### PR TITLE
feat(server): share Claude browser session leases

### DIFF
--- a/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
+++ b/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
@@ -157,9 +157,14 @@ describe("ClaudeProvider browser session lease lifecycle", () => {
     expect(lease.status()).toEqual({ active: 0, pending: 0 });
   });
 
-  it("delegates shutdown and revokes shared leases", () => {
+  it("delegates shutdown without revoking leases owned by other providers", () => {
     const lease = configuredLease();
-    lease.issue(scope);
+    const claudeGrant = lease.issue(scope)!;
+    const nonClaudeGrant = lease.issue({
+      ...scope,
+      providerId: "codex",
+      providerSessionId: "codex-thread-1",
+    })!;
     const provider = new ClaudeProvider(
       { getEnv: () => ({}) } as any,
       { isWindowsJob: false } as any,
@@ -172,6 +177,7 @@ describe("ClaudeProvider browser session lease lifecycle", () => {
     provider.shutdown();
 
     expect(shutdown).toHaveBeenCalledOnce();
-    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+    expect(lease.credentials.authenticate(nonClaudeGrant.token)).not.toBeNull();
+    expect(lease.credentials.authenticate(claudeGrant.token)).not.toBeNull();
   });
 });

--- a/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
+++ b/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
@@ -1,0 +1,177 @@
+import "reflect-metadata";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  BrowserAutomationSessionLease,
+  type BrowserAutomationSessionLeaseScope,
+} from "../../../services/browser-automation/browser-automation-session-lease.js";
+import { ClaudeProvider } from "../claude-provider.js";
+
+const { mockQuery } = vi.hoisted(() => ({ mockQuery: vi.fn() }));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({ query: mockQuery }));
+vi.mock("@mcode/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcode/shared")>();
+  return { ...actual, logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } };
+});
+
+const scope: BrowserAutomationSessionLeaseScope = {
+  providerId: "claude",
+  providerSessionId: "mcode-thread-1",
+  mcodeSessionId: "mcode-thread-1",
+  threadId: "thread-1",
+  workspaceId: "workspace-1",
+  permissionCapability: "interact",
+};
+
+function configuredLease(): BrowserAutomationSessionLease {
+  const lease = new BrowserAutomationSessionLease();
+  lease.configure({ mcpUrl: "http://127.0.0.1:19400/mcp", worktreeIdentity: "worktree-1" });
+  return lease;
+}
+
+function makeProvider(lease: BrowserAutomationSessionLease) {
+  const provider = Object.create(ClaudeProvider.prototype) as ClaudeProvider;
+  const existingState = {
+    sessionId: "mcode-thread-1",
+    cwd: process.cwd(),
+    query: { close: vi.fn() },
+    pushMessage: vi.fn(),
+    closeQueue: vi.fn(),
+    model: "claude-sonnet-4-6",
+    permissionMode: "default",
+    contextWindowMode: undefined,
+    orchestrationMode: "standard",
+    lastUsedAt: Date.now(),
+    pendingToolUses: new Set<string>(),
+    hasFiredToolThisTurn: false,
+    workspaceId: "workspace-1",
+    browserPermissionCapability: "interact" as const,
+  };
+  let spawnedState: unknown;
+  const runtime = {
+    get: vi.fn(() => existingState),
+    recordUsage: vi.fn(),
+    acquire: vi.fn(async (args: any) => {
+      const result = await (provider as any).spawn(args);
+      spawnedState = result.state;
+      return result.state;
+    }),
+    stop: vi.fn(async () => {
+      await (provider as any).close(existingState);
+    }),
+    shutdown: vi.fn(async () => {}),
+  };
+  Object.assign(provider as any, {
+    runtime,
+    pendingSpawnTurns: new Map(),
+    pendingBrowserAccess: new Map(),
+    sdkSessionIds: new Map(),
+    recentStderr: new Map(),
+    goalsBySession: new Map(),
+    nativeGoalsBySession: new Map(),
+    nativeGoalSupportBySession: new Map(),
+    pendingStops: new Set(),
+    suppressEndedQueries: new Set(),
+    suppressSessionStartHooks: new Set(),
+    planAnswerThreads: new Set(),
+    pendingPermissions: new Map(),
+    browserAutomationSessionLease: lease,
+    browserAutomationAccess: { isConfigured: () => true },
+    scopedPreGrant: { tryConsume: () => false },
+    envService: { getEnv: () => ({}) },
+    jobObject: { isWindowsJob: false },
+    threadControlMcp: undefined,
+    startStreamLoop: vi.fn(),
+  });
+  return {
+    provider,
+    runtime,
+    existingState,
+    get spawnedState() { return spawnedState as any; },
+  };
+}
+
+function request() {
+  return {
+    sessionId: "mcode-thread-1",
+    workspaceId: "workspace-1",
+    threadId: "thread-1",
+    message: "hello",
+    cwd: process.cwd(),
+    model: "claude-sonnet-4-6",
+    permissionMode: "default",
+    interactionMode: "build" as const,
+    providerOptions: {},
+  } as any;
+}
+
+describe("ClaudeProvider browser session lease lifecycle", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockQuery.mockReturnValue({ close: vi.fn() });
+  });
+
+  it("keeps a refreshed grant active across replacement close and passes it to SDK", async () => {
+    const lease = configuredLease();
+    const oldGrant = lease.issue(scope)!;
+    const harness = makeProvider(lease);
+    const { provider, runtime, existingState } = harness;
+    existingState.browserLease = { ...oldGrant, expiresAt: 0 };
+    (provider as any).runtime.get = vi.fn(() => existingState);
+    (provider as any).pendingBrowserAccess.set("mcode-thread-1", {
+      scope,
+      stage: lease.stage(scope),
+    });
+
+    await (provider as any).sendTurn(request());
+
+    expect(runtime.stop).toHaveBeenCalledOnce();
+    const options = mockQuery.mock.calls[0][0].options;
+    const token = options.mcpServers["mcode-browser"].headers.Authorization.slice("Bearer ".length);
+    expect(lease.credentials.authenticate(token)).not.toBeNull();
+    expect((provider as any).browserAutomationSessionLease.status()).toEqual({ active: 1, pending: 0 });
+    const spawnedState = harness.spawnedState;
+    expect(spawnedState).toBeDefined();
+    await (provider as any).close(spawnedState);
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
+  it("releases a fresh grant when SDK spawn fails", async () => {
+    const lease = configuredLease();
+    const { provider } = makeProvider(lease);
+    (provider as any).runtime.get = vi.fn(() => undefined);
+    mockQuery.mockImplementationOnce(() => { throw new Error("spawn failed"); });
+
+    await expect((provider as any).sendTurn(request())).rejects.toThrow("spawn failed");
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
+  it("releases active grant exactly once on close", async () => {
+    const lease = configuredLease();
+    const grant = lease.issue(scope)!;
+    const { provider } = makeProvider(lease);
+    const state = { ...(makeProvider(lease).existingState), browserLease: grant };
+
+    await (provider as any).close(state);
+    await (provider as any).close(state);
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
+  it("delegates shutdown and revokes shared leases", () => {
+    const lease = configuredLease();
+    lease.issue(scope);
+    const provider = new ClaudeProvider(
+      { getEnv: () => ({}) } as any,
+      { isWindowsJob: false } as any,
+      undefined,
+      undefined,
+      lease,
+    );
+    const shutdown = vi.spyOn((provider as any).runtime, "shutdown").mockResolvedValue(undefined);
+
+    provider.shutdown();
+
+    expect(shutdown).toHaveBeenCalledOnce();
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+});

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -51,9 +51,13 @@ import { CleanForker } from "../../services/handoff/session-forker.js";
 import {
   BrowserAutomationAccessService,
   browserAutomationPermissionCapability,
-  type BrowserAutomationAccessRequest,
-  type BrowserAutomationCredentialMetadata,
 } from "../../services/browser-automation/access-service.js";
+import {
+  BrowserAutomationSessionLease,
+  type BrowserAutomationSessionLeaseGrant,
+  type BrowserAutomationSessionLeaseScope,
+  type BrowserAutomationSessionLeaseStage,
+} from "../../services/browser-automation/browser-automation-session-lease.js";
 import type { SessionForker } from "@mcode/contracts";
 import { parseClaudeGoalCommandResult } from "./claude-goal-command-parser.js";
 
@@ -148,8 +152,8 @@ interface ClaudeSessionState {
    * same user turn continues.
    */
   hasFiredToolThisTurn: boolean;
-  /** Non-secret browser credential lifecycle metadata for this main session. */
-  browserCredential?: BrowserAutomationCredentialMetadata;
+  /** Non-secret browser lease lifecycle metadata for this main session. */
+  browserLease?: Pick<BrowserAutomationSessionLeaseGrant, "leaseId" | "credentialId" | "expiresAt">;
   /** Workspace fixed to this SDK query at spawn. */
   workspaceId: string;
   /** Browser permission class fixed to this SDK query at spawn. */
@@ -325,6 +329,12 @@ interface PendingSpawnTurn {
   orchestrationMode: OrchestrationMode;
 }
 
+interface PendingBrowserAccess {
+  scope: BrowserAutomationSessionLeaseScope;
+  stage?: BrowserAutomationSessionLeaseStage;
+  grant?: BrowserAutomationSessionLeaseGrant;
+}
+
 /** Claude Agent SDK adapter implementing IAgentProvider with prompt queue pattern. */
 @injectable()
 export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoalCapable, ISessionEvictable, ProtocolAdapter<ClaudeSessionState> {
@@ -340,8 +350,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
   private readonly runtime: SessionRuntime<ClaudeSessionState>;
   /** Per-turn payload staged for `spawn` to run a fresh session's first turn. */
   private pendingSpawnTurns = new Map<string, PendingSpawnTurn>();
-  /** Browser scope staged only until a fresh normal SDK query starts. */
-  private pendingBrowserAccess = new Map<string, BrowserAutomationAccessRequest>();
+  /** Browser lease staged only until a fresh normal SDK query starts. */
+  private pendingBrowserAccess = new Map<string, PendingBrowserAccess>();
   private sdkSessionIds = new Map<string, string>();
   /**
    * Tail of the most recent stderr emitted by each session's Claude Code
@@ -416,6 +426,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     private readonly scopedPreGrant: ScopedPreGrantService = new ScopedPreGrantService(),
     @inject(BrowserAutomationAccessService)
     private readonly browserAutomationAccess: BrowserAutomationAccessService = new BrowserAutomationAccessService(),
+    @inject(BrowserAutomationSessionLease)
+    private readonly browserAutomationSessionLease: BrowserAutomationSessionLease = new BrowserAutomationSessionLease(),
     @inject(InternalThreadControlMcpRuntime)
     private readonly threadControlMcp: InternalThreadControlMcpRuntime = undefined as never,
   ) {
@@ -450,7 +462,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     if (req.resumeFrom !== undefined) {
       this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
     }
-    this.pendingBrowserAccess.set(req.sessionId, {
+    const browserScope: BrowserAutomationSessionLeaseScope = {
       providerId: this.id,
       providerSessionId: req.resumeFrom ?? req.sessionId,
       mcodeSessionId: req.sessionId,
@@ -460,6 +472,10 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
         req.permissionMode,
         req.interactionMode,
       ),
+    };
+    this.pendingBrowserAccess.set(req.sessionId, {
+      scope: browserScope,
+      stage: this.browserAutomationSessionLease.stage(browserScope),
     });
     const params = {
       sessionId: req.sessionId,
@@ -486,6 +502,15 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
       });
       throw e;
     } finally {
+      const pendingBrowserAccess = this.pendingBrowserAccess.get(req.sessionId);
+      if (pendingBrowserAccess) {
+        if (pendingBrowserAccess.grant) {
+          this.browserAutomationSessionLease.release(pendingBrowserAccess.grant.leaseId);
+        }
+        if (pendingBrowserAccess.stage) {
+          this.browserAutomationSessionLease.release(pendingBrowserAccess.stage.leaseId);
+        }
+      }
       this.pendingBrowserAccess.delete(req.sessionId);
     }
   }
@@ -909,7 +934,22 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     } = params;
 
     const existing = this.runtime.get(sessionId);
-    const browserScope = this.pendingBrowserAccess.get(sessionId);
+    const pendingBrowserAccess = this.pendingBrowserAccess.get(sessionId);
+    const browserScope = pendingBrowserAccess?.scope;
+    const browserLeaseExpired = existing?.browserLease !== undefined && existing.browserLease.expiresAt <= Date.now();
+    if (browserLeaseExpired && existing?.browserLease && pendingBrowserAccess) {
+      const previousLeaseId = existing.browserLease.leaseId;
+      const refreshed = this.browserAutomationSessionLease.refresh(previousLeaseId);
+      // Transfer lease ownership before SessionRuntime.stop invokes close.
+      // close must not revoke a refreshed grant needed by replacement spawn.
+      existing.browserLease = undefined;
+      if (refreshed.ok) {
+        pendingBrowserAccess.grant = refreshed.grant;
+        pendingBrowserAccess.stage = undefined;
+      } else {
+        this.browserAutomationSessionLease.release(previousLeaseId);
+      }
+    }
     const isBypass = permissionMode === "full";
     const sdkPermissionMode = isBypass
       ? ("bypassPermissions" as const)
@@ -946,7 +986,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
         !browserScope ||
         (existing.workspaceId === browserScope.workspaceId &&
           existing.browserPermissionCapability === browserScope.permissionCapability &&
-          (!existing.browserCredential || existing.browserCredential.expiresAt > Date.now())));
+          !browserLeaseExpired));
 
     if (existing && !reusable) {
       logger.info("Session spawn parameters changed, recreating session", {
@@ -962,6 +1002,11 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     }
 
     if (existing && reusable) {
+      const pendingBrowserAccess = this.pendingBrowserAccess.get(sessionId);
+      if (pendingBrowserAccess?.stage) {
+        this.browserAutomationSessionLease.release(pendingBrowserAccess.stage.leaseId);
+        this.pendingBrowserAccess.delete(sessionId);
+      }
       this.runtime.recordUsage(sessionId);
       existing.lastUsedAt = Date.now();
 
@@ -1419,8 +1464,16 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
       contextWindowMode,
       orchestrationMode,
     } = staged;
-    const browserScope = this.pendingBrowserAccess.get(sessionId);
-    const browserGrant = browserScope ? this.browserAutomationAccess.issue(browserScope) : null;
+    const pendingBrowserAccess = this.pendingBrowserAccess.get(sessionId);
+    const browserScope = pendingBrowserAccess?.scope;
+    const browserGrant = pendingBrowserAccess?.grant ??
+      (pendingBrowserAccess?.stage
+        ? this.browserAutomationSessionLease.issue(pendingBrowserAccess.stage)
+        : null);
+    if (pendingBrowserAccess?.grant && pendingBrowserAccess.stage) {
+      this.browserAutomationSessionLease.release(pendingBrowserAccess.stage.leaseId);
+    }
+    this.pendingBrowserAccess.delete(sessionId);
 
     // Capture the subprocess stderr tail so a non-zero exit (which the SDK
     // reports as a bare "process exited with code N") carries the actual CLI
@@ -1470,7 +1523,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     try {
       q = this.withSdkSpawnEnv(() => sdkQuery({ prompt: queue.iterable, options }));
     } catch (error) {
-      if (browserGrant) this.browserAutomationAccess.revokeCredential(browserGrant.credentialId);
+      if (browserGrant) this.browserAutomationSessionLease.release(browserGrant.leaseId);
       throw error;
     }
 
@@ -1506,7 +1559,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
       workspaceId: browserScope?.workspaceId ?? "unknown-workspace",
       browserPermissionCapability: browserScope?.permissionCapability ?? "interact",
       ...(browserGrant && {
-        browserCredential: {
+        browserLease: {
+          leaseId: browserGrant.leaseId,
           credentialId: browserGrant.credentialId,
           expiresAt: browserGrant.expiresAt,
         },
@@ -1550,8 +1604,8 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
 
   /** Provider teardown: close the SDK query handle. */
   async close(state: ClaudeSessionState): Promise<void> {
-    if (state.browserCredential) {
-      this.browserAutomationAccess.revokeCredential(state.browserCredential.credentialId);
+    if (state.browserLease) {
+      this.browserAutomationSessionLease.release(state.browserLease.leaseId);
     }
     await this.threadControlMcp?.close(state.sessionId);
     state.query.close();
@@ -2768,6 +2822,7 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     void this.runtime.shutdown().catch((err: unknown) => {
       logger.warn("Claude runtime shutdown failed", { error: String(err) });
     });
+    this.browserAutomationSessionLease.shutdown();
     this.pendingSpawnTurns.clear();
     this.pendingBrowserAccess.clear();
     this.sdkSessionIds.clear();

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -2822,7 +2822,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     void this.runtime.shutdown().catch((err: unknown) => {
       logger.warn("Claude runtime shutdown failed", { error: String(err) });
     });
-    this.browserAutomationSessionLease.shutdown();
     this.pendingSpawnTurns.clear();
     this.pendingBrowserAccess.clear();
     this.sdkSessionIds.clear();


### PR DESCRIPTION
Closes #989\n\nMigrates Claude browser credential lifecycle to the shared session lease, including refresh, failure cleanup, session close, and shutdown isolation.\n\nVerification: high-risk review finding-free. Focused suite is blocked before assertions by an existing cross-checkout contract-resolution fault; full verify timed out after 124 seconds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787972582&installation_model_id=20477&pr_number=1015&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1015&signature=526bd4c9f122ffedd2be715e43f1f5a8df3d81d07c9298e87eb51ddd4315c28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->