### PR TITLE
fix(codex): use shared browser session lease

### DIFF
--- a/apps/server/src/container.ts
+++ b/apps/server/src/container.ts
@@ -95,6 +95,7 @@ import { ReviewWorktreeService } from "./services/pull-requests/review-worktree-
 import {
   BrowserAutomationAccessService,
   BrowserAutomationCredentialRegistry,
+  BrowserAutomationSessionLease,
 } from "./services/browser-automation/index.js";
 
 /** Initialize the DI container with all server dependencies. */
@@ -104,6 +105,10 @@ export function setupContainer(mcodeDir: string): typeof container {
   container.registerInstance(
     BrowserAutomationAccessService,
     new BrowserAutomationAccessService(browserAutomationCredentials),
+  );
+  container.registerInstance(
+    BrowserAutomationSessionLease,
+    new BrowserAutomationSessionLease(browserAutomationCredentials),
   );
 
   // PtyPidRegistry — registered before TerminalService because it is injected into it

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -80,6 +80,7 @@ import {
   BrowserAutomationAccessService,
   BrowserAutomationBroker,
   BrowserAutomationMcpHandler,
+  BrowserAutomationSessionLease,
 } from "./services/browser-automation/index.js";
 
 // process.title affects `ps`/`top`/`htop` output on Unix and the console window
@@ -221,6 +222,7 @@ applyDevGitCheckoutEnv();
 const container = setupContainer(getMcodeDir());
 
 const browserAutomationAccess = container.resolve(BrowserAutomationAccessService);
+const browserAutomationSessionLease = container.resolve(BrowserAutomationSessionLease);
 const browserAutomationBroker = new BrowserAutomationBroker({});
 const browserAutomationMcpHandler = new BrowserAutomationMcpHandler({
   credentials: browserAutomationAccess.credentials,
@@ -708,6 +710,10 @@ function listen(port: number, attempt = 1): void {
       mcpUrl: `http://${browserMcpHost}:${port}/mcp`,
       worktreeIdentity: WORKTREE_IDENTITY ?? "shared-server",
     });
+    browserAutomationSessionLease.configure({
+      mcpUrl: `http://${browserMcpHost}:${port}/mcp`,
+      worktreeIdentity: WORKTREE_IDENTITY ?? "shared-server",
+    });
 
     // Write lock file so other instances can discover this server
     try {
@@ -831,6 +837,7 @@ async function shutdown(): Promise<void> {
   providerRegistry.shutdown();
   browserAutomationBroker.shutdown();
   browserAutomationAccess.shutdown();
+  browserAutomationSessionLease.shutdown();
 
   // 4. Mark active threads as interrupted
   threadService.markActiveThreadsInterrupted(activeThreadIds);

--- a/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
+++ b/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
@@ -2,7 +2,6 @@ import "reflect-metadata";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import {
   BrowserAutomationSessionLease,
-  type BrowserAutomationSessionLeaseGrant,
   type BrowserAutomationSessionLeaseScope,
 } from "../../../services/browser-automation/browser-automation-session-lease.js";
 import { ClaudeProvider } from "../claude-provider.js";
@@ -47,8 +46,7 @@ function makeProvider(lease: BrowserAutomationSessionLease) {
     hasFiredToolThisTurn: false,
     workspaceId: "workspace-1",
     browserPermissionCapability: "interact" as const,
-    browserLease: undefined as BrowserAutomationSessionLeaseGrant | undefined,
-  };
+  } as unknown as Parameters<ClaudeProvider["close"]>[0];
   let spawnedState: unknown;
   const runtime = {
     get: vi.fn(() => existingState),

--- a/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
+++ b/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import {
   BrowserAutomationSessionLease,
+  type BrowserAutomationSessionLeaseGrant,
   type BrowserAutomationSessionLeaseScope,
 } from "../../../services/browser-automation/browser-automation-session-lease.js";
 import { ClaudeProvider } from "../claude-provider.js";
@@ -46,6 +47,7 @@ function makeProvider(lease: BrowserAutomationSessionLease) {
     hasFiredToolThisTurn: false,
     workspaceId: "workspace-1",
     browserPermissionCapability: "interact" as const,
+    browserLease: undefined as BrowserAutomationSessionLeaseGrant | undefined,
   };
   let spawnedState: unknown;
   const runtime = {

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -168,6 +168,72 @@ describe("CodexProvider first turn on new session", () => {
     expect(lease.credentials.size()).toBe(0);
   });
 
+  it("releases staged browser access when stopped before runtime acquisition", async () => {
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({
+      mcpUrl: "http://127.0.0.1:19400/mcp",
+      worktreeIdentity: "worktree-test",
+    });
+    const provider = makeProvider(undefined, lease);
+    let rejectAcquire!: (error: Error) => void;
+    const acquirePromise = new Promise<never>((_, reject) => {
+      rejectAcquire = reject;
+    });
+    (provider as any).runtime.acquire = vi.fn(() => acquirePromise);
+
+    const sessionId = "mcode-pending-stop";
+    const sendPromise = provider.sendTurn({
+      sessionId,
+      workspaceId: "workspace-test",
+      threadId: "pending-stop",
+      message: "inspect the page",
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "supervised",
+    });
+
+    await vi.waitFor(() => expect(lease.status()).toEqual({ active: 0, pending: 1 }));
+    await provider.stopSession(sessionId);
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+
+    rejectAcquire(new Error("stop requested"));
+    await sendPromise;
+  });
+
+  it("does not shut down the shared lease when Codex stops", () => {
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({
+      mcpUrl: "http://127.0.0.1:19400/mcp",
+      worktreeIdentity: "worktree-test",
+    });
+    const claudeGrant = lease.issue({
+      providerId: "claude",
+      providerSessionId: "claude-session",
+      mcodeSessionId: "claude-session",
+      threadId: "claude-thread",
+      workspaceId: "workspace-test",
+      permissionCapability: "interact",
+    })!;
+    const codexGrant = lease.issue({
+      providerId: "codex",
+      providerSessionId: "codex-session",
+      mcodeSessionId: "codex-session",
+      threadId: "codex-thread",
+      workspaceId: "workspace-test",
+      permissionCapability: "interact",
+    })!;
+    const provider = makeProvider(undefined, lease);
+    const shutdown = vi.spyOn(lease, "shutdown");
+
+    provider.shutdown();
+
+    expect(shutdown).not.toHaveBeenCalled();
+    expect(lease.credentials.authenticate(claudeGrant.token)).not.toBeNull();
+    expect(lease.credentials.authenticate(codexGrant.token)).not.toBeNull();
+  });
+
   it("sent turn/start after spawn when the runtime pool registers on the next tick", async () => {
     const provider = makeProvider();
 

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -168,6 +168,72 @@ describe("CodexProvider first turn on new session", () => {
     expect(lease.credentials.size()).toBe(0);
   });
 
+  it("releases staged browser access when internal MCP configuration fails", async () => {
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({
+      mcpUrl: "http://127.0.0.1:19400/mcp",
+      worktreeIdentity: "worktree-test",
+    });
+    const provider = makeProvider(undefined, lease);
+    (provider as any).threadControlMcp = {
+      createCodexConfiguration: vi.fn().mockRejectedValue(new Error("MCP config failed")),
+    };
+
+    await provider.sendTurn({
+      sessionId: "mcode-browser-config-failure",
+      workspaceId: "workspace-test",
+      threadId: "browser-config-failure",
+      message: "inspect the page",
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "supervised",
+    });
+
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+    expect(appServers).toHaveLength(0);
+  });
+
+  it("releases the previous staged browser access for overlapping sends", async () => {
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({
+      mcpUrl: "http://127.0.0.1:19400/mcp",
+      worktreeIdentity: "worktree-test",
+    });
+    const provider = makeProvider(undefined, lease);
+    let rejectAcquire!: (error: Error) => void;
+    const acquirePromise = new Promise<never>((_, reject) => {
+      rejectAcquire = reject;
+    });
+    (provider as any).runtime.acquire = vi.fn(() => acquirePromise);
+    const release = vi.spyOn(lease, "release");
+    const request = {
+      sessionId: "mcode-overlapping-browser-stage",
+      workspaceId: "workspace-test",
+      threadId: "overlapping-browser-stage",
+      message: "inspect the page",
+      cwd: process.cwd(),
+      model: "gpt-5.4",
+      interactionMode: "build" as const,
+      providerOptions: {},
+      permissionMode: "supervised" as const,
+    };
+
+    const firstSend = provider.sendTurn(request);
+    await vi.waitFor(() => expect(lease.status()).toEqual({ active: 0, pending: 1 }));
+    const firstStage = (provider as any).pendingBrowserAccess.get(request.sessionId).stage.leaseId;
+
+    const secondSend = provider.sendTurn({ ...request, message: "inspect again" });
+    await vi.waitFor(() => expect(release).toHaveBeenCalledWith(firstStage));
+    expect(lease.status()).toEqual({ active: 0, pending: 1 });
+    expect((provider as any).pendingBrowserAccess.get(request.sessionId).stage.leaseId).not.toBe(firstStage);
+
+    rejectAcquire(new Error("acquire failed"));
+    await Promise.all([firstSend, secondSend]);
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
   it("releases staged browser access when stopped before runtime acquisition", async () => {
     const lease = new BrowserAutomationSessionLease();
     lease.configure({

--- a/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-first-turn.test.ts
@@ -65,7 +65,7 @@ import { CodexProvider } from "../codex-provider.js";
 import { AgentEventType } from "@mcode/contracts";
 import type { AgentEvent } from "@mcode/contracts";
 import { stubEnvService } from "../../../__tests__/stub-env-service.js";
-import { BrowserAutomationAccessService } from "../../../services/browser-automation/access-service.js";
+import { BrowserAutomationSessionLease } from "../../../services/browser-automation/browser-automation-session-lease.js";
 
 function makeProvider(
   catalogService: {
@@ -83,7 +83,7 @@ function makeProvider(
     onSkillsChanged: vi.fn(() => () => undefined),
     shutdown: vi.fn(async () => undefined),
   },
-  browserAutomationAccess = new BrowserAutomationAccessService(),
+  browserAutomationLease = new BrowserAutomationSessionLease(),
 ): CodexProvider {
   return new CodexProvider(
     { get: async () => ({ provider: { cli: { codex: "codex" } } }) } as never,
@@ -91,7 +91,7 @@ function makeProvider(
     stubEnvService() as never,
     { persistGeneratedImageFromPath: vi.fn() } as never,
     catalogService as never,
-    browserAutomationAccess,
+    browserAutomationLease,
   );
 }
 
@@ -113,12 +113,12 @@ describe("CodexProvider first turn on new session", () => {
   });
 
   it("passes loopback browser MCP config and a child-only bearer token", async () => {
-    const access = new BrowserAutomationAccessService();
-    access.configure({
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({
       mcpUrl: "http://127.0.0.1:19400/mcp",
       worktreeIdentity: "worktree-test",
     });
-    const provider = makeProvider(undefined, access);
+    const provider = makeProvider(undefined, lease);
 
     await provider.sendTurn({
       sessionId,
@@ -141,17 +141,17 @@ describe("CodexProvider first turn on new session", () => {
     expect(process.env.MCODE_BROWSER_MCP_TOKEN).toBeUndefined();
     await new Promise<void>((resolve) => setImmediate(resolve));
     await provider.stopSession(sessionId);
-    expect(access.credentials.size()).toBe(0);
+    expect(lease.credentials.size()).toBe(0);
   });
 
   it("revokes a browser credential when app-server startup fails", async () => {
-    const access = new BrowserAutomationAccessService();
-    access.configure({
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({
       mcpUrl: "http://127.0.0.1:19400/mcp",
       worktreeIdentity: "worktree-test",
     });
     startError.current = new Error("handshake failed");
-    const provider = makeProvider(undefined, access);
+    const provider = makeProvider(undefined, lease);
 
     await provider.sendTurn({
       sessionId: "mcode-browser-spawn-failure",
@@ -165,7 +165,7 @@ describe("CodexProvider first turn on new session", () => {
       permissionMode: "supervised",
     });
 
-    expect(access.credentials.size()).toBe(0);
+    expect(lease.credentials.size()).toBe(0);
   });
 
   it("sent turn/start after spawn when the runtime pool registers on the next tick", async () => {

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -528,7 +528,11 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     { input: string | TurnInputPart[]; turnOptions: CodexTurnOptions }
   >();
   /** Browser scope staged only until a fresh main app-server process starts. */
-  private pendingBrowserAccess = new Map<string, BrowserAutomationSessionLeaseStage>();
+  private pendingBrowserAccess = new Map<string, {
+    stage: BrowserAutomationSessionLeaseStage;
+    workspaceId: string;
+    permissionCapability: "observe" | "interact" | "privileged";
+  }>();
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
@@ -995,7 +999,13 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       permissionCapability: browserPermissionCapability,
       })
       : undefined;
-    if (browserStage) this.pendingBrowserAccess.set(sessionId, browserStage);
+    if (browserStage) {
+      this.pendingBrowserAccess.set(sessionId, {
+        stage: browserStage,
+        workspaceId: req.workspaceId,
+        permissionCapability: browserPermissionCapability,
+      });
+    }
 
     let state: CodexSessionState;
     try {
@@ -1011,7 +1021,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       this.pendingSpawnTurns.delete(sessionId);
       const stagedBrowser = this.pendingBrowserAccess.get(sessionId);
       this.pendingBrowserAccess.delete(sessionId);
-      if (stagedBrowser) this.browserAutomationLease.release(stagedBrowser.leaseId);
+      if (stagedBrowser) this.browserAutomationLease.release(stagedBrowser.stage.leaseId);
       const errorMessage = e instanceof Error ? e.message : String(e);
       logger.error("CodexAppServer start failed", { sessionId, error: errorMessage });
       this.emitTurnFailure(threadId, errorMessage);
@@ -1020,7 +1030,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     this.runtime.recordUsage(sessionId);
     const stagedBrowser = this.pendingBrowserAccess.get(sessionId);
     this.pendingBrowserAccess.delete(sessionId);
-    if (state === existing && stagedBrowser) this.browserAutomationLease.release(stagedBrowser.leaseId);
+    if (state === existing && stagedBrowser) this.browserAutomationLease.release(stagedBrowser.stage.leaseId);
 
     // A stop requested before the session finished spawning: tear it down now.
     if (this.pendingStops.delete(sessionId)) {
@@ -1063,8 +1073,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     // still runs locally), so this guard is defensive and keeps the wiring
     // obvious in logs.
     const supervised = approvalPolicy === "on-request";
-    const browserScope = this.pendingBrowserAccess.get(sessionId);
-    const browserGrant = browserScope ? this.browserAutomationLease.issue(browserScope) : null;
+    const browserAccess = this.pendingBrowserAccess.get(sessionId);
+    const browserGrant = browserAccess ? this.browserAutomationLease.issue(browserAccess.stage) : null;
     const spawnEnv = { ...args.env };
     const browserTokenEnvName = "MCODE_BROWSER_MCP_TOKEN";
     if (browserGrant) spawnEnv[browserTokenEnvName] = browserGrant.token;
@@ -1208,8 +1218,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       sandboxMode: sandbox,
       runTurnSeq: 0,
       pendingTurnId: null,
-      workspaceId: browserScope?.workspaceId ?? "unknown-workspace",
-      browserPermissionCapability: browserScope?.permissionCapability ?? "interact",
+      workspaceId: browserAccess?.workspaceId ?? "unknown-workspace",
+      browserPermissionCapability: browserAccess?.permissionCapability ?? "interact",
       ...(browserGrant && {
         browserCredential: {
           credentialId: browserGrant.credentialId,
@@ -1822,7 +1832,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       this.pendingSpawnTurns.delete(sessionId);
       const stagedBrowser = this.pendingBrowserAccess.get(sessionId);
       this.pendingBrowserAccess.delete(sessionId);
-      if (stagedBrowser) this.browserAutomationLease.release(stagedBrowser.leaseId);
+      if (stagedBrowser) this.browserAutomationLease.release(stagedBrowser.stage.leaseId);
       setTimeout(() => this.pendingStops.delete(sessionId), 10_000);
     }
   }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -1862,7 +1862,6 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     this.sdkSessionIds.clear();
     this.pendingSpawnTurns.clear();
     this.pendingBrowserAccess.clear();
-    this.browserAutomationLease.shutdown();
     this.liveSessionIds.clear();
     logger.info("CodexProvider shutdown complete");
   }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -20,11 +20,13 @@ import { InternalThreadControlMcpRuntime } from "../../services/thread-control-m
 import { SessionRuntime } from "../../services/session-runtime.js";
 import { AttachmentService } from "../../services/attachment-service.js";
 import {
-  BrowserAutomationAccessService,
   browserAutomationPermissionCapability,
-  type BrowserAutomationAccessRequest,
   type BrowserAutomationCredentialMetadata,
 } from "../../services/browser-automation/access-service.js";
+import {
+  BrowserAutomationSessionLease,
+  type BrowserAutomationSessionLeaseStage,
+} from "../../services/browser-automation/browser-automation-session-lease.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import type { MemoryPressureLevel } from "../../services/memory-pressure-service.js";
 import { CleanForker } from "../../services/handoff/session-forker.js";
@@ -262,6 +264,7 @@ interface CodexSessionState {
   abortPendingTurnWait?: () => void;
   /** Non-secret browser credential lifecycle metadata for this main session. */
   browserCredential?: BrowserAutomationCredentialMetadata;
+  browserLeaseId?: string;
   /** Workspace fixed to the provider process at spawn. */
   workspaceId: string;
   /** Browser permission class fixed to the provider process at spawn. */
@@ -525,7 +528,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     { input: string | TurnInputPart[]; turnOptions: CodexTurnOptions }
   >();
   /** Browser scope staged only until a fresh main app-server process starts. */
-  private pendingBrowserAccess = new Map<string, BrowserAutomationAccessRequest>();
+  private pendingBrowserAccess = new Map<string, BrowserAutomationSessionLeaseStage>();
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
@@ -533,8 +536,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     @inject(EnvService) private readonly envService: EnvService,
     @inject(AttachmentService) private readonly attachmentService: AttachmentService,
     @inject(CodexCatalogService) private readonly codexCatalogService: CodexCatalogService,
-    @inject(BrowserAutomationAccessService)
-    private readonly browserAutomationAccess: BrowserAutomationAccessService = new BrowserAutomationAccessService(),
+    @inject(BrowserAutomationSessionLease)
+    private readonly browserAutomationLease: BrowserAutomationSessionLease = new BrowserAutomationSessionLease(),
     @inject(InternalThreadControlMcpRuntime)
     private readonly threadControlMcp: InternalThreadControlMcpRuntime = undefined as never,
   ) {
@@ -932,7 +935,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     let existing = this.runtime.get(sessionId);
     if (
       existing &&
-      this.browserAutomationAccess.isConfigured() &&
+      this.browserAutomationLease.isConfigured() &&
       (existing.workspaceId !== req.workspaceId ||
         existing.browserPermissionCapability !== browserPermissionCapability ||
         (existing.browserCredential && existing.browserCredential.expiresAt <= Date.now()))
@@ -982,14 +985,17 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     // Stage the per-turn payload so `spawn` can run the first turn of a fresh
     // session; reuse reads it directly below. Keyed by sessionId.
     this.pendingSpawnTurns.set(sessionId, { input, turnOptions });
-    this.pendingBrowserAccess.set(sessionId, {
+    const browserStage = this.browserAutomationLease.isConfigured()
+      ? this.browserAutomationLease.stage({
       providerId: this.id,
       providerSessionId: req.resumeFrom ?? sessionId,
       mcodeSessionId: sessionId,
       threadId: req.threadId,
       workspaceId: req.workspaceId,
       permissionCapability: browserPermissionCapability,
-    });
+      })
+      : undefined;
+    if (browserStage) this.pendingBrowserAccess.set(sessionId, browserStage);
 
     let state: CodexSessionState;
     try {
@@ -1003,14 +1009,18 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       });
     } catch (e: unknown) {
       this.pendingSpawnTurns.delete(sessionId);
+      const stagedBrowser = this.pendingBrowserAccess.get(sessionId);
       this.pendingBrowserAccess.delete(sessionId);
+      if (stagedBrowser) this.browserAutomationLease.release(stagedBrowser.leaseId);
       const errorMessage = e instanceof Error ? e.message : String(e);
       logger.error("CodexAppServer start failed", { sessionId, error: errorMessage });
       this.emitTurnFailure(threadId, errorMessage);
       return;
     }
     this.runtime.recordUsage(sessionId);
+    const stagedBrowser = this.pendingBrowserAccess.get(sessionId);
     this.pendingBrowserAccess.delete(sessionId);
+    if (state === existing && stagedBrowser) this.browserAutomationLease.release(stagedBrowser.leaseId);
 
     // A stop requested before the session finished spawning: tear it down now.
     if (this.pendingStops.delete(sessionId)) {
@@ -1054,7 +1064,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     // obvious in logs.
     const supervised = approvalPolicy === "on-request";
     const browserScope = this.pendingBrowserAccess.get(sessionId);
-    const browserGrant = browserScope ? this.browserAutomationAccess.issue(browserScope) : null;
+    const browserGrant = browserScope ? this.browserAutomationLease.issue(browserScope) : null;
     const spawnEnv = { ...args.env };
     const browserTokenEnvName = "MCODE_BROWSER_MCP_TOKEN";
     if (browserGrant) spawnEnv[browserTokenEnvName] = browserGrant.token;
@@ -1149,7 +1159,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     try {
       await server.start();
     } catch (error) {
-      if (browserGrant) this.browserAutomationAccess.revokeCredential(browserGrant.credentialId);
+      if (browserGrant) this.browserAutomationLease.release(browserGrant.leaseId);
       throw error;
     } finally {
       delete spawnEnv[browserTokenEnvName];
@@ -1205,6 +1215,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
           credentialId: browserGrant.credentialId,
           expiresAt: browserGrant.expiresAt,
         },
+        browserLeaseId: browserGrant.leaseId,
       }),
       childMetadataFetches: new Set(),
     };
@@ -1288,9 +1299,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     }
     this.liveSessionIds.delete(state.sessionId);
     this.drainPending((e) => e.sessionId === state.sessionId);
-    if (state.browserCredential) {
-      this.browserAutomationAccess.revokeCredential(state.browserCredential.credentialId);
-    }
+    if (state.browserLeaseId) this.browserAutomationLease.release(state.browserLeaseId);
+    else if (state.browserCredential) this.browserAutomationLease.revokeCredential(state.browserCredential.credentialId);
     await state.server.kill();
   }
 
@@ -1810,6 +1820,9 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       this.drainPending((e) => e.sessionId === sessionId);
       this.pendingStops.add(sessionId);
       this.pendingSpawnTurns.delete(sessionId);
+      const stagedBrowser = this.pendingBrowserAccess.get(sessionId);
+      this.pendingBrowserAccess.delete(sessionId);
+      if (stagedBrowser) this.browserAutomationLease.release(stagedBrowser.leaseId);
       setTimeout(() => this.pendingStops.delete(sessionId), 10_000);
     }
   }
@@ -1839,6 +1852,7 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     this.sdkSessionIds.clear();
     this.pendingSpawnTurns.clear();
     this.pendingBrowserAccess.clear();
+    this.browserAutomationLease.shutdown();
     this.liveSessionIds.clear();
     logger.info("CodexProvider shutdown complete");
   }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -1000,6 +1000,10 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       })
       : undefined;
     if (browserStage) {
+      const previousBrowserAccess = this.pendingBrowserAccess.get(sessionId);
+      if (previousBrowserAccess) {
+        this.browserAutomationLease.release(previousBrowserAccess.stage.leaseId);
+      }
       this.pendingBrowserAccess.set(sessionId, {
         stage: browserStage,
         workspaceId: req.workspaceId,
@@ -1074,11 +1078,11 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
     // obvious in logs.
     const supervised = approvalPolicy === "on-request";
     const browserAccess = this.pendingBrowserAccess.get(sessionId);
+    const internalMcp = await this.threadControlMcp?.createCodexConfiguration(sessionId);
     const browserGrant = browserAccess ? this.browserAutomationLease.issue(browserAccess.stage) : null;
     const spawnEnv = { ...args.env };
     const browserTokenEnvName = "MCODE_BROWSER_MCP_TOKEN";
     if (browserGrant) spawnEnv[browserTokenEnvName] = browserGrant.token;
-    const internalMcp = await this.threadControlMcp?.createCodexConfiguration(sessionId);
 
     const server = new CodexAppServer({
       cliPath,

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
@@ -191,6 +191,11 @@ export class BrowserAutomationSessionLease {
     this.configuration = { ...configuration };
   }
 
+  /** Returns whether the composition root supplied a usable MCP endpoint. */
+  isConfigured(): boolean {
+    return this.configuration !== null;
+  }
+
   /** Stages one bounded scope and returns its opaque lease handle. */
   stage(request: BrowserAutomationSessionLeaseRequest): BrowserAutomationSessionLeaseStage {
     this.cleanupPending();


### PR DESCRIPTION
## What
Move Codex browser credential and session lifecycle onto the shared BrowserAutomationSessionLease.

## Why
Codex now shares the provider-neutral lease lifecycle while preserving its provider-specific process behavior.

## Key Changes
- Stage, issue, release, and clean up Codex browser leases through the shared singleton.
- Keep application shutdown as the sole shared-lease shutdown owner.
- Cover startup, stop, configuration failure, and overlapping-stage cleanup.

Closes #990

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787974276&installation_model_id=20477&pr_number=1016&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1016&signature=e4f5c41c91735a622ff61b44109e15907cbdce0665f19ea8b304c2d5b3373dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->