### PR TITLE
fix(claude): repair browser lease lifecycle cleanup

### DIFF
--- a/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
+++ b/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
@@ -62,6 +62,7 @@ function makeProvider(lease: BrowserAutomationSessionLease) {
     shutdown: vi.fn(async () => {}),
   };
   Object.assign(provider as any, {
+    id: "claude",
     runtime,
     pendingSpawnTurns: new Map(),
     pendingBrowserAccess: new Map(),

--- a/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
+++ b/apps/server/src/providers/claude/__tests__/claude-browser-lease.test.ts
@@ -111,7 +111,7 @@ describe("ClaudeProvider browser session lease lifecycle", () => {
     mockQuery.mockReturnValue({ close: vi.fn() });
   });
 
-  it("keeps a refreshed grant active across replacement close and passes it to SDK", async () => {
+  it("closes a refreshed replacement with no active or pending lease", async () => {
     const lease = configuredLease();
     const oldGrant = lease.issue(scope)!;
     const harness = makeProvider(lease);
@@ -128,6 +128,7 @@ describe("ClaudeProvider browser session lease lifecycle", () => {
     expect(runtime.stop).toHaveBeenCalledOnce();
     const options = mockQuery.mock.calls[0][0].options;
     const token = options.mcpServers["mcode-browser"].headers.Authorization.slice("Bearer ".length);
+    expect(lease.credentials.authenticate(oldGrant.token)).toBeNull();
     expect(lease.credentials.authenticate(token)).not.toBeNull();
     expect((provider as any).browserAutomationSessionLease.status()).toEqual({ active: 1, pending: 0 });
     const spawnedState = harness.spawnedState;
@@ -140,9 +141,10 @@ describe("ClaudeProvider browser session lease lifecycle", () => {
     const lease = configuredLease();
     const { provider } = makeProvider(lease);
     (provider as any).runtime.get = vi.fn(() => undefined);
-    mockQuery.mockImplementationOnce(() => { throw new Error("spawn failed"); });
+    const spawnError = new Error("spawn failed");
+    mockQuery.mockImplementationOnce(() => { throw spawnError; });
 
-    await expect((provider as any).sendTurn(request())).rejects.toThrow("spawn failed");
+    await expect((provider as any).sendTurn(request())).rejects.toBe(spawnError);
     expect(lease.status()).toEqual({ active: 0, pending: 0 });
   });
 

--- a/apps/server/src/providers/claude/claude-provider.ts
+++ b/apps/server/src/providers/claude/claude-provider.ts
@@ -473,6 +473,10 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
         req.interactionMode,
       ),
     };
+    const previousBrowserAccess = this.pendingBrowserAccess.get(req.sessionId);
+    if (previousBrowserAccess?.stage) {
+      this.browserAutomationSessionLease.release(previousBrowserAccess.stage.leaseId);
+    }
     this.pendingBrowserAccess.set(req.sessionId, {
       scope: browserScope,
       stage: this.browserAutomationSessionLease.stage(browserScope),
@@ -944,6 +948,9 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
       // close must not revoke a refreshed grant needed by replacement spawn.
       existing.browserLease = undefined;
       if (refreshed.ok) {
+        if (pendingBrowserAccess.stage) {
+          this.browserAutomationSessionLease.release(pendingBrowserAccess.stage.leaseId);
+        }
         pendingBrowserAccess.grant = refreshed.grant;
         pendingBrowserAccess.stage = undefined;
       } else {
@@ -1473,8 +1480,6 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
     if (pendingBrowserAccess?.grant && pendingBrowserAccess.stage) {
       this.browserAutomationSessionLease.release(pendingBrowserAccess.stage.leaseId);
     }
-    this.pendingBrowserAccess.delete(sessionId);
-
     // Capture the subprocess stderr tail so a non-zero exit (which the SDK
     // reports as a bare "process exited with code N") carries the actual CLI
     // error instead of an opaque code. Reset per spawn so a crash is never
@@ -1524,8 +1529,16 @@ export class ClaudeProvider extends EventEmitter implements IAgentProvider, IGoa
       q = this.withSdkSpawnEnv(() => sdkQuery({ prompt: queue.iterable, options }));
     } catch (error) {
       if (browserGrant) this.browserAutomationSessionLease.release(browserGrant.leaseId);
+      if (pendingBrowserAccess?.stage) {
+        this.browserAutomationSessionLease.release(pendingBrowserAccess.stage.leaseId);
+      }
+      this.pendingBrowserAccess.delete(sessionId);
       throw error;
     }
+    if (pendingBrowserAccess?.grant && pendingBrowserAccess.stage) {
+      this.browserAutomationSessionLease.release(pendingBrowserAccess.stage.leaseId);
+    }
+    this.pendingBrowserAccess.delete(sessionId);
 
     // Discover the newly-spawned child PID(s) so the runtime can JobObject-
     // attach and taskkill them. Mirrors the old `labelSdkSubprocess` diff, but


### PR DESCRIPTION
Repairs the merged #989 Claude browser lease regression.\n\n- Releases stale staged access during refreshed replacement.\n- Preserves the original SDK spawn error while cleaning lease state.\n- Covers replacement close and spawn failure cleanup deterministically.\n\nVerification: focused Claude/shared lease tests pass (8 tests). un run verify has unrelated server/process failures; live smoke is blocked by local Electron resolution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787975714&installation_model_id=20477&pr_number=1017&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1017&signature=10c9fdd84af906e439bc3944e3213150da0902886490e9f5be1edd1d7bf46c51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->