### PR TITLE
feat(server): migrate Copilot browser sessions to shared lease

### DIFF
--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -84,6 +84,7 @@ import { stubEnvService } from "./stub-env-service.js";
 import { stubJobObject } from "./stub-job-object.js";
 import { BrowserAutomationAccessService } from "../services/browser-automation/access-service.js";
 import { BrowserAutomationSessionLease } from "../services/browser-automation/browser-automation-session-lease.js";
+import { BrowserAutomationCredentialRegistry } from "../services/browser-automation/credential-registry.js";
 
 describe("ClaudeProvider permission mode changes", () => {
   let provider: ClaudeProvider;
@@ -98,8 +99,9 @@ describe("ClaudeProvider permission mode changes", () => {
   });
 
   it("passes browser MCP through query options without touching process.env", async () => {
-    const access = new BrowserAutomationAccessService();
-    const lease = new BrowserAutomationSessionLease(access.credentials);
+    const credentials = new BrowserAutomationCredentialRegistry();
+    const access = new BrowserAutomationAccessService(credentials);
+    const lease = new BrowserAutomationSessionLease(credentials);
     access.configure({
       mcpUrl: "http://127.0.0.1:19400/mcp",
       worktreeIdentity: "worktree-test",
@@ -110,28 +112,32 @@ describe("ClaudeProvider permission mode changes", () => {
     });
     provider = new ClaudeProvider(stubEnvService(), stubJobObject(), undefined, access, lease);
 
-    await provider.sendTurn({
-      sessionId: "mcode-browser-claude",
-      workspaceId: "workspace-test",
-      threadId: "browser-claude",
-      message: "inspect the page",
-      cwd: process.cwd(),
-      model: "claude-sonnet-4-6",
-      permissionMode: "supervised",
-      interactionMode: "build",
-      providerOptions: {},
-    });
+    try {
+      await provider.sendTurn({
+        sessionId: "mcode-browser-claude",
+        workspaceId: "workspace-test",
+        threadId: "browser-claude",
+        message: "inspect the page",
+        cwd: process.cwd(),
+        model: "claude-sonnet-4-6",
+        permissionMode: "supervised",
+        interactionMode: "build",
+        providerOptions: {},
+      });
 
-    expect(sdkCalls[0]!.options.mcpServers).toMatchObject({
-      "mcode-browser": {
-        type: "http",
-        url: "http://127.0.0.1:19400/mcp",
-        headers: { Authorization: expect.stringMatching(/^Bearer [A-Za-z0-9_-]{40,}$/) },
-      },
-    });
-    expect(process.env.MCODE_BROWSER_MCP_TOKEN).toBeUndefined();
-    await provider.stopSession("mcode-browser-claude");
-    expect(access.credentials.size()).toBe(0);
+      expect(sdkCalls[0]!.options.mcpServers).toMatchObject({
+        "mcode-browser": {
+          type: "http",
+          url: "http://127.0.0.1:19400/mcp",
+          headers: { Authorization: expect.stringMatching(/^Bearer [A-Za-z0-9_-]{40,}$/) },
+        },
+      });
+      expect(process.env.MCODE_BROWSER_MCP_TOKEN).toBeUndefined();
+      await provider.stopSession("mcode-browser-claude");
+    } finally {
+      lease.shutdown();
+    }
+    expect(credentials.size()).toBe(0);
   });
 
   it("reuses the session when permissionMode is unchanged", async () => {

--- a/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
+++ b/apps/server/src/__tests__/claude-provider-permission-mode.test.ts
@@ -83,6 +83,7 @@ import { ClaudeProvider } from "../providers/claude/claude-provider";
 import { stubEnvService } from "./stub-env-service.js";
 import { stubJobObject } from "./stub-job-object.js";
 import { BrowserAutomationAccessService } from "../services/browser-automation/access-service.js";
+import { BrowserAutomationSessionLease } from "../services/browser-automation/browser-automation-session-lease.js";
 
 describe("ClaudeProvider permission mode changes", () => {
   let provider: ClaudeProvider;
@@ -98,11 +99,16 @@ describe("ClaudeProvider permission mode changes", () => {
 
   it("passes browser MCP through query options without touching process.env", async () => {
     const access = new BrowserAutomationAccessService();
+    const lease = new BrowserAutomationSessionLease(access.credentials);
     access.configure({
       mcpUrl: "http://127.0.0.1:19400/mcp",
       worktreeIdentity: "worktree-test",
     });
-    provider = new ClaudeProvider(stubEnvService(), stubJobObject(), undefined, access);
+    lease.configure({
+      mcpUrl: "http://127.0.0.1:19400/mcp",
+      worktreeIdentity: "worktree-test",
+    });
+    provider = new ClaudeProvider(stubEnvService(), stubJobObject(), undefined, access, lease);
 
     await provider.sendTurn({
       sessionId: "mcode-browser-claude",

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -105,7 +105,7 @@ import which from "which";
 import { CopilotProvider } from "../providers/copilot/copilot-provider.js";
 import { stubEnvService } from "./stub-env-service.js";
 import { stubJobObject } from "./stub-job-object.js";
-import { BrowserAutomationAccessService } from "../services/browser-automation/access-service.js";
+import { BrowserAutomationSessionLease } from "../services/browser-automation/browser-automation-session-lease.js";
 
 /** Minimal SettingsService stub. */
 function makeSettingsService(cliPath = "") {
@@ -237,8 +237,8 @@ describe("CopilotProvider bootstrap", () => {
     mockClient.getState.mockReturnValue("connected");
     const mockSession = makeMockSession();
     mockClient.createSession.mockResolvedValue(mockSession);
-    const access = new BrowserAutomationAccessService();
-    access.configure({
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({
       mcpUrl: "http://127.0.0.1:19400/mcp",
       worktreeIdentity: "worktree-test",
     });
@@ -246,7 +246,7 @@ describe("CopilotProvider bootstrap", () => {
       makeSettingsService() as any,
       stubJobObject(),
       stubEnvService(),
-      access,
+      lease,
     );
 
     await provider.sendTurn({
@@ -270,7 +270,7 @@ describe("CopilotProvider bootstrap", () => {
     expect(config.mcpServers["mcode-browser"].tools).toHaveLength(17);
     expect(config.mcpServers["mcode-browser"].tools).not.toContain("browser_evaluate");
     await provider.stopSession("mcode-browser-copilot");
-    expect(access.credentials.size()).toBe(0);
+    expect(lease.credentials.size()).toBe(0);
   });
 
   describe("error translation", () => {

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -269,8 +269,89 @@ describe("CopilotProvider bootstrap", () => {
     });
     expect(config.mcpServers["mcode-browser"].tools).toHaveLength(17);
     expect(config.mcpServers["mcode-browser"].tools).not.toContain("browser_evaluate");
+    expect(lease.status()).toEqual({ active: 1, pending: 0 });
     await provider.stopSession("mcode-browser-copilot");
     expect(lease.credentials.size()).toBe(0);
+  });
+
+  it("recreates a pooled session after its browser lease is revoked externally", async () => {
+    mockClient.getState.mockReturnValue("connected");
+    const firstSession = makeMockSession();
+    const secondSession = makeMockSession();
+    mockClient.createSession.mockResolvedValueOnce(firstSession).mockResolvedValueOnce(secondSession);
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({ mcpUrl: "http://127.0.0.1:19400/mcp", worktreeIdentity: "worktree-test" });
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService(), lease);
+    const request = {
+      sessionId: "mcode-browser-revoked",
+      workspaceId: "workspace-test",
+      threadId: "browser-revoked",
+      message: "inspect the page",
+      cwd: "/tmp",
+      model: "gpt-4o",
+      interactionMode: "build" as const,
+      providerOptions: {},
+      permissionMode: "supervised" as const,
+    };
+
+    await provider.sendTurn(request);
+    const authHeader = mockClient.createSession.mock.calls[0]![0].mcpServers["mcode-browser"].headers.Authorization as string;
+    const claims = lease.credentials.authenticate(authHeader.slice("Bearer ".length));
+    expect(claims).not.toBeNull();
+    lease.credentials.revoke(claims!.credentialId);
+
+    await provider.sendTurn({ ...request, message: "inspect again" });
+
+    expect(mockClient.createSession).toHaveBeenCalledTimes(2);
+    expect(firstSession.disconnect).toHaveBeenCalled();
+    expect(lease.status()).toEqual({ active: 1, pending: 0 });
+    await provider.stopSession(request.sessionId);
+  });
+
+  it("releases staged browser access when spawning fails", async () => {
+    mockClient.getState.mockReturnValue("connected");
+    mockClient.createSession.mockRejectedValue(new Error("spawn failed"));
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({ mcpUrl: "http://127.0.0.1:19400/mcp", worktreeIdentity: "worktree-test" });
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService(), lease);
+
+    await expect(provider.sendTurn({
+      sessionId: "mcode-browser-spawn-failed",
+      workspaceId: "workspace-test",
+      threadId: "browser-spawn-failed",
+      message: "inspect the page",
+      cwd: "/tmp",
+      model: "gpt-4o",
+      interactionMode: "build",
+      providerOptions: {},
+      permissionMode: "supervised",
+    })).rejects.toThrow("spawn failed");
+
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
+  it("releases exactly one staged handle when sends overlap", async () => {
+    mockClient.getState.mockReturnValue("connected");
+    mockClient.createSession.mockResolvedValue(makeMockSession());
+    const lease = new BrowserAutomationSessionLease();
+    lease.configure({ mcpUrl: "http://127.0.0.1:19400/mcp", worktreeIdentity: "worktree-test" });
+    const provider = new CopilotProvider(makeSettingsService() as any, stubJobObject(), stubEnvService(), lease);
+    const request = {
+      sessionId: "mcode-browser-overlap",
+      workspaceId: "workspace-test",
+      threadId: "browser-overlap",
+      message: "inspect the page",
+      cwd: "/tmp",
+      model: "gpt-4o",
+      interactionMode: "build" as const,
+      providerOptions: {},
+      permissionMode: "supervised" as const,
+    };
+
+    await Promise.all([provider.sendTurn(request), provider.sendTurn({ ...request, message: "inspect again" })]);
+
+    expect(lease.status()).toEqual({ active: 1, pending: 0 });
+    await provider.stopSession(request.sessionId);
   });
 
   describe("error translation", () => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -79,6 +79,7 @@ import { resolveWebAutomationFlag } from "./startup-policy.js";
 import {
   BrowserAutomationAccessService,
   BrowserAutomationBroker,
+  BrowserAutomationCredentialRegistry,
   BrowserAutomationMcpHandler,
   BrowserAutomationSessionLease,
 } from "./services/browser-automation/index.js";
@@ -222,13 +223,14 @@ applyDevGitCheckoutEnv();
 const container = setupContainer(getMcodeDir());
 
 const browserAutomationAccess = container.resolve(BrowserAutomationAccessService);
+const browserAutomationCredentials = container.resolve(BrowserAutomationCredentialRegistry);
 const browserAutomationSessionLease = container.resolve(BrowserAutomationSessionLease);
 const browserAutomationBroker = new BrowserAutomationBroker({});
 const browserAutomationMcpHandler = new BrowserAutomationMcpHandler({
-  credentials: browserAutomationAccess.credentials,
+  credentials: browserAutomationCredentials,
   broker: browserAutomationBroker,
 });
-browserAutomationAccess.onCredentialRevoked((revocation) => {
+browserAutomationCredentials.onRemoved((revocation) => {
   browserAutomationMcpHandler.releaseCredential(revocation.credentialId);
   browserAutomationBroker.releaseProviderSession(
     revocation.providerId,
@@ -836,8 +838,8 @@ async function shutdown(): Promise<void> {
   // 3. Shutdown provider registry
   providerRegistry.shutdown();
   browserAutomationBroker.shutdown();
-  browserAutomationAccess.shutdown();
   browserAutomationSessionLease.shutdown();
+  browserAutomationAccess.shutdown();
 
   // 4. Mark active threads as interrupted
   threadService.markActiveThreadsInterrupted(activeThreadIds);

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -35,11 +35,14 @@ import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import { CleanForker } from "../../services/handoff/session-forker.js";
 import {
-  BrowserAutomationAccessService,
   browserAutomationPermissionCapability,
-  type BrowserAutomationAccessRequest,
   type BrowserAutomationCredentialMetadata,
 } from "../../services/browser-automation/access-service.js";
+import {
+  BrowserAutomationSessionLease,
+  type BrowserAutomationSessionLeaseScope,
+  type BrowserAutomationSessionLeaseStage,
+} from "../../services/browser-automation/browser-automation-session-lease.js";
 import type {
   IAgentProvider,
   ISessionEvictable,
@@ -173,6 +176,8 @@ interface CopilotSessionState {
   turnActive: boolean;
   /** Non-secret browser credential lifecycle metadata for this main session. */
   browserCredential?: BrowserAutomationCredentialMetadata;
+  /** Lease handle owning the browser credential for this main session. */
+  browserLeaseId?: string;
   /** Workspace fixed to this SDK session at creation. */
   workspaceId: string;
   /** Browser permission class fixed to this SDK session at creation. */
@@ -211,7 +216,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
    */
   private pendingSpawnTurns = new Map<string, { message: string; model?: string; copilotAgent?: string }>();
   /** Browser scope staged only until a fresh normal SDK session starts. */
-  private pendingBrowserAccess = new Map<string, BrowserAutomationAccessRequest>();
+  private pendingBrowserAccess = new Map<
+    string,
+    { scope: BrowserAutomationSessionLeaseScope; stage: BrowserAutomationSessionLeaseStage }
+  >();
   /** Serialises concurrent refreshClient() calls so only one rebuild runs at a time. */
   private clientStartLock: Promise<void> = Promise.resolve();
 
@@ -224,8 +232,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     @inject(SettingsService) private readonly settingsService: SettingsService,
     @inject("JobObject") private readonly jobObject: JobObject,
     @inject(EnvService) private readonly envService: EnvService,
-    @inject(BrowserAutomationAccessService)
-    private readonly browserAutomationAccess: BrowserAutomationAccessService = new BrowserAutomationAccessService(),
+    @inject(BrowserAutomationSessionLease)
+    private readonly browserAutomationLease: BrowserAutomationSessionLease = new BrowserAutomationSessionLease(),
   ) {
     super();
     this.runtime = new SessionRuntime<CopilotSessionState>(this, {
@@ -700,7 +708,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     if (req.resumeFrom !== undefined) {
       this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
     }
-    this.pendingBrowserAccess.set(req.sessionId, {
+    const browserScope: BrowserAutomationSessionLeaseScope = {
       providerId: this.id,
       providerSessionId: req.resumeFrom ?? req.sessionId,
       mcodeSessionId: req.sessionId,
@@ -710,6 +718,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
         req.permissionMode,
         req.interactionMode,
       ),
+    };
+    this.pendingBrowserAccess.set(req.sessionId, {
+      scope: browserScope,
+      stage: this.browserAutomationLease.stage(browserScope),
     });
     const params = {
       sessionId: req.sessionId,
@@ -794,17 +806,26 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     // Re-read after the async refreshClient() await so concurrent sends that
     // both passed the first check don't each create a new SDK session for the
     // same sessionId.
-    const existing = this.runtime.get(sessionId);
-    const browserScope = this.pendingBrowserAccess.get(sessionId);
+    let existing = this.runtime.get(sessionId);
+    const browserAccess = this.pendingBrowserAccess.get(sessionId);
+    const browserScope = browserAccess?.scope;
     if (
       existing &&
       browserScope &&
-      this.browserAutomationAccess.isConfigured() &&
+      this.browserAutomationLease.isConfigured() &&
       (existing.workspaceId !== browserScope.workspaceId ||
         existing.browserPermissionCapability !== browserScope.permissionCapability ||
         (existing.browserCredential && existing.browserCredential.expiresAt <= Date.now()))
     ) {
+      if (
+        existing.browserCredential &&
+        existing.browserLeaseId &&
+        existing.browserCredential.expiresAt <= Date.now()
+      ) {
+        this.browserAutomationLease.refresh(existing.browserLeaseId);
+      }
       await this.runtime.stop(sessionId);
+      existing = undefined;
     }
 
     // Stage the per-turn options (model, agent routing) so `spawn` can build a
@@ -824,10 +845,14 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
       });
     } catch (e: unknown) {
       this.pendingSpawnTurns.delete(sessionId);
+      if (browserAccess) this.browserAutomationLease.release(browserAccess.stage.leaseId);
       this.pendingBrowserAccess.delete(sessionId);
       throw e;
     }
     this.pendingSpawnTurns.delete(sessionId);
+    if (existing && browserAccess) {
+      this.browserAutomationLease.release(browserAccess.stage.leaseId);
+    }
     this.pendingBrowserAccess.delete(sessionId);
     this.runtime.recordUsage(sessionId);
 
@@ -886,8 +911,11 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
 
     const staged = this.pendingSpawnTurns.get(sessionId);
     const copilotAgent = staged?.copilotAgent;
-    const browserScope = this.pendingBrowserAccess.get(sessionId);
-    const browserGrant = browserScope ? this.browserAutomationAccess.issue(browserScope) : null;
+    const browserAccess = this.pendingBrowserAccess.get(sessionId);
+    const browserScope = browserAccess?.scope;
+    const browserGrant = browserAccess
+      ? this.browserAutomationLease.issue(browserAccess.stage)
+      : null;
 
     let session: CopilotSession;
 
@@ -951,7 +979,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
         session = await client.createSession(sessionBase);
       }
     } catch (error) {
-      if (browserGrant) this.browserAutomationAccess.revokeCredential(browserGrant.credentialId);
+      if (browserGrant) this.browserAutomationLease.release(browserGrant.leaseId);
       throw error;
     }
 
@@ -991,6 +1019,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
             credentialId: browserGrant.credentialId,
             expiresAt: browserGrant.expiresAt,
           },
+          browserLeaseId: browserGrant.leaseId,
         }),
       };
 
@@ -1002,7 +1031,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
 
       return { state, pids: [] };
     } catch (error) {
-      if (browserGrant) this.browserAutomationAccess.revokeCredential(browserGrant.credentialId);
+      if (browserGrant) this.browserAutomationLease.release(browserGrant.leaseId);
       await session.disconnect().catch(() => {});
       throw error;
     }
@@ -1035,7 +1064,11 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
    */
   async close(state: CopilotSessionState): Promise<void> {
     if (state.browserCredential) {
-      this.browserAutomationAccess.revokeCredential(state.browserCredential.credentialId);
+      if (state.browserLeaseId) {
+        this.browserAutomationLease.release(state.browserLeaseId);
+      } else {
+        this.browserAutomationLease.revokeCredential(state.browserCredential.credentialId);
+      }
     }
     try {
       await state.session.disconnect();
@@ -1344,6 +1377,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     if (this.runtime.get(sessionId) !== undefined) {
       await this.runtime.stop(sessionId);
     } else {
+      this.browserAutomationLease.releaseSession(this.id, sessionId);
       this.pendingStops.add(sessionId);
       this.pendingSpawnTurns.delete(sessionId);
       setTimeout(() => this.pendingStops.delete(sessionId), 10_000);
@@ -1367,6 +1401,9 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     );
     this.sdkSessionIds.clear();
     this.pendingSpawnTurns.clear();
+    for (const { stage } of this.pendingBrowserAccess.values()) {
+      this.browserAutomationLease.release(stage.leaseId);
+    }
     this.pendingBrowserAccess.clear();
     this.contextWindowBySession.clear();
 

--- a/apps/server/src/providers/copilot/copilot-provider.ts
+++ b/apps/server/src/providers/copilot/copilot-provider.ts
@@ -220,6 +220,8 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     string,
     { scope: BrowserAutomationSessionLeaseScope; stage: BrowserAutomationSessionLeaseStage }
   >();
+  /** Serialises setup of overlapping sends so staged browser handles cannot be overwritten. */
+  private sendLocks = new Map<string, Promise<void>>();
   /** Serialises concurrent refreshClient() calls so only one rebuild runs at a time. */
   private clientStartLock: Promise<void> = Promise.resolve();
 
@@ -704,6 +706,14 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
 
   /** Start or continue a session by sending a message via the Copilot SDK. When `copilotAgent` is provided, routes the session to the appropriate built-in mode or custom agent before sending. */
   async sendTurn(req: TurnRequest<"copilot">): Promise<void> {
+    const previousSend = this.sendLocks.get(req.sessionId) ?? Promise.resolve();
+    let releaseSend!: () => void;
+    const currentSend = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    this.sendLocks.set(req.sessionId, currentSend);
+    await previousSend;
+
     // `resumeFrom` defined ⇒ resume that SDK session; undefined ⇒ fresh.
     if (req.resumeFrom !== undefined) {
       this.sdkSessionIds.set(req.sessionId, req.resumeFrom);
@@ -719,10 +729,11 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
         req.interactionMode,
       ),
     };
-    this.pendingBrowserAccess.set(req.sessionId, {
+    const browserAccess = {
       scope: browserScope,
       stage: this.browserAutomationLease.stage(browserScope),
-    });
+    };
+    this.pendingBrowserAccess.set(req.sessionId, browserAccess);
     const params = {
       sessionId: req.sessionId,
       message: req.message,
@@ -773,7 +784,13 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
 
       throw e;
     } finally {
-      this.pendingBrowserAccess.delete(req.sessionId);
+      const currentBrowserAccess = this.pendingBrowserAccess.get(req.sessionId);
+      if (currentBrowserAccess === browserAccess) {
+        this.browserAutomationLease.release(browserAccess.stage.leaseId);
+        this.pendingBrowserAccess.delete(req.sessionId);
+      }
+      releaseSend();
+      if (this.sendLocks.get(req.sessionId) === currentSend) this.sendLocks.delete(req.sessionId);
     }
   }
 
@@ -815,12 +832,15 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
       this.browserAutomationLease.isConfigured() &&
       (existing.workspaceId !== browserScope.workspaceId ||
         existing.browserPermissionCapability !== browserScope.permissionCapability ||
-        (existing.browserCredential && existing.browserCredential.expiresAt <= Date.now()))
+        (existing.browserCredential &&
+          (existing.browserCredential.expiresAt <= Date.now() ||
+            (existing.browserLeaseId !== undefined && !this.browserAutomationLease.isActive(existing.browserLeaseId)))))
     ) {
       if (
         existing.browserCredential &&
         existing.browserLeaseId &&
-        existing.browserCredential.expiresAt <= Date.now()
+        existing.browserCredential.expiresAt <= Date.now() &&
+        this.browserAutomationLease.isActive(existing.browserLeaseId)
       ) {
         this.browserAutomationLease.refresh(existing.browserLeaseId);
       }
@@ -845,8 +865,10 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
       });
     } catch (e: unknown) {
       this.pendingSpawnTurns.delete(sessionId);
-      if (browserAccess) this.browserAutomationLease.release(browserAccess.stage.leaseId);
-      this.pendingBrowserAccess.delete(sessionId);
+      if (browserAccess) {
+        this.browserAutomationLease.release(browserAccess.stage.leaseId);
+        this.pendingBrowserAccess.delete(sessionId);
+      }
       throw e;
     }
     this.pendingSpawnTurns.delete(sessionId);
@@ -1401,6 +1423,7 @@ export class CopilotProvider extends EventEmitter implements IAgentProvider, ISe
     );
     this.sdkSessionIds.clear();
     this.pendingSpawnTurns.clear();
+    this.sendLocks.clear();
     for (const { stage } of this.pendingBrowserAccess.values()) {
       this.browserAutomationLease.release(stage.leaseId);
     }

--- a/apps/server/src/services/__tests__/external-thread-control-pairing-service.test.ts
+++ b/apps/server/src/services/__tests__/external-thread-control-pairing-service.test.ts
@@ -239,11 +239,12 @@ describe("external thread-control pairing service", () => {
     const service = new ExternalThreadControlPairingService(db as unknown as Database.Database);
     const secret = service.create(input());
     const authority = authenticate(service, secret.credential);
+    const retainedUntil = new Date(Date.now() + 60 * 60 * 1000).toISOString();
     for (let index = 0; index < 10_000; index += 1) {
       db.deliveries.push({
         pairing_id: authority.pairing.pairingId, authority_epoch: authority.pairing.authorityEpoch, delivery_id: `delivery-${index}`,
         fingerprint: "fingerprint", status: "in_flight", result_json: null,
-        created_at: "2026-07-29T00:00:00.000Z", updated_at: "2026-07-29T00:00:00.000Z", expires_at: "2026-07-30T00:00:00.000Z",
+        created_at: "2026-07-29T00:00:00.000Z", updated_at: "2026-07-29T00:00:00.000Z", expires_at: retainedUntil,
       });
     }
     expect(() => service.beginDelivery(authority, "delivery-new", "fingerprint")).toThrowError("External replay retention is full");

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
@@ -69,6 +69,15 @@ describe("BrowserAutomationSessionLease", () => {
     expect(lease.status()).toEqual({ active: 0, pending: 0 });
   });
 
+  it("reports a lease inactive after registry revocation", () => {
+    const lease = configuredLease();
+    const grant = lease.issue(scope())!;
+
+    expect(lease.isActive(grant.leaseId)).toBe(true);
+    lease.credentials.revoke(grant.credentialId);
+    expect(lease.isActive(grant.leaseId)).toBe(false);
+  });
+
   it("expires pending scopes and releases every credential on shutdown", () => {
     let now = 100;
     const registry = new BrowserAutomationCredentialRegistry({ idleTtlMs: 10, absoluteTtlMs: 100, now: () => now });

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
@@ -196,6 +196,14 @@ export class BrowserAutomationSessionLease {
     return this.configuration !== null;
   }
 
+  /** Returns whether an active lease still owns a retained registry credential. */
+  isActive(leaseId: string): boolean {
+    // Registry sweeps expired or evicted credentials from its own accessors and
+    // synchronously notifies this lease, so refresh state before checking it.
+    this.credentials.size();
+    return this.active.has(leaseId);
+  }
+
   /** Stages one bounded scope and returns its opaque lease handle. */
   stage(request: BrowserAutomationSessionLeaseRequest): BrowserAutomationSessionLeaseStage {
     this.cleanupPending();


### PR DESCRIPTION
## What
Migrates GitHub Copilot browser automation credentials and session lifecycle to the shared BrowserAutomationSessionLease.

## Why
Ensures Copilot uses the provider-neutral credential registry, revocation cleanup, bounded lease lifecycle, and shutdown ordering used by the other browser providers.

## Key Changes
- Registers and configures the shared lease with the existing MCP credential registry.
- Moves Copilot issue, refresh, revoke, failure, and shutdown cleanup to the shared lease while preserving Copilot descriptors, restart behavior, and events.
- Adds focused lifecycle coverage and aligns affected integration fixtures with the shared lease.

Closes #988

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787979136&installation_model_id=20477&pr_number=1018&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1018&signature=3ecc979ff30b74781947cfcb6854e572ccebf1628ab170c9575a0b9a3c0cd26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->