### PR TITLE
fix(cursor): migrate browser sessions to shared lease

### DIFF
--- a/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
@@ -1,9 +1,32 @@
 import "reflect-metadata";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import {
+  BrowserAutomationSessionLease,
+  type BrowserAutomationSessionLeaseGrant,
+  type BrowserAutomationSessionLeaseScope,
+  type BrowserAutomationSessionLeaseStage,
+} from "../../../services/browser-automation/browser-automation-session-lease.js";
 import {
   buildCursorBrowserMcpServers,
+  CursorProvider,
   cursorSupportsHttpMcp,
 } from "../cursor-provider.js";
+
+const browserScope = (overrides: Partial<BrowserAutomationSessionLeaseScope> = {}) => ({
+  providerId: "cursor",
+  providerSessionId: "provider-a",
+  mcodeSessionId: "mcode-a",
+  threadId: "thread-a",
+  workspaceId: "workspace-a",
+  permissionCapability: "interact" as const,
+  ...overrides,
+});
+
+function configuredLease(): BrowserAutomationSessionLease {
+  const lease = new BrowserAutomationSessionLease();
+  lease.configure({ mcpUrl: "http://127.0.0.1:19400/mcp", worktreeIdentity: "worktree-a" });
+  return lease;
+}
 
 describe("Cursor browser MCP configuration", () => {
   it("uses ACP HTTP headers for a normal main-session grant", () => {
@@ -26,5 +49,57 @@ describe("Cursor browser MCP configuration", () => {
     expect(cursorSupportsHttpMcp({})).toBe(false);
     expect(cursorSupportsHttpMcp({ agentCapabilities: { mcpCapabilities: { http: false } } })).toBe(false);
     expect(cursorSupportsHttpMcp({ agentCapabilities: { mcpCapabilities: { http: true } } })).toBe(true);
+  });
+
+  it("releases session lease when Cursor closes a pooled session", () => {
+    const lease = configuredLease();
+    const grant = lease.issue(browserScope())!;
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.browserAutomationLease = lease;
+    provider.pendingPermissions = new Map();
+    provider.liveSessionIds = new Set(["mcode-a"]);
+
+    provider.close({ mcodeSessionId: "mcode-a" } as never);
+
+    expect(lease.credentials.authenticate(grant.token)).toBeNull();
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+    expect(provider.liveSessionIds.has("mcode-a")).toBe(false);
+  });
+
+  it("keeps a refreshed grant alive while the replacement session is opening", () => {
+    const lease = configuredLease();
+    const grant = lease.issue(browserScope())!;
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.browserAutomationLease = lease;
+    provider.pendingPermissions = new Map();
+    provider.pendingBrowserGrants = new Map([["mcode-a", grant]]);
+    provider.liveSessionIds = new Set(["mcode-a"]);
+
+    provider.close({ mcodeSessionId: "mcode-a" } as never);
+
+    expect(lease.credentials.authenticate(grant.token)?.mcodeSessionId).toBe("mcode-a");
+    lease.release(grant.leaseId);
+  });
+
+  it("releases staged and refreshed leases during shutdown", () => {
+    const lease = configuredLease();
+    const staged = lease.stage(browserScope());
+    const grant = lease.issue(browserScope({ mcodeSessionId: "mcode-b", providerSessionId: "provider-b" }))!;
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.browserAutomationLease = lease;
+    provider.pendingPermissions = new Map();
+    provider.pendingBrowserLeases = new Map([["mcode-a", staged satisfies BrowserAutomationSessionLeaseStage]]);
+    provider.pendingBrowserContext = new Map();
+    provider.pendingBrowserGrants = new Map([["mcode-b", grant satisfies BrowserAutomationSessionLeaseGrant]]);
+    provider.pendingBrowserGrantContext = new Map();
+    provider.planQuestionModeThreads = new Set();
+    provider.sdkSessionIds = new Map();
+    provider.liveSessionIds = new Set();
+    provider.runtime = { shutdown: vi.fn().mockResolvedValue(undefined) };
+
+    provider.shutdown();
+
+    expect(lease.credentials.authenticate(grant.token)).toBeNull();
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
   });
 });

--- a/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
@@ -133,6 +133,54 @@ describe("Cursor browser MCP configuration", () => {
     expect(child.kill).not.toHaveBeenCalled();
   });
 
+  it("continues without MCP when browser lease is unconfigured", async () => {
+    const lease = new BrowserAutomationSessionLease();
+    const child = { pid: 107, kill: vi.fn() };
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.id = "cursor";
+    provider.settingsService = { get: vi.fn(() => ({})) };
+    provider.browserAutomationLease = lease;
+    provider.pendingPermissions = new Map();
+    provider.pendingBrowserLeases = new Map();
+    provider.pendingBrowserContext = new Map();
+    provider.pendingBrowserGrants = new Map();
+    provider.pendingBrowserGrantContext = new Map();
+    provider.pendingStops = new Set();
+    provider.liveSessionIds = new Set();
+    provider.planQuestionModeThreads = new Set();
+    provider.sdkSessionIds = new Map();
+    provider.spawnChild = vi.fn().mockResolvedValue({
+      child,
+      browserHttpMcpSupported: true,
+      turnChain: Promise.resolve(),
+    });
+    let mcpServers: unknown;
+    provider.openLogicalSession = vi.fn(async (_state: unknown, _resume: boolean, servers: unknown) => {
+      mcpServers = servers;
+    });
+    provider.runTurn = vi.fn().mockResolvedValue(undefined);
+    provider.runtime = {
+      get: vi.fn().mockReturnValue(undefined),
+      stop: vi.fn(),
+      acquire: vi.fn(async (args: any) => (await provider.spawn({ ...args, env: {} })).state),
+      recordUsage: vi.fn(),
+    };
+
+    await provider.sendTurn({
+      sessionId: "mcode-a",
+      threadId: "thread-a",
+      workspaceId: "workspace-a",
+      cwd: ".",
+      message: "hello",
+      model: "auto",
+      permissionMode: "default",
+      interactionMode: "build",
+    });
+
+    expect(mcpServers).toEqual([]);
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
   it("releases a preserved lease when stale replacement setup fails", async () => {
     const lease = configuredLease();
     const previousGrant = lease.issue(browserScope())!;

--- a/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
@@ -1,5 +1,8 @@
 import "reflect-metadata";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
+
 import {
   BrowserAutomationSessionLease,
   type BrowserAutomationSessionLeaseGrant,
@@ -11,6 +14,12 @@ import {
   CursorProvider,
   cursorSupportsHttpMcp,
 } from "../cursor-provider.js";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawn: spawnMock };
+});
 
 const browserScope = (overrides: Partial<BrowserAutomationSessionLeaseScope> = {}) => ({
   providerId: "cursor",
@@ -33,9 +42,6 @@ describe("Cursor browser MCP configuration", () => {
     expect(buildCursorBrowserMcpServers({
       mcpUrl: "http://127.0.0.1:19400/mcp",
       token: "opaque-token",
-      credentialId: "credential-a",
-      expiresAt: 10,
-      allowedOperations: ["status"],
     })).toEqual([{
       type: "http",
       name: "mcode-browser",
@@ -55,8 +61,10 @@ describe("Cursor browser MCP configuration", () => {
     const lease = configuredLease();
     const grant = lease.issue(browserScope())!;
     const provider = Object.create(CursorProvider.prototype) as any;
+    provider.id = "cursor";
     provider.browserAutomationLease = lease;
     provider.pendingPermissions = new Map();
+    provider.pendingBrowserGrants = new Map();
     provider.liveSessionIds = new Set(["mcode-a"]);
 
     provider.close({ mcodeSessionId: "mcode-a" } as never);
@@ -64,6 +72,114 @@ describe("Cursor browser MCP configuration", () => {
     expect(lease.credentials.authenticate(grant.token)).toBeNull();
     expect(lease.status()).toEqual({ active: 0, pending: 0 });
     expect(provider.liveSessionIds.has("mcode-a")).toBe(false);
+  });
+
+  it("kills spawned child and releases staged lease when issuance fails", async () => {
+    const lease = configuredLease();
+    const staged = lease.stage(browserScope({ allowedOperations: ["evaluate"] } as never));
+    const child = { pid: 101, kill: vi.fn() };
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.settingsService = { get: vi.fn(() => ({})) };
+    provider.browserAutomationLease = lease;
+    provider.pendingBrowserLeases = new Map([["mcode-a", staged]]);
+    provider.pendingBrowserContext = new Map();
+    provider.pendingBrowserGrants = new Map();
+    provider.pendingBrowserGrantContext = new Map();
+    provider.liveSessionIds = new Set();
+    provider.spawnChild = vi.fn().mockResolvedValue({ child, browserHttpMcpSupported: true });
+
+    await expect(provider.spawn({
+      sessionId: "mcode-a",
+      threadId: "thread-a",
+      cwd: ".",
+      permissionMode: "default",
+      env: {},
+    })).rejects.toThrow(/Evaluate requires/);
+
+    expect(child.kill).toHaveBeenCalledOnce();
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
+  it("releases staged and refreshed leases and omits MCP when HTTP support is unavailable", async () => {
+    const lease = configuredLease();
+    const staged = lease.stage(browserScope());
+    const refreshed = lease.issue(browserScope());
+    const child = { pid: 102, kill: vi.fn() };
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.settingsService = { get: vi.fn(() => ({})) };
+    provider.browserAutomationLease = lease;
+    provider.pendingBrowserLeases = new Map([["mcode-a", staged]]);
+    provider.pendingBrowserContext = new Map();
+    provider.pendingBrowserGrants = new Map([["mcode-a", refreshed]]);
+    provider.pendingBrowserGrantContext = new Map();
+    provider.liveSessionIds = new Set();
+    provider.spawnChild = vi.fn().mockResolvedValue({ child, browserHttpMcpSupported: false });
+    let mcpServers: unknown;
+    provider.openLogicalSession = vi.fn(async (_state: unknown, _resume: boolean, servers: unknown) => {
+      mcpServers = servers;
+    });
+
+    await provider.spawn({
+      sessionId: "mcode-a",
+      threadId: "thread-a",
+      cwd: ".",
+      permissionMode: "default",
+      env: {},
+    });
+
+    expect(mcpServers).toEqual([]);
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("kills child and releases issued lease when logical session setup fails", async () => {
+    const lease = configuredLease();
+    const staged = lease.stage(browserScope());
+    const child = { pid: 103, kill: vi.fn() };
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.settingsService = { get: vi.fn(() => ({})) };
+    provider.browserAutomationLease = lease;
+    provider.pendingBrowserLeases = new Map([["mcode-a", staged]]);
+    provider.pendingBrowserContext = new Map();
+    provider.pendingBrowserGrants = new Map();
+    provider.pendingBrowserGrantContext = new Map();
+    provider.liveSessionIds = new Set();
+    provider.spawnChild = vi.fn().mockResolvedValue({ child, browserHttpMcpSupported: true });
+    provider.openLogicalSession = vi.fn().mockRejectedValue(new Error("logical session failed"));
+
+    await expect(provider.spawn({
+      sessionId: "mcode-a",
+      threadId: "thread-a",
+      cwd: ".",
+      permissionMode: "default",
+      env: {},
+    })).rejects.toThrow("logical session failed");
+
+    expect(child.kill).toHaveBeenCalledOnce();
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
+  it("kills child when ACP handshake fails before spawn returns", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      pid: 104,
+      kill: vi.fn(),
+    });
+    spawnMock.mockReturnValue(child as never);
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.envService = { getEnv: vi.fn(() => ({})) };
+    provider.settingsService = { get: vi.fn(() => ({ provider: { cursor: { verboseFailureLogs: false } } })) };
+    provider.pendingBrowserContext = new Map();
+    vi.spyOn(provider, "acpHandshake").mockRejectedValue(new Error("handshake failed"));
+
+    await expect(provider.spawnOneCli("cursor-agent", "mcode-a", "C:\\", "default")).rejects.toThrow(
+      "handshake failed",
+    );
+
+    expect(child.kill).toHaveBeenCalledOnce();
+    spawnMock.mockReset();
   });
 
   it("keeps a refreshed grant alive while the replacement session is opening", () => {

--- a/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
@@ -193,6 +193,41 @@ describe("Cursor browser MCP configuration", () => {
     expect(lease.status()).toEqual({ active: 0, pending: 0 });
   });
 
+  it("fails closed when stale replacement lease stage expires", async () => {
+    let now = 0;
+    const lease = new BrowserAutomationSessionLease({ now: () => now });
+    lease.configure({ mcpUrl: "http://127.0.0.1:19400/mcp", worktreeIdentity: "worktree-a" });
+    const previousGrant = lease.issue(browserScope())!;
+    const staged = lease.stage(browserScope());
+    now = staged.expiresAt;
+    const child = { pid: 106, kill: vi.fn() };
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.id = "cursor";
+    provider.settingsService = { get: vi.fn(() => ({})) };
+    provider.browserAutomationLease = lease;
+    provider.pendingPermissions = new Map();
+    provider.pendingBrowserLeases = new Map([["mcode-a", staged]]);
+    provider.pendingBrowserContext = new Map();
+    provider.pendingBrowserGrants = new Map();
+    provider.pendingBrowserGrantContext = new Map();
+    provider.liveSessionIds = new Set();
+    provider.spawnChild = vi.fn().mockResolvedValue({ child, browserHttpMcpSupported: true });
+    provider.openLogicalSession = vi.fn();
+
+    await expect(provider.spawn({
+      sessionId: "mcode-a",
+      threadId: "thread-a",
+      cwd: ".",
+      permissionMode: "default",
+      env: {},
+    })).rejects.toThrow("Cursor browser automation lease issuance failed");
+
+    expect(provider.openLogicalSession).not.toHaveBeenCalled();
+    expect(child.kill).toHaveBeenCalledOnce();
+    expect(lease.credentials.authenticate(previousGrant.token)).toBeNull();
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
   it("kills child and releases issued lease when logical session setup fails", async () => {
     const lease = configuredLease();
     const staged = lease.stage(browserScope());

--- a/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
@@ -64,6 +64,7 @@ describe("Cursor browser MCP configuration", () => {
     provider.id = "cursor";
     provider.browserAutomationLease = lease;
     provider.pendingPermissions = new Map();
+    provider.pendingBrowserLeases = new Map();
     provider.pendingBrowserGrants = new Map();
     provider.liveSessionIds = new Set(["mcode-a"]);
 
@@ -195,6 +196,82 @@ describe("Cursor browser MCP configuration", () => {
 
     expect(lease.credentials.authenticate(grant.token)?.mcodeSessionId).toBe("mcode-a");
     lease.release(grant.leaseId);
+  });
+
+  it("propagates MCP grant when a stale pooled session is replaced", async () => {
+    const lease = configuredLease();
+    const previousGrant = lease.issue(browserScope())!;
+    const provider = Object.create(CursorProvider.prototype) as any;
+    const existing = {
+      child: { exitCode: 1, signalCode: null },
+      workspaceId: "workspace-a",
+      browserPermissionCapability: "interact",
+      browserCredential: {
+        credentialId: previousGrant.credentialId,
+        expiresAt: previousGrant.expiresAt,
+        leaseId: previousGrant.leaseId,
+      },
+      mcodeSessionId: "mcode-a",
+      threadId: "thread-a",
+      cwd: ".",
+      permissionMode: "default",
+      turnChain: Promise.resolve(),
+      lastUsedAt: Date.now(),
+      activeTurnState: null,
+    };
+    const replacement = {
+      ...existing,
+      child: { pid: 105, kill: vi.fn() },
+      browserCredential: undefined,
+      browserHttpMcpSupported: true,
+    };
+    let mcpServers: unknown;
+    provider.id = "cursor";
+    provider.browserAutomationLease = lease;
+    provider.settingsService = { get: vi.fn(() => ({})) };
+    provider.pendingPermissions = new Map();
+    provider.pendingBrowserLeases = new Map();
+    provider.pendingBrowserContext = new Map();
+    provider.pendingBrowserGrants = new Map();
+    provider.pendingBrowserGrantContext = new Map();
+    provider.pendingStops = new Set();
+    provider.liveSessionIds = new Set(["mcode-a"]);
+    provider.planQuestionModeThreads = new Set();
+    provider.spawnChild = vi.fn().mockResolvedValue(replacement);
+    provider.openLogicalSession = vi.fn(async (_state: unknown, _resume: boolean, servers: unknown) => {
+      mcpServers = servers;
+    });
+    provider.runTurn = vi.fn().mockResolvedValue(undefined);
+    provider.runtime = {
+      get: vi.fn().mockReturnValueOnce(existing).mockReturnValue(undefined),
+      stop: vi.fn(async () => provider.close(existing)),
+      acquire: vi.fn(async (args: any) => (await provider.spawn({ ...args, env: {} })).state),
+      recordUsage: vi.fn(),
+    };
+
+    await provider.sendTurn({
+      sessionId: "mcode-a",
+      threadId: "thread-a",
+      workspaceId: "workspace-a",
+      cwd: ".",
+      message: "hello",
+      model: "auto",
+      permissionMode: "default",
+      interactionMode: "build",
+    });
+
+    expect(mcpServers).toEqual([{
+      type: "http",
+      name: "mcode-browser",
+      url: "http://127.0.0.1:19400/mcp",
+      headers: [{
+        name: "Authorization",
+        value: expect.stringMatching(/^Bearer /),
+      }],
+    }]);
+    const authorization = (mcpServers as any[])[0].headers[0].value as string;
+    expect(lease.credentials.authenticate(authorization.slice("Bearer ".length))?.mcodeSessionId).toBe("mcode-a");
+    expect(lease.credentials.authenticate(previousGrant.token)).toBeNull();
   });
 
   it("releases staged and refreshed leases during shutdown", () => {

--- a/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
@@ -201,7 +201,13 @@ describe("Cursor browser MCP configuration", () => {
     const lease = configuredLease();
     const staged = lease.stage(browserScope());
     const grant = lease.issue(browserScope({ mcodeSessionId: "mcode-b", providerSessionId: "provider-b" }))!;
+    const unrelatedGrant = lease.issue(browserScope({
+      providerId: "claude",
+      mcodeSessionId: "mcode-other",
+      providerSessionId: "provider-other",
+    }))!;
     const provider = Object.create(CursorProvider.prototype) as any;
+    provider.id = "cursor";
     provider.browserAutomationLease = lease;
     provider.pendingPermissions = new Map();
     provider.pendingBrowserLeases = new Map([["mcode-a", staged satisfies BrowserAutomationSessionLeaseStage]]);
@@ -210,12 +216,13 @@ describe("Cursor browser MCP configuration", () => {
     provider.pendingBrowserGrantContext = new Map();
     provider.planQuestionModeThreads = new Set();
     provider.sdkSessionIds = new Map();
-    provider.liveSessionIds = new Set();
+    provider.liveSessionIds = new Set(["mcode-b"]);
     provider.runtime = { shutdown: vi.fn().mockResolvedValue(undefined) };
 
     provider.shutdown();
 
     expect(lease.credentials.authenticate(grant.token)).toBeNull();
-    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+    expect(lease.credentials.authenticate(unrelatedGrant.token)?.providerId).toBe("claude");
+    expect(lease.status()).toEqual({ active: 1, pending: 0 });
   });
 });

--- a/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
+++ b/apps/server/src/providers/cursor/__tests__/cursor-browser-mcp.test.ts
@@ -133,6 +133,66 @@ describe("Cursor browser MCP configuration", () => {
     expect(child.kill).not.toHaveBeenCalled();
   });
 
+  it("releases a preserved lease when stale replacement setup fails", async () => {
+    const lease = configuredLease();
+    const previousGrant = lease.issue(browserScope())!;
+    const staged = lease.stage(browserScope());
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.id = "cursor";
+    provider.settingsService = { get: vi.fn(() => ({})) };
+    provider.browserAutomationLease = lease;
+    provider.pendingPermissions = new Map();
+    provider.pendingBrowserLeases = new Map([["mcode-a", staged]]);
+    provider.pendingBrowserContext = new Map();
+    provider.pendingBrowserGrants = new Map();
+    provider.pendingBrowserGrantContext = new Map();
+    provider.liveSessionIds = new Set(["mcode-a"]);
+    provider.close({ mcodeSessionId: "mcode-a" } as never);
+    provider.spawnChild = vi.fn().mockRejectedValue(new Error("replacement failed"));
+
+    await expect(provider.spawn({
+      sessionId: "mcode-a",
+      threadId: "thread-a",
+      cwd: ".",
+      permissionMode: "default",
+      env: {},
+    })).rejects.toThrow("replacement failed");
+
+    expect(lease.credentials.authenticate(previousGrant.token)).toBeNull();
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
+  it("releases a preserved lease when stale replacement lacks HTTP MCP", async () => {
+    const lease = configuredLease();
+    const previousGrant = lease.issue(browserScope())!;
+    const staged = lease.stage(browserScope());
+    const child = { pid: 105, kill: vi.fn() };
+    const provider = Object.create(CursorProvider.prototype) as any;
+    provider.id = "cursor";
+    provider.settingsService = { get: vi.fn(() => ({})) };
+    provider.browserAutomationLease = lease;
+    provider.pendingPermissions = new Map();
+    provider.pendingBrowserLeases = new Map([["mcode-a", staged]]);
+    provider.pendingBrowserContext = new Map();
+    provider.pendingBrowserGrants = new Map();
+    provider.pendingBrowserGrantContext = new Map();
+    provider.liveSessionIds = new Set(["mcode-a"]);
+    provider.close({ mcodeSessionId: "mcode-a" } as never);
+    provider.spawnChild = vi.fn().mockResolvedValue({ child, browserHttpMcpSupported: false });
+    provider.openLogicalSession = vi.fn();
+
+    await provider.spawn({
+      sessionId: "mcode-a",
+      threadId: "thread-a",
+      cwd: ".",
+      permissionMode: "default",
+      env: {},
+    });
+
+    expect(lease.credentials.authenticate(previousGrant.token)).toBeNull();
+    expect(lease.status()).toEqual({ active: 0, pending: 0 });
+  });
+
   it("kills child and releases issued lease when logical session setup fails", async () => {
     const lease = configuredLease();
     const staged = lease.stage(browserScope());

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -617,6 +617,7 @@ export class CursorProvider
         }
       } else {
         this.releaseBrowserLeases(browserStage, refreshedGrant);
+        this.browserAutomationLease.releaseSession(this.id, sessionId);
         this.pendingBrowserGrants.delete(sessionId);
         this.pendingBrowserGrantContext.delete(sessionId);
       }
@@ -696,6 +697,7 @@ export class CursorProvider
     ...leases: Array<{ leaseId: string } | null | undefined>
   ): void {
     this.releaseBrowserLeases(...leases);
+    this.browserAutomationLease.releaseSession(this.id, sessionId);
     this.pendingBrowserLeases.delete(sessionId);
     this.pendingBrowserContext.delete(sessionId);
     this.pendingBrowserGrants.delete(sessionId);

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -350,13 +350,36 @@ export class CursorProvider
         existing.browserPermissionCapability !== browserPermissionCapability;
       const browserExpired = existing.browserCredential !== undefined &&
         existing.browserCredential.expiresAt <= Date.now();
-      if (browserContextChanged || browserExpired) {
+      const acquireWillReplace = this.isStale(existing, { cwd, permissionMode });
+      if (browserContextChanged || browserExpired || acquireWillReplace) {
         if (!browserContextChanged && browserExpired && existing.browserCredential) {
           const refreshed = this.browserAutomationLease.refresh(existing.browserCredential.leaseId);
           if (refreshed.ok) {
             this.pendingBrowserGrants.set(sessionId, refreshed.grant);
             this.pendingBrowserGrantContext.set(sessionId, browserContext);
             existing.browserCredential = undefined;
+          }
+        }
+        if (acquireWillReplace && !this.pendingBrowserGrants.has(sessionId)) {
+          browserStage = this.pendingBrowserLeases.get(sessionId);
+          const stagedContext = this.pendingBrowserContext.get(sessionId);
+          if (browserStage && (!stagedContext || !this.sameBrowserContext(stagedContext, browserContext))) {
+            this.releaseBrowserLeases(browserStage);
+            this.pendingBrowserLeases.delete(sessionId);
+            this.pendingBrowserContext.delete(sessionId);
+            browserStage = undefined;
+          }
+          if (!browserStage) {
+            browserStage = this.browserAutomationLease.stage({
+              providerId: this.id,
+              providerSessionId: req.resumeFrom ?? sessionId,
+              mcodeSessionId: sessionId,
+              threadId: req.threadId,
+              workspaceId: req.workspaceId,
+              permissionCapability: browserPermissionCapability,
+            });
+            this.pendingBrowserLeases.set(sessionId, browserStage);
+            this.pendingBrowserContext.set(sessionId, browserContext);
           }
         }
         await this.runtime.stop(sessionId);
@@ -648,7 +671,7 @@ export class CursorProvider
   close(state: CursorSessionState): void {
     this.cancelPendingForThread(state.mcodeSessionId);
     this.liveSessionIds.delete(state.mcodeSessionId);
-    if (!this.pendingBrowserGrants.has(state.mcodeSessionId)) {
+    if (!this.pendingBrowserGrants.has(state.mcodeSessionId) && !this.pendingBrowserLeases.has(state.mcodeSessionId)) {
       this.browserAutomationLease.releaseSession(this.id, state.mcodeSessionId);
     }
   }

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -575,37 +575,35 @@ export class CursorProvider
     const { sessionId, threadId, cwd, permissionMode, resumeFrom } = args;
     const pm: "full" | "default" = permissionMode === "full" ? "full" : "default";
     const settings = this.settingsService.get();
-    const state = await this.spawnChild(sessionId, threadId, cwd, pm, settings);
     const browserStage = this.pendingBrowserLeases.get(sessionId);
     const refreshedGrant = this.pendingBrowserGrants.get(sessionId);
     let browserGrant: BrowserAutomationSessionLeaseGrant | null = null;
-    if (state.browserHttpMcpSupported) {
-      if (refreshedGrant) {
-        browserGrant = refreshedGrant;
+    let state: CursorAcpSessionEntry | undefined;
+    try {
+      state = await this.spawnChild(sessionId, threadId, cwd, pm, settings);
+      if (state.browserHttpMcpSupported) {
+        if (refreshedGrant) {
+          browserGrant = refreshedGrant;
+          this.pendingBrowserGrants.delete(sessionId);
+          this.pendingBrowserGrantContext.delete(sessionId);
+          if (browserStage) this.releaseBrowserLeases(browserStage);
+        } else if (browserStage) {
+          browserGrant = this.browserAutomationLease.issue(browserStage);
+        }
+      } else {
+        this.releaseBrowserLeases(browserStage, refreshedGrant);
         this.pendingBrowserGrants.delete(sessionId);
         this.pendingBrowserGrantContext.delete(sessionId);
-        if (browserStage) this.releaseBrowserLeases(browserStage);
-      } else if (browserStage) {
-        browserGrant = this.browserAutomationLease.issue(browserStage);
       }
-    } else {
-      this.releaseBrowserLeases(browserStage, refreshedGrant);
-      this.pendingBrowserGrants.delete(sessionId);
-      this.pendingBrowserGrantContext.delete(sessionId);
-    }
-    if (browserStage && !state.browserHttpMcpSupported) {
-      logger.info("Cursor ACP does not advertise HTTP MCP; browser automation is unavailable", {
-        threadId,
-      });
-    }
-    const mcpServers = buildCursorBrowserMcpServers(browserGrant);
+      if (browserStage && !state.browserHttpMcpSupported) {
+        logger.info("Cursor ACP does not advertise HTTP MCP; browser automation is unavailable", {
+          threadId,
+        });
+      }
+      const mcpServers = buildCursorBrowserMcpServers(browserGrant);
 
-    // Open the logical ACP session up front so reuse paths see a ready
-    // `acpSessionId`. `runTurn`'s own `openLogicalSession` call then early-returns.
-    // If the handshake throws, the runtime never received the child's pid, so
-    // it cannot kill it on `stop`. Tear the child down here before rethrowing
-    // so the subprocess does not leak.
-    try {
+      // Open logical ACP session before runtime registration so every setup
+      // failure tears down child and browser state through one boundary.
       await this.openLogicalSession(state, resumeFrom !== undefined, mcpServers);
       if (browserGrant) {
         state.browserCredential = {
@@ -615,17 +613,7 @@ export class CursorProvider
         };
       }
     } catch (err) {
-      this.releaseBrowserLeases(browserGrant, browserStage, refreshedGrant);
-      this.pendingBrowserLeases.delete(sessionId);
-      this.pendingBrowserContext.delete(sessionId);
-      this.pendingBrowserGrants.delete(sessionId);
-      this.pendingBrowserGrantContext.delete(sessionId);
-      this.liveSessionIds.delete(sessionId);
-      try {
-        state.child.kill();
-      } catch {
-        /* best-effort: the child may already be gone */
-      }
+      this.cleanupSpawnFailure(sessionId, state, browserGrant, browserStage, refreshedGrant);
       throw err;
     }
 
@@ -677,6 +665,24 @@ export class CursorProvider
     }
   }
 
+  private cleanupSpawnFailure(
+    sessionId: string,
+    state: CursorAcpSessionEntry | undefined,
+    ...leases: Array<{ leaseId: string } | null | undefined>
+  ): void {
+    this.releaseBrowserLeases(...leases);
+    this.pendingBrowserLeases.delete(sessionId);
+    this.pendingBrowserContext.delete(sessionId);
+    this.pendingBrowserGrants.delete(sessionId);
+    this.pendingBrowserGrantContext.delete(sessionId);
+    this.liveSessionIds.delete(sessionId);
+    try {
+      state?.child.kill();
+    } catch {
+      /* best-effort: the child may already be gone */
+    }
+  }
+
   /** A pooled session must be discarded before reuse if the child died or the cwd/permission mode changed. */
   isStale(state: CursorSessionState, args: { cwd: string; permissionMode: string }): boolean {
     const dead = state.child.exitCode != null || state.child.signalCode != null;
@@ -725,6 +731,11 @@ export class CursorProvider
     });
 
     if (!child.stdin || !child.stdout) {
+      try {
+        child.kill();
+      } catch {
+        /* best-effort: the child may already be gone */
+      }
       throw new Error("Failed to spawn cursor-agent: stdio pipes unavailable");
     }
 
@@ -792,7 +803,16 @@ export class CursorProvider
       void this.runtime.stop(mcodeSessionId);
     });
 
-    entry.browserHttpMcpSupported = await this.acpHandshake(connection, threadId);
+    try {
+      entry.browserHttpMcpSupported = await this.acpHandshake(connection, threadId);
+    } catch (error) {
+      try {
+        child.kill();
+      } catch {
+        /* best-effort: the child may already be gone */
+      }
+      throw error;
+    }
 
     return entry as CursorAcpSessionEntry;
   }

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -369,7 +369,7 @@ export class CursorProvider
             this.pendingBrowserContext.delete(sessionId);
             browserStage = undefined;
           }
-          if (!browserStage) {
+          if (this.browserAutomationLease.isConfigured() && !browserStage) {
             browserStage = this.browserAutomationLease.stage({
               providerId: this.id,
               providerSessionId: req.resumeFrom ?? sessionId,
@@ -401,7 +401,11 @@ export class CursorProvider
           browserStage = undefined;
         }
       }
-      if (!browserStage && !this.pendingBrowserGrants.has(sessionId)) {
+      if (
+        this.browserAutomationLease.isConfigured() &&
+        !browserStage &&
+        !this.pendingBrowserGrants.has(sessionId)
+      ) {
         browserStage = this.browserAutomationLease.stage({
           providerId: this.id,
           providerSessionId: req.resumeFrom ?? sessionId,
@@ -1168,7 +1172,7 @@ export class CursorProvider
     const sessionId = dead.mcodeSessionId;
     this.logAcpChildDisconnect(dead, "ACP connection closed");
     await this.runtime.stop(sessionId);
-    const browserStage = dead.browserHttpMcpSupported
+    const browserStage = this.browserAutomationLease.isConfigured() && dead.browserHttpMcpSupported
       ? this.browserAutomationLease.stage({
         providerId: this.id,
         providerSessionId: this.sdkSessionIds.get(sessionId) ?? sessionId,

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -614,6 +614,9 @@ export class CursorProvider
           if (browserStage) this.releaseBrowserLeases(browserStage);
         } else if (browserStage) {
           browserGrant = this.browserAutomationLease.issue(browserStage);
+          if (!browserGrant) {
+            throw new Error("Cursor browser automation lease issuance failed");
+          }
         }
       } else {
         this.releaseBrowserLeases(browserStage, refreshedGrant);

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -486,6 +486,9 @@ export class CursorProvider
   /** Tear down all sessions, cancel pending permissions, and stop the eviction timer. */
   shutdown(): void {
     this.drainAllPendingCancelled();
+    for (const sessionId of this.liveSessionIds) {
+      this.browserAutomationLease.releaseSession(this.id, sessionId);
+    }
     void this.runtime.shutdown().catch((err: unknown) => {
       logger.warn("Cursor runtime shutdown failed", { error: String(err) });
     });
@@ -502,7 +505,6 @@ export class CursorProvider
     this.pendingBrowserContext.clear();
     this.pendingBrowserGrants.clear();
     this.pendingBrowserGrantContext.clear();
-    this.browserAutomationLease.shutdown();
     logger.info("CursorProvider shutdown complete");
   }
 

--- a/apps/server/src/providers/cursor/cursor-provider.ts
+++ b/apps/server/src/providers/cursor/cursor-provider.ts
@@ -31,12 +31,14 @@ import { SkillService } from "../../services/skill-service.js";
 import { EnvService } from "../../services/env-service.js";
 import { JobObject } from "../../services/job-object.js";
 import {
-  BrowserAutomationAccessService,
   browserAutomationPermissionCapability,
-  type BrowserAutomationAccessRequest,
-  type BrowserAutomationAccessGrant,
   type BrowserAutomationCredentialMetadata,
 } from "../../services/browser-automation/access-service.js";
+import {
+  BrowserAutomationSessionLease,
+  type BrowserAutomationSessionLeaseGrant,
+  type BrowserAutomationSessionLeaseStage,
+} from "../../services/browser-automation/browser-automation-session-lease.js";
 import { SessionRuntime } from "../../services/session-runtime.js";
 import type { ProtocolAdapter, SpawnArgs, SpawnResult } from "../../services/session-runtime.js";
 import { CleanForker } from "../../services/handoff/session-forker.js";
@@ -176,7 +178,7 @@ interface CursorAcpSessionEntry {
   /** Whether this ACP version advertised HTTP MCP session support. */
   browserHttpMcpSupported: boolean;
   /** Non-secret browser credential lifecycle metadata for this main session. */
-  browserCredential?: BrowserAutomationCredentialMetadata;
+  browserCredential?: BrowserAutomationCredentialMetadata & { leaseId: string };
   /** Workspace fixed to this provider process at spawn. */
   workspaceId: string;
   /** Browser permission class fixed to this provider process at spawn. */
@@ -193,9 +195,11 @@ interface CursorAcpSessionEntry {
  */
 type CursorSessionState = CursorAcpSessionEntry;
 
+type CursorBrowserContext = Pick<CursorAcpSessionEntry, "workspaceId" | "browserPermissionCapability">;
+
 /** Builds the ACP HTTP MCP descriptor for one short-lived browser grant. */
 export function buildCursorBrowserMcpServers(
-  grant: BrowserAutomationAccessGrant | null,
+  grant: Pick<BrowserAutomationSessionLeaseGrant, "mcpUrl" | "token"> | null,
 ): McpServer[] {
   return grant
     ? [{
@@ -253,16 +257,22 @@ export class CursorProvider
    * in `spawn`, pruned in `close`.
    */
   private liveSessionIds = new Set<string>();
-  /** Browser scope staged only until a fresh normal ACP session opens. */
-  private pendingBrowserAccess = new Map<string, BrowserAutomationAccessRequest>();
+  /** Browser lease staged only until a fresh normal ACP session opens. */
+  private pendingBrowserLeases = new Map<string, BrowserAutomationSessionLeaseStage>();
+  /** Non-secret provider state needed while a staged lease is being opened. */
+  private pendingBrowserContext = new Map<string, CursorBrowserContext>();
+  /** Refreshed browser grant carried across a provider restart. */
+  private pendingBrowserGrants = new Map<string, BrowserAutomationSessionLeaseGrant>();
+  /** Context captured with a refreshed grant so a changed request cannot reuse it. */
+  private pendingBrowserGrantContext = new Map<string, CursorBrowserContext>();
 
   constructor(
     @inject(SettingsService) private readonly settingsService: SettingsService,
     @inject(SkillService) private readonly skillService: SkillService,
     @inject(EnvService) private readonly envService: EnvService,
     @inject("JobObject") private readonly jobObject: JobObject,
-    @inject(BrowserAutomationAccessService)
-    private readonly browserAutomationAccess: BrowserAutomationAccessService = new BrowserAutomationAccessService(),
+    @inject(BrowserAutomationSessionLease)
+    private readonly browserAutomationLease: BrowserAutomationSessionLease = new BrowserAutomationSessionLease(),
   ) {
     super();
     this.runtime = new SessionRuntime<CursorSessionState>(this, {
@@ -311,6 +321,10 @@ export class CursorProvider
       permissionMode,
       req.interactionMode,
     );
+    const browserContext: CursorBrowserContext = {
+      workspaceId: req.workspaceId,
+      browserPermissionCapability,
+    };
 
     // interactionMode absorbs the retired setPlanQuestionMode: a plan-mode Turn
     // suppresses Cursor's native auto-answer of ask_question; build clears it.
@@ -322,23 +336,61 @@ export class CursorProvider
     }
 
     const existing = this.runtime.get(sessionId);
-    if (
-      existing &&
-      this.browserAutomationAccess.isConfigured() &&
-      (existing.workspaceId !== req.workspaceId ||
-        existing.browserPermissionCapability !== browserPermissionCapability ||
-        (existing.browserCredential && existing.browserCredential.expiresAt <= Date.now()))
-    ) {
-      await this.runtime.stop(sessionId);
+    const pendingGrant = this.pendingBrowserGrants.get(sessionId);
+    const pendingGrantContext = this.pendingBrowserGrantContext.get(sessionId);
+    if (pendingGrant && (!pendingGrantContext || !this.sameBrowserContext(pendingGrantContext, browserContext))) {
+      this.releaseBrowserLeases(pendingGrant);
+      this.pendingBrowserGrants.delete(sessionId);
+      this.pendingBrowserGrantContext.delete(sessionId);
     }
-    this.pendingBrowserAccess.set(sessionId, {
-      providerId: this.id,
-      providerSessionId: req.resumeFrom ?? sessionId,
-      mcodeSessionId: sessionId,
-      threadId: req.threadId,
-      workspaceId: req.workspaceId,
-      permissionCapability: browserPermissionCapability,
-    });
+    let browserStage: BrowserAutomationSessionLeaseStage | undefined;
+    if (existing) {
+      const browserContextChanged =
+        existing.workspaceId !== req.workspaceId ||
+        existing.browserPermissionCapability !== browserPermissionCapability;
+      const browserExpired = existing.browserCredential !== undefined &&
+        existing.browserCredential.expiresAt <= Date.now();
+      if (browserContextChanged || browserExpired) {
+        if (!browserContextChanged && browserExpired && existing.browserCredential) {
+          const refreshed = this.browserAutomationLease.refresh(existing.browserCredential.leaseId);
+          if (refreshed.ok) {
+            this.pendingBrowserGrants.set(sessionId, refreshed.grant);
+            this.pendingBrowserGrantContext.set(sessionId, browserContext);
+            existing.browserCredential = undefined;
+          }
+        }
+        await this.runtime.stop(sessionId);
+      }
+    }
+    if (!this.runtime.get(sessionId)) {
+      if (this.pendingBrowserGrants.has(sessionId)) {
+        const staleStage = this.pendingBrowserLeases.get(sessionId);
+        this.releaseBrowserLeases(staleStage);
+        this.pendingBrowserLeases.delete(sessionId);
+        this.pendingBrowserContext.delete(sessionId);
+      } else {
+        browserStage = this.pendingBrowserLeases.get(sessionId);
+        const stagedContext = this.pendingBrowserContext.get(sessionId);
+        if (browserStage && (!stagedContext || !this.sameBrowserContext(stagedContext, browserContext))) {
+          this.releaseBrowserLeases(browserStage);
+          this.pendingBrowserLeases.delete(sessionId);
+          this.pendingBrowserContext.delete(sessionId);
+          browserStage = undefined;
+        }
+      }
+      if (!browserStage && !this.pendingBrowserGrants.has(sessionId)) {
+        browserStage = this.browserAutomationLease.stage({
+          providerId: this.id,
+          providerSessionId: req.resumeFrom ?? sessionId,
+          mcodeSessionId: sessionId,
+          threadId: req.threadId,
+          workspaceId: req.workspaceId,
+          permissionCapability: browserPermissionCapability,
+        });
+        this.pendingBrowserLeases.set(sessionId, browserStage);
+        this.pendingBrowserContext.set(sessionId, browserContext);
+      }
+    }
 
     let entry: CursorSessionState;
     try {
@@ -353,14 +405,22 @@ export class CursorProvider
         resumeFrom: resume ? this.sdkSessionIds.get(sessionId) : undefined,
       });
     } catch (err) {
-      this.pendingBrowserAccess.delete(sessionId);
+      this.releaseBrowserLeases(browserStage);
+      this.pendingBrowserLeases.delete(sessionId);
+      this.pendingBrowserContext.delete(sessionId);
+      const refreshed = this.pendingBrowserGrants.get(sessionId);
+      this.releaseBrowserLeases(refreshed);
+      this.pendingBrowserGrants.delete(sessionId);
+      this.pendingBrowserGrantContext.delete(sessionId);
       const errMsg = err instanceof Error ? err.message : String(err);
       logger.error("Cursor ACP spawn failed", { sessionId, error: errMsg });
       this.emit("event", { type: AgentEventType.Error, threadId, error: errMsg } satisfies AgentEvent);
       this.emit("event", { type: AgentEventType.Ended, threadId } satisfies AgentEvent);
       return;
     }
-    this.pendingBrowserAccess.delete(sessionId);
+    this.pendingBrowserLeases.delete(sessionId);
+    this.pendingBrowserContext.delete(sessionId);
+    if (browserStage && entry === existing) this.releaseBrowserLeases(browserStage);
 
     // A stop requested before the session finished spawning: tear it down now.
     if (this.pendingStops.delete(sessionId)) {
@@ -432,7 +492,17 @@ export class CursorProvider
     this.planQuestionModeThreads.clear();
     this.sdkSessionIds.clear();
     this.liveSessionIds.clear();
-    this.pendingBrowserAccess.clear();
+    for (const stage of this.pendingBrowserLeases.values()) {
+      this.browserAutomationLease.release(stage.leaseId);
+    }
+    for (const grant of this.pendingBrowserGrants.values()) {
+      this.browserAutomationLease.release(grant.leaseId);
+    }
+    this.pendingBrowserLeases.clear();
+    this.pendingBrowserContext.clear();
+    this.pendingBrowserGrants.clear();
+    this.pendingBrowserGrantContext.clear();
+    this.browserAutomationLease.shutdown();
     logger.info("CursorProvider shutdown complete");
   }
 
@@ -506,15 +576,24 @@ export class CursorProvider
     const pm: "full" | "default" = permissionMode === "full" ? "full" : "default";
     const settings = this.settingsService.get();
     const state = await this.spawnChild(sessionId, threadId, cwd, pm, settings);
-    const browserScope = this.pendingBrowserAccess.get(sessionId);
-    const browserGrant = state.browserHttpMcpSupported && browserScope
-      ? this.browserAutomationAccess.issue(browserScope)
-      : null;
-    if (
-      browserScope &&
-      this.browserAutomationAccess.isConfigured() &&
-      !state.browserHttpMcpSupported
-    ) {
+    const browserStage = this.pendingBrowserLeases.get(sessionId);
+    const refreshedGrant = this.pendingBrowserGrants.get(sessionId);
+    let browserGrant: BrowserAutomationSessionLeaseGrant | null = null;
+    if (state.browserHttpMcpSupported) {
+      if (refreshedGrant) {
+        browserGrant = refreshedGrant;
+        this.pendingBrowserGrants.delete(sessionId);
+        this.pendingBrowserGrantContext.delete(sessionId);
+        if (browserStage) this.releaseBrowserLeases(browserStage);
+      } else if (browserStage) {
+        browserGrant = this.browserAutomationLease.issue(browserStage);
+      }
+    } else {
+      this.releaseBrowserLeases(browserStage, refreshedGrant);
+      this.pendingBrowserGrants.delete(sessionId);
+      this.pendingBrowserGrantContext.delete(sessionId);
+    }
+    if (browserStage && !state.browserHttpMcpSupported) {
       logger.info("Cursor ACP does not advertise HTTP MCP; browser automation is unavailable", {
         threadId,
       });
@@ -532,10 +611,15 @@ export class CursorProvider
         state.browserCredential = {
           credentialId: browserGrant.credentialId,
           expiresAt: browserGrant.expiresAt,
+          leaseId: browserGrant.leaseId,
         };
       }
     } catch (err) {
-      if (browserGrant) this.browserAutomationAccess.revokeCredential(browserGrant.credentialId);
+      this.releaseBrowserLeases(browserGrant, browserStage, refreshedGrant);
+      this.pendingBrowserLeases.delete(sessionId);
+      this.pendingBrowserContext.delete(sessionId);
+      this.pendingBrowserGrants.delete(sessionId);
+      this.pendingBrowserGrantContext.delete(sessionId);
       this.liveSessionIds.delete(sessionId);
       try {
         state.child.kill();
@@ -574,8 +658,22 @@ export class CursorProvider
   close(state: CursorSessionState): void {
     this.cancelPendingForThread(state.mcodeSessionId);
     this.liveSessionIds.delete(state.mcodeSessionId);
-    if (state.browserCredential) {
-      this.browserAutomationAccess.revokeCredential(state.browserCredential.credentialId);
+    if (!this.pendingBrowserGrants.has(state.mcodeSessionId)) {
+      this.browserAutomationLease.releaseSession(this.id, state.mcodeSessionId);
+    }
+  }
+
+  private sameBrowserContext(left: CursorBrowserContext, right: CursorBrowserContext): boolean {
+    return left.workspaceId === right.workspaceId &&
+      left.browserPermissionCapability === right.browserPermissionCapability;
+  }
+
+  private releaseBrowserLeases(...leases: Array<{ leaseId: string } | null | undefined>): void {
+    const released = new Set<string>();
+    for (const lease of leases) {
+      if (!lease || released.has(lease.leaseId)) continue;
+      released.add(lease.leaseId);
+      this.browserAutomationLease.release(lease.leaseId);
     }
   }
 
@@ -640,9 +738,9 @@ export class CursorProvider
     const entry: Omit<CursorAcpSessionEntry, "connection"> & {
       connection?: CursorAcpSessionEntry["connection"];
     } = {
-      workspaceId: this.pendingBrowserAccess.get(mcodeSessionId)?.workspaceId ?? "unknown-workspace",
+      workspaceId: this.pendingBrowserContext.get(mcodeSessionId)?.workspaceId ?? "unknown-workspace",
       browserPermissionCapability:
-        this.pendingBrowserAccess.get(mcodeSessionId)?.permissionCapability ?? "interact",
+        this.pendingBrowserContext.get(mcodeSessionId)?.browserPermissionCapability ?? "interact",
       browserHttpMcpSupported: false,
       mcodeSessionId,
       threadId,
@@ -1020,13 +1118,40 @@ export class CursorProvider
     const sessionId = dead.mcodeSessionId;
     this.logAcpChildDisconnect(dead, "ACP connection closed");
     await this.runtime.stop(sessionId);
-    const fresh = await this.runtime.acquire({
-      sessionId,
-      threadId: dead.threadId,
-      cwd: dead.cwd,
-      permissionMode: dead.permissionMode,
-      resumeFrom: this.sdkSessionIds.get(sessionId),
-    });
+    const browserStage = dead.browserHttpMcpSupported
+      ? this.browserAutomationLease.stage({
+        providerId: this.id,
+        providerSessionId: this.sdkSessionIds.get(sessionId) ?? sessionId,
+        mcodeSessionId: sessionId,
+        threadId: dead.threadId,
+        workspaceId: dead.workspaceId,
+        permissionCapability: dead.browserPermissionCapability,
+      })
+      : undefined;
+    if (browserStage) {
+      this.pendingBrowserLeases.set(sessionId, browserStage);
+      this.pendingBrowserContext.set(sessionId, {
+        workspaceId: dead.workspaceId,
+        browserPermissionCapability: dead.browserPermissionCapability,
+      });
+    }
+    let fresh: CursorAcpSessionEntry;
+    try {
+      fresh = await this.runtime.acquire({
+        sessionId,
+        threadId: dead.threadId,
+        cwd: dead.cwd,
+        permissionMode: dead.permissionMode,
+        resumeFrom: this.sdkSessionIds.get(sessionId),
+      });
+    } catch (error) {
+      if (browserStage) this.browserAutomationLease.release(browserStage.leaseId);
+      this.pendingBrowserLeases.delete(sessionId);
+      this.pendingBrowserContext.delete(sessionId);
+      throw error;
+    }
+    this.pendingBrowserLeases.delete(sessionId);
+    this.pendingBrowserContext.delete(sessionId);
     fresh.stickyHeavyInstructionsSent = dead.stickyHeavyInstructionsSent;
     fresh.cursorPromptOrdinal = dead.cursorPromptOrdinal;
     fresh.lastUsedAt = Date.now();


### PR DESCRIPTION
## What
Migrates Cursor browser credential and session lifecycle to the shared BrowserAutomationSessionLease.

## Why
Cursor had a duplicate lifecycle path. The shared lease now owns credential issue, refresh, revocation, expiry, failure cleanup, and Cursor-scoped shutdown cleanup.

## Key Changes
- Keeps ACP HTTP-MCP capability gating, events, transport, and restart policy in Cursor.
- Covers stale replacement success and failure, expired staged leases, and unconfigured browser MCP.
- Preserves other providers' shared lease state during Cursor shutdown.

Closes #991

## Verification
- Focused Cursor and lease tests: 19 passed.
- Server typecheck: passed.
- Full verification: typecheck and lint passed; three Windows process-cleanup tests failed outside this diff because 	asklist was denied and orphan cleanup could not verify process death.