### PR TITLE
fix(desktop): log safe renderer crash diagnostics

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-crash-report.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-crash-report.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loggerInfo } = vi.hoisted(() => ({ loggerInfo: vi.fn() }));
+
+vi.mock("electron", () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn().mockReturnValue("C:/mcode-test"),
+    setPath: vi.fn(),
+    getAppPath: vi.fn().mockReturnValue("C:/mcode-test"),
+    getName: vi.fn().mockReturnValue("Mcode"),
+    getVersion: vi.fn().mockReturnValue("0.0.0-test"),
+    whenReady: vi.fn(() => new Promise<void>(() => undefined)),
+    on: vi.fn(),
+    exit: vi.fn(),
+    quit: vi.fn(),
+    disableHardwareAcceleration: vi.fn(),
+    commandLine: { appendSwitch: vi.fn() },
+    setAppUserModelId: vi.fn(),
+  },
+  BrowserWindow: {
+    fromWebContents: vi.fn(),
+    getAllWindows: vi.fn().mockReturnValue([]),
+  },
+  clipboard: {},
+  dialog: { showErrorBox: vi.fn() },
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
+  Menu: { buildFromTemplate: vi.fn(), setApplicationMenu: vi.fn() },
+  Notification: { isSupported: vi.fn().mockReturnValue(false) },
+  powerMonitor: { on: vi.fn() },
+  powerSaveBlocker: { start: vi.fn(), stop: vi.fn() },
+  protocol: { handle: vi.fn() },
+  session: { defaultSession: { cookies: { set: vi.fn() } } },
+  shell: { openExternal: vi.fn(), openPath: vi.fn() },
+}));
+
+vi.mock("@mcode/shared", () => ({
+  getLogPath: vi.fn(),
+  getMcodeDir: vi.fn().mockReturnValue("C:/mcode-test"),
+  getRecentLogs: vi.fn(),
+  logger: { info: loggerInfo, warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@mcode/contracts", () => ({
+  getExtension: vi.fn().mockReturnValue(""),
+  isMcodeWorkspacePreviewUrl: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../open-in/index.js", () => ({ openInRegistry: vi.fn() }));
+vi.mock("../server-manager.js", () => ({
+  ServerManager: class {
+    start = vi.fn();
+    restart = vi.fn();
+    isHealthy = vi.fn();
+    forceReplace = vi.fn();
+  },
+}));
+vi.mock("../server-crash-recovery.js", () => ({
+  ServerCrashRecovery: class {},
+}));
+vi.mock("../ipc-relay.js", () => ({ startIpcRelay: vi.fn() }));
+vi.mock("../auto-updater.js", () => ({
+  applyReleaseLineSwitch: vi.fn(),
+  checkForUpdatesNow: vi.fn(),
+  downloadUpdate: vi.fn(),
+  getUpdateStatus: vi.fn().mockReturnValue({ state: "idle" }),
+  initAutoUpdater: vi.fn(),
+  installUpdate: vi.fn(),
+  cleanupAutoUpdater: vi.fn(),
+  setBeforeInstallHook: vi.fn(),
+}));
+vi.mock("../spellcheck.js", () => ({ setupSpellcheck: vi.fn() }));
+vi.mock("../preview/index.js", () => ({
+  registerPreviewBrowserHandlers: vi.fn(),
+  disposePreviewForWindow: vi.fn(),
+}));
+vi.mock("../browser-automation/index.js", () => ({
+  disposeBrowserAutomationForWindow: vi.fn(),
+}));
+vi.mock("../browser-use/index.js", () => ({
+  startBrowserUseBridge: vi.fn(),
+  disposeBrowserUseBridge: vi.fn(),
+}));
+vi.mock("../browser-use/rollout.js", () => ({
+  shouldStartLegacyBrowserUseBridge: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../preview/preview-local-file.js", () => ({
+  resolveMcodeWorkspacePreviewUrl: vi.fn(),
+}));
+vi.mock("../is-desktop-dev.js", () => ({ isDesktopDev: vi.fn().mockReturnValue(false) }));
+vi.mock("../cli-args.js", () => ({ shouldPrintVersion: vi.fn().mockReturnValue(false) }));
+vi.mock("../preview/preview-webview-security.js", () => ({
+  hardenPreviewWebviewAttachment: vi.fn(),
+  resolvePreviewGuestPreloadPath: vi.fn(),
+}));
+
+import {
+  handleRendererCrashReport,
+  normalizeRendererCrashReport,
+} from "../main.js";
+
+describe("renderer crash report IPC boundary", () => {
+  beforeEach(() => {
+    loggerInfo.mockClear();
+  });
+
+  it("drops reports from unauthorized senders", () => {
+    const authorized = { id: 101 };
+    handleRendererCrashReport(
+      { sender: { id: 1 } },
+      { errorName: "Error", componentStack: "\n    at App (https://example.test/App.tsx:1:1)" },
+      authorized,
+    );
+
+    expect(loggerInfo).not.toHaveBeenCalled();
+  });
+
+  it("drops malformed and extra-field payloads", () => {
+    const authorized = { id: 102 };
+    const event = { sender: authorized };
+    handleRendererCrashReport(event, null, authorized);
+    handleRendererCrashReport(
+      event,
+      { errorName: "Error", componentStack: "\n    at App", extra: true },
+      authorized,
+    );
+
+    expect(loggerInfo).not.toHaveBeenCalled();
+    expect(
+      normalizeRendererCrashReport({ errorName: "Error", componentStack: "not a React stack" }),
+    ).toBeNull();
+  });
+
+  it("logs only bounded frame names, never renderer locations or free-form text", () => {
+    const authorized = { id: 103 };
+    handleRendererCrashReport(
+      { sender: authorized },
+      {
+        errorName: "TypeError",
+        componentStack: [
+          "",
+          "    at App (https://example.test/src/App.tsx:10:4)",
+          "    at Button props=secret state=token (file:///C:/repo/Button.tsx:2:1)",
+          "    at div (C:\\repo\\index.tsx:1:1)",
+        ].join("\n"),
+      },
+      authorized,
+    );
+
+    expect(loggerInfo).toHaveBeenCalledWith("Renderer crash report", {
+      errorName: "TypeError",
+      componentStack: "App\ndiv",
+      componentStackTruncated: false,
+    });
+    const serialized = JSON.stringify(loggerInfo.mock.calls[0]);
+    expect(serialized).not.toMatch(/https?:|file:|C:\\\\|props|state|src\/|\.tsx/);
+  });
+
+  it("returns only safe structured fields for valid frames", () => {
+    expect(
+      normalizeRendererCrashReport({
+        errorName: "UnknownError",
+        componentStack: "\n    at App\n    at ForwardRef.Button (https://host/path:1:1)",
+      }),
+    ).toEqual({
+      errorName: "Error",
+      componentStack: "App\nForwardRef.Button",
+      componentStackTruncated: false,
+    });
+  });
+
+  it("bounds frame count and marks dropped safe frames", () => {
+    const stack = Array.from({ length: 40 }, (_, index) => `    at Component${index}`).join("\n");
+    const normalized = normalizeRendererCrashReport({ errorName: "Error", componentStack: stack });
+
+    expect(normalized?.componentStack.split("\n")).toHaveLength(32);
+    expect(normalized?.componentStackTruncated).toBe(true);
+  });
+
+  it("rate-limits reports per sender within the sliding window", () => {
+    vi.useFakeTimers();
+    try {
+      const authorized = { id: 104 };
+      const event = { sender: authorized };
+      const payload = { errorName: "Error", componentStack: "\n    at App" };
+      for (let index = 0; index < 4; index += 1) {
+        handleRendererCrashReport(event, payload, authorized);
+      }
+      expect(loggerInfo).toHaveBeenCalledTimes(3);
+
+      vi.advanceTimersByTime(60_001);
+      handleRendererCrashReport(event, payload, authorized);
+      expect(loggerInfo).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -142,6 +142,8 @@ let mainWindow: BrowserWindow | null = null;
 /** Channel used by the renderer crash boundary to report local diagnostics. */
 export const RENDERER_CRASH_REPORT_CHANNEL = "renderer:crash-report";
 const RENDERER_CRASH_COMPONENT_STACK_MAX_LENGTH = 16 * 1024;
+const RENDERER_CRASH_COMPONENT_FRAME_MAX_COUNT = 32;
+const RENDERER_CRASH_COMPONENT_FRAME_MAX_LENGTH = 128;
 const RENDERER_CRASH_REPORT_LIMIT = 3;
 const RENDERER_CRASH_REPORT_WINDOW_MS = 60_000;
 const RENDERER_CRASH_ERROR_NAMES = new Set([
@@ -161,14 +163,31 @@ const rendererCrashReportTimestamps = new Map<number, number[]>();
 export interface RendererCrashReportPayload {
   readonly errorName: string;
   readonly componentStack: string;
+  readonly componentStackTruncated: boolean;
 }
 
-/** Remove terminal escape sequences and non-printing control characters. */
-function sanitizeRendererComponentStack(value: string): string {
-  return value
-    .replace(/\u001B(?:[@-_][0-?]*[ -/]*[@-~]|\[[0-?]*[ -/]*[@-~])/g, "")
-    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "")
-    .replace(/\r\n?/g, "\n");
+/** Extract bounded React frame names, dropping renderer-controlled locations and text. */
+function normalizeRendererComponentStack(value: string): {
+  componentStack: string;
+  componentStackTruncated: boolean;
+} | null {
+  const framePattern = /^\s*at\s+([A-Za-z_$][A-Za-z0-9_$]*(?:[.$][A-Za-z_$][A-Za-z0-9_$]*){0,7})\s*(?:\(|$)/;
+  const frames: string[] = [];
+  for (const line of value.replace(/\r\n?/g, "\n").split("\n")) {
+    const frameName = framePattern.exec(line)?.[1];
+    if (!frameName || frameName.length > RENDERER_CRASH_COMPONENT_FRAME_MAX_LENGTH) {
+      continue;
+    }
+    frames.push(frameName);
+  }
+  if (frames.length === 0) return null;
+  const componentStackTruncated = frames.length > RENDERER_CRASH_COMPONENT_FRAME_MAX_COUNT;
+  return {
+    componentStack: frames
+      .slice(0, RENDERER_CRASH_COMPONENT_FRAME_MAX_COUNT)
+      .join("\n"),
+    componentStackTruncated,
+  };
 }
 
 /** Validate and normalize untrusted renderer crash diagnostics. */
@@ -191,15 +210,16 @@ export function normalizeRendererCrashReport(
     ) {
       return null;
     }
-    const componentStack = sanitizeRendererComponentStack(record.componentStack);
-    if (componentStack.length > RENDERER_CRASH_COMPONENT_STACK_MAX_LENGTH) {
+    if (record.componentStack.length > RENDERER_CRASH_COMPONENT_STACK_MAX_LENGTH) {
       return null;
     }
+    const normalizedStack = normalizeRendererComponentStack(record.componentStack);
+    if (!normalizedStack) return null;
     return {
       errorName: RENDERER_CRASH_ERROR_NAMES.has(record.errorName)
         ? record.errorName
         : "Error",
-      componentStack,
+      ...normalizedStack,
     };
   } catch {
     return null;
@@ -225,7 +245,7 @@ export function handleRendererCrashReport(
   logger.info("Renderer crash report", {
     errorName: normalized.errorName,
     componentStack: normalized.componentStack,
-    componentStackTruncated: false,
+    componentStackTruncated: normalized.componentStackTruncated,
   });
 }
 const serverManager = new ServerManager();

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -26,7 +26,7 @@ import { mkdir, writeFile } from "fs/promises";
 import { isAbsolute, join } from "path";
 import { randomUUID } from "crypto";
 import { Readable } from "stream";
-import { getLogPath, getMcodeDir, getRecentLogs } from "@mcode/shared";
+import { getLogPath, getMcodeDir, getRecentLogs, logger } from "@mcode/shared";
 import {
   getExtension as bundledGetExtension,
   isMcodeWorkspacePreviewUrl,
@@ -138,6 +138,96 @@ function openIfAllowed(url: string): void {
 
 const APP_ID = "com.mzeey.mcode";
 let mainWindow: BrowserWindow | null = null;
+
+/** Channel used by the renderer crash boundary to report local diagnostics. */
+export const RENDERER_CRASH_REPORT_CHANNEL = "renderer:crash-report";
+const RENDERER_CRASH_COMPONENT_STACK_MAX_LENGTH = 16 * 1024;
+const RENDERER_CRASH_REPORT_LIMIT = 3;
+const RENDERER_CRASH_REPORT_WINDOW_MS = 60_000;
+const RENDERER_CRASH_ERROR_NAMES = new Set([
+  "Error",
+  "EvalError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
+  "AggregateError",
+  "DOMException",
+]);
+const rendererCrashReportTimestamps = new Map<number, number[]>();
+
+/** Safe renderer crash report payload accepted at the desktop IPC boundary. */
+export interface RendererCrashReportPayload {
+  readonly errorName: string;
+  readonly componentStack: string;
+}
+
+/** Remove terminal escape sequences and non-printing control characters. */
+function sanitizeRendererComponentStack(value: string): string {
+  return value
+    .replace(/\u001B(?:[@-_][0-?]*[ -/]*[@-~]|\[[0-?]*[ -/]*[@-~])/g, "")
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "")
+    .replace(/\r\n?/g, "\n");
+}
+
+/** Validate and normalize untrusted renderer crash diagnostics. */
+export function normalizeRendererCrashReport(
+  payload: unknown,
+): RendererCrashReportPayload | null {
+  if (payload === null || typeof payload !== "object") return null;
+  try {
+    const record = payload as Record<string, unknown>;
+    if (
+      Object.getPrototypeOf(record) !== Object.prototype ||
+      Object.keys(record).length !== 2 ||
+      typeof record.errorName !== "string" ||
+      typeof record.componentStack !== "string"
+    ) {
+      return null;
+    }
+    if (
+      record.componentStack.length > RENDERER_CRASH_COMPONENT_STACK_MAX_LENGTH
+    ) {
+      return null;
+    }
+    const componentStack = sanitizeRendererComponentStack(record.componentStack);
+    if (componentStack.length > RENDERER_CRASH_COMPONENT_STACK_MAX_LENGTH) {
+      return null;
+    }
+    return {
+      errorName: RENDERER_CRASH_ERROR_NAMES.has(record.errorName)
+        ? record.errorName
+        : "Error",
+      componentStack,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Accept an authorized, rate-limited renderer crash report and write safe fields. */
+export function handleRendererCrashReport(
+  event: { sender: { id: number } },
+  payload: unknown,
+  authorizedSender: unknown = mainWindow?.webContents,
+): void {
+  if (event.sender !== authorizedSender) return;
+  const normalized = normalizeRendererCrashReport(payload);
+  if (!normalized) return;
+  const now = Date.now();
+  const recent = (rendererCrashReportTimestamps.get(event.sender.id) ?? []).filter(
+    (timestamp) => now - timestamp < RENDERER_CRASH_REPORT_WINDOW_MS,
+  );
+  if (recent.length >= RENDERER_CRASH_REPORT_LIMIT) return;
+  recent.push(now);
+  rendererCrashReportTimestamps.set(event.sender.id, recent);
+  logger.info("Renderer crash report", {
+    errorName: normalized.errorName,
+    componentStack: normalized.componentStack,
+    componentStackTruncated: false,
+  });
+}
 const serverManager = new ServerManager();
 const serverCrashRecovery = new ServerCrashRecovery({
   restart: () => serverManager.restart(),
@@ -505,6 +595,12 @@ function registerIpcHandlers(): void {
   // Recent log lines
   ipcMain.handle("get-recent-logs", (_event, lines: number) => {
     return getRecentLogs(lines);
+  });
+
+  // Renderer crash diagnostics are local-only and accepted only from the main app window.
+  ipcMain.handle(RENDERER_CRASH_REPORT_CHANNEL, (event, payload: unknown) => {
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    handleRendererCrashReport(event, payload, mainWindow.webContents);
   });
 
   /** Ensure a config file exists in the mcode data dir, then open it. */

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -80,6 +80,12 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   getRecentLogs: (lines: number): Promise<string> =>
     ipcRenderer.invoke("get-recent-logs", lines),
 
+  /** Report safe renderer crash diagnostics to the local desktop logger. */
+  reportRendererCrash: (payload: {
+    errorName: string;
+    componentStack: string;
+  }): Promise<void> => ipcRenderer.invoke("renderer:crash-report", payload),
+
   /** Resolve the native file path for a File object (drag-and-drop). */
   getPathForFile: (file: File): string => webUtils.getPathForFile(file),
 

--- a/apps/web/src/app/AppErrorBoundary.tsx
+++ b/apps/web/src/app/AppErrorBoundary.tsx
@@ -19,7 +19,21 @@ export class AppErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
-    console.error("[AppErrorBoundary] Caught application render error", error, info);
+    const errorName = typeof error?.name === "string" ? error.name : "Error";
+    console.error(
+      "[AppErrorBoundary] Caught application render error",
+      errorName,
+      info.componentStack,
+    );
+    try {
+      const report = window.desktopBridge?.reportRendererCrash({
+        errorName,
+        componentStack: info.componentStack,
+      });
+      void report?.catch(() => undefined);
+    } catch {
+      // Diagnostics must never interfere with the crash recovery UI.
+    }
   }
 
   render(): ReactNode {

--- a/apps/web/src/app/AppErrorBoundary.tsx
+++ b/apps/web/src/app/AppErrorBoundary.tsx
@@ -26,9 +26,10 @@ export class AppErrorBoundary extends Component<
       info.componentStack,
     );
     try {
-      const report = window.desktopBridge?.reportRendererCrash({
+      const reportRendererCrash = window.desktopBridge?.reportRendererCrash;
+      const report = reportRendererCrash?.({
         errorName,
-        componentStack: info.componentStack,
+        componentStack: info.componentStack ?? "",
       });
       void report?.catch(() => undefined);
     } catch {

--- a/apps/web/src/app/__tests__/AppErrorBoundary.test.tsx
+++ b/apps/web/src/app/__tests__/AppErrorBoundary.test.tsx
@@ -20,6 +20,9 @@ describe("AppErrorBoundary", () => {
 
   it("renders recovery UI and reports a descendant render failure", () => {
     const diagnostic = vi.spyOn(console, "error").mockImplementation(() => {});
+    const reportRendererCrash = vi.fn().mockResolvedValue(undefined);
+    const previousBridge = window.desktopBridge;
+    window.desktopBridge = { reportRendererCrash } as typeof window.desktopBridge;
 
     render(
       <AppErrorBoundary>
@@ -33,10 +36,15 @@ describe("AppErrorBoundary", () => {
     expect(screen.getByText("Reload the app to continue.")).toBeInTheDocument();
     expect(diagnostic).toHaveBeenCalledWith(
       "[AppErrorBoundary] Caught application render error",
-      expect.any(Error),
-      expect.objectContaining({ componentStack: expect.any(String) }),
+      "Error",
+      expect.any(String),
     );
+    expect(reportRendererCrash).toHaveBeenCalledWith({
+      errorName: "Error",
+      componentStack: expect.any(String),
+    });
 
+    window.desktopBridge = previousBridge;
     diagnostic.mockRestore();
   });
 

--- a/apps/web/src/app/__tests__/AppErrorBoundary.test.tsx
+++ b/apps/web/src/app/__tests__/AppErrorBoundary.test.tsx
@@ -22,7 +22,14 @@ describe("AppErrorBoundary", () => {
     const diagnostic = vi.spyOn(console, "error").mockImplementation(() => {});
     const reportRendererCrash = vi.fn().mockResolvedValue(undefined);
     const previousBridge = window.desktopBridge;
-    window.desktopBridge = { reportRendererCrash } as typeof window.desktopBridge;
+    const testBridge = {
+      reportRendererCrash,
+    } satisfies Pick<NonNullable<typeof window.desktopBridge>, "reportRendererCrash">;
+    Object.defineProperty(window, "desktopBridge", {
+      configurable: true,
+      value: testBridge,
+      writable: true,
+    });
 
     render(
       <AppErrorBoundary>
@@ -44,7 +51,11 @@ describe("AppErrorBoundary", () => {
       componentStack: expect.any(String),
     });
 
-    window.desktopBridge = previousBridge;
+    Object.defineProperty(window, "desktopBridge", {
+      configurable: true,
+      value: previousBridge,
+      writable: true,
+    });
     diagnostic.mockRestore();
   });
 

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -20,6 +20,12 @@ export type UpdateStatus =
   | { state: "downloaded"; version: string; releaseNotes?: string }
   | { state: "error"; message: string };
 
+/** Safe renderer crash diagnostics sent to the desktop main process. */
+export interface RendererCrashReport {
+  readonly errorName: string;
+  readonly componentStack: string;
+}
+
 /** App version and auto-update controls exposed by the main process. */
 interface AppBridge {
   /** Read the running app version (from package.json at build time). */
@@ -399,6 +405,8 @@ interface DesktopBridge {
   getLogPath(): Promise<string>;
   /** Return recent log lines. */
   getRecentLogs(lines: number): Promise<string>;
+  /** Report safe renderer crash diagnostics to the local desktop logger. */
+  reportRendererCrash?(payload: RendererCrashReport): Promise<void>;
   /** Map a browser File object to its real filesystem path. */
   getPathForFile(file: File): string;
   /** Clear Blink's in-memory resource caches (images, scripts, CSS).


### PR DESCRIPTION
## What
Add local logging for React render crashes that reach the Mcode recovery page.

## Why
Production logs did not capture the renderer error that triggered the recovery page.

## Key Changes
- Send a bounded crash report through the desktop IPC bridge.
- Log only the error class and sanitized React component frames.
- Validate senders and payloads, and rate-limit reports.
- Add focused tests for the boundary and main-process IPC handler.

Related to the reported production UI crash.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788015158&installation_model_id=20477&pr_number=1023&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1023&signature=2624c93bfd328e5553725909c2d7af08b82280bfa6a909a00ea944c69019f467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic renderer crash diagnostics reporting for desktop app errors.
  * Crash reports include safe error names and component stack information.
  * Added safeguards to validate, sanitize, limit, authorize, and rate-limit diagnostic reports.

* **Bug Fixes**
  * Renderer crash reporting failures no longer interfere with the recovery experience.

* **Tests**
  * Added coverage for validation, sanitization, authorization, truncation, and rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->