### PR TITLE
fix(codex): capture bounded crash diagnostics

### DIFF
--- a/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
@@ -534,6 +534,30 @@ describe("CodexAppServer.start (failed handshake teardown)", () => {
     expect(JSON.stringify(breadcrumb)).not.toContain("response payload");
   }, 10_000);
 
+  it("bounds oversized protocol identifiers in crash breadcrumbs", async () => {
+    const { child } = harnessFakeServer((req): Record<string, unknown> =>
+      req.method === "thread/start" ? { result: { thread: { id: "thread-bounded-identifiers" } } } : { result: {} },
+    );
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+    const oversizedTurnId = "turn-" + "x".repeat(1024);
+    const oversizedMethod = "method/" + "y".repeat(1024);
+
+    await server.start();
+    child.stdout.write(JSON.stringify({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { turnId: oversizedTurnId },
+    }) + "\n");
+    child.stdout.write(JSON.stringify({ jsonrpc: "2.0", method: oversizedMethod, params: {} }) + "\n");
+    child.emit("exit", 2, null);
+
+    const breadcrumb = server.lastTransportBreadcrumb;
+    expect(breadcrumb?.activeTurnId).toBe("turn-" + "x".repeat(251));
+    expect(breadcrumb?.lastActivity?.method).toBe("method/" + "y".repeat(249));
+    expect(breadcrumb?.activeTurnId).toHaveLength(256);
+    expect(breadcrumb?.lastActivity?.method).toHaveLength(256);
+  }, 10_000);
+
   it("reports when unexpected exit has no captured non-benign stderr", async () => {
     const { child, stderr } = harnessFakeServer((req): Record<string, unknown> =>
       req.method === "thread/start" ? { result: { thread: { id: "thread-no-stderr" } } } : { result: {} },

--- a/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
@@ -465,6 +465,7 @@ describe("CodexAppServer.start (failed handshake teardown)", () => {
     server.on("fatal", fatal);
 
     await server.start();
+    child.stdout.write(JSON.stringify({ jsonrpc: "2.0", method: "turn/started", params: { turnId: "turn-crash" } }) + "\n");
     stderr.write("ExperimentalWarning: ignore me\n");
     stderr.write("\u001b[31mfirst useful line\u001b[0m\n");
     stderr.write("latest crash cause\n");
@@ -489,6 +490,46 @@ describe("CodexAppServer.start (failed handshake teardown)", () => {
         stderrTail: ["first useful line", "latest crash cause"],
       }),
     );
+
+    const breadcrumb = vi.mocked(fatal).mock.calls[0]?.[1] as {
+      cause: string;
+      pid: number | null;
+      activeTurnId: string | null;
+      lastActivity: { method: string; timestamp: number } | null;
+      exit: { code: number | null; signal: string | null };
+      stderrTail: readonly string[];
+    };
+    expect(breadcrumb).toMatchObject({
+      cause: "unexpected_exit",
+      pid: 4321,
+      activeTurnId: "turn-crash",
+      lastActivity: { method: "turn/started" },
+      exit: { code: 4294967295, signal: null },
+      stderrTail: ["first useful line", "latest crash cause"],
+    });
+    expect(Object.isFrozen(breadcrumb)).toBe(true);
+    expect(Object.isFrozen(breadcrumb.stderrTail)).toBe(true);
+    expect(JSON.stringify(breadcrumb)).not.toContain("prompt");
+  }, 10_000);
+
+  it("captures crash breadcrumb without request payload content", async () => {
+    const { child } = harnessFakeServer((req): Record<string, unknown> => {
+      if (req.method === "thread/start") return { result: { thread: { id: "thread-redacted" } } };
+      if (req.method === "turn/start") return { result: { turn: { id: "turn-redacted" } } };
+      return { result: {} };
+    });
+    const server = new CodexAppServer({ cliPath: "codex", workingDirectory: "/tmp", getSpawnEnv: () => ({}) });
+    const fatal = vi.fn();
+    server.on("fatal", fatal);
+
+    await server.start();
+    await server.sendTurn("secret prompt and response payload");
+    child.emit("exit", 9, "SIGKILL");
+
+    const breadcrumb = vi.mocked(fatal).mock.calls[0]?.[1];
+    expect(breadcrumb).toMatchObject({ activeTurnId: "turn-redacted", exit: { code: 9, signal: "SIGKILL" } });
+    expect(JSON.stringify(breadcrumb)).not.toContain("secret prompt");
+    expect(JSON.stringify(breadcrumb)).not.toContain("response payload");
   }, 10_000);
 
   it("reports when unexpected exit has no captured non-benign stderr", async () => {

--- a/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-app-server-handshake.test.ts
@@ -491,7 +491,8 @@ describe("CodexAppServer.start (failed handshake teardown)", () => {
       }),
     );
 
-    const breadcrumb = vi.mocked(fatal).mock.calls[0]?.[1] as {
+    expect(vi.mocked(fatal).mock.calls[0]).toHaveLength(1);
+    const breadcrumb = server.lastTransportBreadcrumb as {
       cause: string;
       pid: number | null;
       activeTurnId: string | null;
@@ -526,7 +527,8 @@ describe("CodexAppServer.start (failed handshake teardown)", () => {
     await server.sendTurn("secret prompt and response payload");
     child.emit("exit", 9, "SIGKILL");
 
-    const breadcrumb = vi.mocked(fatal).mock.calls[0]?.[1];
+    expect(vi.mocked(fatal).mock.calls[0]).toHaveLength(1);
+    const breadcrumb = server.lastTransportBreadcrumb;
     expect(breadcrumb).toMatchObject({ activeTurnId: "turn-redacted", exit: { code: 9, signal: "SIGKILL" } });
     expect(JSON.stringify(breadcrumb)).not.toContain("secret prompt");
     expect(JSON.stringify(breadcrumb)).not.toContain("response payload");

--- a/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
+++ b/apps/server/src/providers/codex/__tests__/codex-provider-permission.test.ts
@@ -7,7 +7,10 @@ vi.mock("@mcode/shared", () => ({
 }));
 
 import { CodexProvider } from "../codex-provider.js";
+import { CodexAppServer } from "../codex-app-server.js";
 import type { PermissionRequest, PermissionDecision } from "@mcode/contracts";
+import { AgentEventType } from "@mcode/contracts";
+import { logger } from "@mcode/shared";
 import { stubEnvService } from "../../../__tests__/stub-env-service.js";
 
 /**
@@ -208,6 +211,55 @@ describe("CodexProvider permission flow", () => {
     expect(response).toEqual({ decision: "cancel" });
     expect(resolved).toHaveLength(1);
     expect(resolved[0].decision).toBe("cancelled");
+  });
+
+  it("logs fatal breadcrumbs and preserves failure events from the app-server", async () => {
+    const start = vi.spyOn(CodexAppServer.prototype, "start").mockResolvedValue(undefined);
+    try {
+      const events: Array<{ type: AgentEventType; threadId: string; error?: string }> = [];
+      provider.on("event", (event) => events.push(event as never));
+
+      const result = await (provider as unknown as {
+        spawn: (args: {
+          sessionId: string;
+          threadId: string;
+          cwd: string;
+          permissionMode: string;
+          env: Record<string, string>;
+        }) => Promise<{ state: { server: CodexAppServer }; pids: number[] }>;
+      }).spawn({
+        sessionId,
+        threadId,
+        cwd: "/",
+        permissionMode: "workspace-write",
+        env: {},
+      });
+      const breadcrumb = {
+        cause: "unexpected_exit" as const,
+        pid: 4321,
+        activeRequestId: null,
+        activeTurnId: "turn-bounded",
+        lastActivity: { method: "turn/started", timestamp: Date.now() },
+        exit: { code: 2, signal: null },
+        stderrTail: ["crash"],
+      };
+      Object.assign(result.state.server as unknown as { _lastTransportBreadcrumb: unknown }, {
+        _lastTransportBreadcrumb: breadcrumb,
+      });
+
+      result.state.server.emit("fatal", "simulated fatal");
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        "CodexAppServer fatal",
+        expect.objectContaining({ sessionId, error: "simulated fatal", breadcrumb }),
+      );
+      expect(events).toEqual([
+        { type: AgentEventType.Error, threadId, error: "simulated fatal" },
+        { type: AgentEventType.Ended, threadId },
+      ]);
+    } finally {
+      start.mockRestore();
+    }
   });
 
   it("runtime eviction spares a session with a turn in flight (busy guard)", async () => {

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -644,7 +644,7 @@ export async function warmCodexAppServer(
  * Emits:
  * - `notification(data: unknown)` - JSON-RPC notification forwarded from the RPC client
  * - `activity()` - a server-initiated request arrived (liveness signal for turn watchdogs)
- * - `fatal(error: string, breadcrumb?: CodexTransportBreadcrumb)` - unrecoverable error from stderr, unexpected exit, or handshake failure
+ * - `fatal(error: string)` - unrecoverable error from stderr, unexpected exit, or handshake failure
  * - `exit(code: number | null, signal: string | null)` - child process exit
  */
 export class CodexAppServer extends EventEmitter {
@@ -674,6 +674,12 @@ export class CodexAppServer extends EventEmitter {
 
   /** Bounded non-benign stderr tail shared by handshake and exit diagnostics. */
   private readonly stderrTail = new StderrTail();
+  /** Most recent immutable crash context, available without changing fatal listener arity. */
+  private _lastTransportBreadcrumb: CodexTransportBreadcrumb | null = null;
+  /** Most recent immutable crash context, if the child exited unexpectedly. */
+  public get lastTransportBreadcrumb(): CodexTransportBreadcrumb | null {
+    return this._lastTransportBreadcrumb;
+  }
   private activeRequestId: number | null = null;
   private activeTurnId: string | null = null;
   private lastActivity: { method: string; timestamp: number } | null = null;
@@ -702,6 +708,7 @@ export class CodexAppServer extends EventEmitter {
    */
   async start(): Promise<void> {
     const { cliPath, workingDirectory } = this.options;
+    this._lastTransportBreadcrumb = null;
 
     // Resolve bare command names to absolute paths so spawn works without shell.
     // On Windows, which() respects PATHEXT (.EXE before .CMD), so native binaries
@@ -1176,8 +1183,9 @@ export class CodexAppServer extends EventEmitter {
           exit: Object.freeze({ code, signal }),
           stderrTail: Object.freeze(stderrTail),
         }) satisfies CodexTransportBreadcrumb;
+        this._lastTransportBreadcrumb = breadcrumb;
         logger.error(msg, { cliPath, exit, stderrTail, breadcrumb });
-        this.emit("fatal", msg, breadcrumb);
+        this.emit("fatal", msg);
       }
     });
   }

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -252,6 +252,24 @@ interface ExitDiagnostics {
   hexCode?: string;
 }
 
+/** Bounded, payload-free context captured at an unexpected app-server exit. */
+export interface CodexTransportBreadcrumb {
+  /** Failure boundary that produced this snapshot. */
+  readonly cause: "unexpected_exit";
+  /** Child PID when Node exposed one. */
+  readonly pid: number | null;
+  /** Latest server-initiated request ID, when one was waiting. */
+  readonly activeRequestId: number | null;
+  /** Latest Codex turn ID observed for this process, when available. */
+  readonly activeTurnId: string | null;
+  /** Last inbound protocol method and wall-clock timestamp. */
+  readonly lastActivity: Readonly<{ method: string; timestamp: number }> | null;
+  /** Raw child exit code and signal. */
+  readonly exit: Readonly<{ code: number | null; signal: string | null }>;
+  /** Bounded, non-benign stderr tail. */
+  readonly stderrTail: readonly string[];
+}
+
 /** Retains a bounded tail of non-benign stderr lines for Codex crash diagnostics. */
 class StderrTail {
   private readonly lines: string[] = [];
@@ -626,7 +644,7 @@ export async function warmCodexAppServer(
  * Emits:
  * - `notification(data: unknown)` - JSON-RPC notification forwarded from the RPC client
  * - `activity()` - a server-initiated request arrived (liveness signal for turn watchdogs)
- * - `fatal(error: string)` - unrecoverable error from stderr, unexpected exit, or handshake failure
+ * - `fatal(error: string, breadcrumb?: CodexTransportBreadcrumb)` - unrecoverable error from stderr, unexpected exit, or handshake failure
  * - `exit(code: number | null, signal: string | null)` - child process exit
  */
 export class CodexAppServer extends EventEmitter {
@@ -656,6 +674,9 @@ export class CodexAppServer extends EventEmitter {
 
   /** Bounded non-benign stderr tail shared by handshake and exit diagnostics. */
   private readonly stderrTail = new StderrTail();
+  private activeRequestId: number | null = null;
+  private activeTurnId: string | null = null;
+  private lastActivity: { method: string; timestamp: number } | null = null;
 
   private readonly options: CodexAppServerOptions;
 
@@ -744,6 +765,7 @@ export class CodexAppServer extends EventEmitter {
 
     this.rpc.on("notification", (notification) => {
       const method = (notification as { method?: string }).method ?? "";
+      this.lastActivity = { method, timestamp: Date.now() };
       if (method === "account/rateLimits/updated" || method === "account/updated") {
         this.emit("activity");
         this.emit("notification", notification);
@@ -773,6 +795,15 @@ export class CodexAppServer extends EventEmitter {
         return;
       }
 
+      if (method === "turn/started") {
+        const params = (notification as { params?: Record<string, unknown> }).params;
+        const turn = params?.turn as { id?: string } | undefined;
+        const turnId = turn?.id ?? (typeof params?.turnId === "string" ? params.turnId : undefined);
+        if (turnId) this.activeTurnId = turnId;
+      } else if (method === "turn/completed") {
+        this.activeTurnId = null;
+      }
+
       if (
         !method.startsWith("thread/goal/") &&
         LIFECYCLE_NOTIFICATION_PREFIXES.some((p) => method.startsWith(p))
@@ -792,6 +823,11 @@ export class CodexAppServer extends EventEmitter {
     // for policy="never", handler-driven supervised mode, silent-deny fallback).
     this.rpc.on("serverRequest", (msg: unknown) => {
       const request = msg as { id?: number; method?: string; params?: Record<string, unknown> };
+      this.lastActivity = {
+        method: typeof request.method === "string" ? request.method : "",
+        timestamp: Date.now(),
+      };
+      this.activeRequestId = typeof request.id === "number" ? request.id : null;
       // Let turn-level watchdogs treat an inbound approval request as liveness:
       // the server is healthy, it is just waiting on a user decision.
       this.emit("activity");
@@ -800,6 +836,8 @@ export class CodexAppServer extends EventEmitter {
         approvalPolicy: this.options.approvalPolicy,
         approvalHandler: this.options.approvalHandler,
         sendResponse: (id, result) => this.rpc.sendResponse(id, result),
+      }).finally(() => {
+        if (this.activeRequestId === request.id) this.activeRequestId = null;
       });
     });
 
@@ -910,6 +948,7 @@ export class CodexAppServer extends EventEmitter {
     }, 60000);
     const turnId = result?.turnId ?? result?.turn?.id ?? null;
     if (turnId) {
+      this.activeTurnId = turnId;
       logger.debug("Codex turn/start acknowledged", { threadId: this.threadId, turnId });
     }
     return turnId;
@@ -1128,8 +1167,17 @@ export class CodexAppServer extends EventEmitter {
         const stderrTail = this.stderrTail.snapshot();
         const latestStderr = this.stderrTail.latest();
         const msg = formatUnexpectedExitMessage(exit, latestStderr);
-        logger.error(msg, { cliPath, exit, stderrTail });
-        this.emit("fatal", msg);
+        const breadcrumb = Object.freeze({
+          cause: "unexpected_exit" as const,
+          pid: this.child.pid ?? null,
+          activeRequestId: this.activeRequestId,
+          activeTurnId: this.activeTurnId,
+          lastActivity: this.lastActivity ? Object.freeze({ ...this.lastActivity }) : null,
+          exit: Object.freeze({ code, signal }),
+          stderrTail: Object.freeze(stderrTail),
+        }) satisfies CodexTransportBreadcrumb;
+        logger.error(msg, { cliPath, exit, stderrTail, breadcrumb });
+        this.emit("fatal", msg, breadcrumb);
       }
     });
   }

--- a/apps/server/src/providers/codex/codex-app-server.ts
+++ b/apps/server/src/providers/codex/codex-app-server.ts
@@ -118,11 +118,12 @@ export async function routeCodexServerRequest(args: {
   if (typeof msg.id !== "number") return;
 
   const method = msg.method ?? "";
+  const diagnosticMethod = boundProtocolIdentifier(method);
   const params = msg.params ?? {};
   const autoApprove = approvalPolicy === "never";
 
   if (autoApprove) {
-    logger.info("Codex serverRequest auto-approved", { id: msg.id, method });
+    logger.info("Codex serverRequest auto-approved", { id: msg.id, method: diagnosticMethod });
     if (method === "item/permissions/requestApproval") {
       sendResponse(msg.id, {
         permissions: {
@@ -146,7 +147,7 @@ export async function routeCodexServerRequest(args: {
     } catch (err) {
       logger.error("Codex approvalHandler rejected; sending safe-deny", {
         id: msg.id,
-        method,
+        method: diagnosticMethod,
         error: String(err),
       });
       sendResponse(msg.id, mapDecisionToCodexResponse(method, "deny", params));
@@ -159,7 +160,7 @@ export async function routeCodexServerRequest(args: {
   // and permissions requests get an empty-permissions turn-scoped response.
   logger.info("Codex serverRequest denied (no approvalHandler and policy is not auto-approve)", {
     id: msg.id,
-    method,
+    method: diagnosticMethod,
   });
   sendResponse(msg.id, mapDecisionToCodexResponse(method, "deny", params));
 }
@@ -239,6 +240,20 @@ const THREAD_HANDSHAKE_TIMEOUT_MS = 30_000;
 const STDERR_TAIL_MAX_LINES = 50;
 /** Maximum UTF-8 bytes retained across non-benign stderr diagnostics. */
 const STDERR_TAIL_MAX_BYTES = 16 * 1024;
+/** Maximum code points retained for protocol identifiers in diagnostics. */
+const MAX_PROTOCOL_IDENTIFIER_LENGTH = 256;
+
+/** Bounds an untrusted protocol identifier before retaining it in diagnostics. */
+function boundProtocolIdentifier(value: string): string {
+  let bounded = "";
+  let length = 0;
+  for (const character of value) {
+    if (length >= MAX_PROTOCOL_IDENTIFIER_LENGTH) break;
+    bounded += character;
+    length += 1;
+  }
+  return bounded;
+}
 
 /** Decoded child-process exit details used in user-facing and structured diagnostics. */
 interface ExitDiagnostics {
@@ -772,7 +787,8 @@ export class CodexAppServer extends EventEmitter {
 
     this.rpc.on("notification", (notification) => {
       const method = (notification as { method?: string }).method ?? "";
-      this.lastActivity = { method, timestamp: Date.now() };
+      const diagnosticMethod = boundProtocolIdentifier(method);
+      this.lastActivity = { method: diagnosticMethod, timestamp: Date.now() };
       if (method === "account/rateLimits/updated" || method === "account/updated") {
         this.emit("activity");
         this.emit("notification", notification);
@@ -798,7 +814,7 @@ export class CodexAppServer extends EventEmitter {
           this.emit("threadIdChanged", newThreadId);
         }
         this.emit("activity");
-        logger.debug("Codex lifecycle notification", { method });
+        logger.debug("Codex lifecycle notification", { method: diagnosticMethod });
         return;
       }
 
@@ -806,7 +822,7 @@ export class CodexAppServer extends EventEmitter {
         const params = (notification as { params?: Record<string, unknown> }).params;
         const turn = params?.turn as { id?: string } | undefined;
         const turnId = turn?.id ?? (typeof params?.turnId === "string" ? params.turnId : undefined);
-        if (turnId) this.activeTurnId = turnId;
+        if (turnId) this.activeTurnId = boundProtocolIdentifier(turnId);
       } else if (method === "turn/completed") {
         this.activeTurnId = null;
       }
@@ -818,7 +834,7 @@ export class CodexAppServer extends EventEmitter {
         // Swallowed from the mapper, but still proof of life: thread/status
         // and similar lifecycle traffic must reset turn-level watchdogs.
         this.emit("activity");
-        logger.debug("Codex lifecycle notification", { method });
+        logger.debug("Codex lifecycle notification", { method: diagnosticMethod });
         return;
       }
       this.emit("notification", notification);
@@ -831,7 +847,7 @@ export class CodexAppServer extends EventEmitter {
     this.rpc.on("serverRequest", (msg: unknown) => {
       const request = msg as { id?: number; method?: string; params?: Record<string, unknown> };
       this.lastActivity = {
-        method: typeof request.method === "string" ? request.method : "",
+        method: typeof request.method === "string" ? boundProtocolIdentifier(request.method) : "",
         timestamp: Date.now(),
       };
       this.activeRequestId = typeof request.id === "number" ? request.id : null;
@@ -955,8 +971,11 @@ export class CodexAppServer extends EventEmitter {
     }, 60000);
     const turnId = result?.turnId ?? result?.turn?.id ?? null;
     if (turnId) {
-      this.activeTurnId = turnId;
-      logger.debug("Codex turn/start acknowledged", { threadId: this.threadId, turnId });
+      this.activeTurnId = boundProtocolIdentifier(turnId);
+      logger.debug("Codex turn/start acknowledged", {
+        threadId: this.threadId,
+        turnId: boundProtocolIdentifier(turnId),
+      });
     }
     return turnId;
   }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -54,7 +54,7 @@ import type {
 import { AgentEventType, CODEX_STATIC_MODELS, isGoalOpen, isVirtualBrowserContextAttachment, supportsCodexUltraOrchestration } from "@mcode/contracts";
 import { checkCodexVersion, meetsMinVersion } from "./codex-version.js";
 import { CodexAppServer, warmCodexAppServer } from "./codex-app-server.js";
-import type { CodexApprovalRequest, CodexTransportBreadcrumb } from "./codex-app-server.js";
+import type { CodexApprovalRequest } from "./codex-app-server.js";
 import { CodexEventMapper } from "./codex-event-mapper.js";
 import { traceCodexIngest } from "./codex-trace.js";
 import type {
@@ -1207,8 +1207,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       if (childThreadId) this.fetchChildThreadMetadata(sessionId, threadId, server, mapper, childThreadId);
     });
 
-    server.on("fatal", (error: string, breadcrumb?: CodexTransportBreadcrumb) => {
-      logger.error("CodexAppServer fatal", { sessionId, error, breadcrumb });
+    server.on("fatal", (error: string) => {
+      logger.error("CodexAppServer fatal", { sessionId, error, breadcrumb: server.lastTransportBreadcrumb });
       for (const event of mapper.drainPendingAssistantBoundary(false)) {
         this.emit("event", event);
       }

--- a/apps/server/src/providers/codex/codex-provider.ts
+++ b/apps/server/src/providers/codex/codex-provider.ts
@@ -54,7 +54,7 @@ import type {
 import { AgentEventType, CODEX_STATIC_MODELS, isGoalOpen, isVirtualBrowserContextAttachment, supportsCodexUltraOrchestration } from "@mcode/contracts";
 import { checkCodexVersion, meetsMinVersion } from "./codex-version.js";
 import { CodexAppServer, warmCodexAppServer } from "./codex-app-server.js";
-import type { CodexApprovalRequest } from "./codex-app-server.js";
+import type { CodexApprovalRequest, CodexTransportBreadcrumb } from "./codex-app-server.js";
 import { CodexEventMapper } from "./codex-event-mapper.js";
 import { traceCodexIngest } from "./codex-trace.js";
 import type {
@@ -1207,8 +1207,8 @@ export class CodexProvider extends EventEmitter implements IAgentProvider, IGoal
       if (childThreadId) this.fetchChildThreadMetadata(sessionId, threadId, server, mapper, childThreadId);
     });
 
-    server.on("fatal", (error: string) => {
-      logger.error("CodexAppServer fatal", { sessionId, error });
+    server.on("fatal", (error: string, breadcrumb?: CodexTransportBreadcrumb) => {
+      logger.error("CodexAppServer fatal", { sessionId, error, breadcrumb });
       for (const event of mapper.drainPendingAssistantBoundary(false)) {
         this.emit("event", event);
       }


### PR DESCRIPTION
## What
Capture bounded, immutable diagnostics when the Codex app-server exits unexpectedly.

## Why
Intermittent Codex provider drops lacked enough context to identify whether the child process, transport, or current turn failed.

## Key Changes
- Record a redacted crash breadcrumb with exit metadata, activity, identifiers, and bounded stderr.
- Keep the existing one-argument fatal event contract.
- Add deterministic unexpected-child-exit and provider terminal-flow coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788016491&installation_model_id=20477&pr_number=1024&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1024&signature=6c5855447c333e300e0160f19e899424aa8c54b427d13ba3c8af4407b5e31d79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->