### PR TITLE
feat: add Mcode browser and thread-control guides

### DIFF
--- a/apps/server/src/services/__tests__/mcode-capability-guide.test.ts
+++ b/apps/server/src/services/__tests__/mcode-capability-guide.test.ts
@@ -12,6 +12,9 @@ describe("Mcode capability guide", () => {
     expect(result.guide).toContain("omit branchName");
     expect(result.guide).toContain("no branchName");
     expect(result.guide).toContain("providerId codex");
+    const example = result.guide.slice(result.guide.indexOf("- Example:"), result.guide.indexOf("\n\nMcode Browser"));
+    expect(example).not.toContain("workspace_search");
+    expect(example).not.toContain("worktree_list");
     expect(result.guide).toContain("browser_status");
     expect(result.guide).toContain("expectedControlEpoch");
     expect(result.guide).not.toContain("password");

--- a/apps/server/src/services/__tests__/mcode-capability-guide.test.ts
+++ b/apps/server/src/services/__tests__/mcode-capability-guide.test.ts
@@ -8,6 +8,9 @@ describe("Mcode capability guide", () => {
     expect(result).toEqual({ guide: MCODE_CAPABILITY_GUIDE });
     expect(result.guide).toContain("workspace_search");
     expect(result.guide).toContain("thread_create_batch");
+    expect(result.guide).toContain("active source thread's Project");
+    expect(result.guide).toContain("omit branchName");
+    expect(result.guide).toContain("no branchName");
     expect(result.guide).toContain("providerId codex");
     expect(result.guide).toContain("browser_status");
     expect(result.guide).toContain("expectedControlEpoch");

--- a/apps/server/src/services/__tests__/mcode-capability-guide.test.ts
+++ b/apps/server/src/services/__tests__/mcode-capability-guide.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { MCODE_CAPABILITY_GUIDE, getMcodeCapabilityGuide } from "../mcode-capability-guide.js";
+
+describe("Mcode capability guide", () => {
+  it("returns stable guidance for thread control and browser operations", () => {
+    const result = getMcodeCapabilityGuide();
+
+    expect(result).toEqual({ guide: MCODE_CAPABILITY_GUIDE });
+    expect(result.guide).toContain("workspace_search");
+    expect(result.guide).toContain("thread_create_batch");
+    expect(result.guide).toContain("providerId codex");
+    expect(result.guide).toContain("browser_status");
+    expect(result.guide).toContain("expectedControlEpoch");
+    expect(result.guide).not.toContain("password");
+    expect(result.guide).not.toContain("api key");
+  });
+});

--- a/apps/server/src/services/__tests__/mcode-capability-guide.test.ts
+++ b/apps/server/src/services/__tests__/mcode-capability-guide.test.ts
@@ -1,23 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { MCODE_CAPABILITY_GUIDE, getMcodeCapabilityGuide } from "../mcode-capability-guide.js";
+import {
+  MCODE_BROWSER_GUIDE,
+  THREAD_CONTROL_GUIDE,
+  getMcodeBrowserGuide,
+  getThreadControlGuide,
+} from "../mcode-capability-guide.js";
 
 describe("Mcode capability guide", () => {
-  it("returns stable guidance for thread control and browser operations", () => {
-    const result = getMcodeCapabilityGuide();
+  it("returns browser-only guidance", () => {
+    const result = getMcodeBrowserGuide();
 
-    expect(result).toEqual({ guide: MCODE_CAPABILITY_GUIDE });
+    expect(result).toEqual({ guide: MCODE_BROWSER_GUIDE });
+    expect(result.guide).toContain("browser_status");
+    expect(result.guide).toContain("expectedControlEpoch");
+    expect(result.guide).not.toContain("thread_create_batch");
+    expect(result.guide).not.toContain("workspace_search");
+  });
+
+  it("returns thread-control-only guidance", () => {
+    const result = getThreadControlGuide();
+
+    expect(result).toEqual({ guide: THREAD_CONTROL_GUIDE });
     expect(result.guide).toContain("workspace_search");
     expect(result.guide).toContain("thread_create_batch");
     expect(result.guide).toContain("active source thread's Project");
     expect(result.guide).toContain("omit branchName");
-    expect(result.guide).toContain("no branchName");
     expect(result.guide).toContain("providerId codex");
-    const example = result.guide.slice(result.guide.indexOf("- Example:"), result.guide.indexOf("\n\nMcode Browser"));
-    expect(example).not.toContain("workspace_search");
-    expect(example).not.toContain("worktree_list");
-    expect(result.guide).toContain("browser_status");
-    expect(result.guide).toContain("expectedControlEpoch");
-    expect(result.guide).not.toContain("password");
-    expect(result.guide).not.toContain("api key");
+    expect(result.guide).not.toContain("browser_status");
+    expect(result.guide).not.toContain("expectedControlEpoch");
   });
 });

--- a/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
@@ -99,6 +99,7 @@ describe("internal thread-control MCP transport", () => {
     await client.connect(clientTransport);
     await expect(client.listTools()).resolves.toMatchObject({
       tools: [
+        { name: "mcode_guide", description: expect.stringContaining("Mcode Browser") },
         { name: "workspace_search" },
         { name: "worktree_list" },
         { name: "thread_create_batch" },
@@ -108,6 +109,10 @@ describe("internal thread-control MCP transport", () => {
         { name: "thread_stop" },
         { name: "thread_wait" },
       ],
+    });
+    await expect(client.callTool({ name: "mcode_guide" })).resolves.toMatchObject({
+      structuredContent: { guide: expect.stringContaining("thread_create_batch") },
+      content: [{ type: "text", text: expect.stringContaining("browser_status") }],
     });
     await expect(client.callTool({
       name: "thread_wait",
@@ -158,6 +163,7 @@ describe("internal thread-control MCP transport", () => {
     await client.connect(clientTransport);
     await expect(client.listTools()).resolves.toMatchObject({
       tools: [
+        { name: "mcode_guide" },
         { name: "workspace_search" },
         { name: "worktree_list" },
         { name: "thread_create_batch" },

--- a/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-mcp-transport.test.ts
@@ -99,7 +99,8 @@ describe("internal thread-control MCP transport", () => {
     await client.connect(clientTransport);
     await expect(client.listTools()).resolves.toMatchObject({
       tools: [
-        { name: "mcode_guide", description: expect.stringContaining("Mcode Browser") },
+        { name: "mcode_browser_guide", description: expect.stringContaining("Mcode Browser") },
+        { name: "thread_control_guide", description: expect.stringContaining("thread-control") },
         { name: "workspace_search" },
         { name: "worktree_list" },
         { name: "thread_create_batch" },
@@ -110,9 +111,13 @@ describe("internal thread-control MCP transport", () => {
         { name: "thread_wait" },
       ],
     });
-    await expect(client.callTool({ name: "mcode_guide" })).resolves.toMatchObject({
+    await expect(client.callTool({ name: "mcode_browser_guide" })).resolves.toMatchObject({
+      structuredContent: { guide: expect.stringContaining("browser_status") },
+      content: [{ type: "text", text: expect.not.stringContaining("thread_create_batch") }],
+    });
+    await expect(client.callTool({ name: "thread_control_guide" })).resolves.toMatchObject({
       structuredContent: { guide: expect.stringContaining("thread_create_batch") },
-      content: [{ type: "text", text: expect.stringContaining("browser_status") }],
+      content: [{ type: "text", text: expect.not.stringContaining("browser_status") }],
     });
     await expect(client.callTool({
       name: "thread_wait",
@@ -163,7 +168,8 @@ describe("internal thread-control MCP transport", () => {
     await client.connect(clientTransport);
     await expect(client.listTools()).resolves.toMatchObject({
       tools: [
-        { name: "mcode_guide" },
+        { name: "mcode_browser_guide" },
+        { name: "thread_control_guide" },
         { name: "workspace_search" },
         { name: "worktree_list" },
         { name: "thread_create_batch" },

--- a/apps/server/src/services/__tests__/thread-control-service.test.ts
+++ b/apps/server/src/services/__tests__/thread-control-service.test.ts
@@ -437,6 +437,71 @@ describe("ThreadControlService", () => {
     }));
   });
 
+  it("defaults an internal item without a Project to its source thread Project", async () => {
+    const service = createService();
+    threads.findById.mockImplementation((id: string) => id === authority.sourceThreadId
+      ? { ...createdThread, id: authority.sourceThreadId, deleted_at: null }
+      : null);
+
+    const result = await service.threadCreateBatch(authority, {
+      items: [{
+        title: "Inherited Project",
+        prompt: "Create in source Project.",
+        placement: { type: "direct" },
+      }],
+    });
+
+    expect(result.results[0]).toMatchObject({ status: "created", workspaceId: workspace.id });
+    expect(threads.create).toHaveBeenCalledWith(workspace.id, expect.any(String), "direct", "main", true, "codex", undefined, "named", null);
+  });
+
+  it("rejects an external item without a Project without looking up or creating", async () => {
+    const service = createService();
+    const externalAuthority = {
+      type: "external" as const,
+      integrationId: "integration-1",
+      allowedWorkspaceIds: [workspace.id],
+      scopes: ["threads:create"] as const,
+      limits: { callsPerMinute: 10, maxActiveThreads: 1 },
+    };
+
+    const result = await service.threadCreateBatch(externalAuthority, {
+      items: [{
+        title: "Missing Project",
+        prompt: "Reject this.",
+        placement: { type: "direct" },
+      }],
+    });
+
+    expect(result.results).toEqual([{
+      index: 0,
+      status: "rejected",
+      error: { code: "not_found", message: "Workspace not found", retryable: false },
+    }]);
+    expect(workspaces.findById).not.toHaveBeenCalled();
+    expect(threads.create).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when an internal source thread is unavailable", async () => {
+    const service = createService();
+
+    const result = await service.threadCreateBatch(authority, {
+      items: [{
+        title: "Unavailable source",
+        prompt: "Reject this.",
+        placement: { type: "direct" },
+      }],
+    });
+
+    expect(result.results).toEqual([{
+      index: 0,
+      status: "rejected",
+      error: { code: "not_found", message: "Source thread not found", retryable: false },
+    }]);
+    expect(workspaces.findById).not.toHaveBeenCalled();
+    expect(threads.create).not.toHaveBeenCalled();
+  });
+
   it("returns a created result when audit storage fails", async () => {
     const service = createService();
     audit.write.mockImplementationOnce(() => { throw new Error("audit unavailable"); });
@@ -630,6 +695,30 @@ describe("ThreadControlService", () => {
         branchName: "codex/issue-960",
       },
     );
+  });
+
+  it("keeps new worktree branchless when branchName is omitted", async () => {
+    const service = createService();
+    const fullAuthority = { ...authority, permissionMode: "full" as const };
+
+    const result = await service.threadCreateBatch(fullAuthority, {
+      items: [{
+        workspaceId: workspace.id,
+        title: "Branchless worktree",
+        prompt: "Start branchless.",
+        placement: { type: "new_worktree", baseRef: "main" },
+      }],
+    });
+
+    expect(result.results[0]).toMatchObject({
+      status: "created",
+      placement: { type: "new_worktree", baseRef: "main", worktreeId: "worktree-created" },
+    });
+    expect(result.results[0]).not.toHaveProperty("placement.branchName");
+    expect(threadService.provisionWorktree).toHaveBeenCalledWith(createdThread.id, workspace.id, {
+      type: "new_worktree",
+      baseRef: "main",
+    });
   });
 
   it("resumes the same pending operation exactly once after human approval", async () => {

--- a/apps/server/src/services/mcode-capability-guide.ts
+++ b/apps/server/src/services/mcode-capability-guide.ts
@@ -1,23 +1,28 @@
-/** Stable operating guidance for capabilities owned by the Mcode app. */
-export const MCODE_CAPABILITY_GUIDE = `Mcode capability guide (available only inside authenticated Mcode provider sessions)
+/** Stable operating guidance for the Mcode Browser capability. */
+export const MCODE_BROWSER_GUIDE = `Mcode Browser guide (available only inside authenticated Mcode provider sessions)
 
-Read this guide when a user asks you to create, inspect, coordinate, send work to, stop, or wait on Mcode threads, or asks you to use or control the Mcode Browser. Tool schemas remain authoritative for arguments, permissions, and result shapes.
-
-Thread control
-- Resolve an explicitly named Project with workspace_search; use worktree_list only when resolving an explicit worktree or reference. For default delegated work, use the active source thread's Project without discovery.
-- Create delegated work with thread_create_batch. Preserve the user's title and task in the prompt. If a new thread is requested without an explicit Project, create it in the active source thread's Project; do not ask for or select another Project. When a new worktree thread is requested without an explicit branch, use placement type new_worktree with the appropriate baseRef and omit branchName. Set branchName only when the user explicitly names a branch. Resolve an explicitly named Project and respect an explicitly requested worktree. When the user names a provider or execution setting, pass it (for example providerId codex) in the creation request.
-- Use returned workspaceId, threadId, turnId, and worktree references for follow-up operations. Use thread_search for discovery, thread_get for one bounded transcript, thread_send to assign or continue work, thread_stop to stop work, and thread_wait to wait for attention or a terminal state.
-- Never target the active source thread. Keep delegated prompts faithful to the user's request and inspect results before sending follow-up work.
-- Example: for “create a worktree thread with the Codex provider for <task>”, run thread_create_batch directly in the active source thread's Project with placement type new_worktree, the appropriate baseRef, no branchName, and providerId codex. Track the returned threadId with thread_get or thread_wait, then use thread_send or thread_stop as needed.
-
-Mcode Browser
 - Check browser_status before an action, then use browser_snapshot to understand the current page and available semantic targets.
 - Prefer semantic targets from the snapshot when clicking, typing, pressing keys, scrolling, or waiting. Use browser_open or browser_navigate for navigation, then snapshot again.
 - For every mutating operation, pass expectedControlEpoch from the latest browser_status. If the epoch is stale, refresh status and snapshot before retrying. Observe the result with another snapshot or status call.
 - Use browser_screenshot for visual evidence. Use browser_console, browser_network, browser_accessibility, and browser_performance for diagnostics. Browser tool schemas define exact arguments and permissions; do not infer or reproduce them here.
 `;
 
-/** Returns the structured app-owned capability guide exposed by mcode_guide. */
-export function getMcodeCapabilityGuide(): { guide: string } {
-  return { guide: MCODE_CAPABILITY_GUIDE };
+/** Stable operating guidance for Mcode thread and worktree control. */
+export const THREAD_CONTROL_GUIDE = `Mcode thread-control guide (available only inside authenticated Mcode provider sessions)
+
+- Resolve an explicitly named Project with workspace_search; use worktree_list only when resolving an explicit worktree or reference. For default delegated work, use the active source thread's Project without discovery.
+- Create delegated work with thread_create_batch. Preserve the user's title and task in the prompt. If a new thread is requested without an explicit Project, create it in the active source thread's Project; do not ask for or select another Project. When a new worktree thread is requested without an explicit branch, use placement type new_worktree with the appropriate baseRef and omit branchName. Set branchName only when the user explicitly names a branch. Resolve an explicitly named Project and respect an explicitly requested worktree. When the user names a provider or execution setting, pass it (for example providerId codex) in the creation request.
+- Use returned workspaceId, threadId, turnId, and worktree references for follow-up operations. Use thread_search for discovery, thread_get for one bounded transcript, thread_send to assign or continue work, thread_stop to stop work, and thread_wait to wait for attention or a terminal state.
+- Never target the active source thread. Keep delegated prompts faithful to the user's request and inspect results before sending follow-up work.
+- Example: for “create a worktree thread with the Codex provider for <task>”, run thread_create_batch directly in the active source thread's Project with placement type new_worktree, the appropriate baseRef, no branchName, and providerId codex. Track the returned threadId with thread_get or thread_wait, then use thread_send or thread_stop as needed.
+`;
+
+/** Returns the structured app-owned Browser operating guide. */
+export function getMcodeBrowserGuide(): { guide: string } {
+  return { guide: MCODE_BROWSER_GUIDE };
+}
+
+/** Returns the structured app-owned thread-control operating guide. */
+export function getThreadControlGuide(): { guide: string } {
+  return { guide: THREAD_CONTROL_GUIDE };
 }

--- a/apps/server/src/services/mcode-capability-guide.ts
+++ b/apps/server/src/services/mcode-capability-guide.ts
@@ -1,0 +1,23 @@
+/** Stable operating guidance for capabilities owned by the Mcode app. */
+export const MCODE_CAPABILITY_GUIDE = `Mcode capability guide (available only inside authenticated Mcode provider sessions)
+
+Read this guide when a user asks you to create, inspect, coordinate, send work to, stop, or wait on Mcode threads, or asks you to use or control the Mcode Browser. Tool schemas remain authoritative for arguments, permissions, and result shapes.
+
+Thread control
+- Discover before acting: use workspace_search to find the registered Project, then worktree_list when a worktree reference is needed.
+- Create delegated work with thread_create_batch. Preserve the user's title and task in the prompt. For a new isolated checkout, use placement type new_worktree with the requested base ref. When the user names a provider or execution setting, pass it (for example providerId codex) in the creation request.
+- Use returned workspaceId, threadId, turnId, and worktree references for follow-up operations. Use thread_search for discovery, thread_get for one bounded transcript, thread_send to assign or continue work, thread_stop to stop work, and thread_wait to wait for attention or a terminal state.
+- Never target the active source thread. Keep delegated prompts faithful to the user's request and inspect results before sending follow-up work.
+- Example: for “create a worktree thread with the Codex provider for <task>”, run workspace_search, optionally worktree_list, then thread_create_batch with the requested task, placement type new_worktree, base ref, and providerId codex. Track the returned threadId with thread_get or thread_wait, then use thread_send or thread_stop as needed.
+
+Mcode Browser
+- Check browser_status before an action, then use browser_snapshot to understand the current page and available semantic targets.
+- Prefer semantic targets from the snapshot when clicking, typing, pressing keys, scrolling, or waiting. Use browser_open or browser_navigate for navigation, then snapshot again.
+- For every mutating operation, pass expectedControlEpoch from the latest browser_status. If the epoch is stale, refresh status and snapshot before retrying. Observe the result with another snapshot or status call.
+- Use browser_screenshot for visual evidence. Use browser_console, browser_network, browser_accessibility, and browser_performance for diagnostics. Browser tool schemas define exact arguments and permissions; do not infer or reproduce them here.
+`;
+
+/** Returns the structured app-owned capability guide exposed by mcode_guide. */
+export function getMcodeCapabilityGuide(): { guide: string } {
+  return { guide: MCODE_CAPABILITY_GUIDE };
+}

--- a/apps/server/src/services/mcode-capability-guide.ts
+++ b/apps/server/src/services/mcode-capability-guide.ts
@@ -4,11 +4,11 @@ export const MCODE_CAPABILITY_GUIDE = `Mcode capability guide (available only in
 Read this guide when a user asks you to create, inspect, coordinate, send work to, stop, or wait on Mcode threads, or asks you to use or control the Mcode Browser. Tool schemas remain authoritative for arguments, permissions, and result shapes.
 
 Thread control
-- Discover before acting: use workspace_search to find the registered Project, then worktree_list when a worktree reference is needed.
+- Resolve an explicitly named Project with workspace_search; use worktree_list only when resolving an explicit worktree or reference. For default delegated work, use the active source thread's Project without discovery.
 - Create delegated work with thread_create_batch. Preserve the user's title and task in the prompt. If a new thread is requested without an explicit Project, create it in the active source thread's Project; do not ask for or select another Project. When a new worktree thread is requested without an explicit branch, use placement type new_worktree with the appropriate baseRef and omit branchName. Set branchName only when the user explicitly names a branch. Resolve an explicitly named Project and respect an explicitly requested worktree. When the user names a provider or execution setting, pass it (for example providerId codex) in the creation request.
 - Use returned workspaceId, threadId, turnId, and worktree references for follow-up operations. Use thread_search for discovery, thread_get for one bounded transcript, thread_send to assign or continue work, thread_stop to stop work, and thread_wait to wait for attention or a terminal state.
 - Never target the active source thread. Keep delegated prompts faithful to the user's request and inspect results before sending follow-up work.
-- Example: for “create a worktree thread with the Codex provider for <task>”, run workspace_search, optionally worktree_list, then thread_create_batch in the active source thread's Project with placement type new_worktree, the appropriate baseRef, no branchName, and providerId codex. Track the returned threadId with thread_get or thread_wait, then use thread_send or thread_stop as needed.
+- Example: for “create a worktree thread with the Codex provider for <task>”, run thread_create_batch directly in the active source thread's Project with placement type new_worktree, the appropriate baseRef, no branchName, and providerId codex. Track the returned threadId with thread_get or thread_wait, then use thread_send or thread_stop as needed.
 
 Mcode Browser
 - Check browser_status before an action, then use browser_snapshot to understand the current page and available semantic targets.

--- a/apps/server/src/services/mcode-capability-guide.ts
+++ b/apps/server/src/services/mcode-capability-guide.ts
@@ -5,10 +5,10 @@ Read this guide when a user asks you to create, inspect, coordinate, send work t
 
 Thread control
 - Discover before acting: use workspace_search to find the registered Project, then worktree_list when a worktree reference is needed.
-- Create delegated work with thread_create_batch. Preserve the user's title and task in the prompt. For a new isolated checkout, use placement type new_worktree with the requested base ref. When the user names a provider or execution setting, pass it (for example providerId codex) in the creation request.
+- Create delegated work with thread_create_batch. Preserve the user's title and task in the prompt. If a new thread is requested without an explicit Project, create it in the active source thread's Project; do not ask for or select another Project. When a new worktree thread is requested without an explicit branch, use placement type new_worktree with the appropriate baseRef and omit branchName. Set branchName only when the user explicitly names a branch. Resolve an explicitly named Project and respect an explicitly requested worktree. When the user names a provider or execution setting, pass it (for example providerId codex) in the creation request.
 - Use returned workspaceId, threadId, turnId, and worktree references for follow-up operations. Use thread_search for discovery, thread_get for one bounded transcript, thread_send to assign or continue work, thread_stop to stop work, and thread_wait to wait for attention or a terminal state.
 - Never target the active source thread. Keep delegated prompts faithful to the user's request and inspect results before sending follow-up work.
-- Example: for “create a worktree thread with the Codex provider for <task>”, run workspace_search, optionally worktree_list, then thread_create_batch with the requested task, placement type new_worktree, base ref, and providerId codex. Track the returned threadId with thread_get or thread_wait, then use thread_send or thread_stop as needed.
+- Example: for “create a worktree thread with the Codex provider for <task>”, run workspace_search, optionally worktree_list, then thread_create_batch in the active source thread's Project with placement type new_worktree, the appropriate baseRef, no branchName, and providerId codex. Track the returned threadId with thread_get or thread_wait, then use thread_send or thread_stop as needed.
 
 Mcode Browser
 - Check browser_status before an action, then use browser_snapshot to understand the current page and available semantic targets.

--- a/apps/server/src/services/thread-control-mcp-transport.ts
+++ b/apps/server/src/services/thread-control-mcp-transport.ts
@@ -19,7 +19,7 @@ import {
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { InternalThreadControlMcpAuthority } from "./thread-control-mcp-authority.js";
 import type { ThreadControlService } from "./thread-control-service.js";
-import { getMcodeCapabilityGuide } from "./mcode-capability-guide.js";
+import { getMcodeBrowserGuide, getThreadControlGuide } from "./mcode-capability-guide.js";
 
 /** Incoming request context for the server-internal MCP transport. */
 export interface InternalThreadControlMcpRequest {
@@ -99,11 +99,17 @@ export function createInternalThreadControlMcpSession(
         const input = ThreadWaitInputSchema().parse(request.arguments);
         return ThreadWaitResultSchema().parse(await options.service.threadWait(authority, input, signal));
       }
-      case "mcode_guide": {
+      case "mcode_browser_guide": {
         if (!isEmptyArguments(request.arguments)) {
-          throw new Error("mcode_guide accepts no arguments");
+          throw new Error("mcode_browser_guide accepts no arguments");
         }
-        return getMcodeCapabilityGuide();
+        return getMcodeBrowserGuide();
+      }
+      case "thread_control_guide": {
+        if (!isEmptyArguments(request.arguments)) {
+          throw new Error("thread_control_guide accepts no arguments");
+        }
+        return getThreadControlGuide();
       }
       default:
         throw new InternalThreadControlMcpAuthorizationError();
@@ -114,12 +120,21 @@ export function createInternalThreadControlMcpSession(
     dispatch,
     createServer(bearerCredential) {
       const server = new McpServer({ name: "mcode-internal-thread-control", version: "0.1.0" });
-      server.registerTool("mcode_guide", {
-        description: "Read the Mcode operating guide when a user asks to create, inspect, coordinate, send work to, stop, or wait on Mcode threads, or to use or control the Mcode Browser.",
+      server.registerTool("mcode_browser_guide", {
+        description: "Read the Mcode Browser operating guide.",
       }, async (extra) => createToolResult(await dispatch({
         bearerCredential,
         requestId: extra.requestId,
-        toolName: "mcode_guide",
+        toolName: "mcode_browser_guide",
+        arguments: undefined,
+        signal: extra.signal,
+      })));
+      server.registerTool("thread_control_guide", {
+        description: "Read the Mcode thread-control operating guide.",
+      }, async (extra) => createToolResult(await dispatch({
+        bearerCredential,
+        requestId: extra.requestId,
+        toolName: "thread_control_guide",
         arguments: undefined,
         signal: extra.signal,
       })));

--- a/apps/server/src/services/thread-control-mcp-transport.ts
+++ b/apps/server/src/services/thread-control-mcp-transport.ts
@@ -19,6 +19,7 @@ import {
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { InternalThreadControlMcpAuthority } from "./thread-control-mcp-authority.js";
 import type { ThreadControlService } from "./thread-control-service.js";
+import { getMcodeCapabilityGuide } from "./mcode-capability-guide.js";
 
 /** Incoming request context for the server-internal MCP transport. */
 export interface InternalThreadControlMcpRequest {
@@ -98,6 +99,12 @@ export function createInternalThreadControlMcpSession(
         const input = ThreadWaitInputSchema().parse(request.arguments);
         return ThreadWaitResultSchema().parse(await options.service.threadWait(authority, input, signal));
       }
+      case "mcode_guide": {
+        if (!isEmptyArguments(request.arguments)) {
+          throw new Error("mcode_guide accepts no arguments");
+        }
+        return getMcodeCapabilityGuide();
+      }
       default:
         throw new InternalThreadControlMcpAuthorizationError();
     }
@@ -107,6 +114,15 @@ export function createInternalThreadControlMcpSession(
     dispatch,
     createServer(bearerCredential) {
       const server = new McpServer({ name: "mcode-internal-thread-control", version: "0.1.0" });
+      server.registerTool("mcode_guide", {
+        description: "Read the Mcode operating guide when a user asks to create, inspect, coordinate, send work to, stop, or wait on Mcode threads, or to use or control the Mcode Browser.",
+      }, async (extra) => createToolResult(await dispatch({
+        bearerCredential,
+        requestId: extra.requestId,
+        toolName: "mcode_guide",
+        arguments: undefined,
+        signal: extra.signal,
+      })));
       server.registerTool("workspace_search", {
         description: "Search registered Mcode workspaces.",
         inputSchema: WorkspaceSearchInputSchema(),
@@ -194,6 +210,12 @@ export function createInternalThreadControlMcpSession(
       return server;
     },
   };
+}
+
+function isEmptyArguments(arguments_: unknown): boolean {
+  if (arguments_ === undefined || arguments_ === null) return true;
+  if (typeof arguments_ !== "object" || Array.isArray(arguments_)) return false;
+  return Object.keys(arguments_).length === 0;
 }
 
 function combineAbortSignals(signals: Array<AbortSignal | undefined>): AbortSignal | undefined {

--- a/apps/server/src/services/thread-control-service.ts
+++ b/apps/server/src/services/thread-control-service.ts
@@ -365,20 +365,39 @@ export class ThreadControlService {
     input: ThreadCreateBatchInput,
   ): Promise<ThreadCreateBatchResult> {
     const validatedInput = ThreadCreateBatchInputSchema().parse(input);
+    const sourceWorkspaceId = authority.type === "internal"
+      && validatedInput.items.some((item) => item.workspaceId === undefined)
+      ? this.resolveInternalSourceWorkspaceId(authority)
+      : undefined;
+    const items = validatedInput.items.map((item) => item.workspaceId === undefined && sourceWorkspaceId
+      ? { ...item, workspaceId: sourceWorkspaceId }
+      : item);
+    const normalizedInput = { items };
     const reservations = authority.type === "external"
-      ? await this.reserveExternalCapacity(authority, validatedInput)
-      : validatedInput.items.map(() => false);
+      ? await this.reserveExternalCapacity(authority, normalizedInput)
+      : items.map(() => false);
     const results: ThreadCreateItemResult[] = [];
-    for (let index = 0; index < validatedInput.items.length; index += 1) {
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index]!;
+      if (authority.type === "internal" && item.workspaceId === undefined) {
+        const result: ThreadCreateItemResult = {
+          index,
+          status: "rejected",
+          error: this.error("not_found", "Source thread not found", false),
+        };
+        this.auditCreateResult(authority, result);
+        results.push(result);
+        continue;
+      }
       if (
         authority.type === "external"
-        && this.externalItemCanCreate(authority, validatedInput.items[index]!)
+        && this.externalItemCanCreate(authority, item)
         && !reservations[index]
       ) {
         const result: ThreadCreateItemResult = {
           index,
           status: "rejected",
-          workspaceId: validatedInput.items[index]!.workspaceId,
+          workspaceId: item.workspaceId,
           error: this.error("limit_exceeded", "External active-thread limit reached", true),
         };
         this.auditCreateResult(authority, result);
@@ -386,7 +405,7 @@ export class ThreadControlService {
         continue;
       }
       try {
-        const result = await this.createOne(authority, validatedInput.items[index]!, index);
+        const result = await this.createOne(authority, item, index);
         this.auditCreateResult(authority, result);
         results.push(result);
         if ("threadId" in result && result.threadId) {
@@ -1086,10 +1105,13 @@ export class ThreadControlService {
     index: number,
   ): Promise<ThreadCreateItemResult> {
     if (
+      input.workspaceId === undefined
+      || (
       authority.type === "external"
       && (
         !authority.allowedWorkspaceIds.includes(input.workspaceId)
         || !authority.scopes.includes("threads:create")
+      )
       )
     ) {
       return {
@@ -1156,7 +1178,11 @@ export class ThreadControlService {
 
     let threadId: string | undefined;
     try {
-      const persisted = await this.persistThread(input, execution.value, existingWorktree);
+      const persisted = await this.persistThread(
+        input as ThreadCreateInput & { workspaceId: string },
+        execution.value,
+        existingWorktree,
+      );
       threadId = persisted.threadId;
       if (authority.type === "internal") {
         this.threads.updateDelegationLineage(threadId, {
@@ -1335,7 +1361,7 @@ export class ThreadControlService {
   }
 
   private async persistThread(
-    input: ThreadCreateInput,
+    input: ThreadCreateInput & { workspaceId: string },
     execution: ResolvedExecution,
     existingWorktree: InternalRegisteredWorktree | null,
   ): Promise<{ threadId: string }> {
@@ -1640,12 +1666,19 @@ export class ThreadControlService {
     authority: ExternalThreadControlAuthority,
     input: ThreadCreateInput,
   ): boolean {
+    if (input.workspaceId === undefined) return false;
     return authority.allowedWorkspaceIds.includes(input.workspaceId)
       && authority.scopes.includes("threads:create")
       && (
         input.placement.type !== "new_worktree"
         || authority.scopes.includes("worktrees:create")
       );
+  }
+
+  private resolveInternalSourceWorkspaceId(authority: InternalThreadControlAuthority): string | undefined {
+    const source = this.threads.findById(authority.sourceThreadId);
+    if (!source || source.deleted_at != null) return undefined;
+    return source.workspace_id;
   }
 
   private async reserveExternalCapacity(

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -325,25 +325,40 @@ describe("selection + text replacement", () => {
     expect(result.current.isOpen).toBe(false);
   });
 
-  it("inserts the Mcode capability guide slash command", async () => {
+  it("inserts focused Mcode guide slash commands", async () => {
     const ref = makeAnchor();
     const { result } = renderHook(() => useSlashCommand({ anchorRef: ref }));
-    await act(async () => { result.current.onInputChange("/mcode-g"); });
+    await act(async () => { result.current.onInputChange("/mcode-b"); });
     await act(async () => {});
 
-    const guideCommand = result.current.items.find((item) => item.name === "mcode-guide");
-    expect(guideCommand).toBeDefined();
-    expect(guideCommand).toMatchObject({
+    const browserCommand = result.current.items.find((item) => item.name === "mcode-browser");
+    expect(browserCommand).toBeDefined();
+    expect(browserCommand).toMatchObject({
       namespace: "mcode",
       capabilityKind: "mcode",
-      id: "builtin:mcode:mcode-guide",
+      id: "builtin:mcode:mcode-browser",
     });
 
     let inserted = "";
     await act(async () => {
-      result.current.onSelect(guideCommand!, (value: string) => { inserted = value; });
+      result.current.onSelect(browserCommand!, (value: string) => { inserted = value; });
     });
-    expect(inserted).toBe("/mcode-guide ");
+    expect(inserted).toBe("/mcode-browser ");
+
+    await act(async () => { result.current.onInputChange("/thread-c"); });
+    await act(async () => {});
+    const threadCommand = result.current.items.find((item) => item.name === "thread-control");
+    expect(threadCommand).toMatchObject({
+      namespace: "mcode",
+      capabilityKind: "mcode",
+      id: "builtin:mcode:thread-control",
+    });
+    await act(async () => {
+      result.current.onSelect(threadCommand!, (value: string) => { inserted = value; });
+    });
+    expect(inserted).toBe("/thread-control ");
+
+    expect(result.current.allCommands.map((item) => item.name)).not.toContain("mcode-guide");
   });
 });
 

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -324,6 +324,22 @@ describe("selection + text replacement", () => {
     expect(emittedValue).toBe("/commit ");
     expect(result.current.isOpen).toBe(false);
   });
+
+  it("inserts the Mcode capability guide slash command", async () => {
+    const ref = makeAnchor();
+    const { result } = renderHook(() => useSlashCommand({ anchorRef: ref }));
+    await act(async () => { result.current.onInputChange("/mcode-g"); });
+    await act(async () => {});
+
+    const guideCommand = result.current.items.find((item) => item.name === "mcode-guide");
+    expect(guideCommand).toBeDefined();
+
+    let inserted = "";
+    await act(async () => {
+      result.current.onSelect(guideCommand!, (value: string) => { inserted = value; });
+    });
+    expect(inserted).toBe("/mcode-guide ");
+  });
 });
 
 describe("mcode side-effect dispatch", () => {

--- a/apps/web/src/__tests__/slash-command.test.ts
+++ b/apps/web/src/__tests__/slash-command.test.ts
@@ -333,6 +333,11 @@ describe("selection + text replacement", () => {
 
     const guideCommand = result.current.items.find((item) => item.name === "mcode-guide");
     expect(guideCommand).toBeDefined();
+    expect(guideCommand).toMatchObject({
+      namespace: "mcode",
+      capabilityKind: "mcode",
+      id: "builtin:mcode:mcode-guide",
+    });
 
     let inserted = "";
     await act(async () => {

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -53,11 +53,11 @@ const MAX_SLASH_COMMAND_ITEMS = 100;
 
 const BUILTIN_COMMANDS: Command[] = [
   {
-    id: "builtin:command:mcode-guide",
+    id: "builtin:mcode:mcode-guide",
     name: "mcode-guide",
     description: "Read the Mcode thread-control and Browser operating guide",
-    namespace: "command",
-    capabilityKind: "providerCommand",
+    namespace: "mcode",
+    capabilityKind: "mcode",
     nativeId: "mcode-guide",
   },
   {

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -53,6 +53,14 @@ const MAX_SLASH_COMMAND_ITEMS = 100;
 
 const BUILTIN_COMMANDS: Command[] = [
   {
+    id: "builtin:command:mcode-guide",
+    name: "mcode-guide",
+    description: "Read the Mcode thread-control and Browser operating guide",
+    namespace: "command",
+    capabilityKind: "providerCommand",
+    nativeId: "mcode-guide",
+  },
+  {
     id: "builtin:command:compact",
     name: "compact",
     description: "Summarise conversation history to free up context window",
@@ -151,7 +159,7 @@ interface UseSlashCommandOptions {
   /** Model ID used to resolve model-specific composer capabilities. */
   modelId?: string;
   /**
-   * Whether to include mcode built-in commands (plan, compact, goal) in the
+   * Whether to include mcode built-in commands (plan, compact, goal, mcode-guide) in the
    * command list. Default `true`. Pass `false` for contexts like the annotation
    * bubble where mcode actions are meaningless and must not be selectable.
    */

--- a/apps/web/src/components/chat/useSlashCommand.ts
+++ b/apps/web/src/components/chat/useSlashCommand.ts
@@ -53,12 +53,20 @@ const MAX_SLASH_COMMAND_ITEMS = 100;
 
 const BUILTIN_COMMANDS: Command[] = [
   {
-    id: "builtin:mcode:mcode-guide",
-    name: "mcode-guide",
-    description: "Read the Mcode thread-control and Browser operating guide",
+    id: "builtin:mcode:mcode-browser",
+    name: "mcode-browser",
+    description: "Read the Mcode Browser operating guide",
     namespace: "mcode",
     capabilityKind: "mcode",
-    nativeId: "mcode-guide",
+    nativeId: "mcode-browser",
+  },
+  {
+    id: "builtin:mcode:thread-control",
+    name: "thread-control",
+    description: "Read the Mcode thread-control operating guide",
+    namespace: "mcode",
+    capabilityKind: "mcode",
+    nativeId: "thread-control",
   },
   {
     id: "builtin:command:compact",
@@ -159,7 +167,7 @@ interface UseSlashCommandOptions {
   /** Model ID used to resolve model-specific composer capabilities. */
   modelId?: string;
   /**
-   * Whether to include mcode built-in commands (plan, compact, goal, mcode-guide) in the
+   * Whether to include mcode built-in commands (plan, compact, goal, mcode-browser, thread-control) in the
    * command list. Default `true`. Pass `false` for contexts like the annotation
    * bubble where mcode actions are meaningless and must not be selectable.
    */

--- a/packages/contracts/src/__tests__/thread-control.test.ts
+++ b/packages/contracts/src/__tests__/thread-control.test.ts
@@ -186,6 +186,8 @@ describe("thread_create_batch schemas", () => {
 
   it("accepts one to twenty ordered creation items and rejects authority fields", () => {
     expect(ThreadCreateBatchInputSchema().parse({ items: [item] })).toEqual({ items: [item] });
+    const itemWithoutWorkspace = { title: item.title, prompt: item.prompt, placement: item.placement };
+    expect(ThreadCreateBatchInputSchema().parse({ items: [itemWithoutWorkspace] })).toEqual({ items: [itemWithoutWorkspace] });
     expect(ThreadCreateBatchInputSchema().safeParse({ items: [] }).success).toBe(false);
     expect(ThreadCreateBatchInputSchema().safeParse({
       items: Array.from({ length: THREAD_CREATE_BATCH_MAX_ITEMS + 1 }, () => item),

--- a/packages/contracts/src/thread-control.ts
+++ b/packages/contracts/src/thread-control.ts
@@ -178,7 +178,7 @@ export type ResolvedPlacement = z.infer<ReturnType<typeof ResolvedPlacementSchem
 /** One requested delegated thread and its initial turn. */
 export const ThreadCreateInputSchema = lazySchema(() =>
   z.object({
-    workspaceId: opaqueId,
+    workspaceId: opaqueId.optional(),
     title: z.string().trim().min(1).max(THREAD_CREATE_TITLE_MAX_LENGTH),
     prompt: z.string().min(1).max(THREAD_CREATE_PROMPT_MAX_LENGTH),
     placement: ThreadPlacementSchema(),


### PR DESCRIPTION
## What
Add app-only guides for Mcode Browser and thread control, available through focused slash commands and authenticated internal MCP tools.

## Why
Agents need targeted guidance for Mcode-specific tools without exposing it to standalone provider CLIs.

## Key Changes
- Add /mcode-browser and /thread-control commands with separate session-only guides.
- Default internal thread creation to the source Project and keep new worktrees branchless unless a branch is explicit.
- Reject external thread creation without an explicit Project.

## Verification
- Focused server and web tests pass.
- bun run verify:changed timed out twice without diagnostics; live MCP verification also needs an active provider lease.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788021158&installation_model_id=20477&pr_number=1025&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1025&signature=d38f206440e7216bf76351de5c52b66cc2f1699987d325072b55bce09b83c56b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Mcode Browser and Thread Control operating guides.
  - Added `/mcode-browser` and `/thread-control` slash commands.
  - Exposed both guides through internal tool integrations.

- **Improvements**
  - Thread creation can now infer the project for eligible internal requests.
  - Improved validation for missing project details and unavailable source threads.
  - Worktree creation no longer returns an empty branch name when none is provided.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->