### PR TITLE
fix(web): keep running thread switches responsive

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -562,8 +562,8 @@ for (const provider of providerRegistry.resolveAll()) {
       };
     }
 
-    broadcast("agent.event", enrichedEvent);
-    portPush.send("agent.event", enrichedEvent);
+    const sequencedEvent = broadcast("agent.event", enrichedEvent) ?? enrichedEvent;
+    portPush.send("agent.event", sequencedEvent);
 
     if (event.type === AgentEventType.TurnComplete) {
       threadRepo.updateStatus(event.threadId, "completed");

--- a/apps/server/src/transport/push.test.ts
+++ b/apps/server/src/transport/push.test.ts
@@ -159,6 +159,41 @@ describe("broadcast", () => {
     expect(JSON.parse(received[0].buf.toString("utf-8")).data.threadId).toBe("thread-new");
   });
 
+  it("assigns ordered sequences and replays retained events before live delivery", () => {
+    const received: Array<{ buf: Buffer; binary: boolean }> = [];
+    broadcast("agent.event", { type: "textDelta", threadId: "thread-replay", delta: "one" });
+    broadcast("agent.event", { type: "textDelta", threadId: "thread-replay", delta: "two" });
+    const ws = fakeOpenSocket(received);
+    addClient(ws);
+
+    const result = setClientThreadSubscriptions(ws, ["thread-replay"], { "thread-replay": 0 });
+    expect(result).toEqual({ hydrationRequiredThreadIds: [], replayedThrough: { "thread-replay": 2 } });
+    broadcast("agent.event", { type: "textDelta", threadId: "thread-replay", delta: "three" });
+
+    expect(received.map((entry) => JSON.parse(entry.buf.toString("utf-8")).data.sequence)).toEqual([1, 2, 3]);
+  });
+
+  it("does not replay history for legacy subscription calls without cursors", () => {
+    const received: Array<{ buf: Buffer; binary: boolean }> = [];
+    broadcast("agent.event", { type: "textDelta", threadId: "thread-legacy", delta: "old" });
+    const ws = fakeOpenSocket(received);
+    addClient(ws);
+    setClientThreadSubscriptions(ws, ["thread-legacy"]);
+    expect(received).toHaveLength(0);
+  });
+
+  it("reports hydration when a cursor falls behind the bounded journal", () => {
+    const received: Array<{ buf: Buffer; binary: boolean }> = [];
+    for (let i = 0; i < 257; i++) {
+      broadcast("agent.event", { type: "textDelta", threadId: "thread-gap", delta: String(i) });
+    }
+    const ws = fakeOpenSocket(received);
+    addClient(ws);
+    const result = setClientThreadSubscriptions(ws, ["thread-gap"], { "thread-gap": 0 });
+    expect(result.hydrationRequiredThreadIds).toEqual(["thread-gap"]);
+    expect(received).toHaveLength(0);
+  });
+
   it("clears all thread subscriptions when replacing with an empty set", () => {
     const received: Array<{ buf: Buffer; binary: boolean }> = [];
     const ws = fakeOpenSocket(received);

--- a/apps/server/src/transport/push.test.ts
+++ b/apps/server/src/transport/push.test.ts
@@ -194,6 +194,18 @@ describe("broadcast", () => {
     expect(received).toHaveLength(0);
   });
 
+  it("reports hydration for a cursor from another server epoch without replay", () => {
+    const received: Array<{ buf: Buffer; binary: boolean }> = [];
+    broadcast("agent.event", { type: "textDelta", threadId: "thread-epoch", delta: "one" });
+    const ws = fakeOpenSocket(received);
+    addClient(ws);
+    const result = setClientThreadSubscriptions(ws, ["thread-epoch"], {
+      "thread-epoch": { epoch: "00000000-0000-4000-8000-000000000001", sequence: 0 },
+    });
+    expect(result.hydrationRequiredThreadIds).toEqual(["thread-epoch"]);
+    expect(received).toHaveLength(0);
+  });
+
   it("clears all thread subscriptions when replacing with an empty set", () => {
     const received: Array<{ buf: Buffer; binary: boolean }> = [];
     const ws = fakeOpenSocket(received);

--- a/apps/server/src/transport/push.ts
+++ b/apps/server/src/transport/push.ts
@@ -4,7 +4,8 @@
  */
 
 import type { WebSocket } from "ws";
-import { WS_CHANNELS, type WsChannelName, encodeTerminalDataFrame } from "@mcode/contracts";
+import { randomUUID } from "node:crypto";
+import { WS_CHANNELS, type WsChannelName, type SetThreadSubscriptionsInput, encodeTerminalDataFrame } from "@mcode/contracts";
 import { logger } from "@mcode/shared";
 import { getTransportPayloadValidator } from "./payload-validation.js";
 
@@ -17,6 +18,7 @@ const clients = new Set<WebSocket>();
 const threadSubscriptions = new Map<WebSocket, Set<string>>();
 const threadJournals = new Map<string, { events: unknown[] }>();
 const nextSequenceByThread = new Map<string, number>();
+const eventEpoch = randomUUID();
 const SUBSCRIPTION_SCOPED_CHANNELS = new Set<WsChannelName>([
   "agent.event",
   "turn.fileEffectsUpdated",
@@ -82,7 +84,7 @@ export function unsubscribeClientFromThread(ws: WebSocket, threadId: string): vo
 export function setClientThreadSubscriptions(
   ws: WebSocket,
   threadIds: readonly string[],
-  cursors?: Readonly<Record<string, number>>,
+  cursors?: NonNullable<SetThreadSubscriptionsInput["cursors"]>,
 ): { hydrationRequiredThreadIds: string[]; replayedThrough: Record<string, number> } {
   if (!clients.has(ws)) return { hydrationRequiredThreadIds: [], replayedThrough: {} };
   threadSubscriptions.set(ws, new Set(threadIds));
@@ -91,8 +93,13 @@ export function setClientThreadSubscriptions(
   if (!cursors) return { hydrationRequiredThreadIds, replayedThrough };
 
   for (const threadId of threadIds) {
-    const cursor = cursors[threadId];
-    if (cursor === undefined) continue;
+    const rawCursor = cursors[threadId];
+    if (rawCursor === undefined) continue;
+    const cursor = typeof rawCursor === "number" ? rawCursor : rawCursor.sequence;
+    if (typeof rawCursor !== "number" && rawCursor.epoch !== eventEpoch) {
+      hydrationRequiredThreadIds.push(threadId);
+      continue;
+    }
     const journal = threadJournals.get(threadId);
     if (!journal) {
       if (cursor > 0) hydrationRequiredThreadIds.push(threadId);
@@ -157,7 +164,7 @@ export function broadcast(
   const threadId = payloadThreadId(data);
   if (channel === "agent.event" && threadId && data && typeof data === "object") {
     const sequence = (nextSequenceByThread.get(threadId) ?? 0) + 1;
-    candidate = { ...(data as Record<string, unknown>), sequence };
+    candidate = { ...(data as Record<string, unknown>), sequence, epoch: eventEpoch };
   }
 
   const validation = getTransportPayloadValidator().validatePush(channel, candidate, schema);

--- a/apps/server/src/transport/push.ts
+++ b/apps/server/src/transport/push.ts
@@ -8,8 +8,15 @@ import { WS_CHANNELS, type WsChannelName, encodeTerminalDataFrame } from "@mcode
 import { logger } from "@mcode/shared";
 import { getTransportPayloadValidator } from "./payload-validation.js";
 
+/** Maximum transient agent events retained for one thread. */
+export const MAX_AGENT_EVENT_JOURNAL_EVENTS_PER_THREAD = 256;
+/** Maximum thread journals retained by the process. */
+export const MAX_AGENT_EVENT_JOURNAL_THREADS = 100;
+
 const clients = new Set<WebSocket>();
 const threadSubscriptions = new Map<WebSocket, Set<string>>();
+const threadJournals = new Map<string, { events: unknown[] }>();
+const nextSequenceByThread = new Map<string, number>();
 const SUBSCRIPTION_SCOPED_CHANNELS = new Set<WsChannelName>([
   "agent.event",
   "turn.fileEffectsUpdated",
@@ -75,9 +82,36 @@ export function unsubscribeClientFromThread(ws: WebSocket, threadId: string): vo
 export function setClientThreadSubscriptions(
   ws: WebSocket,
   threadIds: readonly string[],
-): void {
-  if (!clients.has(ws)) return;
+  cursors?: Readonly<Record<string, number>>,
+): { hydrationRequiredThreadIds: string[]; replayedThrough: Record<string, number> } {
+  if (!clients.has(ws)) return { hydrationRequiredThreadIds: [], replayedThrough: {} };
   threadSubscriptions.set(ws, new Set(threadIds));
+  const hydrationRequiredThreadIds: string[] = [];
+  const replayedThrough: Record<string, number> = {};
+  if (!cursors) return { hydrationRequiredThreadIds, replayedThrough };
+
+  for (const threadId of threadIds) {
+    const cursor = cursors[threadId];
+    if (cursor === undefined) continue;
+    const journal = threadJournals.get(threadId);
+    if (!journal) {
+      if (cursor > 0) hydrationRequiredThreadIds.push(threadId);
+      continue;
+    }
+    if (journal.events.length > 0 && cursor < (journal.events[0] as { sequence: number }).sequence - 1) {
+      hydrationRequiredThreadIds.push(threadId);
+      continue;
+    }
+    const pending = journal.events.filter((event) => (event as { sequence: number }).sequence > cursor);
+    if (pending.length === 0) continue;
+    let deliveredThrough = cursor;
+    for (const event of pending) {
+      if (!sendToClient(ws, "agent.event", event)) break;
+      deliveredThrough = (event as { sequence: number }).sequence;
+    }
+    if (deliveredThrough !== cursor) replayedThrough[threadId] = deliveredThrough;
+  }
+  return { hydrationRequiredThreadIds, replayedThrough };
 }
 
 /** Get the current number of connected clients. */
@@ -112,16 +146,44 @@ function payloadThreadId(data: unknown): string | undefined {
 export function broadcast(
   channel: WsChannelName,
   data: unknown,
-): void {
+): unknown {
   const schema = WS_CHANNELS[channel];
   if (!schema) {
     logger.warn("Unknown push channel", { channel });
-    return;
+    return undefined;
   }
 
-  const validation = getTransportPayloadValidator().validatePush(channel, data, schema);
+  let candidate = data;
+  const threadId = payloadThreadId(data);
+  if (channel === "agent.event" && threadId && data && typeof data === "object") {
+    const sequence = (nextSequenceByThread.get(threadId) ?? 0) + 1;
+    candidate = { ...(data as Record<string, unknown>), sequence };
+  }
+
+  const validation = getTransportPayloadValidator().validatePush(channel, candidate, schema);
   if (!validation.ok) {
-    return;
+    return undefined;
+  }
+
+  if (channel === "agent.event" && threadId) {
+    const event = validation.data as { sequence: number };
+    nextSequenceByThread.delete(threadId);
+    nextSequenceByThread.set(threadId, event.sequence);
+    const existing = threadJournals.get(threadId);
+    const events = existing ? [...existing.events, validation.data] : [validation.data];
+    if (events.length > MAX_AGENT_EVENT_JOURNAL_EVENTS_PER_THREAD) {
+      events.splice(0, events.length - MAX_AGENT_EVENT_JOURNAL_EVENTS_PER_THREAD);
+    }
+    threadJournals.delete(threadId);
+    threadJournals.set(threadId, { events });
+    while (threadJournals.size > MAX_AGENT_EVENT_JOURNAL_THREADS) {
+      const oldestThreadId = threadJournals.keys().next().value as string;
+      threadJournals.delete(oldestThreadId);
+    }
+    while (nextSequenceByThread.size > MAX_AGENT_EVENT_JOURNAL_THREADS) {
+      const oldestThreadId = nextSequenceByThread.keys().next().value as string;
+      nextSequenceByThread.delete(oldestThreadId);
+    }
   }
 
   const payload = JSON.stringify({
@@ -129,7 +191,6 @@ export function broadcast(
     channel,
     data: validation.data,
   });
-  const threadId = payloadThreadId(validation.data);
   const requiresThreadSubscription = SUBSCRIPTION_SCOPED_CHANNELS.has(channel);
 
   for (const ws of clients) {
@@ -144,6 +205,7 @@ export function broadcast(
       ws.send(payload);
     }
   }
+  return validation.data;
 }
 
 /** Sends one validated push event to exactly one connected WebSocket client. */
@@ -208,4 +270,6 @@ export function _resetForTest(): void {
   sessionChangeListeners.length = 0;
   clients.clear();
   threadSubscriptions.clear();
+  threadJournals.clear();
+  nextSequenceByThread.clear();
 }

--- a/apps/server/src/transport/ws-router.ts
+++ b/apps/server/src/transport/ws-router.ts
@@ -493,9 +493,9 @@ async function dispatch(
       return;
     case "push.setThreadSubscriptions":
       if (context.client) {
-        setClientThreadSubscriptions(context.client, params.threadIds);
+        return setClientThreadSubscriptions(context.client, params.threadIds, params.cursors);
       }
-      return;
+      return { hydrationRequiredThreadIds: [], replayedThrough: {} };
 
     // Workspace
     case "workspace.list":

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -96,7 +96,7 @@ describe("handleAgentEvent branches", () => {
   });
 
   it("background textDelta keeps streaming state without growing narrative state", async () => {
-    const backgroundThreadId = "thread-2";
+    const backgroundThreadId = "thread-deferred";
     const backgroundToolCall = {
       id: "background-tool",
       toolName: "Read",
@@ -138,6 +138,137 @@ describe("handleAgentEvent branches", () => {
     expect(record.streaming).toBe("background text");
     expect(record.thoughtSegments).toEqual([backgroundThought]);
     expect(record.toolCalls).toEqual([backgroundToolCall]);
+  });
+
+  it("promotes deferred text, boundaries, and tool progress once in source order", async () => {
+    const backgroundThreadId = "thread-2";
+    const backgroundToolCall = {
+      id: "background-tool",
+      toolName: "Read",
+      toolInput: { path: "/tmp/background" },
+      output: null,
+      isError: false,
+      isComplete: false,
+    };
+    resetThreadStoreForTests({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1", backgroundThreadId]),
+      records: new Map<string, ThreadRecord>([
+        ["thread-1", { ...createEmptyThreadRecord() }],
+        [backgroundThreadId, { ...createEmptyThreadRecord(), toolCalls: [backgroundToolCall] }],
+      ]),
+    });
+
+    useThreadStore.getState().handleAgentEvent({
+      type: "textDelta",
+      threadId: backgroundThreadId,
+      delta: "first sentence that is deliberately long enough to stay closed.",
+      isFinalResponse: false,
+    } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({
+      type: "assistantMessageBoundary",
+      threadId: backgroundThreadId,
+      isFinalResponse: false,
+    } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({
+      type: "textDelta",
+      threadId: backgroundThreadId,
+      delta: "Second",
+      isFinalResponse: false,
+    } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({
+      type: "toolProgress",
+      threadId: backgroundThreadId,
+      toolCallId: backgroundToolCall.id,
+      elapsedSeconds: 3,
+    } as AgentEvent);
+    vi.runAllTimers();
+
+    useThreadStore.setState({ currentThreadId: backgroundThreadId });
+    useThreadStore.getState().handleTurnPersisted({
+      threadId: backgroundThreadId,
+      messageId: "server-message",
+      toolCallCount: 0,
+      filesChanged: [],
+    });
+
+    const promoted = readThreadField(backgroundThreadId, (thread) => thread);
+    expect(promoted.thoughtSegments.map((segment) => segment.text)).toEqual([
+      "first sentence that is deliberately long enough to stay closed.",
+      "Second",
+    ]);
+    expect(promoted.thoughtSegments[0]?.endedAt).toBeDefined();
+    expect(promoted.toolCalls[0]?.elapsedSeconds).toBe(3);
+
+    useThreadStore.getState().handleAgentEvent({
+      type: "toolProgress",
+      threadId: backgroundThreadId,
+      toolCallId: "missing-tool",
+      elapsedSeconds: 0,
+    } as AgentEvent);
+    expect(readThreadField(backgroundThreadId, (thread) => thread.thoughtSegments))
+      .toHaveLength(2);
+  });
+
+  it("does not treat null selection as active for multiple running threads", async () => {
+    resetThreadStoreForTests({
+      currentThreadId: null,
+      runningThreadIds: new Set(["thread-2", "thread-3"]),
+      records: new Map<string, ThreadRecord>([
+        ["thread-2", { ...createEmptyThreadRecord() }],
+        ["thread-3", { ...createEmptyThreadRecord() }],
+      ]),
+    });
+
+    for (const threadId of ["thread-2", "thread-3"]) {
+      useThreadStore.getState().handleAgentEvent({
+        type: "textDelta",
+        threadId,
+        delta: `background-${threadId}`,
+      } as AgentEvent);
+    }
+    vi.runAllTimers();
+
+    for (const threadId of ["thread-2", "thread-3"]) {
+      const record = readThreadField(threadId, (thread) => thread);
+      expect(record.streaming).toBe(`background-${threadId}`);
+      expect(record.thoughtSegments).toEqual([]);
+    }
+  });
+
+  it("does not promote final-response deltas into thought segments", () => {
+    const backgroundThreadId = "thread-final-response";
+    resetThreadStoreForTests({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1", backgroundThreadId]),
+      records: new Map<string, ThreadRecord>([
+        ["thread-1", { ...createEmptyThreadRecord() }],
+        [backgroundThreadId, { ...createEmptyThreadRecord() }],
+      ]),
+    });
+
+    useThreadStore.getState().handleAgentEvent({
+      type: "textDelta",
+      threadId: backgroundThreadId,
+      delta: "final response",
+      isFinalResponse: true,
+    } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({
+      type: "assistantMessageBoundary",
+      threadId: backgroundThreadId,
+      isFinalResponse: true,
+    } as AgentEvent);
+    vi.runAllTimers();
+
+    useThreadStore.setState({ currentThreadId: backgroundThreadId });
+    useThreadStore.getState().handleTurnPersisted({
+      threadId: backgroundThreadId,
+      messageId: "server-message",
+      toolCallCount: 0,
+      filesChanged: [],
+    });
+
+    expect(readThreadField(backgroundThreadId, (thread) => thread.thoughtSegments)).toEqual([]);
   });
 
   it("session.toolUse ignores duplicate toolCallId (defense in depth)", () => {

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -180,6 +180,21 @@ describe("handleAgentEvent branches", () => {
     expect(record.toolCalls[0]?.toolInput).toEqual({ path: "/first" });
   });
 
+  it("resets sequence authority when server event epoch changes", () => {
+    const handleAgentEvent = useThreadStore.getState().handleAgentEvent;
+    handleAgentEvent({
+      type: "toolUse", threadId: "thread-1", epoch: "00000000-0000-4000-8000-000000000001",
+      sequence: 9, toolCallId: "old", toolName: "Read", toolInput: {},
+    } as AgentEvent);
+    handleAgentEvent({
+      type: "toolUse", threadId: "thread-1", epoch: "00000000-0000-4000-8000-000000000002",
+      sequence: 1, toolCallId: "new", toolName: "Write", toolInput: {},
+    } as AgentEvent);
+    expect(readThreadField("thread-1", (thread) => thread.lastAgentEventSequence)).toBe(1);
+    expect(readThreadField("thread-1", (thread) => thread.lastAgentEventEpoch))
+      .toBe("00000000-0000-4000-8000-000000000002");
+  });
+
   it("retains hook progress for an inactive thread", () => {
     const backgroundThreadId = "thread-background-hook";
     resetThreadStoreForTests({

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -146,6 +146,69 @@ describe("handleAgentEvent branches", () => {
     expect(calls[0].isComplete).toBe(false);
   });
 
+  it("deduplicates sequenced replay events while accepting a first sequence above one", () => {
+    const handleAgentEvent = useThreadStore.getState().handleAgentEvent;
+
+    handleAgentEvent({
+      type: "toolUse",
+      threadId: "thread-1",
+      sequence: 17,
+      toolCallId: "seq-tool-1",
+      toolName: "Read",
+      toolInput: { path: "/first" },
+    } as AgentEvent);
+    handleAgentEvent({
+      type: "toolUse",
+      threadId: "thread-1",
+      sequence: 17,
+      toolCallId: "seq-tool-1",
+      toolName: "Read",
+      toolInput: { path: "/replay" },
+    } as AgentEvent);
+    handleAgentEvent({
+      type: "toolUse",
+      threadId: "thread-1",
+      sequence: 18,
+      toolCallId: "seq-tool-2",
+      toolName: "Write",
+      toolInput: { path: "/second" },
+    } as AgentEvent);
+
+    const record = readThreadField("thread-1", (thread) => thread);
+    expect(record.lastAgentEventSequence).toBe(18);
+    expect(record.toolCalls.map((call) => call.id)).toEqual(["seq-tool-1", "seq-tool-2"]);
+    expect(record.toolCalls[0]?.toolInput).toEqual({ path: "/first" });
+  });
+
+  it("retains hook progress for an inactive thread", () => {
+    const backgroundThreadId = "thread-background-hook";
+    resetThreadStoreForTests({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1", backgroundThreadId]),
+      records: new Map([
+        ["thread-1", createEmptyThreadRecord()],
+        [backgroundThreadId, createEmptyThreadRecord()],
+      ]),
+    });
+
+    const handleAgentEvent = useThreadStore.getState().handleAgentEvent;
+    handleAgentEvent({
+      type: "hookStarted",
+      threadId: backgroundThreadId,
+      hookName: "format",
+      hookType: "stop",
+    } as AgentEvent);
+    handleAgentEvent({
+      type: "hookProgress",
+      threadId: backgroundThreadId,
+      hookName: "format",
+      output: "line one\nline two",
+    } as AgentEvent);
+
+    expect(readThreadField(backgroundThreadId, (thread) => thread.hooks[0]?.outputLines))
+      .toEqual(["line one", "line two"]);
+  });
+
   it("background textDelta keeps streaming state without growing narrative state", async () => {
     const backgroundThreadId = "thread-deferred";
     const backgroundToolCall = {

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -461,6 +461,47 @@ describe("handleAgentEvent branches", () => {
       .toHaveLength(2);
   });
 
+  it("promotes inactive text before projecting its following toolUse", () => {
+    const backgroundThreadId = "thread-tool-boundary";
+    resetThreadStoreForTests({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1", backgroundThreadId]),
+      records: new Map([
+        ["thread-1", createEmptyThreadRecord()],
+        [backgroundThreadId, createEmptyThreadRecord()],
+      ]),
+    });
+
+    useThreadStore.getState().handleAgentEvent({
+      type: "textDelta",
+      threadId: backgroundThreadId,
+      delta: "Before the tool call.",
+      isFinalResponse: false,
+    } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({
+      type: "toolUse",
+      threadId: backgroundThreadId,
+      toolCallId: "background-tool",
+      toolName: "Read",
+      toolInput: { path: "/tmp/background" },
+    } as AgentEvent);
+
+    const beforeSwitch = readThreadField(backgroundThreadId, (thread) => thread);
+    expect(beforeSwitch.thoughtSegments.map((segment) => segment.text)).toEqual([
+      "Before the tool call.",
+    ]);
+    expect(beforeSwitch.thoughtSegments[0]?.endedAt).toBeDefined();
+    expect(beforeSwitch.toolCalls.map((call) => call.id)).toEqual(["background-tool"]);
+
+    useThreadStore.setState({ currentThreadId: backgroundThreadId });
+    const afterSwitch = readThreadField(backgroundThreadId, (thread) => thread);
+    expect(afterSwitch.thoughtSegments.map((segment) => segment.text)).toEqual([
+      "Before the tool call.",
+    ]);
+    expect(afterSwitch.thoughtSegments[0]?.endedAt).toBeDefined();
+    expect(afterSwitch.toolCalls.map((call) => call.id)).toEqual(["background-tool"]);
+  });
+
   it("does not treat null selection as active for multiple running threads", async () => {
     resetThreadStoreForTests({
       currentThreadId: null,

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -269,6 +269,128 @@ describe("handleAgentEvent branches", () => {
     expect(record.toolCalls).toEqual([backgroundToolCall]);
   });
 
+  it("materializes deferred events at the count cap without reordering or duplication", () => {
+    const backgroundThreadId = "thread-deferred-count-cap";
+    resetThreadStoreForTests({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1", backgroundThreadId]),
+      records: new Map([
+        ["thread-1", createEmptyThreadRecord()],
+        [backgroundThreadId, createEmptyThreadRecord()],
+      ]),
+    });
+
+    const deltas = Array.from({ length: 2049 }, (_, index) => `event-${index}|`);
+    for (const delta of deltas) {
+      useThreadStore.getState().handleAgentEvent({
+        type: "textDelta",
+        threadId: backgroundThreadId,
+        delta,
+      } as AgentEvent);
+    }
+    vi.runAllTimers();
+
+    const materializedBeforeActivation = readThreadField(
+      backgroundThreadId,
+      (thread) => thread.thoughtSegments.map((segment) => segment.text).join(""),
+    );
+    expect(materializedBeforeActivation).toBe(deltas.slice(0, 2048).join(""));
+
+    useThreadStore.setState({ currentThreadId: backgroundThreadId });
+    useThreadStore.getState().handleAgentEvent({
+      type: "toolProgress",
+      threadId: backgroundThreadId,
+      toolCallId: "missing-tool",
+      elapsedSeconds: 0,
+    } as AgentEvent);
+
+    const materialized = readThreadField(
+      backgroundThreadId,
+      (thread) => thread.thoughtSegments.map((segment) => segment.text).join(""),
+    );
+    expect(materialized).toBe(deltas.join(""));
+    expect(materialized.match(/event-/g)).toHaveLength(2049);
+  });
+
+  it("materializes deferred events at the byte cap without losing content", () => {
+    const backgroundThreadId = "thread-deferred-byte-cap";
+    resetThreadStoreForTests({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1", backgroundThreadId]),
+      records: new Map([
+        ["thread-1", createEmptyThreadRecord()],
+        [backgroundThreadId, createEmptyThreadRecord()],
+      ]),
+    });
+
+    const deltas = ["A".repeat(100_000), "B".repeat(100_000)];
+    for (const delta of deltas) {
+      useThreadStore.getState().handleAgentEvent({
+        type: "textDelta",
+        threadId: backgroundThreadId,
+        delta,
+      } as AgentEvent);
+    }
+    vi.runAllTimers();
+
+    expect(readThreadField(
+      backgroundThreadId,
+      (thread) => thread.thoughtSegments.map((segment) => segment.text).join(""),
+    )).toBe(deltas[0]);
+
+    useThreadStore.setState({ currentThreadId: backgroundThreadId });
+    useThreadStore.getState().handleAgentEvent({
+      type: "toolProgress",
+      threadId: backgroundThreadId,
+      toolCallId: "missing-tool",
+      elapsedSeconds: 0,
+    } as AgentEvent);
+
+    expect(readThreadField(
+      backgroundThreadId,
+      (thread) => thread.thoughtSegments.map((segment) => segment.text).join(""),
+    )).toBe(deltas.join(""));
+  });
+
+  it("splits an oversized deferred textDelta into bounded ordered chunks", () => {
+    const backgroundThreadId = "thread-deferred-oversized-delta";
+    resetThreadStoreForTests({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1", backgroundThreadId]),
+      records: new Map([
+        ["thread-1", createEmptyThreadRecord()],
+        [backgroundThreadId, createEmptyThreadRecord()],
+      ]),
+    });
+
+    const maxChunkLength = Math.floor((256 * 1024 - 32) / 2);
+    const delta = "x".repeat(maxChunkLength + 17);
+    useThreadStore.getState().handleAgentEvent({
+      type: "textDelta",
+      threadId: backgroundThreadId,
+      delta,
+    } as AgentEvent);
+    vi.runAllTimers();
+
+    expect(readThreadField(
+      backgroundThreadId,
+      (thread) => thread.thoughtSegments.map((segment) => segment.text).join(""),
+    )).toBe(delta.slice(0, maxChunkLength));
+
+    useThreadStore.setState({ currentThreadId: backgroundThreadId });
+    useThreadStore.getState().handleAgentEvent({
+      type: "toolProgress",
+      threadId: backgroundThreadId,
+      toolCallId: "missing-tool",
+      elapsedSeconds: 0,
+    } as AgentEvent);
+
+    expect(readThreadField(
+      backgroundThreadId,
+      (thread) => thread.thoughtSegments.map((segment) => segment.text).join(""),
+    )).toBe(delta);
+  });
+
   it("promotes deferred text, boundaries, and tool progress once in source order", async () => {
     const backgroundThreadId = "thread-2";
     const backgroundToolCall = {

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -83,6 +83,57 @@ describe("handleAgentEvent branches", () => {
     expect(state.runningThreadIds.has("thread-1")).toBe(false);
   });
 
+  it("flushes same-frame textDelta before turnComplete persists assistant content", () => {
+    useThreadStore.getState().handleAgentEvent({
+      type: "textDelta",
+      threadId: "thread-1",
+      delta: "final assistant answer",
+      isFinalResponse: true,
+    } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({
+      type: "turnComplete",
+      threadId: "thread-1",
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 0,
+      tokensOut: 0,
+    } as AgentEvent);
+
+    expect(getTestActiveMessages().find((message) => message.role === "assistant")?.content)
+      .toBe("final assistant answer");
+  });
+
+  it("flushes same-frame background textDelta before turnComplete persists content", () => {
+    const backgroundThreadId = "thread-background-complete";
+    resetThreadStoreForTests({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1", backgroundThreadId]),
+      records: new Map<string, ThreadRecord>([
+        ["thread-1", { ...createEmptyThreadRecord() }],
+        [backgroundThreadId, { ...createEmptyThreadRecord() }],
+      ]),
+    });
+
+    useThreadStore.getState().handleAgentEvent({
+      type: "textDelta",
+      threadId: backgroundThreadId,
+      delta: "background final answer",
+      isFinalResponse: true,
+    } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({
+      type: "turnComplete",
+      threadId: backgroundThreadId,
+      reason: "end_turn",
+      costUsd: null,
+      tokensIn: 0,
+      tokensOut: 0,
+    } as AgentEvent);
+
+    expect(readThreadField(backgroundThreadId, (thread) => thread.messages)
+      .find((message) => message.role === "assistant")?.content)
+      .toBe("background final answer");
+  });
+
   it("session.toolUse adds tool call to toolCallsByThread", () => {
     useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "tc1", toolName: "Read", toolInput: { path: "/foo" } } as AgentEvent);
     vi.runAllTimers();

--- a/apps/web/src/__tests__/agent-event-branches.test.ts
+++ b/apps/web/src/__tests__/agent-event-branches.test.ts
@@ -95,6 +95,51 @@ describe("handleAgentEvent branches", () => {
     expect(calls[0].isComplete).toBe(false);
   });
 
+  it("background textDelta keeps streaming state without growing narrative state", async () => {
+    const backgroundThreadId = "thread-2";
+    const backgroundToolCall = {
+      id: "background-tool",
+      toolName: "Read",
+      toolInput: { path: "/tmp/background" },
+      output: null,
+      isError: false,
+      isComplete: false,
+    };
+    const backgroundThought = { text: "existing thought", startedAt: 1, endedAt: 2 };
+    resetThreadStoreForTests({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1", backgroundThreadId]),
+      records: new Map<string, ThreadRecord>([
+        ["thread-1", { ...createEmptyThreadRecord() }],
+        [backgroundThreadId, {
+          ...createEmptyThreadRecord(),
+          streaming: "",
+          thoughtSegments: [backgroundThought],
+          toolCalls: [backgroundToolCall],
+        }],
+      ]),
+    });
+
+    useThreadStore.getState().handleAgentEvent({
+      type: "textDelta",
+      threadId: backgroundThreadId,
+      delta: "background text",
+    } as AgentEvent);
+    useThreadStore.getState().handleAgentEvent({
+      type: "toolProgress",
+      threadId: backgroundThreadId,
+      toolCallId: backgroundToolCall.id,
+      elapsedSeconds: 1,
+    } as AgentEvent);
+    await Promise.resolve();
+    vi.runAllTimers();
+
+    const record = readThreadField(backgroundThreadId, (thread) => thread);
+    expect(record.streaming).toBe("background text");
+    expect(record.thoughtSegments).toEqual([backgroundThought]);
+    expect(record.toolCalls).toEqual([backgroundToolCall]);
+  });
+
   it("session.toolUse ignores duplicate toolCallId (defense in depth)", () => {
     useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "dup", toolName: "Read", toolInput: { path: "/a" } } as AgentEvent);
     useThreadStore.getState().handleAgentEvent({ type: "toolUse", threadId: "thread-1", toolCallId: "dup", toolName: "Read", toolInput: { path: "/b" } } as AgentEvent);

--- a/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
+++ b/apps/web/src/__tests__/agent-event-thread-isolation.test.ts
@@ -7,6 +7,8 @@ import {
   getTestThreadStreaming,
   getTestThreadToolCalls,
   getTestThreadError,
+  getTestThreadMessages,
+  getTestThreadHasMoreMessages,
   getTestThreadLoadEpoch,
   getTestThreadPlanQuestionsStatus,
   readActiveThreadField,
@@ -210,6 +212,70 @@ await activateTestConversation(THREAD_A);
       expect(getTestActiveMessages()).toHaveLength(0);
       // Streaming state is cleaned up for Thread B
       expect(getTestThreadStreaming(THREAD_B)).toBeUndefined();
+    });
+  });
+
+  // ── Compaction notice isolation ──────────────────────────────────────
+
+  describe("compaction notice isolation", () => {
+    it("appends background compaction notice to event thread, not selected thread", () => {
+      const { handleAgentEvent } = useThreadStore.getState();
+
+      handleAgentEvent({ type: "compacting", threadId: THREAD_B, active: true } as AgentEvent);
+      handleAgentEvent({ type: "compacting", threadId: THREAD_B, active: false } as AgentEvent);
+
+      expect(getTestThreadMessages(THREAD_B).map((message) => message.content)).toEqual([
+        "Context compacted",
+      ]);
+      expect(getTestThreadMessages(THREAD_A)).toHaveLength(0);
+    });
+
+    it("appends background compaction notice when no thread is selected", () => {
+      resetThreadStoreForTests({
+        currentThreadId: null,
+        runningThreadIds: new Set([THREAD_B]),
+        records: new Map([[THREAD_B, createEmptyThreadRecord()]]),
+      });
+      const { handleAgentEvent } = useThreadStore.getState();
+
+      handleAgentEvent({ type: "compacting", threadId: THREAD_B, active: true } as AgentEvent);
+      handleAgentEvent({ type: "compacting", threadId: THREAD_B, active: false } as AgentEvent);
+
+      expect(getTestThreadMessages(THREAD_B)).toHaveLength(1);
+      expect(getTestThreadMessages(THREAD_B)[0]?.content).toBe("Context compacted");
+    });
+
+    it("sets hasMoreMessages when compaction notice evicts an older message", () => {
+      const messages = Array.from({ length: 200 }, (_, index) => ({
+        id: `message-${index}`,
+        thread_id: THREAD_B,
+        role: "user" as const,
+        content: `message ${index}`,
+        tool_calls: null,
+        files_changed: null,
+        cost_usd: null,
+        tokens_used: null,
+        timestamp: "",
+        sequence: index + 1,
+        attachments: null,
+      }));
+      resetThreadStoreForTests({
+        currentThreadId: THREAD_A,
+        records: new Map([
+          [THREAD_A, createEmptyThreadRecord()],
+          [THREAD_B, { ...createEmptyThreadRecord(), messages }],
+        ]),
+      });
+      const { handleAgentEvent } = useThreadStore.getState();
+
+      handleAgentEvent({ type: "compacting", threadId: THREAD_B, active: true } as AgentEvent);
+      handleAgentEvent({ type: "compacting", threadId: THREAD_B, active: false } as AgentEvent);
+
+      expect(getTestThreadMessages(THREAD_B)).toHaveLength(200);
+      expect(getTestThreadMessages(THREAD_B)[0]?.id).toBe("message-1");
+      expect(getTestThreadMessages(THREAD_B).at(-1)?.content).toBe("Context compacted");
+      expect(getTestThreadHasMoreMessages(THREAD_B)).toBe(true);
+      expect(getTestThreadMessages(THREAD_A)).toHaveLength(0);
     });
   });
 

--- a/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
+++ b/apps/web/src/__tests__/threadStore-text-delta-batch.test.ts
@@ -38,6 +38,7 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-coalesce";
+    resetThreadStoreForTests({ currentThreadId: tid, runningThreadIds: new Set([tid]) });
     for (let i = 0; i < 8; i++) {
       useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: String(i) } satisfies AgentEvent);
     }
@@ -61,6 +62,7 @@ describe("threadStore textDelta batching", () => {
       .mockImplementation(() => undefined);
     const tid = "thread-stale-reconnect";
     resetThreadStoreForTests({
+      currentThreadId: tid,
       runningThreadIds: new Set([tid]),
       records: new Map([
         [
@@ -100,6 +102,7 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-final-flag";
+    resetThreadStoreForTests({ currentThreadId: tid, runningThreadIds: new Set([tid]) });
     useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "think ", isFinalResponse: false } satisfies AgentEvent);
     useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "final", isFinalResponse: true } satisfies AgentEvent);
     expect(queue).toHaveLength(1);
@@ -122,6 +125,8 @@ describe("threadStore textDelta batching", () => {
     const tid = "thread-final-reference";
     const thoughtSegments = [{ text: "closed narration", startedAt: 1, endedAt: 2 }];
     resetThreadStoreForTests({
+      currentThreadId: tid,
+      runningThreadIds: new Set([tid]),
       records: new Map([
         [
           tid,
@@ -151,6 +156,8 @@ describe("threadStore textDelta batching", () => {
     const closedText = "This closed narration is long enough to stay closed. ";
     const thoughtSegments = [{ text: closedText, startedAt: 1, endedAt: 2 }];
     resetThreadStoreForTests({
+      currentThreadId: tid,
+      runningThreadIds: new Set([tid]),
       records: new Map([
         [
           tid,
@@ -181,6 +188,7 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-legacy-unclassified";
+    resetThreadStoreForTests({ currentThreadId: tid, runningThreadIds: new Set([tid]) });
     useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "legacy " } satisfies AgentEvent);
     expect(queue).toHaveLength(1);
 
@@ -198,6 +206,7 @@ describe("threadStore textDelta batching", () => {
     });
 
     const tid = "thread-flush";
+    resetThreadStoreForTests({ currentThreadId: tid, runningThreadIds: new Set([tid]) });
     useThreadStore.getState().handleAgentEvent({ type: "textDelta", threadId: tid, delta: "hello " } satisfies AgentEvent);
     expect(queue).toHaveLength(1);
 

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -819,6 +819,31 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     expect(chatViewResidencyMock.refresh).not.toHaveBeenCalled();
   });
 
+  it("swallows rejected atomic hydration refreshes", async () => {
+    const setThreadSubscriptions = vi.fn().mockResolvedValue({
+      hydrationRequiredThreadIds: ["thread-1"],
+    });
+    Object.defineProperty(chatViewTransportMock, "setThreadSubscriptions", {
+      configurable: true,
+      writable: true,
+      value: setThreadSubscriptions,
+    });
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: "thread-1",
+      runningThreadIds: new Set(["thread-1"]),
+    });
+    chatViewResidencyMock.refresh.mockRejectedValueOnce(new Error("refresh failed"));
+
+    render(<ChatView />);
+
+    await waitFor(() => {
+      expect(chatViewResidencyMock.refresh).toHaveBeenCalledWith(
+        "thread-1",
+        expect.any(Array),
+      );
+    });
+  });
+
   it("ignores same-epoch stale atomic hydration responses after the target changes", async () => {
     const requests: Array<(result: { hydrationRequiredThreadIds: string[] }) => void> = [];
     const setThreadSubscriptions = vi.fn(

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -658,6 +658,57 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
   });
 
+  it("sends observed cursors without reconciling cursor-only changes", async () => {
+    const setThreadSubscriptions = enableAtomicSubscriptionTransport();
+    const runningThreadIds = new Set<string>();
+    const firstRecord = { ...createEmptyThreadRecord(), lastAgentEventSequence: 7 };
+    setupWorkspaceMock(defaultWorkspaceState({ activeThreadId: "thread-1" }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: "thread-1",
+      runningThreadIds,
+      activeRecord: firstRecord,
+      records: new Map([["thread-1", firstRecord]]),
+    });
+    const { rerender } = render(<ChatView />);
+
+    await waitFor(() => {
+      expect(setThreadSubscriptions).toHaveBeenCalledWith({
+        threadIds: ["thread-1"],
+        cursors: { "thread-1": 7 },
+      });
+    });
+
+    const secondRecord = { ...firstRecord, lastAgentEventSequence: 8 };
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: "thread-1",
+      runningThreadIds,
+      activeRecord: secondRecord,
+      records: new Map([["thread-1", secondRecord]]),
+    });
+    rerender(<ChatView />);
+
+    expect(setThreadSubscriptions).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the active thread first while bounding running subscriptions", async () => {
+    const setThreadSubscriptions = enableAtomicSubscriptionTransport();
+    const activeThreadId = "thread-active";
+    const runningThreadIds = new Set(
+      Array.from({ length: 105 }, (_, index) => `thread-${String(index).padStart(3, "0")}`),
+    );
+    setupWorkspaceMock(defaultWorkspaceState({ activeThreadId, threads: [] }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: activeThreadId,
+      runningThreadIds,
+    });
+    render(<ChatView />);
+
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(1));
+    const input = setThreadSubscriptions.mock.calls[0]?.[0] as { threadIds: string[] };
+    expect(input.threadIds).toHaveLength(100);
+    expect(input.threadIds[0]).toBe(activeThreadId);
+  });
+
   it("coalesces repeated reconciliation while an atomic request is pending", async () => {
     const requestResolvers: Array<() => void> = [];
     const setThreadSubscriptions = vi.fn(() => new Promise<void>((resolve) => {

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -819,6 +819,60 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     expect(chatViewResidencyMock.refresh).not.toHaveBeenCalled();
   });
 
+  it("ignores same-epoch stale atomic hydration responses after the target changes", async () => {
+    const requests: Array<(result: { hydrationRequiredThreadIds: string[] }) => void> = [];
+    const setThreadSubscriptions = vi.fn(
+      () => new Promise<{ hydrationRequiredThreadIds: string[] }>((resolve) => {
+        requests.push(resolve);
+      }),
+    );
+    Object.defineProperty(chatViewTransportMock, "setThreadSubscriptions", {
+      configurable: true,
+      writable: true,
+      value: setThreadSubscriptions,
+    });
+    const thread1 = makeThread({ id: "thread-1", title: "Thread 1" });
+    const thread2 = makeThread({ id: "thread-2", title: "Thread 2", status: "active" });
+    const record = {
+      ...createEmptyThreadRecord(),
+      lastAgentEventEpoch: "epoch-a",
+      lastAgentEventSequence: 7,
+    };
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread1.id,
+      threads: [thread1, thread2],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread1.id,
+      activeRecord: record,
+      records: new Map([[thread1.id, record]]),
+    });
+    const { rerender } = render(<ChatView />);
+
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(1));
+
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread1.id,
+      runningThreadIds: new Set([thread2.id]),
+      activeRecord: record,
+      records: new Map([[thread1.id, record]]),
+    });
+    rerender(<ChatView />);
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(2));
+
+    requests[0]?.({ hydrationRequiredThreadIds: [thread1.id] });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chatViewThreadStoreSetStateMock).not.toHaveBeenCalled();
+    expect(chatViewResidencyMock.invalidateConversation).not.toHaveBeenCalled();
+    expect(chatViewResidencyMock.refresh).not.toHaveBeenCalled();
+    expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
+
+    requests[1]?.({ hydrationRequiredThreadIds: [] });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
+  });
+
   it("reconciles a newer atomic target after an older response and failed replacement", async () => {
     const requests: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
     const setThreadSubscriptions = vi.fn(() => new Promise<void>((resolve, reject) => {

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -415,6 +415,41 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     expect(screen.getByTestId("message-list")).not.toHaveAttribute("data-display-thread-id");
   });
 
+  it("holds the outgoing transcript for an empty running target", () => {
+    const thread1 = makeThread({ id: "thread-1", title: "Thread 1" });
+    const thread2 = makeThread({ id: "thread-2", title: "Thread 2", status: "active" });
+    const outgoingRecord = {
+      ...createEmptyThreadRecord(),
+      messages: [createMockMessage({ id: "thread-1-message", thread_id: thread1.id })],
+    };
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread1.id,
+      threads: [thread1, thread2],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread1.id,
+      activeRecord: outgoingRecord,
+      records: new Map([[thread1.id, outgoingRecord]]),
+    });
+
+    const { rerender } = render(<ChatView />);
+
+    setupWorkspaceMock(defaultWorkspaceState({
+      activeThreadId: thread2.id,
+      threads: [thread1, thread2],
+    }));
+    chatViewThreadMockRef.current = defaultThreadState({
+      currentThreadId: thread2.id,
+      runningThreadIds: new Set([thread2.id]),
+      activeRecord: createEmptyThreadRecord(),
+      records: new Map([[thread1.id, outgoingRecord]]),
+    });
+    act(() => rerender(<ChatView />));
+
+    expect(screen.getByTestId("message-list")).toHaveAttribute("data-display-thread-id", thread1.id);
+    expect(screen.getByTestId("conversation-hold-overlay")).toBeInTheDocument();
+  });
+
   it("drops a stale hold when rapid switching reaches another cold thread", () => {
     const thread1 = makeThread({ id: "thread-1", title: "Thread 1" });
     const thread2 = makeThread({ id: "thread-2", title: "Thread 2" });

--- a/apps/web/src/components/chat/ChatView.test.tsx
+++ b/apps/web/src/components/chat/ChatView.test.tsx
@@ -12,6 +12,8 @@ const {
   chatViewConnectionStatusRef,
   chatViewGetTransportMock,
   chatViewTransportMock,
+  chatViewThreadStoreSetStateMock,
+  chatViewResidencyMock,
 } = vi.hoisted(() => ({
   chatViewWorkspaceMockRef: { current: null as Record<string, unknown> | null },
   chatViewThreadMockRef: { current: null as Record<string, unknown> | null },
@@ -21,6 +23,11 @@ const {
     subscribeThread: vi.fn(),
     unsubscribeThread: vi.fn(),
     setThreadSubscriptions: vi.fn(),
+  },
+  chatViewThreadStoreSetStateMock: vi.fn(),
+  chatViewResidencyMock: {
+    invalidateConversation: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -45,14 +52,18 @@ vi.mock("@/stores/workspaceStore", () => ({
   ),
 }));
 
-vi.mock("@/stores/threadStore", () => ({
-  useThreadStore: vi.fn((selector: (s: unknown) => unknown) => {
-    if (!chatViewThreadMockRef.current) {
-      throw new Error("ChatView tests: set chatViewThreadMockRef before render");
-    }
-    return selector(chatViewThreadMockRef.current);
-  }),
-}));
+vi.mock("@/stores/threadStore", () => {
+  const useThreadStore = Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => {
+      if (!chatViewThreadMockRef.current) {
+        throw new Error("ChatView tests: set chatViewThreadMockRef before render");
+      }
+      return selector(chatViewThreadMockRef.current);
+    }),
+    { setState: chatViewThreadStoreSetStateMock },
+  );
+  return { useThreadStore };
+});
 
 vi.mock("@/stores/connectionStore", () => ({
   useConnectionStore: vi.fn((selector: (s: unknown) => unknown) =>
@@ -87,6 +98,10 @@ vi.mock("@/transport", () => ({
   getTransport: chatViewGetTransportMock,
 }));
 
+vi.mock("@/stores/conversation-residency", () => ({
+  getConversationResidency: () => chatViewResidencyMock,
+}));
+
 // Composer and MessageList have deep dependencies; stub them out.
 vi.mock("./Composer", () => ({
   Composer: () => <div data-testid="composer" />,
@@ -114,6 +129,10 @@ vi.mock("./CliErrorBanner", () => ({
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { createEmptyThreadRecord } from "@/stores/thread-record";
 import { createMockMessage } from "@/__tests__/mocks/transport";
+import {
+  __resetThreadSwitchTelemetryForTests,
+  getThreadSwitchTelemetryCounters,
+} from "@/lib/thread-switch-telemetry";
 import { ChatView } from "./ChatView";
 
 /** Build a minimal Thread fixture. */
@@ -255,6 +274,10 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     chatViewTransportMock.unsubscribeThread.mockClear();
     chatViewGetTransportMock.mockReset();
     chatViewGetTransportMock.mockReturnValue(chatViewTransportMock);
+    chatViewThreadStoreSetStateMock.mockClear();
+    chatViewResidencyMock.invalidateConversation.mockClear();
+    chatViewResidencyMock.refresh.mockClear();
+    __resetThreadSwitchTelemetryForTests();
     disableAtomicSubscriptionTransport();
     setupWorkspaceMock(defaultWorkspaceState());
     chatViewThreadMockRef.current = defaultThreadState();
@@ -690,6 +713,16 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     expect(setThreadSubscriptions).toHaveBeenCalledTimes(1);
   });
 
+  it("does not record telemetry for an already-applied empty atomic subscription set", () => {
+    enableAtomicSubscriptionTransport();
+    setupWorkspaceMock(defaultWorkspaceState({ activeThreadId: null, threads: [] }));
+    chatViewThreadMockRef.current = defaultThreadState({ currentThreadId: null });
+
+    render(<ChatView />);
+
+    expect(getThreadSwitchTelemetryCounters().subscriptionsSkipped).toBe(0);
+  });
+
   it("keeps the active thread first while bounding running subscriptions", async () => {
     const setThreadSubscriptions = enableAtomicSubscriptionTransport();
     const activeThreadId = "thread-active";
@@ -759,6 +792,31 @@ describe("ChatView - Thread Title Double-Click Rename", () => {
     requests[0]?.resolve();
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(setThreadSubscriptions).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores stale atomic hydration responses before mutating cursor or residency state", async () => {
+    const requests: Array<(result: { hydrationRequiredThreadIds: string[] }) => void> = [];
+    const setThreadSubscriptions = vi.fn(
+      () => new Promise<{ hydrationRequiredThreadIds: string[] }>((resolve) => {
+        requests.push(resolve);
+      }),
+    );
+    Object.defineProperty(chatViewTransportMock, "setThreadSubscriptions", {
+      configurable: true,
+      writable: true,
+      value: setThreadSubscriptions,
+    });
+    const { rerender } = render(<ChatView />);
+
+    await waitFor(() => expect(setThreadSubscriptions).toHaveBeenCalledTimes(1));
+    chatViewConnectionStatusRef.current = "reconnecting";
+    rerender(<ChatView />);
+    requests[0]?.({ hydrationRequiredThreadIds: ["thread-1"] });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chatViewThreadStoreSetStateMock).not.toHaveBeenCalled();
+    expect(chatViewResidencyMock.invalidateConversation).not.toHaveBeenCalled();
+    expect(chatViewResidencyMock.refresh).not.toHaveBeenCalled();
   });
 
   it("reconciles a newer atomic target after an older response and failed replacement", async () => {

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/stores/workspace-selectors";
 import { useThreadStore } from "@/stores/threadStore";
 import { useActiveThreadRecord, readThreadRecord } from "@/stores/thread-selectors";
+import { getConversationResidency } from "@/stores/conversation-residency";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useComposerDraftStore } from "@/stores/composerDraftStore";
 import { useOverviewStore } from "@/stores/overviewStore";
@@ -37,9 +38,11 @@ import { McodeLogo } from "@/components/brand/McodeLogo";
 import { NewThreadProjectPicker } from "./NewThreadProjectPicker";
 import {
   recordFirstMessageVisible,
+  recordSubscriptionSkipped,
   recordThreadHoldEnd,
   recordThreadHoldStart,
 } from "@/lib/thread-switch-telemetry";
+import { MAX_THREAD_SUBSCRIPTIONS } from "@mcode/contracts";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
 const ENTRY_POINTS = [
@@ -561,11 +564,14 @@ export function ChatView() {
   const [subscriptionReconcileVersion, setSubscriptionReconcileVersion] = useState(0);
 
   useEffect(() => {
-    const desired = new Set(runningThreadIds);
-    if (activeThreadId) desired.add(activeThreadId);
+    const orderedDesiredThreadIds = [
+      ...(activeThreadId ? [activeThreadId] : []),
+      ...Array.from(runningThreadIds).filter((threadId) => threadId !== activeThreadId).sort(),
+    ].slice(0, MAX_THREAD_SUBSCRIPTIONS);
+    const desired = new Set(orderedDesiredThreadIds);
     desiredThreadIdsRef.current = desired;
 
-    const targetSignature = `${connectionStatus}:${Array.from(desired).sort().join("\u0000")}`;
+    const targetSignature = `${connectionStatus}:${orderedDesiredThreadIds.join("\u0000")}`;
     if (subscriptionTargetSignatureRef.current !== targetSignature) {
       subscriptionTargetSignatureRef.current = targetSignature;
       subscriptionRetryAttemptRef.current = 0;
@@ -592,13 +598,17 @@ export function ChatView() {
     const epoch = subscriptionEpochRef.current;
     const setThreadSubscriptions = getTransport().setThreadSubscriptions;
     if (setThreadSubscriptions) {
-      const sortedThreadIds = Array.from(desired).sort();
+      const sortedThreadIds = orderedDesiredThreadIds;
       const sentThreadIds = new Set(sortedThreadIds);
       const confirmed = confirmedThreadIdsRef.current;
       const alreadyApplied = confirmed.size === desired.size
         && Array.from(confirmed).every((threadId) => desired.has(threadId));
       const pending = atomicSubscriptionRequestRef.current;
-      if (alreadyApplied || (pending?.epoch === epoch && pending.signature === targetSignature)) return;
+      if (alreadyApplied) {
+        recordSubscriptionSkipped(activeThreadId ?? sortedThreadIds[0] ?? "");
+        return;
+      }
+      if (pending?.epoch === epoch && pending.signature === targetSignature) return;
       const requestId = atomicSubscriptionRequestIdRef.current + 1;
       atomicSubscriptionRequestIdRef.current = requestId;
       atomicSubscriptionRequestRef.current = {
@@ -607,7 +617,24 @@ export function ChatView() {
         id: requestId,
       };
       pendingAtomicThreadIdsRef.current.set(requestId, sortedThreadIds);
-      void setThreadSubscriptions({ threadIds: sortedThreadIds }).then(() => {
+      const cursors: Record<string, number> = {};
+      for (const threadId of sortedThreadIds) {
+        const sequence = readThreadRecord(threadId).lastAgentEventSequence;
+        if (typeof sequence === "number" && sequence > 0) cursors[threadId] = sequence;
+      }
+      const input = Object.keys(cursors).length > 0
+        ? { threadIds: sortedThreadIds, cursors }
+        : { threadIds: sortedThreadIds };
+      void setThreadSubscriptions(input).then((result) => {
+        if (result?.hydrationRequiredThreadIds?.length) {
+          const residency = getConversationResidency();
+          for (const threadId of result.hydrationRequiredThreadIds) {
+            residency.invalidateConversation(threadId);
+            if (threadId === activeThreadId && runningThreadIds.has(threadId)) {
+              void residency.refresh(threadId, useWorkspaceStore.getState().threads);
+            }
+          }
+        }
         if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
         confirmedThreadIdsRef.current = sentThreadIds;
         const latestDesired = desiredThreadIdsRef.current;

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -605,7 +605,8 @@ export function ChatView() {
         && Array.from(confirmed).every((threadId) => desired.has(threadId));
       const pending = atomicSubscriptionRequestRef.current;
       if (alreadyApplied) {
-        recordSubscriptionSkipped(activeThreadId ?? sortedThreadIds[0] ?? "");
+        const telemetryThreadId = activeThreadId ?? sortedThreadIds[0];
+        if (telemetryThreadId) recordSubscriptionSkipped(telemetryThreadId);
         return;
       }
       if (pending?.epoch === epoch && pending.signature === targetSignature) return;
@@ -636,6 +637,7 @@ export function ChatView() {
         ? { threadIds: sortedThreadIds, cursors }
         : { threadIds: sortedThreadIds };
       void setThreadSubscriptions(input).then((result) => {
+        if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
         if (result?.hydrationRequiredThreadIds?.length) {
           const residency = getConversationResidency();
           for (const threadId of result.hydrationRequiredThreadIds) {
@@ -663,7 +665,6 @@ export function ChatView() {
             }
           }
         }
-        if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
         confirmedThreadIdsRef.current = sentThreadIds;
         const latestDesired = desiredThreadIdsRef.current;
         const responseIsCurrent = subscriptionTargetSignatureRef.current === targetSignature

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -33,6 +33,7 @@ import { useReplyStore } from "@/stores/replyStore";
 import { getTransport } from "@/transport";
 import { useElementWidth } from "@/hooks/useElementWidth";
 import { overviewResponsivePaddingRight } from "@/lib/composer-layout";
+import { hasResidentContent } from "@/lib/thread-hydrator/resident-content";
 import { Button } from "@/components/ui/button";
 import { McodeLogo } from "@/components/brand/McodeLogo";
 import { NewThreadProjectPicker } from "./NewThreadProjectPicker";
@@ -341,20 +342,13 @@ export function ChatView() {
   const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
   const hydratedThreadId = useThreadStore((s) => s.currentThreadId);
   const messageCount = useActiveThreadRecord((r) => r.messages.length);
-  const hasResidentContent = useActiveThreadRecord((r) =>
-    r.messages.length > 0
-    || r.streaming.length > 0
-    || r.streamingPreview.length > 0
-    || r.toolCalls.length > 0
-    || r.thoughtSegments.length > 0
-    || r.hooks.length > 0,
-  );
+  const residentContent = useActiveThreadRecord(hasResidentContent);
   const historyLoading = useActiveThreadRecord((r) => r.loading);
   const setPendingPrefill = useComposerDraftStore((s) => s.setPendingPrefill);
 
   const isAgentRunning = activeThreadId ? runningThreadIds.has(activeThreadId) : false;
   const targetPaintable = hydratedThreadId === activeThreadId
-    && (messageCount > 0 || (isAgentRunning && hasResidentContent));
+    && (messageCount > 0 || (isAgentRunning && residentContent));
   const previousActiveThreadIdRef = useRef<string | null>(activeThreadId);
   const [heldOutgoingThreadId, setHeldOutgoingThreadId] = useState<string | null>(null);
   const previousThreadId = previousActiveThreadIdRef.current;
@@ -676,7 +670,7 @@ export function ChatView() {
             residency.invalidateConversation(threadId);
             if (threadId === activeThreadId && runningThreadIds.has(threadId)) {
               if (!isCurrentAtomicResponse()) return;
-              void residency.refresh(threadId, useWorkspaceStore.getState().threads);
+              void residency.refresh(threadId, useWorkspaceStore.getState().threads).catch(() => {});
             }
           }
         }

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -42,7 +42,7 @@ import {
   recordThreadHoldEnd,
   recordThreadHoldStart,
 } from "@/lib/thread-switch-telemetry";
-import { MAX_THREAD_SUBSCRIPTIONS } from "@mcode/contracts";
+import { MAX_THREAD_SUBSCRIPTIONS, type SetThreadSubscriptionsInput } from "@mcode/contracts";
 
 /** Entry point suggestions shown in the empty state — each maps to a real Mcode capability. */
 const ENTRY_POINTS = [
@@ -617,10 +617,20 @@ export function ChatView() {
         id: requestId,
       };
       pendingAtomicThreadIdsRef.current.set(requestId, sortedThreadIds);
-      const cursors: Record<string, number> = {};
+      const cursors: NonNullable<SetThreadSubscriptionsInput["cursors"]> = {};
+      const cursorAuthority = new Map<string, { epoch?: string; sequence?: number }>();
       for (const threadId of sortedThreadIds) {
-        const sequence = readThreadRecord(threadId).lastAgentEventSequence;
-        if (typeof sequence === "number" && sequence > 0) cursors[threadId] = sequence;
+        const record = readThreadRecord(threadId);
+        const sequence = record.lastAgentEventSequence;
+        if (typeof sequence === "number" && sequence > 0) {
+          cursorAuthority.set(threadId, {
+            epoch: record.lastAgentEventEpoch,
+            sequence,
+          });
+          cursors[threadId] = record.lastAgentEventEpoch
+            ? { epoch: record.lastAgentEventEpoch, sequence }
+            : sequence;
+        }
       }
       const input = Object.keys(cursors).length > 0
         ? { threadIds: sortedThreadIds, cursors }
@@ -629,6 +639,24 @@ export function ChatView() {
         if (result?.hydrationRequiredThreadIds?.length) {
           const residency = getConversationResidency();
           for (const threadId of result.hydrationRequiredThreadIds) {
+            const expected = cursorAuthority.get(threadId);
+            useThreadStore.setState((state) => {
+              const record = state.records.get(threadId);
+              if (!record) return state;
+              const stillOwnsCursor = expected?.epoch
+                ? record.lastAgentEventEpoch === expected.epoch
+                  && record.lastAgentEventSequence === expected.sequence
+                : record.lastAgentEventEpoch === undefined
+                  && record.lastAgentEventSequence === expected?.sequence;
+              if (!stillOwnsCursor) return state;
+              const records = new Map(state.records);
+              records.set(threadId, {
+                ...record,
+                lastAgentEventEpoch: undefined,
+                lastAgentEventSequence: undefined,
+              });
+              return { records };
+            });
             residency.invalidateConversation(threadId);
             if (threadId === activeThreadId && runningThreadIds.has(threadId)) {
               void residency.refresh(threadId, useWorkspaceStore.getState().threads);

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -636,12 +636,25 @@ export function ChatView() {
       const input = Object.keys(cursors).length > 0
         ? { threadIds: sortedThreadIds, cursors }
         : { threadIds: sortedThreadIds };
+      const isCurrentAtomicResponse = () => {
+        const currentRequest = atomicSubscriptionRequestRef.current;
+        const latestDesired = desiredThreadIdsRef.current;
+        return subscriptionMountedRef.current
+          && subscriptionEpochRef.current === epoch
+          && currentRequest?.epoch === epoch
+          && currentRequest?.id === requestId
+          && currentRequest?.signature === targetSignature
+          && subscriptionTargetSignatureRef.current === targetSignature
+          && latestDesired.size === sentThreadIds.size
+          && Array.from(latestDesired).every((threadId) => sentThreadIds.has(threadId));
+      };
       void setThreadSubscriptions(input).then((result) => {
-        if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
+        if (!isCurrentAtomicResponse()) return;
         if (result?.hydrationRequiredThreadIds?.length) {
           const residency = getConversationResidency();
           for (const threadId of result.hydrationRequiredThreadIds) {
             const expected = cursorAuthority.get(threadId);
+            if (!isCurrentAtomicResponse()) return;
             useThreadStore.setState((state) => {
               const record = state.records.get(threadId);
               if (!record) return state;
@@ -659,24 +672,18 @@ export function ChatView() {
               });
               return { records };
             });
+            if (!isCurrentAtomicResponse()) return;
             residency.invalidateConversation(threadId);
             if (threadId === activeThreadId && runningThreadIds.has(threadId)) {
+              if (!isCurrentAtomicResponse()) return;
               void residency.refresh(threadId, useWorkspaceStore.getState().threads);
             }
           }
         }
+        if (!isCurrentAtomicResponse()) return;
         confirmedThreadIdsRef.current = sentThreadIds;
-        const latestDesired = desiredThreadIdsRef.current;
-        const responseIsCurrent = subscriptionTargetSignatureRef.current === targetSignature
-          && latestDesired.size === sentThreadIds.size
-          && Array.from(latestDesired).every((threadId) => sentThreadIds.has(threadId));
-        if (responseIsCurrent) {
-          subscriptionRetryAttemptRef.current = 0;
-          subscriptionRetryExhaustedRef.current = false;
-        }
-        if (!responseIsCurrent) {
-          setSubscriptionReconcileVersion((version) => version + 1);
-        }
+        subscriptionRetryAttemptRef.current = 0;
+        subscriptionRetryExhaustedRef.current = false;
       }).catch(() => {
         if (!subscriptionMountedRef.current || subscriptionEpochRef.current !== epoch) return;
         const currentRequest = atomicSubscriptionRequestRef.current;

--- a/apps/web/src/components/chat/ChatView.tsx
+++ b/apps/web/src/components/chat/ChatView.tsx
@@ -338,12 +338,20 @@ export function ChatView() {
   const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
   const hydratedThreadId = useThreadStore((s) => s.currentThreadId);
   const messageCount = useActiveThreadRecord((r) => r.messages.length);
+  const hasResidentContent = useActiveThreadRecord((r) =>
+    r.messages.length > 0
+    || r.streaming.length > 0
+    || r.streamingPreview.length > 0
+    || r.toolCalls.length > 0
+    || r.thoughtSegments.length > 0
+    || r.hooks.length > 0,
+  );
   const historyLoading = useActiveThreadRecord((r) => r.loading);
   const setPendingPrefill = useComposerDraftStore((s) => s.setPendingPrefill);
 
   const isAgentRunning = activeThreadId ? runningThreadIds.has(activeThreadId) : false;
   const targetPaintable = hydratedThreadId === activeThreadId
-    && (messageCount > 0 || isAgentRunning);
+    && (messageCount > 0 || (isAgentRunning && hasResidentContent));
   const previousActiveThreadIdRef = useRef<string | null>(activeThreadId);
   const [heldOutgoingThreadId, setHeldOutgoingThreadId] = useState<string | null>(null);
   const previousThreadId = previousActiveThreadIdRef.current;

--- a/apps/web/src/components/sidebar/ProjectTree.test.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.test.tsx
@@ -604,6 +604,13 @@ describe("ProjectTree action-required indicator", () => {
     expect(indicator.className).not.toContain("bg-primary");
   });
 
+  it("renders the running marker from the matching thread row state", () => {
+    threadStoreOverrides.runningThreadIds = new Set(["thread-pending"]);
+    render(<ProjectTree />);
+
+    expect(screen.getByLabelText("Running")).toBeInTheDocument();
+  });
+
   it("renders the ring on the right edge when the thread has a pr_number", () => {
     currentThread = makeThread({
       id: "thread-pending",

--- a/apps/web/src/components/sidebar/ProjectTree.tsx
+++ b/apps/web/src/components/sidebar/ProjectTree.tsx
@@ -244,7 +244,6 @@ export function ProjectTree() {
   const updateThreadTitle = useWorkspaceStore((s) => s.updateThreadTitle);
   const reorderWorkspace = useWorkspaceStore((s) => s.reorderWorkspace);
   const error = useWorkspaceStore((s) => s.error);
-  const runningThreadIds = useThreadStore((s) => s.runningThreadIds);
   // Derive pending permission thread IDs directly in the selector with useShallow
   // so the component only re-renders when the actual set of IDs changes, not on
   // every unrelated threadStore update that creates a new permissionsByThread ref.
@@ -632,7 +631,6 @@ export function ProjectTree() {
                     isExpanded={expanded[ws.id] ?? false}
                     isActive={activeWorkspaceId === ws.id}
                     threads={wsThreads}
-                    runningThreadIds={runningThreadIds}
                     pendingPermissionThreadIds={pendingPermissionThreadIds}
                     isThreadListExpanded={threadListExpanded[ws.id] ?? false}
                     checksById={checksById}
@@ -905,7 +903,6 @@ interface VirtualizedThreadListProps {
   treeItems: ThreadTreeItem[];
   /** Maximum number of tree rows to render. Used by the parent to enforce the THREAD_LIST_CAP. */
   maxVisible: number;
-  runningThreadIds: Set<string>;
   /** Thread IDs with at least one unsettled permission request. */
   pendingPermissionThreadIds: Set<string>;
   /** Per-thread CI check status. Passed from parent to avoid duplicate store subscriptions. */
@@ -925,7 +922,6 @@ interface ThreadRowProps {
   workspaceName: string;
   thread: WorkspaceThread;
   depth: number;
-  isRunning: boolean;
   hasPendingPermission: boolean;
   checks?: ChecksStatus;
   isEditing: boolean;
@@ -946,12 +942,11 @@ interface ThreadRowProps {
   onThreadContextMenu: (e: React.MouseEvent, thread: Thread) => void;
 }
 
-/** Renders one sidebar thread row and subscribes only to its own active state. */
+/** Renders one sidebar thread row and subscribes only to its own active and running state. */
 const ThreadRow = memo(function ThreadRow({
   workspaceName,
   thread,
   depth,
-  isRunning,
   hasPendingPermission,
   checks,
   isEditing,
@@ -968,6 +963,7 @@ const ThreadRow = memo(function ThreadRow({
   onThreadContextMenu,
 }: ThreadRowProps) {
   const isActive = useWorkspaceStore((s) => s.activeThreadId === thread.id);
+  const isRunning = useThreadStore((s) => s.runningThreadIds.has(thread.id));
   const marker = getThreadStateMarker({
     thread,
     checks,
@@ -1367,7 +1363,6 @@ function VirtualizedThreadList({
   workspaceName,
   treeItems: allTreeItems,
   maxVisible,
-  runningThreadIds,
   pendingPermissionThreadIds,
   checksById,
   scrollElementRef,
@@ -1492,7 +1487,6 @@ function VirtualizedThreadList({
               workspaceName={workspaceName}
               thread={thread}
               depth={depth}
-              isRunning={runningThreadIds.has(thread.id)}
               hasPendingPermission={pendingPermissionThreadIds.has(thread.id)}
               checks={checksById[thread.id]}
               isEditing={isEditing}
@@ -1523,7 +1517,6 @@ interface ProjectNodeProps {
   isExpanded: boolean;
   isActive: boolean;
   threads: WorkspaceThread[];
-  runningThreadIds: Set<string>;
   /** Thread IDs with at least one unsettled permission request. */
   pendingPermissionThreadIds: Set<string>;
   /** Whether the thread list is fully expanded (persisted by parent). */
@@ -1561,7 +1554,6 @@ const ProjectNode = memo(function ProjectNode({
   isExpanded,
   isActive,
   threads,
-  runningThreadIds,
   pendingPermissionThreadIds,
   isThreadListExpanded,
   checksById,
@@ -1581,9 +1573,8 @@ const ProjectNode = memo(function ProjectNode({
   sortableListeners,
   isProjectDragging = false,
 }: ProjectNodeProps) {
-  const hasRunning = useMemo(
-    () => threads.some((t) => runningThreadIds.has(t.id)),
-    [threads, runningThreadIds],
+  const hasRunning = useThreadStore((s) =>
+    threads.some((thread) => s.runningThreadIds.has(thread.id)),
   );
   // Cap logic: show THREAD_LIST_CAP rows unless the user opted in, or the
   // active thread sits beyond the cap (force expand so the active row is
@@ -1822,7 +1813,6 @@ const ProjectNode = memo(function ProjectNode({
             workspaceName={workspace.name}
             treeItems={treeItems}
             maxVisible={maxVisible}
-            runningThreadIds={runningThreadIds}
             pendingPermissionThreadIds={pendingPermissionThreadIds}
             checksById={checksById}
             scrollElementRef={scrollElementRef}

--- a/apps/web/src/lib/__tests__/thread-switch-telemetry.test.ts
+++ b/apps/web/src/lib/__tests__/thread-switch-telemetry.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   __resetThreadSwitchTelemetryForTests,
+  getThreadSwitchTelemetryCounters,
+  recordBackgroundEventDropped,
   recordFirstMessageVisible,
+  recordRunningFetchRequired,
+  recordRunningResidentHit,
+  recordSubscriptionSkipped,
   recordThreadCommit,
   recordThreadHoldEnd,
   recordThreadHoldStart,
@@ -68,5 +73,24 @@ describe("thread switch telemetry", () => {
 
     expect(names("mcode:thread-switch:positioned:")).toHaveLength(1);
     expect(performance.getEntriesByType("mark").some((entry) => entry.name.includes(":positioned:2"))).toBe(true);
+  });
+
+  it("records bounded running-switch event marks and counters", () => {
+    recordThreadSelection("thread-a");
+    recordRunningResidentHit("thread-a");
+    recordRunningFetchRequired("thread-a");
+    recordBackgroundEventDropped("thread-a");
+    recordSubscriptionSkipped("thread-a");
+
+    expect(names("mcode:thread-switch:running-resident-hit:")).toHaveLength(1);
+    expect(names("mcode:thread-switch:running-fetch-required:")).toHaveLength(1);
+    expect(names("mcode:thread-switch:background-event-dropped:")).toHaveLength(1);
+    expect(names("mcode:thread-switch:subscription-skipped:")).toHaveLength(1);
+    expect(getThreadSwitchTelemetryCounters()).toEqual({
+      runningResidentHits: 1,
+      runningFetchRequired: 1,
+      backgroundEventsDropped: 1,
+      subscriptionsSkipped: 1,
+    });
   });
 });

--- a/apps/web/src/lib/__tests__/thread-switch-telemetry.test.ts
+++ b/apps/web/src/lib/__tests__/thread-switch-telemetry.test.ts
@@ -93,4 +93,28 @@ describe("thread switch telemetry", () => {
       subscriptionsSkipped: 1,
     });
   });
+
+  it("gives repeated events unique marks and evicts only the oldest mark", () => {
+    recordThreadSelection("thread-a");
+    for (let index = 0; index < 65; index++) {
+      recordSubscriptionSkipped("thread-a");
+    }
+
+    const eventNames = names("mcode:thread-switch:subscription-skipped:");
+    expect(eventNames).toHaveLength(64);
+    expect(new Set(eventNames).size).toBe(64);
+    expect(performance.getEntriesByName("mcode:thread-switch:subscription-skipped:1:1")).toHaveLength(0);
+    expect(performance.getEntriesByName("mcode:thread-switch:subscription-skipped:1:2")).toHaveLength(1);
+  });
+
+  it("resets event IDs with telemetry state", () => {
+    recordThreadSelection("thread-a");
+    recordSubscriptionSkipped("thread-a");
+    __resetThreadSwitchTelemetryForTests();
+
+    recordThreadSelection("thread-a");
+    recordSubscriptionSkipped("thread-a");
+
+    expect(performance.getEntriesByName("mcode:thread-switch:subscription-skipped:1:1")).toHaveLength(1);
+  });
 });

--- a/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/auxiliary-hydrator.test.ts
@@ -128,6 +128,26 @@ describe("AuxiliaryHydrator", () => {
     });
   });
 
+  it("pruned permission generation after deleted thread snapshot settled", async () => {
+    let resolvePermissions!: (value: readonly unknown[]) => void;
+    (mockTransport.listPendingPermissions as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise<readonly unknown[]>((resolve) => {
+        resolvePermissions = resolve;
+      }),
+    );
+    const aux = createAux();
+    aux.hydrate(THREAD_ID, { freshnessTtlMs: HYDRATION_TTL_MS, force: true });
+    aux.forgetThread(THREAD_ID);
+
+    resolvePermissions([]);
+    await vi.waitFor(() => {
+      const generations = (aux as unknown as {
+        permissionSnapshotGenerations: Map<string, number>;
+      }).permissionSnapshotGenerations;
+      expect(generations.has(THREAD_ID)).toBe(false);
+    });
+  });
+
   it("did not call setState for permissions when payload was unchanged", async () => {
     records = patchThreadRecord(records, THREAD_ID, {
       permissions: [{ requestId: "r1", toolName: "bash", settled: false, threadId: THREAD_ID, input: {} }],

--- a/apps/web/src/lib/thread-hydrator/__tests__/resident-content.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/resident-content.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { createEmptyThreadRecord } from "@/stores/thread-record";
+import { hasResidentContent } from "@/lib/thread-hydrator/resident-content";
+
+describe("hasResidentContent", () => {
+  it.each([
+    "messages",
+    "streaming",
+    "streamingPreview",
+    "toolCalls",
+    "thoughtSegments",
+    "hooks",
+  ] as const)("recognizes %s as paintable content", (field) => {
+    const record = createEmptyThreadRecord();
+    if (field === "streaming" || field === "streamingPreview") {
+      record[field] = "content";
+    } else {
+      record[field] = [{}] as never;
+    }
+
+    expect(hasResidentContent(record)).toBe(true);
+  });
+
+  it("returns false for an empty record", () => {
+    expect(hasResidentContent(createEmptyThreadRecord())).toBe(false);
+  });
+});

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -872,6 +872,97 @@ describe("ThreadHydrator", () => {
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
   });
 
+  it("force refreshes authoritatively after an in-flight background prefetch", async () => {
+    const resident = createMockMessage({
+      id: "resident-message",
+      thread_id: THREAD_A,
+      content: "resident message",
+      sequence: 1,
+    });
+    const speculative = createMockMessage({
+      id: "speculative-message",
+      thread_id: THREAD_A,
+      content: "speculative background message",
+      sequence: 2,
+    });
+    const authoritative = createMockMessage({
+      id: "authoritative-message",
+      thread_id: THREAD_A,
+      content: "authoritative refresh message",
+      sequence: 3,
+    });
+    let resolveBackground!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    let resolveAuthoritative!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>)
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveBackground = resolve;
+      }))
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveAuthoritative = resolve;
+      }));
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_B,
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map<string, ThreadRecord>([[
+        THREAD_A,
+        {
+          ...createEmptyThreadRecord(),
+          messages: [resident],
+          streaming: "current activity",
+          toolCalls: [
+            { id: "tc1", toolName: "bash", toolInput: {}, output: null, isError: false, isComplete: false },
+          ],
+        },
+      ]]),
+    });
+
+    const background = hydrator.hydrate(THREAD_A, "background");
+    await vi.waitFor(() => {
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+    });
+
+    const force = hydrator.hydrate(THREAD_A, "active", { force: true });
+    await Promise.resolve();
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+    expect(getTestActiveMessages()).toEqual([resident]);
+    expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
+    expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
+
+    resolveBackground({ messages: [resident, speculative], hasMore: false, narrativeByMessage: {} });
+    await vi.waitFor(() => {
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(2);
+    });
+    expect(mockTransport.loadConversationPage).toHaveBeenNthCalledWith(
+      1,
+      THREAD_A,
+      BACKGROUND_PREFETCH_LIMIT,
+    );
+    expect(mockTransport.loadConversationPage).toHaveBeenNthCalledWith(
+      2,
+      THREAD_A,
+      BACKGROUND_PREFETCH_LIMIT,
+    );
+    expect(getTestActiveMessages()).toEqual([resident]);
+    expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
+    expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
+
+    resolveAuthoritative({ messages: [resident, authoritative], hasMore: false, narrativeByMessage: {} });
+    await Promise.all([background, force]);
+
+    expect(getTestActiveMessages()).toEqual([resident, authoritative]);
+    expect(getTestActiveMessages()).not.toContainEqual(speculative);
+    expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
+    expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
+  });
+
   it("does not let late resident permission hydration replace a live request", async () => {
     let resolvePending!: (value: Array<{
       requestId: string;

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -1596,4 +1596,32 @@ describe("ThreadHydrator", () => {
 
     expect(getTestThreadLoadEpoch(THREAD_A)).toBe(4);
   });
+
+  it("defers background hydration while active hydration is in flight", async () => {
+    let resolveActive!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      (threadId: string) => threadId === THREAD_A
+        ? new Promise((resolve) => {
+            resolveActive = resolve;
+          })
+        : Promise.resolve({ messages: [msgB], hasMore: false, narrativeByMessage: {} }),
+    );
+
+    const active = hydrator.hydrate(THREAD_A, "active");
+    await vi.waitFor(() => {
+      expect(hydrator.isActiveHydrationInFlight()).toBe(true);
+    });
+    const background = hydrator.hydrate(THREAD_B, "background");
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledTimes(1);
+
+    resolveActive({ messages: [msgA], hasMore: false, narrativeByMessage: {} });
+    await Promise.all([active, background]);
+    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_B, BACKGROUND_PREFETCH_LIMIT);
+    expect(hydrator.isActiveHydrationInFlight()).toBe(false);
+  });
 });

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -768,7 +768,7 @@ describe("ThreadHydrator", () => {
     expect(getTestActiveMessages()).toEqual([msgA]);
     expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
-    expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, BACKGROUND_PREFETCH_LIMIT);
+    expect(mockTransport.loadConversationPage).not.toHaveBeenCalled();
     expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
   });

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -773,6 +773,50 @@ describe("ThreadHydrator", () => {
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
   });
 
+  it("does not let late resident permission hydration replace a live request", async () => {
+    let resolvePending!: (value: Array<{
+      requestId: string;
+      threadId: string;
+      toolName: string;
+      input: Record<string, never>;
+    }>) => void;
+    (mockTransport.listPendingPermissions as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolvePending = resolve;
+      }),
+    );
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_B,
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map<string, ThreadRecord>([
+        [THREAD_A, { ...createEmptyThreadRecord(), messages: [msgA] }],
+        [THREAD_B, { ...createEmptyThreadRecord(), messages: [msgB] }],
+      ]),
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+    await vi.waitFor(() => {
+      expect(mockTransport.listPendingPermissions).toHaveBeenCalledWith(THREAD_A);
+    });
+
+    useThreadStore.getState().addPermissionRequest({
+      requestId: "live-request",
+      threadId: THREAD_A,
+      toolName: "Bash",
+      input: {},
+    });
+    resolvePending([{
+      requestId: "stale-request",
+      threadId: THREAD_A,
+      toolName: "Read",
+      input: {},
+    }]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(useThreadStore.getState().records.get(THREAD_A)?.permissions)
+      .toEqual([expect.objectContaining({ requestId: "live-request", settled: false })]);
+  });
+
   it("preserves volatile state for a running thread on cache hit", async () => {
     resetThreadStoreForTests({
       runningThreadIds: new Set([THREAD_A]),

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -823,6 +823,32 @@ describe("ThreadHydrator", () => {
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
   });
 
+  it("uses auxiliary TTL by default and when force is false for resident hydration", async () => {
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_B,
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map<string, ThreadRecord>([
+        [THREAD_A, { ...makeCachedRecord(), lastHydratedAt: Date.now() }],
+        [THREAD_B, makeCachedRecord([msgB])],
+      ]),
+    });
+
+    await hydrator.hydrate(THREAD_A, "active");
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(mockTransport.listPendingPermissions).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    await hydrator.hydrate(THREAD_A, "active", { force: false });
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(mockTransport.listPendingPermissions).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    await hydrator.hydrate(THREAD_A, "active", { force: true });
+    await vi.waitFor(() => {
+      expect(mockTransport.listPendingPermissions).toHaveBeenCalledWith(THREAD_A);
+    });
+  });
+
   it("force refreshes a running resident layer without wiping live state", async () => {
     let resolveFetch!: (value: {
       messages: typeof msgA[];

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -823,6 +823,55 @@ describe("ThreadHydrator", () => {
     expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
   });
 
+  it("force refreshes a running resident layer without wiping live state", async () => {
+    let resolveFetch!: (value: {
+      messages: typeof msgA[];
+      hasMore: boolean;
+      narrativeByMessage: Record<string, never>;
+    }) => void;
+    const freshMessage = createMockMessage({
+      id: "fresh-message",
+      thread_id: THREAD_A,
+      content: "fresh authoritative message",
+      sequence: 2,
+    });
+    (mockTransport.loadConversationPage as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_B,
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map<string, ThreadRecord>([[
+        THREAD_A,
+        {
+          ...createEmptyThreadRecord(),
+          messages: [msgA],
+          streaming: "current activity",
+          toolCalls: [
+            { id: "tc1", toolName: "bash", toolInput: {}, output: null, isError: false, isComplete: false },
+          ],
+        },
+      ]]),
+    });
+
+    const hydrate = hydrator.hydrate(THREAD_A, "active", { force: true });
+    await vi.waitFor(() => {
+      expect(mockTransport.loadConversationPage).toHaveBeenCalledWith(THREAD_A, BACKGROUND_PREFETCH_LIMIT);
+    });
+    expect(getTestActiveMessages()).toEqual([msgA]);
+    expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
+    expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
+
+    resolveFetch({ messages: [msgA, freshMessage], hasMore: false, narrativeByMessage: {} });
+    await hydrate;
+
+    expect(getTestActiveMessages()).toEqual([msgA, freshMessage]);
+    expect(getTestThreadStreaming(THREAD_A)).toBe("current activity");
+    expect(getTestThreadToolCalls(THREAD_A)).toHaveLength(1);
+  });
+
   it("does not let late resident permission hydration replace a live request", async () => {
     let resolvePending!: (value: Array<{
       requestId: string;

--- a/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
+++ b/apps/web/src/lib/thread-hydrator/__tests__/thread-hydrator.test.ts
@@ -323,6 +323,56 @@ describe("ThreadHydrator", () => {
     expect(readActiveThreadField((record) => record.fileEffectSummary)).toEqual(liveSummary);
   });
 
+  it("discards resident running snapshots after a newer activation epoch wins", async () => {
+    let resolveSnapshots!: (value: Array<{
+      message_id: string;
+      files_changed: string[];
+      thread_id: string;
+      created_at: string;
+    }>) => void;
+    useWorkspaceStore.setState({
+      threads: [
+        createMockThread({ id: THREAD_A, has_file_changes: true }),
+        createMockThread({ id: THREAD_B, has_file_changes: false }),
+      ],
+    });
+    resetThreadStoreForTests({
+      currentThreadId: THREAD_B,
+      runningThreadIds: new Set([THREAD_A]),
+      records: new Map([
+        [THREAD_A, { ...makeCachedRecord(), loadEpoch: 2 }],
+        [THREAD_B, { ...createEmptyThreadRecord(), messages: [msgB] }],
+      ]),
+    });
+    (mockTransport.listSnapshots as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveSnapshots = resolve;
+      }),
+    );
+
+    await hydrator.hydrate(THREAD_A, "active");
+    await vi.waitFor(() => {
+      expect(mockTransport.listSnapshots).toHaveBeenCalledWith(THREAD_A);
+    });
+
+    useThreadStore.setState((state) => ({
+      records: patchThreadRecord(state.records, THREAD_A, (record) => ({
+        loadEpoch: record.loadEpoch + 1,
+      })),
+    }));
+    resolveSnapshots([{
+      message_id: "stale-turn",
+      files_changed: ["src/stale.ts"],
+      thread_id: THREAD_A,
+      created_at: "2026-01-01T00:00:00Z",
+    }]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readActiveThreadField((record) => record.persistedFilesChanged)).toEqual({});
+    expect(getCachedRecord(THREAD_A)?.persistedFilesChanged).toEqual({});
+  });
+
   it("keeps prefetched earlier history out of live state until pagination", async () => {
     const history = Array.from({ length: 100 }, (_, index) => createMockMessage({
       id: `a-${index + 1}`,

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -50,6 +50,8 @@ export interface AuxiliaryHydratorDeps {
  */
 export class AuxiliaryHydrator {
   private readonly permissionSnapshotGenerations = new Map<string, number>();
+  private readonly pendingPermissionHydrations = new Map<string, number>();
+  private readonly permissionGenerationDisposals = new Set<string>();
 
   constructor(private readonly deps: AuxiliaryHydratorDeps) {}
 
@@ -59,6 +61,19 @@ export class AuxiliaryHydrator {
       threadId,
       (this.permissionSnapshotGenerations.get(threadId) ?? 0) + 1,
     );
+  }
+
+  /**
+   * Release generation state after thread deletion without allowing an in-flight
+   * permission snapshot to commit into a newly-created thread with the same ID.
+   */
+  forgetThread(threadId: string): void {
+    this.invalidatePermissions(threadId);
+    if ((this.pendingPermissionHydrations.get(threadId) ?? 0) === 0) {
+      this.permissionSnapshotGenerations.delete(threadId);
+      return;
+    }
+    this.permissionGenerationDisposals.add(threadId);
   }
 
   /**
@@ -100,6 +115,10 @@ export class AuxiliaryHydrator {
     const startedGeneration = this.permissionSnapshotGenerations.get(threadId) ?? 0;
     const startedRunning = startedState.runningThreadIds.has(threadId);
     const startedCurrentThreadId = startedState.currentThreadId;
+    this.pendingPermissionHydrations.set(
+      threadId,
+      (this.pendingPermissionHydrations.get(threadId) ?? 0) + 1,
+    );
 
     void this.transport()
       .listPendingPermissions(threadId)
@@ -139,6 +158,17 @@ export class AuxiliaryHydrator {
       })
       .catch(() => {
         /* non-critical */
+      })
+      .finally(() => {
+        const pending = (this.pendingPermissionHydrations.get(threadId) ?? 1) - 1;
+        if (pending > 0) {
+          this.pendingPermissionHydrations.set(threadId, pending);
+          return;
+        }
+        this.pendingPermissionHydrations.delete(threadId);
+        if (this.permissionGenerationDisposals.delete(threadId)) {
+          this.permissionSnapshotGenerations.delete(threadId);
+        }
       });
   }
 

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -49,7 +49,17 @@ export interface AuxiliaryHydratorDeps {
  * Owns the freshness TTL gate and diff-before-set discipline.
  */
 export class AuxiliaryHydrator {
+  private readonly permissionSnapshotGenerations = new Map<string, number>();
+
   constructor(private readonly deps: AuxiliaryHydratorDeps) {}
+
+  /** Invalidate pending permission snapshots for one thread instance. */
+  invalidatePermissions(threadId: string): void {
+    this.permissionSnapshotGenerations.set(
+      threadId,
+      (this.permissionSnapshotGenerations.get(threadId) ?? 0) + 1,
+    );
+  }
 
   /**
    * Run the auxiliary fanout for a thread when the TTL gate allows (or force is set).
@@ -85,19 +95,42 @@ export class AuxiliaryHydrator {
 
   private hydratePermissions(threadId: string): void {
     const { getState, setState, shallowEqualBy } = this.deps;
+    const startedState = getState();
+    const startedRecord = getThreadRecord(startedState.records, threadId);
+    const startedGeneration = this.permissionSnapshotGenerations.get(threadId) ?? 0;
+    const startedRunning = startedState.runningThreadIds.has(threadId);
+    const startedCurrentThreadId = startedState.currentThreadId;
 
     void this.transport()
       .listPendingPermissions(threadId)
       .then((pending) => {
-        // Running threads receive authoritative permission events over the
-        // live channel. A resident refresh may have started earlier, so its
-        // late snapshot must never replace a newer live request.
-        if (getState().runningThreadIds.has(threadId)) return;
+        const state = getState();
+        const current = getThreadRecord(state.records, threadId);
+        const generation = this.permissionSnapshotGenerations.get(threadId) ?? 0;
+        const runningNow = state.runningThreadIds.has(threadId);
+        // Snapshot may commit only to same thread instance and lifecycle. A
+        // live request wins once present; empty live state still permits a
+        // running snapshot when no event arrived to populate it.
+        if (
+          generation !== startedGeneration
+          || state.currentThreadId !== startedCurrentThreadId
+          || !state.records.has(threadId)
+          || current.loadEpoch !== startedRecord.loadEpoch
+          || runningNow !== startedRunning
+          || (runningNow && current.permissions.length > 0)
+        ) return;
         const mapped = pending.map((p) => ({ ...p, settled: false }));
-        const current = getThreadRecord(getState().records, threadId).permissions;
-        if (!shallowEqualBy(mapped, current, ["requestId", "toolName", "settled"])) {
+        if (!shallowEqualBy(mapped, current.permissions, ["requestId", "toolName", "settled"])) {
           setState((s: ThreadHydratorWriteState) => {
-            if (!s.records.has(threadId)) return {};
+            const next = getThreadRecord(s.records, threadId);
+            if (
+              !s.records.has(threadId)
+              || s.currentThreadId !== startedCurrentThreadId
+              || next.loadEpoch !== startedRecord.loadEpoch
+              || (this.permissionSnapshotGenerations.get(threadId) ?? 0) !== startedGeneration
+              || s.runningThreadIds.has(threadId) !== startedRunning
+              || (s.runningThreadIds.has(threadId) && next.permissions.length > 0)
+            ) return {};
             return {
               records: patchThreadRecord(s.records, threadId, { permissions: mapped }),
             };

--- a/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/auxiliary-hydrator.ts
@@ -89,6 +89,10 @@ export class AuxiliaryHydrator {
     void this.transport()
       .listPendingPermissions(threadId)
       .then((pending) => {
+        // Running threads receive authoritative permission events over the
+        // live channel. A resident refresh may have started earlier, so its
+        // late snapshot must never replace a newer live request.
+        if (getState().runningThreadIds.has(threadId)) return;
         const mapped = pending.map((p) => ({ ...p, settled: false }));
         const current = getThreadRecord(getState().records, threadId).permissions;
         if (!shallowEqualBy(mapped, current, ["requestId", "toolName", "settled"])) {

--- a/apps/web/src/lib/thread-hydrator/index.ts
+++ b/apps/web/src/lib/thread-hydrator/index.ts
@@ -7,6 +7,7 @@ export {
   MESSAGE_FETCH_SIZE,
   HISTORY_PREFETCH_SIZE,
   HYDRATION_TTL_MS,
+  ACTIVE_HYDRATION_MAX_DELAY_MS,
   BACKGROUND_PREFETCH_LIMIT,
 } from "./thread-hydrator";
 export { SnapshotBuilder, snapshotBuilder } from "./snapshot-builder";

--- a/apps/web/src/lib/thread-hydrator/resident-content.ts
+++ b/apps/web/src/lib/thread-hydrator/resident-content.ts
@@ -1,0 +1,17 @@
+import type { ThreadRecord } from "@/stores/thread-record";
+
+/** Fields that keep a thread paintable while persisted history is hydrating. */
+export type ResidentContentRecord = Pick<
+  ThreadRecord,
+  "messages" | "streaming" | "streamingPreview" | "toolCalls" | "thoughtSegments" | "hooks"
+>;
+
+/** Returns whether a thread has any transcript or live-turn content to keep visible. */
+export function hasResidentContent(record: ResidentContentRecord): boolean {
+  return record.messages.length > 0
+    || record.streaming.length > 0
+    || record.streamingPreview.length > 0
+    || record.toolCalls.length > 0
+    || record.thoughtSegments.length > 0
+    || record.hooks.length > 0;
+}

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -542,7 +542,7 @@ export class ThreadHydrator {
         void this.refreshThreadGoal(threadId, expectedEpoch);
         this.scheduleAuxiliaryHydration(threadId, expectedEpoch, {
           freshnessTtlMs: HYDRATION_TTL_MS,
-          force: opts?.force ?? true,
+          force: opts?.force ?? false,
           commitFileChangesToStore: true,
           expectedLoadEpoch: expectedEpoch,
         });
@@ -628,6 +628,14 @@ export class ThreadHydrator {
     opts?: ThreadHydratorOptions,
     hasResidentContent = false,
   ): Promise<void> {
+    const residentFetchOptions = hasResidentContent
+      ? {
+          skipPrepare: true,
+          fetchLimit: BACKGROUND_PREFETCH_LIMIT,
+          prefetchEarlierHistory: false,
+        }
+      : undefined;
+    const backgroundFetchOptions = residentFetchOptions ?? { skipPrepare: true };
     const background = this.backgroundHydrates.get(threadId);
     if (background) {
       if (!hasResidentContent) {
@@ -638,13 +646,7 @@ export class ThreadHydrator {
       if (this.deps.getState().currentThreadId !== threadId) return;
 
       if (opts?.force) {
-        await this.fetchAndCommit(threadId, opts, hasResidentContent
-          ? {
-              skipPrepare: true,
-              fetchLimit: BACKGROUND_PREFETCH_LIMIT,
-              prefetchEarlierHistory: false,
-            }
-          : { skipPrepare: true });
+        await this.fetchAndCommit(threadId, opts, backgroundFetchOptions);
         return;
       }
 
@@ -664,13 +666,7 @@ export class ThreadHydrator {
       return;
     }
 
-    await this.fetchAndCommit(threadId, opts, hasResidentContent
-      ? {
-          skipPrepare: true,
-          fetchLimit: BACKGROUND_PREFETCH_LIMIT,
-          prefetchEarlierHistory: false,
-        }
-      : undefined);
+    await this.fetchAndCommit(threadId, opts, residentFetchOptions);
   }
 
   /** Makes an already-loading thread current without invalidating its request epoch. */

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -477,6 +477,17 @@ export class ThreadHydrator {
 
     if (hasResidentContent) {
       this.activateResidentLayer(threadId);
+      if (this.deps.getState().runningThreadIds.has(threadId)) {
+        const expectedEpoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
+        this.synchronizeConversation(threadId);
+        void this.refreshThreadGoal(threadId, expectedEpoch);
+        this.scheduleAuxiliaryHydration(threadId, expectedEpoch, {
+          freshnessTtlMs: HYDRATION_TTL_MS,
+          force: opts?.force ?? true,
+          commitFileChangesToStore: true,
+        });
+        return;
+      }
     }
 
     const hydrate = this.fetchActiveReusingBackground(threadId, opts, hasResidentContent).finally(() => {
@@ -836,10 +847,6 @@ export class ThreadHydrator {
         records: patchThreadRecord(state.records, threadId, {
           loading: true,
           error: null,
-          messages: [],
-          persistedToolCallCounts: {},
-          persistedFilesChanged: {},
-          latestTurnWithChanges: null,
           isLoadingMore: false,
           loadEpoch: current.loadEpoch + 1,
           settings: this.deps.getWorkspaceThreadSettings(threadId),

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -551,6 +551,7 @@ export class ThreadHydrator {
           freshnessTtlMs: HYDRATION_TTL_MS,
           force: opts?.force ?? true,
           commitFileChangesToStore: true,
+          expectedLoadEpoch: expectedEpoch,
         });
         return;
       }

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -1197,7 +1197,6 @@ export class ThreadHydrator {
     if (hasPrefetchedHistoryPage(threadId, before)) return;
     const epoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
     const prefetchKey = `${threadId}:${before}`;
-    let deferred!: DeferredWorkHandle;
     let cancelled = false;
     const start = async () => {
       if (cancelled) return;
@@ -1230,7 +1229,7 @@ export class ThreadHydrator {
     const initial = scheduleDeferredWork(() => {
       if (!cancelled) void start();
     }, { maxDelayMs: 100 });
-    deferred = {
+    const deferred: DeferredWorkHandle = {
       cancel: () => {
         cancelled = true;
         initial.cancel();

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -36,18 +36,11 @@ import {
 } from "@/lib/thread-switch-telemetry";
 import { scheduleDeferredWork } from "./deferred-work";
 import type { DeferredWorkHandle } from "./deferred-work";
+import { hasResidentContent } from "./resident-content";
 
 interface PendingHistoryPrefetch {
   expectedEpoch: number;
   promise: Promise<void>;
-}
-
-function hasResidentLayer(record: ThreadRecord): boolean {
-  return record.messages.length > 0
-    || record.streaming.length > 0
-    || record.toolCalls.length > 0
-    || record.thoughtSegments.length > 0
-    || record.hooks.length > 0;
 }
 
 /** Snapshot the transcript and volatile layers that an active page fetch must not replace. */
@@ -469,7 +462,7 @@ export class ThreadHydrator {
       };
       const cachedRecord = projectConversationCacheState(record);
       const resident = this.deps.getState().records.get(threadId);
-      if (resident && hasResidentLayer(resident)) {
+      if (resident && hasResidentContent(resident)) {
         cacheRecord(threadId, mergeResidentConversationCacheState(resident, cachedRecord));
         return;
       }
@@ -514,14 +507,14 @@ export class ThreadHydrator {
     }
 
     const resident = this.deps.getState().records.get(threadId);
-    const hasResidentContent = resident != null && hasResidentLayer(resident);
-    if (hasResidentContent && this.deps.getState().runningThreadIds.has(threadId)) {
+    const residentContent = resident != null && hasResidentContent(resident);
+    if (residentContent && this.deps.getState().runningThreadIds.has(threadId)) {
       recordRunningResidentHit(threadId);
     }
 
     const inFlight = this.activeHydrates.get(threadId);
     if (inFlight) {
-      this.selectInFlightLayer(threadId, hasResidentContent);
+      this.selectInFlightLayer(threadId, residentContent);
       await inFlight;
       const state = this.deps.getState();
       const current = getThreadRecord(state.records, threadId);
@@ -541,7 +534,7 @@ export class ThreadHydrator {
       return;
     }
 
-    if (hasResidentContent) {
+    if (residentContent) {
       this.activateResidentLayer(threadId);
       if (this.deps.getState().runningThreadIds.has(threadId)) {
         const expectedEpoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
@@ -561,7 +554,7 @@ export class ThreadHydrator {
       recordRunningFetchRequired(threadId);
     }
 
-    const hydrate = this.fetchActiveReusingBackground(threadId, opts, hasResidentContent).finally(() => {
+    const hydrate = this.fetchActiveReusingBackground(threadId, opts, residentContent).finally(() => {
       if (this.activeHydrates.get(threadId) === hydrate) {
         this.activeHydrates.delete(threadId);
         this.discardInactiveLoadingRecord(threadId);
@@ -580,7 +573,7 @@ export class ThreadHydrator {
     const resident = state.records.get(threadId);
     if (!resident) return;
     if (
-      !hasResidentLayer(resident)
+      !hasResidentContent(resident)
       && (hadActiveHydrate || this.activeHydrates.has(threadId))
     ) return;
 
@@ -607,7 +600,7 @@ export class ThreadHydrator {
     this.deps.setState((state: ThreadHydratorWriteState) => {
       if (state.currentThreadId === threadId) return {};
       const resident = state.records.get(threadId);
-      if (!resident || hasResidentLayer(resident)) return {};
+      if (!resident || hasResidentContent(resident)) return {};
       return { records: deleteThreadRecord(state.records, threadId) };
     });
   }
@@ -633,11 +626,11 @@ export class ThreadHydrator {
   private async fetchActiveReusingBackground(
     threadId: string,
     opts?: ThreadHydratorOptions,
-    hasResidentLayer = false,
+    hasResidentContent = false,
   ): Promise<void> {
     const background = this.backgroundHydrates.get(threadId);
     if (background) {
-      if (!hasResidentLayer) {
+      if (!hasResidentContent) {
         this.selectInFlightLayer(threadId, false);
       }
       await background;
@@ -660,7 +653,7 @@ export class ThreadHydrator {
       return;
     }
 
-    await this.fetchAndCommit(threadId, opts, hasResidentLayer
+    await this.fetchAndCommit(threadId, opts, hasResidentContent
       ? {
           skipPrepare: true,
           fetchLimit: BACKGROUND_PREFETCH_LIMIT,
@@ -670,10 +663,10 @@ export class ThreadHydrator {
   }
 
   /** Makes an already-loading thread current without invalidating its request epoch. */
-  private selectInFlightLayer(threadId: string, hasResidentLayer: boolean): void {
+  private selectInFlightLayer(threadId: string, hasResidentContent: boolean): void {
     this.deps.setState((state: ThreadHydratorWriteState) => ({
       records: patchThreadRecord(state.records, threadId, {
-        loading: !hasResidentLayer,
+        loading: !hasResidentContent,
         error: null,
         settings: this.deps.getWorkspaceThreadSettings(threadId),
       }),
@@ -1056,7 +1049,7 @@ export class ThreadHydrator {
           ...patch,
           narrativeByMessage: pageResult.narrativeByMessage,
         });
-        const conversation = hasResidentLayer(current)
+        const conversation = hasResidentContent(current)
           ? mergeResidentConversationCacheState(current, fetchedConversation, false)
           : fetchedConversation;
         const ownsLiveFileEffects = current.fileEffectTurnId.length > 0

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -298,6 +298,11 @@ export class ThreadHydrator {
     this.auxiliaryHydrator.invalidatePermissions(threadId);
   }
 
+  /** Release per-thread generation state after its resident record is deleted. */
+  forgetThread(threadId: string): void {
+    this.auxiliaryHydrator.forgetThread(threadId);
+  }
+
   private pruneInvalidationGeneration(threadId: string): void {
     if (!this.activeHydrates.has(threadId) && !this.backgroundHydrates.has(threadId)) {
       this.invalidationGenerations.delete(threadId);

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -536,7 +536,7 @@ export class ThreadHydrator {
 
     if (residentContent) {
       this.activateResidentLayer(threadId);
-      if (this.deps.getState().runningThreadIds.has(threadId)) {
+      if (this.deps.getState().runningThreadIds.has(threadId) && !opts?.force) {
         const expectedEpoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
         this.synchronizeConversation(threadId);
         void this.refreshThreadGoal(threadId, expectedEpoch);

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -283,6 +283,7 @@ export class ThreadHydrator {
 
   /** Discard a stale cached conversation before an authoritative mutation. */
   invalidateConversation(threadId: string): void {
+    this.auxiliaryHydrator.invalidatePermissions(threadId);
     if (this.activeHydrates.has(threadId) || this.backgroundHydrates.has(threadId)) {
       this.invalidationGenerations.set(
         threadId,
@@ -290,6 +291,11 @@ export class ThreadHydrator {
       );
     }
     evictCachedRecord(threadId);
+  }
+
+  /** Invalidate permission snapshots when live request state changes. */
+  invalidatePermissionSnapshots(threadId: string): void {
+    this.auxiliaryHydrator.invalidatePermissions(threadId);
   }
 
   private pruneInvalidationGeneration(threadId: string): void {
@@ -329,6 +335,7 @@ export class ThreadHydrator {
     const threadId = this.deps.getState().currentThreadId;
     if (!threadId) return;
 
+    this.auxiliaryHydrator.invalidatePermissions(threadId);
     this.deps.flushPendingTextDeltas();
     const hadActiveHydrate = this.activeHydrates.has(threadId);
     this.deps.setState((state: ThreadHydratorWriteState) => {

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -637,6 +637,17 @@ export class ThreadHydrator {
 
       if (this.deps.getState().currentThreadId !== threadId) return;
 
+      if (opts?.force) {
+        await this.fetchAndCommit(threadId, opts, hasResidentContent
+          ? {
+              skipPrepare: true,
+              fetchLimit: BACKGROUND_PREFETCH_LIMIT,
+              prefetchEarlierHistory: false,
+            }
+          : { skipPrepare: true });
+        return;
+      }
+
       const cached = getCachedRecord(threadId);
       if (cached) {
         const resident = this.deps.getState().records.get(threadId);

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -29,7 +29,11 @@ import { SnapshotBuilder, snapshotBuilder } from "./snapshot-builder";
 import { AuxiliaryHydrator } from "./auxiliary-hydrator";
 import type { ConversationPage, ConversationTail } from "@mcode/contracts";
 import { hasRememberedHistoryPosition } from "@/components/chat/scrollPositionMemory";
-import { recordThreadCommit } from "@/lib/thread-switch-telemetry";
+import {
+  recordRunningFetchRequired,
+  recordRunningResidentHit,
+  recordThreadCommit,
+} from "@/lib/thread-switch-telemetry";
 import { scheduleDeferredWork } from "./deferred-work";
 import type { DeferredWorkHandle } from "./deferred-work";
 
@@ -219,6 +223,9 @@ export const HISTORY_PREFETCH_SIZE = BACKGROUND_PREFETCH_LIMIT - MESSAGE_FETCH_S
 /** Auxiliary side-effect refresh TTL (permissions, tasks, plans). */
 export const HYDRATION_TTL_MS = 2000;
 
+/** Maximum time auxiliary work may wait for an active hydration to settle. */
+export const ACTIVE_HYDRATION_MAX_DELAY_MS = 500;
+
 /**
  * Owns the full "load this thread" flow: cache lookup, RPC fetch, record
  * commit, auxiliary fanout, and narrative prefetch.
@@ -230,6 +237,7 @@ export class ThreadHydrator {
   private readonly pendingHistoryPrefetches = new Map<string, PendingHistoryPrefetch>();
   private readonly deferredWork = new Map<string, DeferredWorkHandle>();
   private readonly invalidationGenerations = new Map<string, number>();
+  private readonly activeHydrationWaiters = new Set<() => void>();
 
   constructor(private readonly deps: ThreadHydratorDeps) {
     this.auxiliaryHydrator = new AuxiliaryHydrator({
@@ -263,6 +271,34 @@ export class ThreadHydrator {
       return;
     }
     await this.hydrateActive(threadId, opts);
+  }
+
+  /** Return whether any active transcript hydration is currently in flight. */
+  isActiveHydrationInFlight(): boolean {
+    return this.activeHydrates.size > 0;
+  }
+
+  private notifyActiveHydrationSettled(): void {
+    if (this.isActiveHydrationInFlight()) return;
+    const waiters = [...this.activeHydrationWaiters];
+    this.activeHydrationWaiters.clear();
+    for (const waiter of waiters) waiter();
+  }
+
+  private waitForActiveHydration(maxDelayMs = ACTIVE_HYDRATION_MAX_DELAY_MS): Promise<void> {
+    if (!this.isActiveHydrationInFlight()) return Promise.resolve();
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.activeHydrationWaiters.delete(finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, maxDelayMs);
+      this.activeHydrationWaiters.add(finish);
+    });
   }
 
   private cancelDeferredForThread(threadId: string): void {
@@ -373,6 +409,19 @@ export class ThreadHydrator {
       return;
     }
 
+    await this.waitForActiveHydration();
+    if (hasCachedRecord(threadId)) return;
+    const activeAfterWait = this.activeHydrates.get(threadId);
+    if (activeAfterWait) {
+      await activeAfterWait;
+      return;
+    }
+    const backgroundAfterWait = this.backgroundHydrates.get(threadId);
+    if (backgroundAfterWait) {
+      await backgroundAfterWait;
+      return;
+    }
+
     const hydrate = this.fetchAndCacheBackground(threadId).finally(() => {
       if (this.backgroundHydrates.get(threadId) === hydrate) {
         this.backgroundHydrates.delete(threadId);
@@ -464,6 +513,9 @@ export class ThreadHydrator {
 
     const resident = this.deps.getState().records.get(threadId);
     const hasResidentContent = resident != null && hasResidentLayer(resident);
+    if (hasResidentContent && this.deps.getState().runningThreadIds.has(threadId)) {
+      recordRunningResidentHit(threadId);
+    }
 
     const inFlight = this.activeHydrates.get(threadId);
     if (inFlight) {
@@ -502,10 +554,15 @@ export class ThreadHydrator {
       }
     }
 
+    if (this.deps.getState().runningThreadIds.has(threadId)) {
+      recordRunningFetchRequired(threadId);
+    }
+
     const hydrate = this.fetchActiveReusingBackground(threadId, opts, hasResidentContent).finally(() => {
       if (this.activeHydrates.get(threadId) === hydrate) {
         this.activeHydrates.delete(threadId);
         this.discardInactiveLoadingRecord(threadId);
+        this.notifyActiveHydrationSettled();
       }
       this.pruneInvalidationGeneration(threadId);
     });
@@ -654,7 +711,27 @@ export class ThreadHydrator {
     options: Parameters<AuxiliaryHydrator["hydrate"]>[1],
   ): void {
     this.deferredWork.get(threadId)?.cancel();
-    const handle = scheduleDeferredWork(() => {
+    let cancelled = false;
+    let waitingForActive = false;
+    let waitDeadline: ReturnType<typeof setTimeout> | undefined;
+    let resume: (() => void) | undefined;
+    const startedAt = Date.now();
+    const run = (allowActive = false) => {
+      if (cancelled) return;
+      if (!allowActive && this.isActiveHydrationInFlight()) {
+        if (waitingForActive) return;
+        waitingForActive = true;
+        resume = () => run(false);
+        this.activeHydrationWaiters.add(resume);
+        waitDeadline = setTimeout(
+          () => run(true),
+          Math.max(0, ACTIVE_HYDRATION_MAX_DELAY_MS - (Date.now() - startedAt)),
+        );
+        return;
+      }
+      waitingForActive = false;
+      if (resume) this.activeHydrationWaiters.delete(resume);
+      if (waitDeadline !== undefined) clearTimeout(waitDeadline);
       const state = this.deps.getState();
       const record = getThreadRecord(state.records, threadId);
       if (state.currentThreadId !== threadId || record.loadEpoch !== expectedEpoch) {
@@ -663,7 +740,20 @@ export class ThreadHydrator {
       }
       this.auxiliaryHydrator.hydrate(threadId, options);
       this.deferredWork.delete(threadId);
-    }, { maxDelayMs: 100 });
+    };
+    const initial = scheduleDeferredWork(() => run(), { maxDelayMs: 100 });
+    const handle: DeferredWorkHandle = {
+      cancel: () => {
+        if (cancelled) return;
+        cancelled = true;
+        initial.cancel();
+        if (resume) this.activeHydrationWaiters.delete(resume);
+        if (waitDeadline !== undefined) clearTimeout(waitDeadline);
+      },
+      get cancelled() {
+        return cancelled || initial.cancelled;
+      },
+    };
     this.deferredWork.set(threadId, handle);
   }
 
@@ -1107,7 +1197,12 @@ export class ThreadHydrator {
     if (hasPrefetchedHistoryPage(threadId, before)) return;
     const epoch = getThreadRecord(this.deps.getState().records, threadId).loadEpoch;
     const prefetchKey = `${threadId}:${before}`;
-    const deferred = scheduleDeferredWork(() => {
+    let deferred!: DeferredWorkHandle;
+    let cancelled = false;
+    const start = async () => {
+      if (cancelled) return;
+      await this.waitForActiveHydration();
+      if (cancelled) return;
       const state = this.deps.getState();
       if (state.currentThreadId !== threadId) return;
       if (getThreadRecord(state.records, threadId).loadEpoch !== epoch) return;
@@ -1131,7 +1226,19 @@ export class ThreadHydrator {
         this.deferredWork.delete(prefetchKey);
       });
       this.pendingHistoryPrefetches.set(prefetchKey, prefetch);
+    };
+    const initial = scheduleDeferredWork(() => {
+      if (!cancelled) void start();
     }, { maxDelayMs: 100 });
+    deferred = {
+      cancel: () => {
+        cancelled = true;
+        initial.cancel();
+      },
+      get cancelled() {
+        return cancelled || initial.cancelled;
+      },
+    };
     this.deferredWork.set(prefetchKey, deferred);
   }
 

--- a/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
+++ b/apps/web/src/lib/thread-hydrator/thread-hydrator.ts
@@ -409,17 +409,19 @@ export class ThreadHydrator {
       return;
     }
 
-    await this.waitForActiveHydration();
-    if (hasCachedRecord(threadId)) return;
-    const activeAfterWait = this.activeHydrates.get(threadId);
-    if (activeAfterWait) {
-      await activeAfterWait;
-      return;
-    }
-    const backgroundAfterWait = this.backgroundHydrates.get(threadId);
-    if (backgroundAfterWait) {
-      await backgroundAfterWait;
-      return;
+    if (this.isActiveHydrationInFlight()) {
+      await this.waitForActiveHydration();
+      if (hasCachedRecord(threadId)) return;
+      const activeAfterWait = this.activeHydrates.get(threadId);
+      if (activeAfterWait) {
+        await activeAfterWait;
+        return;
+      }
+      const backgroundAfterWait = this.backgroundHydrates.get(threadId);
+      if (backgroundAfterWait) {
+        await backgroundAfterWait;
+        return;
+      }
     }
 
     const hydrate = this.fetchAndCacheBackground(threadId).finally(() => {

--- a/apps/web/src/lib/thread-switch-telemetry.ts
+++ b/apps/web/src/lib/thread-switch-telemetry.ts
@@ -16,7 +16,7 @@ interface ThreadSwitchRecord {
   positionedMark?: string;
 }
 
-/** Bounded counters for running-thread switch pressure signals. */
+/** Bounded dev-only counters for running-thread switch pressure signals. */
 export interface ThreadSwitchTelemetryCounters {
   runningResidentHits: number;
   runningFetchRequired: number;
@@ -91,27 +91,27 @@ function recordEvent(
   }
 }
 
-/** Record that a running thread activated from its resident transcript. */
+/** Record a dev-only hit when a running thread activates from its resident transcript. */
 export function recordRunningResidentHit(threadId: string): void {
   recordEvent(threadId, "runningResidentHits", "running-resident-hit");
 }
 
-/** Record that a running thread activation required a network fetch. */
+/** Record a dev-only fetch when activating a running thread requires network data. */
 export function recordRunningFetchRequired(threadId: string): void {
   recordEvent(threadId, "runningFetchRequired", "running-fetch-required");
 }
 
-/** Record a dropped background event without retaining production state. */
+/** Record a dev-only background event drop without retaining event state. */
 export function recordBackgroundEventDropped(threadId: string): void {
   recordEvent(threadId, "backgroundEventsDropped", "background-event-dropped");
 }
 
-/** Record a skipped subscription callback without retaining production state. */
+/** Record a dev-only skipped subscription callback without retaining event state. */
 export function recordSubscriptionSkipped(threadId: string): void {
   recordEvent(threadId, "subscriptionsSkipped", "subscription-skipped");
 }
 
-/** Read bounded dev counters for diagnostics and tests. */
+/** Return a snapshot of bounded dev-only counters for diagnostics and tests. */
 export function getThreadSwitchTelemetryCounters(): ThreadSwitchTelemetryCounters {
   return { ...counters };
 }

--- a/apps/web/src/lib/thread-switch-telemetry.ts
+++ b/apps/web/src/lib/thread-switch-telemetry.ts
@@ -16,10 +16,29 @@ interface ThreadSwitchRecord {
   positionedMark?: string;
 }
 
+/** Bounded counters for running-thread switch pressure signals. */
+export interface ThreadSwitchTelemetryCounters {
+  runningResidentHits: number;
+  runningFetchRequired: number;
+  backgroundEventsDropped: number;
+  subscriptionsSkipped: number;
+}
+
 const records = new Map<number, ThreadSwitchRecord>();
 const latestByThread = new Map<string, number>();
+const eventMarks: string[] = [];
+const counters: ThreadSwitchTelemetryCounters = {
+  runningResidentHits: 0,
+  runningFetchRequired: 0,
+  backgroundEventsDropped: 0,
+  subscriptionsSkipped: 0,
+};
 let nextSwitchId = 0;
 let latestSelectionId: number | null = null;
+let nextEventId = 0;
+
+const MAX_RETAINED_EVENT_MARKS = 64;
+const MAX_EVENT_COUNT = 10_000;
 
 function isEnabled(): boolean {
   return import.meta.env.DEV && typeof performance !== "undefined";
@@ -52,6 +71,48 @@ function retain(record: ThreadSwitchRecord): void {
 
 function mark(name: string, detail: Record<string, string | number>): void {
   performance.mark(name, { detail });
+}
+
+function recordEvent(
+  threadId: string,
+  event: keyof ThreadSwitchTelemetryCounters,
+  markName: string,
+): void {
+  if (!isEnabled()) return;
+  counters[event] = Math.min(MAX_EVENT_COUNT, counters[event] + 1);
+  const switchId = latestByThread.get(threadId) ?? latestSelectionId ?? ++nextEventId;
+  const name = `${MARK_PREFIX}:${markName}:${switchId}`;
+  mark(name, { threadId, switchId, count: counters[event] });
+  eventMarks.push(name);
+  while (eventMarks.length > MAX_RETAINED_EVENT_MARKS) {
+    const oldest = eventMarks.shift();
+    if (oldest) performance.clearMarks(oldest);
+  }
+}
+
+/** Record that a running thread activated from its resident transcript. */
+export function recordRunningResidentHit(threadId: string): void {
+  recordEvent(threadId, "runningResidentHits", "running-resident-hit");
+}
+
+/** Record that a running thread activation required a network fetch. */
+export function recordRunningFetchRequired(threadId: string): void {
+  recordEvent(threadId, "runningFetchRequired", "running-fetch-required");
+}
+
+/** Record a dropped background event without retaining production state. */
+export function recordBackgroundEventDropped(threadId: string): void {
+  recordEvent(threadId, "backgroundEventsDropped", "background-event-dropped");
+}
+
+/** Record a skipped subscription callback without retaining production state. */
+export function recordSubscriptionSkipped(threadId: string): void {
+  recordEvent(threadId, "subscriptionsSkipped", "subscription-skipped");
+}
+
+/** Read bounded dev counters for diagnostics and tests. */
+export function getThreadSwitchTelemetryCounters(): ThreadSwitchTelemetryCounters {
+  return { ...counters };
 }
 
 /** Record a user's thread selection and return its switch identity. */
@@ -149,6 +210,15 @@ export function __resetThreadSwitchTelemetryForTests(): void {
   }
   records.clear();
   latestByThread.clear();
+  for (const name of eventMarks) {
+    if (isEnabled()) performance.clearMarks(name);
+  }
+  eventMarks.length = 0;
+  counters.runningResidentHits = 0;
+  counters.runningFetchRequired = 0;
+  counters.backgroundEventsDropped = 0;
+  counters.subscriptionsSkipped = 0;
   nextSwitchId = 0;
   latestSelectionId = null;
+  nextEventId = 0;
 }

--- a/apps/web/src/lib/thread-switch-telemetry.ts
+++ b/apps/web/src/lib/thread-switch-telemetry.ts
@@ -80,9 +80,10 @@ function recordEvent(
 ): void {
   if (!isEnabled()) return;
   counters[event] = Math.min(MAX_EVENT_COUNT, counters[event] + 1);
-  const switchId = latestByThread.get(threadId) ?? latestSelectionId ?? ++nextEventId;
-  const name = `${MARK_PREFIX}:${markName}:${switchId}`;
-  mark(name, { threadId, switchId, count: counters[event] });
+  const eventId = ++nextEventId;
+  const switchId = latestByThread.get(threadId) ?? latestSelectionId ?? eventId;
+  const name = `${MARK_PREFIX}:${markName}:${switchId}:${eventId}`;
+  mark(name, { threadId, switchId, eventId, count: counters[event] });
   eventMarks.push(name);
   while (eventMarks.length > MAX_RETAINED_EVENT_MARKS) {
     const oldest = eventMarks.shift();
@@ -203,7 +204,7 @@ export function recordThreadPositioned(threadId: string): void {
   });
 }
 
-/** Clear telemetry state and browser entries. Intended for unit tests only. */
+/** Reset thread-switch telemetry state and browser entries for unit tests. */
 export function __resetThreadSwitchTelemetryForTests(): void {
   if (isEnabled()) {
     for (const record of records.values()) clearRecord(record);

--- a/apps/web/src/stores/thread-record.ts
+++ b/apps/web/src/stores/thread-record.ts
@@ -97,6 +97,8 @@ export interface ThreadRecord {
   answeredPlanMessageIds: Set<string>;
   /** Highest positive server-assigned agent-event sequence observed for this thread. */
   lastAgentEventSequence?: number;
+  /** Server-process epoch paired with {@link lastAgentEventSequence}. */
+  lastAgentEventEpoch?: string;
 
   error: string | null;
   streaming: string;

--- a/apps/web/src/stores/thread-record.ts
+++ b/apps/web/src/stores/thread-record.ts
@@ -95,6 +95,8 @@ export interface ThreadRecord {
   serverMessageIds: Record<string, string>;
   narrativeByMessage: ThreadNarrativeByMessage;
   answeredPlanMessageIds: Set<string>;
+  /** Highest positive server-assigned agent-event sequence observed for this thread. */
+  lastAgentEventSequence?: number;
 
   error: string | null;
   streaming: string;

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -793,6 +793,34 @@ function appendThoughtSegment(
   ];
 }
 
+function projectAssistantMessageBoundary(
+  segments: ThoughtSegment[],
+  isFinalResponse: boolean,
+): ThoughtSegment[] | undefined {
+  const last = segments[segments.length - 1];
+  if (!last || last.endedAt !== undefined) return undefined;
+  return isFinalResponse
+    ? segments.slice(0, -1)
+    : [...segments.slice(0, -1), { ...last, endedAt: Date.now() }];
+}
+
+function projectToolProgress(
+  toolCalls: ToolCall[],
+  toolCallId: string,
+  elapsedSeconds: number,
+  lastActivityAt: number,
+): ToolCall[] | undefined {
+  let changed = false;
+  const updated = toolCalls.map((toolCall) => {
+    if (toolCall.id === toolCallId && !toolCall.isComplete) {
+      changed = true;
+      return { ...toolCall, elapsedSeconds, lastActivityAt };
+    }
+    return toolCall;
+  });
+  return changed ? updated : undefined;
+}
+
 export const useThreadStore = create<ThreadState>((set, get) => {
   let textDeltaFlushRaf: number | null = null;
   const pendingTextDeltaByThread = new Map<string, PendingTextChunk[]>();
@@ -900,12 +928,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const isFinalResponse = event.isFinalResponse === true;
       set((state) => {
         const record = getThreadRecord(state.records, threadId);
-        const last = record.thoughtSegments[record.thoughtSegments.length - 1];
-        if (!last || last.endedAt !== undefined) return state;
-        const thoughtSegments = isFinalResponse
-          ? record.thoughtSegments.slice(0, -1)
-          : [...record.thoughtSegments.slice(0, -1), { ...last, endedAt: Date.now() }];
-        return { records: patchThreadRecord(state.records, threadId, { thoughtSegments }) };
+        const thoughtSegments = projectAssistantMessageBoundary(record.thoughtSegments, isFinalResponse);
+        return thoughtSegments
+          ? { records: patchThreadRecord(state.records, threadId, { thoughtSegments }) }
+          : state;
       });
     } else if (event.type === "toolProgress") {
       const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
@@ -914,15 +940,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const lastActivityAt = Date.now();
       set((state) => {
         const current = getThreadRecord(state.records, threadId).toolCalls;
-        let changed = false;
-        const toolCalls = current.map((toolCall) => {
-          if (toolCall.id === toolCallId && !toolCall.isComplete) {
-            changed = true;
-            return { ...toolCall, elapsedSeconds, lastActivityAt };
-          }
-          return toolCall;
-        });
-        return changed
+        const toolCalls = projectToolProgress(current, toolCallId, elapsedSeconds, lastActivityAt);
+        return toolCalls
           ? { records: patchThreadRecord(state.records, threadId, { toolCalls }) }
           : state;
       });
@@ -2617,14 +2636,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       }
       set((state) => {
         const rec = getThreadRecord(state.records, threadId);
-        const segments = rec.thoughtSegments;
-        const last = segments[segments.length - 1];
-        if (!last || last.endedAt !== undefined) {
-          return state;
-        }
-        const nextSegments = isFinalResponse
-          ? segments.slice(0, -1)
-          : [...segments.slice(0, -1), { ...last, endedAt: Date.now() }];
+        const nextSegments = projectAssistantMessageBoundary(rec.thoughtSegments, isFinalResponse);
+        if (!nextSegments) return state;
         return {
           records: patchThreadRecord(state.records, threadId, {
             thoughtSegments: nextSegments,
@@ -2645,16 +2658,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const lastActivityAt = Date.now();
       set((state) => {
         const current = getThreadRecord(state.records, threadId).toolCalls;
-        let changed = false;
-        const updated = current.map((tc) => {
-          if (tc.id === toolCallId && !tc.isComplete) {
-            changed = true;
-            return { ...tc, elapsedSeconds, lastActivityAt };
-          }
-          return tc;
-        });
+        const updated = projectToolProgress(current, toolCallId, elapsedSeconds, lastActivityAt);
         // Return same state reference when nothing changed — Zustand skips notification.
-        if (!changed) return state;
+        if (!updated) return state;
         return { records: patchThreadRecord(state.records, threadId, { toolCalls: updated }) };
       });
       return;

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -1969,7 +1969,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       });
     }
     const currentThreadId = get().currentThreadId;
-    const isActiveThread = currentThreadId !== null && currentThreadId === threadId;
+    // Before conversation hydration, no running IDs means events belong to the
+    // only known conversation. Once running sessions are known, null selection
+    // must keep background narrative deferred.
+    const isActiveThread = currentThreadId === threadId
+      || (currentThreadId === null && get().runningThreadIds.size === 0);
     const isLifecycleExit = event.type === "turnComplete" || event.type === "ended" || event.type === "error";
     const startsNewInstance = event.type === "turnStarted";
 
@@ -2539,7 +2543,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
     // session.textDelta: accumulate streaming text for live preview and finalization.
     if (event.type === "textDelta") {
-      if (!get().runningThreadIds.has(threadId)) return;
       const delta = (event.delta as string) || "";
       if (!delta) return;
       const rawIsFinalResponse = event.isFinalResponse;
@@ -2564,7 +2567,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         next.push({ delta, isFinalResponse, deferNarrative });
       }
       pendingTextDeltaByThread.set(threadId, next);
-      if (!isActiveThread && get().runningThreadIds.has(threadId)) {
+      if (!isActiveThread) {
         queueDeferredNarrativeEvent(threadId, event);
       }
       if (!deferNarrative && (!hadPending || existing.some((chunk) => chunk.deferNarrative))) {
@@ -2575,7 +2578,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (event.type === "assistantMessageBoundary") {
-      if (!get().runningThreadIds.has(threadId)) return;
       // Authoritative classification of the text deltas just streamed for this
       // assistant message, derived from the Anthropic `stop_reason`.
       //
@@ -2591,7 +2593,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Flush any pending text delta chunks first so the open thought we
       // operate on reflects every delta that arrived for this message.
       flushPendingTextDeltas();
-      if (!isActiveThread && get().runningThreadIds.has(threadId)) {
+      if (!isActiveThread) {
         queueDeferredNarrativeEvent(threadId, event);
         return;
       }
@@ -2615,8 +2617,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (event.type === "toolProgress") {
-      if (!get().runningThreadIds.has(threadId)) return;
-      if (!isActiveThread && get().runningThreadIds.has(threadId)) {
+      if (!isActiveThread) {
         queueDeferredNarrativeEvent(threadId, event);
         return;
       }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -23,6 +23,7 @@ import { findModelById } from "@/lib/model-registry";
 import { resolveContextWindow } from "@/lib/resolve-context-window";
 import { useSettingsStore } from "./settingsStore";
 import { createConversationResidency, registerConversationResidency } from "./conversation-residency";
+import { recordBackgroundEventDropped } from "@/lib/thread-switch-telemetry";
 import {
   clearPendingTurnPersistMessage,
   projectTurnResponse,
@@ -946,19 +947,22 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   };
 
   const invalidateDeferredNarrativeEvents = (threadId: string): void => {
-    flushPendingTextDeltas();
     deferredNarrativeGenerations.set(
       threadId,
       (deferredNarrativeGenerations.get(threadId) ?? 0) + 1,
     );
     dropPendingTextDeltas([threadId]);
+    flushPendingTextDeltas();
   };
 
   const queueDeferredNarrativeEvent = (threadId: string, event: AgentEvent): void => {
     const generation = deferredNarrativeGenerations.get(threadId) ?? 0;
     const queued = deferredNarrativeEventsByThread.get(threadId);
     const events = queued?.generation === generation ? queued.events : [];
-    if (events.length >= MAX_DEFERRED_NARRATIVE_EVENTS) return;
+    if (events.length >= MAX_DEFERRED_NARRATIVE_EVENTS) {
+      recordBackgroundEventDropped(threadId);
+      return;
+    }
     deferredNarrativeEventsByThread.set(threadId, {
       generation,
       events: [...events, event],
@@ -1900,6 +1904,17 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    */
   handleAgentEvent: (event) => {
     const { threadId } = event;
+    const eventSequence = typeof event.sequence === "number" && event.sequence > 0
+      ? event.sequence
+      : undefined;
+    if (eventSequence !== undefined) {
+      const lastSequence = getRec(threadId).lastAgentEventSequence;
+      if (lastSequence !== undefined && eventSequence <= lastSequence) {
+        if (get().currentThreadId !== threadId) recordBackgroundEventDropped(threadId);
+        return;
+      }
+      patchRec(threadId, { lastAgentEventSequence: eventSequence });
+    }
     const currentThreadId = get().currentThreadId;
     const isActiveThread = currentThreadId !== null && currentThreadId === threadId;
     const isLifecycleExit = event.type === "turnComplete" || event.type === "ended" || event.type === "error";
@@ -1909,7 +1924,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Lifecycle events can arrive in same frame as final text delta.
       // Flush first so invalidation cannot discard text needed for persistence.
       flushPendingTextDeltas();
-      invalidateDeferredNarrativeEvents(threadId);
+      if (startsNewInstance) invalidateDeferredNarrativeEvents(threadId);
     }
     if (startsNewInstance) {
       threadHydrator.invalidatePermissionSnapshots(threadId);
@@ -2009,7 +2024,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           attachments: null,
         };
         set((state) => {
-          if (state.currentThreadId !== threadId) return {};
           const rec = getThreadRecord(state.records, threadId);
           const { messages: capped, evicted } = capMessages([...rec.messages, message]);
           return {
@@ -2586,7 +2600,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (event.type === "hookProgress") {
-      if (!isActiveThread) return;
       const hookName = (event.hookName as string) || "";
       const output = (event.output as string) || "";
       if (!hookName || !output) return;
@@ -2818,7 +2831,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
               : {}),
           };
 
-          if (dedupedGuardrail && state.currentThreadId === threadId) {
+          if (dedupedGuardrail) {
             const { messages: capped, evicted } = capMessages([...rec.messages, dedupedGuardrail]);
             return {
               runningThreadIds: nextRunning,
@@ -3059,7 +3072,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const active = event.active as boolean;
       if (!active) {
         const wasCompacting = getRec(threadId).isCompacting;
-        if (wasCompacting && get().currentThreadId === threadId) {
+        if (wasCompacting) {
           const systemMsg: Message = {
             id: crypto.randomUUID(),
             thread_id: threadId,
@@ -3153,12 +3166,6 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           rateLimit: undefined,
           apiRetry: undefined,
         };
-        if (state.currentThreadId !== threadId) {
-          return {
-            runningThreadIds: nextRunning,
-            records: patchThreadRecord(state.records, threadId, basePatch),
-          };
-        }
         const { messages: capped, evicted } = capMessages([...rec.messages, errorMessage]);
         return {
           runningThreadIds: nextRunning,

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -990,14 +990,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (events.length >= MAX_DEFERRED_NARRATIVE_EVENTS || bytes + eventBytes > MAX_DEFERRED_NARRATIVE_BYTES) {
       promoteDeferredNarrativeEvents(threadId);
       if (eventBytes > MAX_DEFERRED_NARRATIVE_BYTES) {
-        const prior = deferredNarrativeEventsByThread.get(threadId);
         deferredNarrativeEventsByThread.set(threadId, {
           generation,
           events: [event],
           bytes: eventBytes,
         });
         promoteDeferredNarrativeEvents(threadId);
-        if (prior) deferredNarrativeEventsByThread.delete(threadId);
         return;
       }
     }

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -795,7 +795,11 @@ function appendThoughtSegment(
 export const useThreadStore = create<ThreadState>((set, get) => {
   let textDeltaFlushRaf: number | null = null;
   const pendingTextDeltaByThread = new Map<string, PendingTextChunk[]>();
-  const deferredNarrativeEventsByThread = new Map<string, AgentEvent[]>();
+  const deferredNarrativeEventsByThread = new Map<
+    string,
+    { generation: number; events: AgentEvent[] }
+  >();
+  const deferredNarrativeGenerations = new Map<string, number>();
 
   const getRec = (threadId: string) => getThreadRecord(get().records, threadId);
 
@@ -875,10 +879,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   };
 
   const promoteDeferredNarrativeEvents = (threadId: string): void => {
-    const events = deferredNarrativeEventsByThread.get(threadId);
-    if (!events || events.length === 0) return;
+    const queued = deferredNarrativeEventsByThread.get(threadId);
+    if (!queued || queued.events.length === 0) return;
     deferredNarrativeEventsByThread.delete(threadId);
-    for (const event of events) {
+    if (queued.generation !== (deferredNarrativeGenerations.get(threadId) ?? 0)) return;
+    for (const event of queued.events) {
       if (event.type === "textDelta") {
         const delta = typeof event.delta === "string" ? event.delta : "";
         if (!delta || event.isFinalResponse === true) continue;
@@ -940,6 +945,25 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
   };
 
+  const invalidateDeferredNarrativeEvents = (threadId: string): void => {
+    deferredNarrativeGenerations.set(
+      threadId,
+      (deferredNarrativeGenerations.get(threadId) ?? 0) + 1,
+    );
+    dropPendingTextDeltas([threadId]);
+  };
+
+  const queueDeferredNarrativeEvent = (threadId: string, event: AgentEvent): void => {
+    const generation = deferredNarrativeGenerations.get(threadId) ?? 0;
+    const queued = deferredNarrativeEventsByThread.get(threadId);
+    const events = queued?.generation === generation ? queued.events : [];
+    if (events.length >= MAX_DEFERRED_NARRATIVE_EVENTS) return;
+    deferredNarrativeEventsByThread.set(threadId, {
+      generation,
+      events: [...events, event],
+    });
+  };
+
   const messageSequenceFor = (threadId: string) =>
     getRec(threadId).messages.reduce(
       (latestSequence, message) => Math.max(latestSequence, message.sequence),
@@ -981,7 +1005,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   const conversationResidency = createConversationResidency({
     restoreConversation: (threadId) => threadHydrator.hydrate(threadId, "active"),
     refreshConversation: (threadId) => threadHydrator.hydrate(threadId, "active", { force: true }),
-    deactivateConversation: () => threadHydrator.deactivate(),
+    deactivateConversation: () => {
+      const current = get().currentThreadId;
+      if (current) invalidateDeferredNarrativeEvents(current);
+      threadHydrator.deactivate();
+    },
     retainInactiveConversation: (threadId) => threadHydrator.retainInactiveConversation(threadId),
     invalidateConversation: (threadId) => threadHydrator.invalidateConversation(threadId),
     synchronizeConversation: (threadId) => threadHydrator.synchronizeConversation(threadId),
@@ -1149,7 +1177,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       throw new Error(`Thread ${threadId} already has an active agent session`);
     }
     if (!isControlCommand) {
-      dropPendingTextDeltas([threadId]);
+      invalidateDeferredNarrativeEvents(threadId);
       useTaskStore.getState().prepareTaskBubbleForNewTurn(threadId);
     }
 
@@ -1289,6 +1317,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           runningThreadIds: next,
         };
       });
+      if (!activeSessionConflict && !isControlCommand) {
+        invalidateDeferredNarrativeEvents(threadId);
+      }
     }
   },
 
@@ -1333,6 +1364,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         })),
       };
     });
+    invalidateDeferredNarrativeEvents(threadId);
+    threadHydrator.invalidatePermissionSnapshots(threadId);
   },
 
   hydrateRunningThreads: (ids) => {
@@ -1367,7 +1400,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       }
       return { runningThreadIds: new Set(ids), records };
     });
-    dropPendingTextDeltas(resetPendingIds);
+    for (const threadId of resetPendingIds) {
+      invalidateDeferredNarrativeEvents(threadId);
+      threadHydrator.invalidatePermissionSnapshots(threadId);
+    }
   },
 
   /** Append a single message to the current thread's message list. */
@@ -1388,9 +1424,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    * Does NOT reset runningThreadIds since agents may still be executing.
    */
   clearMessages: () => {
-    flushPendingTextDeltas();
     const current = get().currentThreadId;
-    if (current) conversationResidency.invalidateConversation(current);
+    if (current) {
+      invalidateDeferredNarrativeEvents(current);
+      conversationResidency.invalidateConversation(current);
+    }
+    flushPendingTextDeltas();
 
     get().toolCallRecordCache.clear();
     if (current) {
@@ -1420,6 +1459,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   },
 
   deactivateConversation: () => {
+    const current = get().currentThreadId;
+    if (current) invalidateDeferredNarrativeEvents(current);
     threadHydrator.deactivate();
   },
 
@@ -1521,6 +1562,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   clearThreadState: (threadId) => {
     conversationResidency.invalidateConversation(threadId);
     clearDequeueTimer(threadId);
+    invalidateDeferredNarrativeEvents(threadId);
     forgetScrollTop(threadId);
 
     const isCurrentThread = get().currentThreadId === threadId;
@@ -1550,6 +1592,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     for (const threadId of threadIds) {
       conversationResidency.invalidateConversation(threadId);
       clearDequeueTimer(threadId);
+      invalidateDeferredNarrativeEvents(threadId);
       forgetScrollTop(threadId);
     }
 
@@ -1763,6 +1806,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   },
 
   addPermissionRequest: (request) => {
+    threadHydrator.invalidatePermissionSnapshots(request.threadId);
     set((s) => {
       const existing = getThreadRecord(s.records, request.threadId).permissions;
       if (existing.some((p) => p.requestId === request.requestId)) return s;
@@ -1775,6 +1819,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   },
 
   resolvePermissionRequest: (requestId, decision) => {
+    for (const [threadId, rec] of get().records) {
+      if (rec.permissions.some((permission) => permission.requestId === requestId)) {
+        threadHydrator.invalidatePermissionSnapshots(threadId);
+        break;
+      }
+    }
     set((s) => {
       let records = s.records;
       for (const [threadId, rec] of s.records) {
@@ -1849,8 +1899,18 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     const { threadId } = event;
     const currentThreadId = get().currentThreadId;
     const isActiveThread = currentThreadId !== null && currentThreadId === threadId;
+    const isLifecycleExit = event.type === "turnComplete" || event.type === "ended" || event.type === "error";
+    const startsNewInstance = event.type === "turnStarted";
 
-    if (isActiveThread) promoteDeferredNarrativeEvents(threadId);
+    if (isLifecycleExit || startsNewInstance) {
+      invalidateDeferredNarrativeEvents(threadId);
+    }
+    if (startsNewInstance) {
+      threadHydrator.invalidatePermissionSnapshots(threadId);
+    }
+    if (isActiveThread && !startsNewInstance && !isLifecycleExit) {
+      promoteDeferredNarrativeEvents(threadId);
+    }
 
     if (event.type !== "textDelta") {
       flushPendingTextDeltas();
@@ -2396,6 +2456,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
 
     // session.textDelta: accumulate streaming text for live preview and finalization.
     if (event.type === "textDelta") {
+      if (!get().runningThreadIds.has(threadId)) return;
       const delta = (event.delta as string) || "";
       if (!delta) return;
       const rawIsFinalResponse = event.isFinalResponse;
@@ -2420,11 +2481,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         next.push({ delta, isFinalResponse, deferNarrative });
       }
       pendingTextDeltaByThread.set(threadId, next);
-      if (!isActiveThread) {
-        const deferred = deferredNarrativeEventsByThread.get(threadId) ?? [];
-        if (deferred.length < MAX_DEFERRED_NARRATIVE_EVENTS) {
-          deferredNarrativeEventsByThread.set(threadId, [...deferred, event]);
-        }
+      if (!isActiveThread && get().runningThreadIds.has(threadId)) {
+        queueDeferredNarrativeEvent(threadId, event);
       }
       if (!deferNarrative && (!hadPending || existing.some((chunk) => chunk.deferNarrative))) {
         markPriorToolCallsComplete();
@@ -2434,6 +2492,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (event.type === "assistantMessageBoundary") {
+      if (!get().runningThreadIds.has(threadId)) return;
       // Authoritative classification of the text deltas just streamed for this
       // assistant message, derived from the Anthropic `stop_reason`.
       //
@@ -2449,11 +2508,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Flush any pending text delta chunks first so the open thought we
       // operate on reflects every delta that arrived for this message.
       flushPendingTextDeltas();
-      if (!isActiveThread) {
-        const deferred = deferredNarrativeEventsByThread.get(threadId) ?? [];
-        if (deferred.length < MAX_DEFERRED_NARRATIVE_EVENTS) {
-          deferredNarrativeEventsByThread.set(threadId, [...deferred, event]);
-        }
+      if (!isActiveThread && get().runningThreadIds.has(threadId)) {
+        queueDeferredNarrativeEvent(threadId, event);
         return;
       }
       set((state) => {
@@ -2476,11 +2532,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (event.type === "toolProgress") {
-      if (!isActiveThread) {
-        const deferred = deferredNarrativeEventsByThread.get(threadId) ?? [];
-        if (deferred.length < MAX_DEFERRED_NARRATIVE_EVENTS) {
-          deferredNarrativeEventsByThread.set(threadId, [...deferred, event]);
-        }
+      if (!get().runningThreadIds.has(threadId)) return;
+      if (!isActiveThread && get().runningThreadIds.has(threadId)) {
+        queueDeferredNarrativeEvent(threadId, event);
         return;
       }
       const toolCallId = (event.toolCallId as string) || "";

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -2280,6 +2280,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (event.type === "toolUse") {
+      // Background text stays deferred until its tool boundary arrives. Project
+      // that queued narrative first so toolUse closes the correct thought.
+      if (!isActiveThread) {
+        promoteDeferredNarrativeEvents(threadId);
+      }
       const toolCallId = (event.toolCallId as string) || "";
       const existingCalls = getRec(threadId).toolCalls;
       const toolName = (event.toolName as string) || "unknown";

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -880,6 +880,55 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (activeThreadId) promoteDeferredNarrativeEvents(activeThreadId);
   };
 
+  const applyDeferredNarrativeEvent = (threadId: string, event: AgentEvent): void => {
+    if (event.type === "textDelta") {
+      const delta = typeof event.delta === "string" ? event.delta : "";
+      if (!delta || event.isFinalResponse === true) return;
+      set((state) => {
+        const record = getThreadRecord(state.records, threadId);
+        return {
+          records: patchThreadRecord(state.records, threadId, {
+            thoughtSegments: appendThoughtSegment(
+              record.thoughtSegments,
+              delta,
+              event.isFinalResponse === false,
+            ),
+          }),
+        };
+      });
+    } else if (event.type === "assistantMessageBoundary") {
+      const isFinalResponse = event.isFinalResponse === true;
+      set((state) => {
+        const record = getThreadRecord(state.records, threadId);
+        const last = record.thoughtSegments[record.thoughtSegments.length - 1];
+        if (!last || last.endedAt !== undefined) return state;
+        const thoughtSegments = isFinalResponse
+          ? record.thoughtSegments.slice(0, -1)
+          : [...record.thoughtSegments.slice(0, -1), { ...last, endedAt: Date.now() }];
+        return { records: patchThreadRecord(state.records, threadId, { thoughtSegments }) };
+      });
+    } else if (event.type === "toolProgress") {
+      const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
+      if (!toolCallId) return;
+      const elapsedSeconds = typeof event.elapsedSeconds === "number" ? event.elapsedSeconds : 0;
+      const lastActivityAt = Date.now();
+      set((state) => {
+        const current = getThreadRecord(state.records, threadId).toolCalls;
+        let changed = false;
+        const toolCalls = current.map((toolCall) => {
+          if (toolCall.id === toolCallId && !toolCall.isComplete) {
+            changed = true;
+            return { ...toolCall, elapsedSeconds, lastActivityAt };
+          }
+          return toolCall;
+        });
+        return changed
+          ? { records: patchThreadRecord(state.records, threadId, { toolCalls }) }
+          : state;
+      });
+    }
+  };
+
   const promoteDeferredNarrativeEvents = (threadId: string): void => {
     const queued = deferredNarrativeEventsByThread.get(threadId);
     if (!queued || queued.events.length === 0) return;
@@ -891,52 +940,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       return;
     }
     for (const event of queued.events) {
-      if (event.type === "textDelta") {
-        const delta = typeof event.delta === "string" ? event.delta : "";
-        if (!delta || event.isFinalResponse === true) continue;
-        set((state) => {
-          const record = getThreadRecord(state.records, threadId);
-          return {
-            records: patchThreadRecord(state.records, threadId, {
-              thoughtSegments: appendThoughtSegment(
-                record.thoughtSegments,
-                delta,
-                event.isFinalResponse === false,
-              ),
-            }),
-          };
-        });
-      } else if (event.type === "assistantMessageBoundary") {
-        const isFinalResponse = event.isFinalResponse === true;
-        set((state) => {
-          const record = getThreadRecord(state.records, threadId);
-          const last = record.thoughtSegments[record.thoughtSegments.length - 1];
-          if (!last || last.endedAt !== undefined) return state;
-          const thoughtSegments = isFinalResponse
-            ? record.thoughtSegments.slice(0, -1)
-            : [...record.thoughtSegments.slice(0, -1), { ...last, endedAt: Date.now() }];
-          return { records: patchThreadRecord(state.records, threadId, { thoughtSegments }) };
-        });
-      } else if (event.type === "toolProgress") {
-        const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
-        if (!toolCallId) continue;
-        const elapsedSeconds = typeof event.elapsedSeconds === "number" ? event.elapsedSeconds : 0;
-        const lastActivityAt = Date.now();
-        set((state) => {
-          const current = getThreadRecord(state.records, threadId).toolCalls;
-          let changed = false;
-          const toolCalls = current.map((toolCall) => {
-            if (toolCall.id === toolCallId && !toolCall.isComplete) {
-              changed = true;
-              return { ...toolCall, elapsedSeconds, lastActivityAt };
-            }
-            return toolCall;
-          });
-          return changed
-            ? { records: patchThreadRecord(state.records, threadId, { toolCalls }) }
-            : state;
-        });
-      }
+      applyDeferredNarrativeEvent(threadId, event);
     }
     if (!pendingTextDeltaByThread.has(threadId) && !get().runningThreadIds.has(threadId)) {
       deferredNarrativeGenerations.delete(threadId);
@@ -954,6 +958,24 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
     if (event.type === "assistantMessageBoundary") return 48;
     return 64;
+  };
+
+  const splitDeferredNarrativeEvent = (event: AgentEvent): AgentEvent[] => {
+    if (event.type !== "textDelta") return [event];
+    const delta = typeof event.delta === "string" ? event.delta : "";
+    const maxDeltaLength = Math.floor((MAX_DEFERRED_NARRATIVE_BYTES - 32) / 2);
+    if (delta.length <= maxDeltaLength) return [event];
+
+    const chunks: AgentEvent[] = [];
+    for (let offset = 0; offset < delta.length;) {
+      let end = Math.min(delta.length, offset + maxDeltaLength);
+      if (end < delta.length && end > offset && /[\uD800-\uDBFF]/.test(delta[end - 1] ?? "")) {
+        end -= 1;
+      }
+      chunks.push({ ...event, delta: delta.slice(offset, end) });
+      offset = end;
+    }
+    return chunks;
   };
 
   const dropPendingTextDeltas = (threadIds: Iterable<string>) => {
@@ -982,31 +1004,29 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   };
 
   const queueDeferredNarrativeEvent = (threadId: string, event: AgentEvent): void => {
-    const generation = deferredNarrativeGenerations.get(threadId) ?? 0;
-    const queued = deferredNarrativeEventsByThread.get(threadId);
-    const events = queued?.generation === generation ? queued.events : [];
-    const bytes = queued?.generation === generation ? queued.bytes : 0;
-    const eventBytes = deferredNarrativeEventBytes(event);
-    if (events.length >= MAX_DEFERRED_NARRATIVE_EVENTS || bytes + eventBytes > MAX_DEFERRED_NARRATIVE_BYTES) {
-      promoteDeferredNarrativeEvents(threadId);
-      if (eventBytes > MAX_DEFERRED_NARRATIVE_BYTES) {
-        deferredNarrativeEventsByThread.set(threadId, {
-          generation,
-          events: [event],
-          bytes: eventBytes,
-        });
+    for (const chunk of splitDeferredNarrativeEvent(event)) {
+      const generation = deferredNarrativeGenerations.get(threadId) ?? 0;
+      const queued = deferredNarrativeEventsByThread.get(threadId);
+      const events = queued?.generation === generation ? queued.events : [];
+      const bytes = queued?.generation === generation ? queued.bytes : 0;
+      const eventBytes = deferredNarrativeEventBytes(chunk);
+      if (events.length >= MAX_DEFERRED_NARRATIVE_EVENTS || bytes + eventBytes > MAX_DEFERRED_NARRATIVE_BYTES) {
         promoteDeferredNarrativeEvents(threadId);
-        return;
       }
+
+      const latest = deferredNarrativeEventsByThread.get(threadId);
+      const nextEvents = latest?.generation === generation ? latest.events : [];
+      const nextBytes = latest?.generation === generation ? latest.bytes : 0;
+      if (eventBytes > MAX_DEFERRED_NARRATIVE_BYTES) {
+        applyDeferredNarrativeEvent(threadId, chunk);
+        continue;
+      }
+      deferredNarrativeEventsByThread.set(threadId, {
+        generation,
+        events: [...nextEvents, chunk],
+        bytes: nextBytes + eventBytes,
+      });
     }
-    const latest = deferredNarrativeEventsByThread.get(threadId);
-    const nextEvents = latest?.generation === generation ? latest.events : [];
-    const nextBytes = latest?.generation === generation ? latest.bytes : 0;
-    deferredNarrativeEventsByThread.set(threadId, {
-      generation,
-      events: [...nextEvents, event],
-      bytes: nextBytes + eventBytes,
-    });
   };
 
   const messageSequenceFor = (threadId: string) =>

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -733,7 +733,12 @@ export function extractPendingPlanQuestions(
 
 /** Zustand store for thread-scoped messages, streaming session state, and agent event handling. */
 /** One coalesced `session.textDelta` span for rAF flushing; preserves missing `isFinalResponse` for legacy fallback behavior. */
-type PendingTextChunk = { delta: string; isFinalResponse?: boolean };
+type PendingTextChunk = {
+  delta: string;
+  isFinalResponse?: boolean;
+  /** Background deltas retain the streaming buffer but defer narrative projection until activation. */
+  deferNarrative?: boolean;
+};
 
 export const useThreadStore = create<ThreadState>((set, get) => {
   let textDeltaFlushRaf: number | null = null;
@@ -766,7 +771,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     if (pendingTextDeltaByThread.size === 0) return;
     const batch = new Map<string, PendingTextChunk[]>();
     for (const [tid, chunks] of pendingTextDeltaByThread) {
-      batch.set(tid, chunks.map((c) => ({ delta: c.delta, isFinalResponse: c.isFinalResponse })));
+      batch.set(tid, chunks.map((c) => ({
+        delta: c.delta,
+        isFinalResponse: c.isFinalResponse,
+        deferNarrative: c.deferNarrative,
+      })));
     }
     pendingTextDeltaByThread.clear();
     set((state) => {
@@ -784,7 +793,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           streaming = combined;
           streamingPreview = combined.length > 200 ? combined.slice(-200) : combined;
 
-          if (chunk.isFinalResponse) {
+          if (chunk.deferNarrative || chunk.isFinalResponse) {
             continue;
           }
 
@@ -1767,6 +1776,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    */
   handleAgentEvent: (event) => {
     const { threadId } = event;
+    const currentThreadId = get().currentThreadId;
+    // A null currentThreadId is the pre-hydration state used while the store
+    // is receiving events for its only known conversation. Preserve the
+    // existing projection until a different conversation is selected.
+    const isActiveThread = currentThreadId == null || currentThreadId === threadId;
 
     if (event.type !== "textDelta") {
       flushPendingTextDeltas();
@@ -2317,17 +2331,26 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       const rawIsFinalResponse = event.isFinalResponse;
       const isFinalResponse =
         typeof rawIsFinalResponse === "boolean" ? rawIsFinalResponse : undefined;
+      const deferNarrative = !isActiveThread;
       const hadPending = pendingTextDeltaByThread.has(threadId);
       const existing = pendingTextDeltaByThread.get(threadId) ?? [];
       const next = [...existing];
       const tail = next[next.length - 1];
-      if (tail && tail.isFinalResponse === isFinalResponse) {
-        next[next.length - 1] = { delta: tail.delta + delta, isFinalResponse };
+      if (
+        tail
+        && tail.isFinalResponse === isFinalResponse
+        && tail.deferNarrative === deferNarrative
+      ) {
+        next[next.length - 1] = {
+          delta: tail.delta + delta,
+          isFinalResponse,
+          deferNarrative,
+        };
       } else {
-        next.push({ delta, isFinalResponse });
+        next.push({ delta, isFinalResponse, deferNarrative });
       }
       pendingTextDeltaByThread.set(threadId, next);
-      if (!hadPending) {
+      if (!deferNarrative && (!hadPending || existing.some((chunk) => chunk.deferNarrative))) {
         markPriorToolCallsComplete();
       }
       scheduleTextDeltaFlush();
@@ -2350,6 +2373,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Flush any pending text delta chunks first so the open thought we
       // operate on reflects every delta that arrived for this message.
       flushPendingTextDeltas();
+      if (!isActiveThread) return;
       set((state) => {
         const rec = getThreadRecord(state.records, threadId);
         const segments = rec.thoughtSegments;
@@ -2370,6 +2394,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (event.type === "toolProgress") {
+      if (!isActiveThread) return;
       const toolCallId = (event.toolCallId as string) || "";
       const elapsedSeconds = (event.elapsedSeconds as number) ?? 0;
       if (!toolCallId) return;
@@ -2413,6 +2438,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (event.type === "hookProgress") {
+      if (!isActiveThread) return;
       const hookName = (event.hookName as string) || "";
       const output = (event.output as string) || "";
       if (!hookName || !output) return;

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -740,9 +740,62 @@ type PendingTextChunk = {
   deferNarrative?: boolean;
 };
 
+const MAX_DEFERRED_NARRATIVE_EVENTS = 2048;
+
+function appendThoughtSegment(
+  segments: ThoughtSegment[],
+  acc: string,
+  isExplicitNonFinal: boolean,
+): ThoughtSegment[] {
+  if (!acc) return segments;
+  const looksLikeContinuation = (prevText: string, nextText: string): boolean => {
+    const trimmedPrev = prevText.trimEnd();
+    const lastChar = trimmedPrev.slice(-1);
+    const prevEndsSentence = /[.!?]/.test(lastChar);
+    const firstChar = nextText.replace(/^\s+/, "").slice(0, 1);
+    const nextStartsLowerOrPunct =
+      firstChar === "" || /[a-z,;:)\]}-]/.test(firstChar);
+    return !prevEndsSentence || nextStartsLowerOrPunct;
+  };
+  const TINY_SEGMENT_THRESHOLD = 40;
+  const last = segments[segments.length - 1];
+  const shouldReopen =
+    last &&
+    last.endedAt !== undefined &&
+    (last.text.length < TINY_SEGMENT_THRESHOLD || looksLikeContinuation(last.text, acc));
+  if (!last || (last.endedAt !== undefined && !shouldReopen)) {
+    return [
+      ...segments,
+      {
+        text: acc,
+        startedAt: Date.now(),
+        ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
+      },
+    ];
+  }
+  if (last.endedAt !== undefined && shouldReopen) {
+    const reopened: ThoughtSegment = {
+      ...last,
+      text: last.text + acc,
+      ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
+    };
+    delete (reopened as { endedAt?: number }).endedAt;
+    return [...segments.slice(0, -1), reopened];
+  }
+  return [
+    ...segments.slice(0, -1),
+    {
+      ...last,
+      text: last.text + acc,
+      ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
+    },
+  ];
+}
+
 export const useThreadStore = create<ThreadState>((set, get) => {
   let textDeltaFlushRaf: number | null = null;
   const pendingTextDeltaByThread = new Map<string, PendingTextChunk[]>();
+  const deferredNarrativeEventsByThread = new Map<string, AgentEvent[]>();
 
   const getRec = (threadId: string) => getThreadRecord(get().records, threadId);
 
@@ -768,7 +821,11 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       cancelAnimationFrame(textDeltaFlushRaf);
       textDeltaFlushRaf = null;
     }
-    if (pendingTextDeltaByThread.size === 0) return;
+    if (pendingTextDeltaByThread.size === 0) {
+      const activeThreadId = get().currentThreadId;
+      if (activeThreadId) promoteDeferredNarrativeEvents(activeThreadId);
+      return;
+    }
     const batch = new Map<string, PendingTextChunk[]>();
     for (const [tid, chunks] of pendingTextDeltaByThread) {
       batch.set(tid, chunks.map((c) => ({
@@ -798,52 +855,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           }
 
           const isExplicitNonFinal = chunk.isFinalResponse === false;
-          const last = segments[segments.length - 1];
-          const looksLikeContinuation = (prevText: string, nextText: string): boolean => {
-            const trimmedPrev = prevText.trimEnd();
-            const lastChar = trimmedPrev.slice(-1);
-            const prevEndsSentence = /[.!?]/.test(lastChar);
-            const firstChar = nextText.replace(/^\s+/, "").slice(0, 1);
-            const nextStartsLowerOrPunct =
-              firstChar === "" || /[a-z,;:)\]}-]/.test(firstChar);
-            return !prevEndsSentence || nextStartsLowerOrPunct;
-          };
-          const TINY_SEGMENT_THRESHOLD = 40;
-          const shouldReopen =
-            last &&
-            last.endedAt !== undefined &&
-            (last.text.length < TINY_SEGMENT_THRESHOLD ||
-              looksLikeContinuation(last.text, acc));
-          if (!last || (last.endedAt !== undefined && !shouldReopen)) {
-            segments = [
-              ...segments,
-              {
-                text: acc,
-                startedAt: Date.now(),
-                ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
-              },
-            ];
-            segmentsChanged = true;
-          } else if (last.endedAt !== undefined && shouldReopen) {
-            const reopened: typeof last = {
-              ...last,
-              text: last.text + acc,
-              ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
-            };
-            delete (reopened as { endedAt?: number }).endedAt;
-            segments = [...segments.slice(0, -1), reopened];
-            segmentsChanged = true;
-          } else {
-            segments = [
-              ...segments.slice(0, -1),
-              {
-                ...last,
-                text: last.text + acc,
-                ...(isExplicitNonFinal ? { isExplicitNonFinal: true } : {}),
-              },
-            ];
-            segmentsChanged = true;
-          }
+          segments = appendThoughtSegment(segments, acc, isExplicitNonFinal);
+          segmentsChanged = true;
         }
         const patch: Partial<ThreadRecord> = {
           streaming,
@@ -856,12 +869,70 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       }
       return { records };
     });
+
+    const activeThreadId = get().currentThreadId;
+    if (activeThreadId) promoteDeferredNarrativeEvents(activeThreadId);
+  };
+
+  const promoteDeferredNarrativeEvents = (threadId: string): void => {
+    const events = deferredNarrativeEventsByThread.get(threadId);
+    if (!events || events.length === 0) return;
+    deferredNarrativeEventsByThread.delete(threadId);
+    for (const event of events) {
+      if (event.type === "textDelta") {
+        const delta = typeof event.delta === "string" ? event.delta : "";
+        if (!delta || event.isFinalResponse === true) continue;
+        set((state) => {
+          const record = getThreadRecord(state.records, threadId);
+          return {
+            records: patchThreadRecord(state.records, threadId, {
+              thoughtSegments: appendThoughtSegment(
+                record.thoughtSegments,
+                delta,
+                event.isFinalResponse === false,
+              ),
+            }),
+          };
+        });
+      } else if (event.type === "assistantMessageBoundary") {
+        const isFinalResponse = event.isFinalResponse === true;
+        set((state) => {
+          const record = getThreadRecord(state.records, threadId);
+          const last = record.thoughtSegments[record.thoughtSegments.length - 1];
+          if (!last || last.endedAt !== undefined) return state;
+          const thoughtSegments = isFinalResponse
+            ? record.thoughtSegments.slice(0, -1)
+            : [...record.thoughtSegments.slice(0, -1), { ...last, endedAt: Date.now() }];
+          return { records: patchThreadRecord(state.records, threadId, { thoughtSegments }) };
+        });
+      } else if (event.type === "toolProgress") {
+        const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
+        if (!toolCallId) continue;
+        const elapsedSeconds = typeof event.elapsedSeconds === "number" ? event.elapsedSeconds : 0;
+        const lastActivityAt = Date.now();
+        set((state) => {
+          const current = getThreadRecord(state.records, threadId).toolCalls;
+          let changed = false;
+          const toolCalls = current.map((toolCall) => {
+            if (toolCall.id === toolCallId && !toolCall.isComplete) {
+              changed = true;
+              return { ...toolCall, elapsedSeconds, lastActivityAt };
+            }
+            return toolCall;
+          });
+          return changed
+            ? { records: patchThreadRecord(state.records, threadId, { toolCalls }) }
+            : state;
+        });
+      }
+    }
   };
 
   const dropPendingTextDeltas = (threadIds: Iterable<string>) => {
     let dropped = false;
     for (const threadId of threadIds) {
       dropped = pendingTextDeltaByThread.delete(threadId) || dropped;
+      dropped = deferredNarrativeEventsByThread.delete(threadId) || dropped;
     }
     if (dropped && pendingTextDeltaByThread.size === 0 && textDeltaFlushRaf != null) {
       cancelAnimationFrame(textDeltaFlushRaf);
@@ -1777,10 +1848,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   handleAgentEvent: (event) => {
     const { threadId } = event;
     const currentThreadId = get().currentThreadId;
-    // A null currentThreadId is the pre-hydration state used while the store
-    // is receiving events for its only known conversation. Preserve the
-    // existing projection until a different conversation is selected.
-    const isActiveThread = currentThreadId == null || currentThreadId === threadId;
+    const isActiveThread = currentThreadId !== null && currentThreadId === threadId;
+
+    if (isActiveThread) promoteDeferredNarrativeEvents(threadId);
 
     if (event.type !== "textDelta") {
       flushPendingTextDeltas();
@@ -2350,6 +2420,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         next.push({ delta, isFinalResponse, deferNarrative });
       }
       pendingTextDeltaByThread.set(threadId, next);
+      if (!isActiveThread) {
+        const deferred = deferredNarrativeEventsByThread.get(threadId) ?? [];
+        if (deferred.length < MAX_DEFERRED_NARRATIVE_EVENTS) {
+          deferredNarrativeEventsByThread.set(threadId, [...deferred, event]);
+        }
+      }
       if (!deferNarrative && (!hadPending || existing.some((chunk) => chunk.deferNarrative))) {
         markPriorToolCallsComplete();
       }
@@ -2373,7 +2449,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Flush any pending text delta chunks first so the open thought we
       // operate on reflects every delta that arrived for this message.
       flushPendingTextDeltas();
-      if (!isActiveThread) return;
+      if (!isActiveThread) {
+        const deferred = deferredNarrativeEventsByThread.get(threadId) ?? [];
+        if (deferred.length < MAX_DEFERRED_NARRATIVE_EVENTS) {
+          deferredNarrativeEventsByThread.set(threadId, [...deferred, event]);
+        }
+        return;
+      }
       set((state) => {
         const rec = getThreadRecord(state.records, threadId);
         const segments = rec.thoughtSegments;
@@ -2394,7 +2476,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     }
 
     if (event.type === "toolProgress") {
-      if (!isActiveThread) return;
+      if (!isActiveThread) {
+        const deferred = deferredNarrativeEventsByThread.get(threadId) ?? [];
+        if (deferred.length < MAX_DEFERRED_NARRATIVE_EVENTS) {
+          deferredNarrativeEventsByThread.set(threadId, [...deferred, event]);
+        }
+        return;
+      }
       const toolCallId = (event.toolCallId as string) || "";
       const elapsedSeconds = (event.elapsedSeconds as number) ?? 0;
       if (!toolCallId) return;

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -946,6 +946,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   };
 
   const invalidateDeferredNarrativeEvents = (threadId: string): void => {
+    flushPendingTextDeltas();
     deferredNarrativeGenerations.set(
       threadId,
       (deferredNarrativeGenerations.get(threadId) ?? 0) + 1,
@@ -1563,6 +1564,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     conversationResidency.invalidateConversation(threadId);
     clearDequeueTimer(threadId);
     invalidateDeferredNarrativeEvents(threadId);
+    threadHydrator.forgetThread(threadId);
     forgetScrollTop(threadId);
 
     const isCurrentThread = get().currentThreadId === threadId;
@@ -1593,6 +1595,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       conversationResidency.invalidateConversation(threadId);
       clearDequeueTimer(threadId);
       invalidateDeferredNarrativeEvents(threadId);
+      threadHydrator.forgetThread(threadId);
       forgetScrollTop(threadId);
     }
 
@@ -1903,6 +1906,9 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     const startsNewInstance = event.type === "turnStarted";
 
     if (isLifecycleExit || startsNewInstance) {
+      // Lifecycle events can arrive in same frame as final text delta.
+      // Flush first so invalidation cannot discard text needed for persistence.
+      flushPendingTextDeltas();
       invalidateDeferredNarrativeEvents(threadId);
     }
     if (startsNewInstance) {

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -798,9 +798,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
   const pendingTextDeltaByThread = new Map<string, PendingTextChunk[]>();
   const deferredNarrativeEventsByThread = new Map<
     string,
-    { generation: number; events: AgentEvent[] }
+    { generation: number; events: AgentEvent[]; bytes: number }
   >();
   const deferredNarrativeGenerations = new Map<string, number>();
+  const MAX_DEFERRED_NARRATIVE_BYTES = 256 * 1024;
 
   const getRec = (threadId: string) => getThreadRecord(get().records, threadId);
 
@@ -883,7 +884,12 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     const queued = deferredNarrativeEventsByThread.get(threadId);
     if (!queued || queued.events.length === 0) return;
     deferredNarrativeEventsByThread.delete(threadId);
-    if (queued.generation !== (deferredNarrativeGenerations.get(threadId) ?? 0)) return;
+    if (queued.generation !== (deferredNarrativeGenerations.get(threadId) ?? 0)) {
+      if (!pendingTextDeltaByThread.has(threadId) && !get().runningThreadIds.has(threadId)) {
+        deferredNarrativeGenerations.delete(threadId);
+      }
+      return;
+    }
     for (const event of queued.events) {
       if (event.type === "textDelta") {
         const delta = typeof event.delta === "string" ? event.delta : "";
@@ -932,6 +938,22 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         });
       }
     }
+    if (!pendingTextDeltaByThread.has(threadId) && !get().runningThreadIds.has(threadId)) {
+      deferredNarrativeGenerations.delete(threadId);
+    }
+  };
+
+  const deferredNarrativeEventBytes = (event: AgentEvent): number => {
+    if (event.type === "textDelta") {
+      return (typeof event.delta === "string" ? event.delta.length : 0) * 2 + 32;
+    }
+    if (event.type === "toolProgress") {
+      const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
+      const toolName = typeof event.toolName === "string" ? event.toolName : "";
+      return 64 + toolCallId.length * 2 + toolName.length * 2;
+    }
+    if (event.type === "assistantMessageBoundary") return 48;
+    return 64;
   };
 
   const dropPendingTextDeltas = (threadIds: Iterable<string>) => {
@@ -939,6 +961,10 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     for (const threadId of threadIds) {
       dropped = pendingTextDeltaByThread.delete(threadId) || dropped;
       dropped = deferredNarrativeEventsByThread.delete(threadId) || dropped;
+      if (!pendingTextDeltaByThread.has(threadId) && !deferredNarrativeEventsByThread.has(threadId)
+        && !get().runningThreadIds.has(threadId)) {
+        deferredNarrativeGenerations.delete(threadId);
+      }
     }
     if (dropped && pendingTextDeltaByThread.size === 0 && textDeltaFlushRaf != null) {
       cancelAnimationFrame(textDeltaFlushRaf);
@@ -959,13 +985,29 @@ export const useThreadStore = create<ThreadState>((set, get) => {
     const generation = deferredNarrativeGenerations.get(threadId) ?? 0;
     const queued = deferredNarrativeEventsByThread.get(threadId);
     const events = queued?.generation === generation ? queued.events : [];
-    if (events.length >= MAX_DEFERRED_NARRATIVE_EVENTS) {
-      recordBackgroundEventDropped(threadId);
-      return;
+    const bytes = queued?.generation === generation ? queued.bytes : 0;
+    const eventBytes = deferredNarrativeEventBytes(event);
+    if (events.length >= MAX_DEFERRED_NARRATIVE_EVENTS || bytes + eventBytes > MAX_DEFERRED_NARRATIVE_BYTES) {
+      promoteDeferredNarrativeEvents(threadId);
+      if (eventBytes > MAX_DEFERRED_NARRATIVE_BYTES) {
+        const prior = deferredNarrativeEventsByThread.get(threadId);
+        deferredNarrativeEventsByThread.set(threadId, {
+          generation,
+          events: [event],
+          bytes: eventBytes,
+        });
+        promoteDeferredNarrativeEvents(threadId);
+        if (prior) deferredNarrativeEventsByThread.delete(threadId);
+        return;
+      }
     }
+    const latest = deferredNarrativeEventsByThread.get(threadId);
+    const nextEvents = latest?.generation === generation ? latest.events : [];
+    const nextBytes = latest?.generation === generation ? latest.bytes : 0;
     deferredNarrativeEventsByThread.set(threadId, {
       generation,
-      events: [...events, event],
+      events: [...nextEvents, event],
+      bytes: nextBytes + eventBytes,
     });
   };
 
@@ -1458,6 +1500,8 @@ export const useThreadStore = create<ThreadState>((set, get) => {
           latestTurnWithChanges: null,
           serverMessageIds: {},
           narrativeByMessage: {},
+          lastAgentEventEpoch: undefined,
+          lastAgentEventSequence: undefined,
         }),
       }));
     }
@@ -1586,6 +1630,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         ...(isCurrentThread ? { currentThreadId: null } : {}),
       };
     });
+    deferredNarrativeGenerations.delete(threadId);
 
     if (isCurrentThread) {
       get().toolCallRecordCache.clear();
@@ -1631,6 +1676,7 @@ export const useThreadStore = create<ThreadState>((set, get) => {
         ...(deletingCurrentThread ? { currentThreadId: null } : {}),
       };
     });
+    for (const threadId of threadIds) deferredNarrativeGenerations.delete(threadId);
 
     if (deletingCurrentThread) {
       get().toolCallRecordCache.clear();
@@ -1904,16 +1950,23 @@ export const useThreadStore = create<ThreadState>((set, get) => {
    */
   handleAgentEvent: (event) => {
     const { threadId } = event;
+    const eventEpoch = typeof event.epoch === "string" ? event.epoch : undefined;
     const eventSequence = typeof event.sequence === "number" && event.sequence > 0
       ? event.sequence
       : undefined;
     if (eventSequence !== undefined) {
-      const lastSequence = getRec(threadId).lastAgentEventSequence;
-      if (lastSequence !== undefined && eventSequence <= lastSequence) {
+      const record = getRec(threadId);
+      const lastSequence = record.lastAgentEventSequence;
+      const epochChanged = eventEpoch !== undefined
+        && eventEpoch !== record.lastAgentEventEpoch;
+      if (!epochChanged && lastSequence !== undefined && eventSequence <= lastSequence) {
         if (get().currentThreadId !== threadId) recordBackgroundEventDropped(threadId);
         return;
       }
-      patchRec(threadId, { lastAgentEventSequence: eventSequence });
+      patchRec(threadId, {
+        lastAgentEventSequence: eventSequence,
+        ...(eventEpoch !== undefined ? { lastAgentEventEpoch: eventEpoch } : {}),
+      });
     }
     const currentThreadId = get().currentThreadId;
     const isActiveThread = currentThreadId !== null && currentThreadId === threadId;
@@ -1925,6 +1978,16 @@ export const useThreadStore = create<ThreadState>((set, get) => {
       // Flush first so invalidation cannot discard text needed for persistence.
       flushPendingTextDeltas();
       if (startsNewInstance) invalidateDeferredNarrativeEvents(threadId);
+      if (isLifecycleExit && !isActiveThread) promoteDeferredNarrativeEvents(threadId);
+      if (isLifecycleExit) {
+        queueMicrotask(() => {
+          if (!get().runningThreadIds.has(threadId)
+            && !pendingTextDeltaByThread.has(threadId)
+            && !deferredNarrativeEventsByThread.has(threadId)) {
+            deferredNarrativeGenerations.delete(threadId);
+          }
+        });
+      }
     }
     if (startsNewInstance) {
       threadHydrator.invalidatePermissionSnapshots(threadId);

--- a/apps/web/src/stores/threadStore.ts
+++ b/apps/web/src/stores/threadStore.ts
@@ -732,7 +732,6 @@ export function extractPendingPlanQuestions(
   }
 }
 
-/** Zustand store for thread-scoped messages, streaming session state, and agent event handling. */
 /** One coalesced `session.textDelta` span for rAF flushing; preserves missing `isFinalResponse` for legacy fallback behavior. */
 type PendingTextChunk = {
   delta: string;
@@ -821,6 +820,7 @@ function projectToolProgress(
   return changed ? updated : undefined;
 }
 
+/** Zustand store for thread-scoped messages, streaming session state, and agent event handling. */
 export const useThreadStore = create<ThreadState>((set, get) => {
   let textDeltaFlushRaf: number | null = null;
   const pendingTextDeltaByThread = new Map<string, PendingTextChunk[]>();
@@ -3179,7 +3179,13 @@ export const useThreadStore = create<ThreadState>((set, get) => {
             tokens_used: null,
             attachments: null,
           };
-          get().addMessage(systemMsg);
+          patchRec(threadId, (rec) => {
+            const { messages: capped, evicted } = capMessages([...rec.messages, systemMsg]);
+            return {
+              messages: capped,
+              ...(evicted ? { hasMoreMessages: true } : {}),
+            };
+          });
         }
       }
       set((state) => {

--- a/apps/web/src/transport/types.ts
+++ b/apps/web/src/transport/types.ts
@@ -40,6 +40,7 @@ import type {
   ConversationPage,
   ConversationTail,
   SetThreadSubscriptionsInput,
+  SetThreadSubscriptionsResult,
   GoalLookupResult,
   BrowserAutomationHostRegistration,
   BrowserAutomationHostDispatchTarget,
@@ -329,7 +330,7 @@ export interface McodeTransport {
   /** Remove this client connection's push subscription for a thread. */
   unsubscribeThread(threadId: string): Promise<void>;
   /** Replace this connection's complete push subscription set atomically. */
-  setThreadSubscriptions?(input: SetThreadSubscriptionsInput): Promise<void>;
+  setThreadSubscriptions?(input: SetThreadSubscriptionsInput): Promise<SetThreadSubscriptionsResult>;
   /** Fetch the current active goal for a thread without starting provider work. */
   getThreadGoal(threadId: string): Promise<GoalLookupResult>;
   /** Clear the current active goal for a thread without sending a chat message. */

--- a/apps/web/src/transport/ws-transport.ts
+++ b/apps/web/src/transport/ws-transport.ts
@@ -57,7 +57,7 @@ import type {
   CreateAndSendInput,
 } from "@mcode/contracts";
 import { emitPtyReconnectGap } from "@/components/terminal/ptyDataRegistry";
-import type { PaginatedMessages, ConversationPage, ConversationTail, SetThreadSubscriptionsInput, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability, GoalLookupResult } from "@mcode/contracts";
+import type { PaginatedMessages, ConversationPage, ConversationTail, SetThreadSubscriptionsInput, SetThreadSubscriptionsResult, TurnSnapshot, PrDraft, CreatePrResult, ProviderUsageInfo, ChecksStatus, ProviderAvailability, GoalLookupResult } from "@mcode/contracts";
 import {
   TERMINAL_DATA_TAG,
   decodeTerminalDataFrame,
@@ -680,7 +680,7 @@ export function createWsTransport(
     subscribeThread: (threadId) => rpc<void>("push.subscribeThread", { threadId }),
     unsubscribeThread: (threadId) => rpc<void>("push.unsubscribeThread", { threadId }),
     setThreadSubscriptions: (input: SetThreadSubscriptionsInput) =>
-      rpc<void>("push.setThreadSubscriptions", input),
+      rpc<SetThreadSubscriptionsResult>("push.setThreadSubscriptions", input),
     getThreadGoal: (threadId) =>
       rpc<GoalLookupResult>("thread.goal.get", { threadId }),
     clearThreadGoal: (threadId) =>

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -357,9 +357,14 @@ const AgentEventPayloadSchema = z.discriminatedUnion("type", [
     }),
   ]);
 
+/** Cryptographic identity for one server process event stream. */
+export const AgentEventEpochSchema = z.string().uuid();
+
 /** Optional server-assigned per-thread ordering metadata. */
 const AgentEventSequenceSchema = z.object({
   sequence: z.number().int().positive().optional(),
+  /** Server-process epoch paired with `sequence`; absent for legacy events. */
+  epoch: AgentEventEpochSchema.optional(),
 });
 
 /** Validated agent event payload, including an optional server ordering sequence. */

--- a/packages/contracts/src/events/agent-event.ts
+++ b/packages/contracts/src/events/agent-event.ts
@@ -48,8 +48,7 @@ export const AgentEventType = {
 export type AgentEventType = typeof AgentEventType[keyof typeof AgentEventType];
 
 /** Discriminated union of all events emitted by an agent provider. */
-export const AgentEventSchema = lazySchema(() =>
-  z.discriminatedUnion("type", [
+const AgentEventPayloadSchema = z.discriminatedUnion("type", [
     z.object({
       /** Emitted at the start of a new turn, before any other events. Mirrors TurnComplete/Ended.
        *  Used by the client to populate `runningThreadIds` for live-session UI indicators. */
@@ -356,7 +355,16 @@ export const AgentEventSchema = lazySchema(() =>
       error: z.string().optional(),
       failureReason: z.string().optional(),
     }),
-  ]),
+  ]);
+
+/** Optional server-assigned per-thread ordering metadata. */
+const AgentEventSequenceSchema = z.object({
+  sequence: z.number().int().positive().optional(),
+});
+
+/** Validated agent event payload, including an optional server ordering sequence. */
+export const AgentEventSchema = lazySchema(() =>
+  z.intersection(AgentEventPayloadSchema, AgentEventSequenceSchema),
 );
 /** Union of all events emitted by an agent provider. */
 export type AgentEvent = z.infer<ReturnType<typeof AgentEventSchema>>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -779,6 +779,7 @@ export {
   RECAP_MAX_PREVIOUS_RECAP_CHARS,
   MAX_THREAD_SUBSCRIPTIONS,
   SetThreadSubscriptionsSchema,
+  SetThreadSubscriptionsResultSchema,
 } from "./ws/methods.js";
 export type {
   WsMethodName,
@@ -786,6 +787,7 @@ export type {
   CreateAndSendInput,
   CreateAndSendResult,
   SetThreadSubscriptionsInput,
+  SetThreadSubscriptionsResult,
 } from "./ws/methods.js";
 
 export { WS_CHANNELS } from "./ws/channels.js";

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -456,7 +456,7 @@ export type {
 } from "./models/browser-automation.js";
 
 // Events
-export { AgentEventSchema, AgentEventType } from "./events/agent-event.js";
+export { AgentEventSchema, AgentEventType, AgentEventEpochSchema } from "./events/agent-event.js";
 export type { AgentEvent } from "./events/agent-event.js";
 
 // Plan questions

--- a/packages/contracts/src/ws/__tests__/methods.test.ts
+++ b/packages/contracts/src/ws/__tests__/methods.test.ts
@@ -21,6 +21,16 @@ describe("thread switching WebSocket contracts", () => {
       threadIds: ["thread-1"],
       cursors: { "thread-1": { epoch: "00000000-0000-4000-8000-000000000001", sequence: 4 } },
     }).success).toBe(true);
+    expect(method.params.safeParse({
+      threadIds: ["thread-1"],
+      cursors: { "thread-1": 4 },
+    }).success).toBe(true);
+    expect(method.params.safeParse({
+      threadIds: ["thread-1"],
+      cursors: Object.fromEntries(
+        Array.from({ length: MAX_THREAD_SUBSCRIPTIONS + 1 }, (_, index) => [`thread-${index}`, index]),
+      ),
+    }).success).toBe(false);
   });
 
   it("keeps legacy single-thread subscription methods available", () => {

--- a/packages/contracts/src/ws/__tests__/methods.test.ts
+++ b/packages/contracts/src/ws/__tests__/methods.test.ts
@@ -17,6 +17,10 @@ describe("thread switching WebSocket contracts", () => {
     expect(method.params.safeParse({ threadIds: ["thread-1", "thread-1"] }).success).toBe(false);
     expect(method.params.safeParse({ threadIds: Array.from({ length: MAX_THREAD_SUBSCRIPTIONS + 1 }, (_, index) => `thread-${index}`) }).success).toBe(false);
     expect(method.params.safeParse({ threadIds: [""] }).success).toBe(false);
+    expect(method.params.safeParse({
+      threadIds: ["thread-1"],
+      cursors: { "thread-1": { epoch: "00000000-0000-4000-8000-000000000001", sequence: 4 } },
+    }).success).toBe(true);
   });
 
   it("keeps legacy single-thread subscription methods available", () => {

--- a/packages/contracts/src/ws/__tests__/methods.test.ts
+++ b/packages/contracts/src/ws/__tests__/methods.test.ts
@@ -27,9 +27,42 @@ describe("thread switching WebSocket contracts", () => {
     }).success).toBe(true);
     expect(method.params.safeParse({
       threadIds: ["thread-1"],
+      cursors: { "thread-1": -1 },
+    }).success).toBe(false);
+    expect(method.params.safeParse({
+      threadIds: ["thread-1"],
+      cursors: { "thread-1": 1.5 },
+    }).success).toBe(false);
+    expect(method.params.safeParse({
+      threadIds: ["thread-1"],
       cursors: Object.fromEntries(
         Array.from({ length: MAX_THREAD_SUBSCRIPTIONS + 1 }, (_, index) => [`thread-${index}`, index]),
       ),
+    }).success).toBe(false);
+  });
+
+  it("parses structured hydration and replay results", () => {
+    const method = WS_METHODS()["push.setThreadSubscriptions"];
+    const result = {
+      hydrationRequiredThreadIds: ["thread-1"],
+      replayedThrough: { "thread-2": 12 },
+    };
+
+    const parsed = method.result.safeParse(result);
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      throw new Error(parsed.error.message);
+    }
+    expect(parsed.data).toEqual(result);
+  });
+
+  it("rejects malformed subscription replay results", () => {
+    const method = WS_METHODS()["push.setThreadSubscriptions"];
+
+    expect(method.result.safeParse({
+      hydrationRequiredThreadIds: ["thread-1"],
+      replayedThrough: { "thread-2": 0 },
     }).success).toBe(false);
   });
 

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -157,7 +157,14 @@ export const SetThreadSubscriptionsSchema = lazySchema(() =>
     cursors: z.record(
       ThreadSubscriptionIdSchema,
       z.union([z.number().int().nonnegative(), AgentEventCursorSchema]),
-    ).optional(),
+    ).superRefine((cursors, context) => {
+      if (Object.keys(cursors).length > MAX_THREAD_SUBSCRIPTIONS) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `cursors must contain at most ${MAX_THREAD_SUBSCRIPTIONS} entries`,
+        });
+      }
+    }).optional(),
   }),
 );
 

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -147,11 +147,24 @@ export const SetThreadSubscriptionsSchema = lazySchema(() =>
         context.addIssue({ code: z.ZodIssueCode.custom, message: "threadIds must be unique" });
       }
     }),
+    /** Last applied agent-event sequence per thread; omitted for legacy subscribe calls. */
+    cursors: z.record(ThreadSubscriptionIdSchema, z.number().int().nonnegative()).optional(),
   }),
 );
 
 /** Input accepted by `push.setThreadSubscriptions`. */
 export type SetThreadSubscriptionsInput = z.infer<ReturnType<typeof SetThreadSubscriptionsSchema>>;
+
+/** Result of an atomic subscription replacement and any synchronous replay. */
+export const SetThreadSubscriptionsResultSchema = lazySchema(() =>
+  z.object({
+    hydrationRequiredThreadIds: z.array(ThreadSubscriptionIdSchema),
+    replayedThrough: z.record(ThreadSubscriptionIdSchema, z.number().int().positive()),
+  }),
+);
+
+/** Replay outcome returned by `push.setThreadSubscriptions`. */
+export type SetThreadSubscriptionsResult = z.infer<ReturnType<typeof SetThreadSubscriptionsResultSchema>>;
 
 /** Schema for creating a new thread. */
 export const CreateThreadSchema = lazySchema(() =>
@@ -728,7 +741,7 @@ export const WS_METHODS = lazySchema(() => ({
   },
   "push.setThreadSubscriptions": {
     params: SetThreadSubscriptionsSchema(),
-    result: z.void(),
+    result: SetThreadSubscriptionsResultSchema(),
   },
   "agent.answerQuestions": {
     params: z.object({

--- a/packages/contracts/src/ws/methods.ts
+++ b/packages/contracts/src/ws/methods.ts
@@ -139,6 +139,12 @@ export const MAX_THREAD_SUBSCRIPTIONS = 100;
 /** Thread identifier schema shared by atomic push subscription updates. */
 const ThreadSubscriptionIdSchema = z.string().trim().min(1).max(CONVERSATION_TAIL_THREAD_ID_MAX_LENGTH);
 
+/** Cursor identity for one server-process event stream. */
+const AgentEventCursorSchema = z.object({
+  epoch: z.string().uuid(),
+  sequence: z.number().int().nonnegative(),
+});
+
 /** Complete desired push subscription set for one WebSocket connection. */
 export const SetThreadSubscriptionsSchema = lazySchema(() =>
   z.object({
@@ -148,7 +154,10 @@ export const SetThreadSubscriptionsSchema = lazySchema(() =>
       }
     }),
     /** Last applied agent-event sequence per thread; omitted for legacy subscribe calls. */
-    cursors: z.record(ThreadSubscriptionIdSchema, z.number().int().nonnegative()).optional(),
+    cursors: z.record(
+      ThreadSubscriptionIdSchema,
+      z.union([z.number().int().nonnegative(), AgentEventCursorSchema]),
+    ).optional(),
   }),
 );
 


### PR DESCRIPTION
## What

Make running-thread switches use resident per-thread live state, ordered event replay, bounded subscriptions, and active-hydration priority.

## Why

Running agents previously competed with thread activation, could blank resident transcripts, and had no safe way to recover transient events after reconnects.

## Key Changes

- Preserve warm running transcripts and skip redundant conversation fetches.
- Keep sequenced live state per thread with bounded deferred narrative processing.
- Replay retained agent events by server epoch and per-thread cursor, with explicit hydration on gaps or restarts.
- Bound subscription membership, replay journals, deferred event bytes, and telemetry retention.
- Defer auxiliary and background hydration while an active switch is in flight.
- Isolate sidebar running-state selectors and skip unchanged subscription reconciliation.

## Verification

- Server replay suite: 16 tests passed.
- Integrated web switch, event, hydration, and subscription suites: 162 tests passed before review repairs; affected repair suites also passed.
- Web, server, and contracts typechecks passed.
- Independent high-risk review resolved all semantic findings.
- `bun run verify` still reports pre-existing thought-merge test failures and server worker timeouts outside this branch's changed scope.
- Live Mcode Browser verification remains blocked because no browser connection is available.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable agent-event ordering and replay when reconnecting or subscribing to threads.
  * Added automatic hydration detection when event history is unavailable or from a previous session.
  * Improved thread switching with cursor-aware subscriptions, clearer running-state indicators, and bounded telemetry.
* **Bug Fixes**
  * Preserved streaming content and outgoing transcripts during hydration and background activity.
  * Prevented stale permission and conversation data from overwriting newer updates.
  * Improved handling of duplicate, deferred, oversized, and session-related events.
* **Tests**
  * Expanded coverage for replay, hydration, streaming, thread switching, telemetry, and permission races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->