### PR TITLE
fix(web): prevent Subagents panel crash

### DIFF
--- a/apps/web/src/components/panels/__tests__/SubagentsPanel.real-store.test.tsx
+++ b/apps/web/src/components/panels/__tests__/SubagentsPanel.real-store.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useDiffStore } from "@/stores/diffStore";
+import { createEmptyThreadRecord, getThreadRecord } from "@/stores/thread-record";
+import { useThreadStore } from "@/stores/threadStore";
+import { SubagentsPanel } from "../SubagentsPanel";
+
+describe("SubagentsPanel real thread store path", () => {
+  beforeEach(() => {
+    useDiffStore.setState({ subagentDetailByThread: {}, subagentReviewScopeByThread: {} });
+    useThreadStore.setState({
+      currentThreadId: "thread-1",
+      records: new Map(),
+    });
+  });
+
+  it("survives a transient record missing hydrated narrative data", () => {
+    const record = createEmptyThreadRecord();
+    const partialRecord = { ...record, narrativeByMessage: undefined } as unknown as typeof record;
+    useThreadStore.setState({
+      currentThreadId: "thread-1",
+      records: new Map([["thread-1", partialRecord as typeof record]]),
+    });
+
+    expect(() => render(<SubagentsPanel threadId="thread-1" />)).not.toThrow();
+    expect(screen.getByTestId("subagents-empty")).toBeInTheDocument();
+  });
+
+  it("normalizes null narrative data and pending persistence ids", () => {
+    const record = createEmptyThreadRecord();
+    const partialRecord = {
+      ...record,
+      narrativeByMessage: null,
+      pendingTurnPersistMessageIds: null,
+    } as unknown as typeof record;
+    useThreadStore.setState({
+      currentThreadId: "thread-1",
+      records: new Map([["thread-1", partialRecord]]),
+    });
+
+    expect(() => render(<SubagentsPanel threadId="thread-1" />)).not.toThrow();
+    const normalized = getThreadRecord(useThreadStore.getState().records, "thread-1");
+    expect(normalized.narrativeByMessage).toEqual({});
+    expect(normalized.pendingTurnPersistMessageIds).toEqual([]);
+  });
+
+  it("normalizes missing pending persistence ids when narrative data exists", () => {
+    const record = createEmptyThreadRecord();
+    const partialRecord = {
+      ...record,
+      pendingTurnPersistMessageIds: undefined,
+    } as unknown as typeof record;
+    useThreadStore.setState({
+      currentThreadId: "thread-1",
+      records: new Map([["thread-1", partialRecord]]),
+    });
+
+    expect(() => render(<SubagentsPanel threadId="thread-1" />)).not.toThrow();
+    expect(
+      getThreadRecord(useThreadStore.getState().records, "thread-1").pendingTurnPersistMessageIds,
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/stores/thread-record.ts
+++ b/apps/web/src/stores/thread-record.ts
@@ -141,6 +141,8 @@ const DEFAULT_THREAD_SETTINGS: ThreadSettings = {
   permissionMode: PERMISSION_MODES.FULL,
   interactionMode: INTERACTION_MODES.BUILD,
 };
+const EMPTY_PENDING_TURN_PERSIST_MESSAGE_IDS: string[] = [];
+const EMPTY_NARRATIVE_BY_MESSAGE: ThreadNarrativeByMessage = {};
 
 /** Returns a fresh empty {@link ThreadRecord} for lazy Map insertion. */
 export function createEmptyThreadRecord(): ThreadRecord {
@@ -186,16 +188,25 @@ export function createEmptyThreadRecord(): ThreadRecord {
   };
 }
 
-/** Read a thread record, returning a fresh empty record when absent. */
+/** Read a thread record, normalizing missing nullable persistence fields. */
 export function getThreadRecord(
   records: Map<string, ThreadRecord>,
   threadId: string,
 ): ThreadRecord {
   const record = records.get(threadId);
   if (!record) return createEmptyThreadRecord();
-  return record.pendingTurnPersistMessageIds === undefined
-    ? { ...record, pendingTurnPersistMessageIds: [] }
-    : record;
+  if (
+    record.pendingTurnPersistMessageIds != null
+    && record.narrativeByMessage != null
+  ) {
+    return record;
+  }
+  return {
+    ...record,
+    pendingTurnPersistMessageIds:
+      record.pendingTurnPersistMessageIds ?? EMPTY_PENDING_TURN_PERSIST_MESSAGE_IDS,
+    narrativeByMessage: record.narrativeByMessage ?? EMPTY_NARRATIVE_BY_MESSAGE,
+  };
 }
 
 /** Immutable Map update with a partial or functional patch for one thread. */


### PR DESCRIPTION
## What
Prevent the Subagents panel from crashing when thread hydration yields a partial record.

## Why
Production renderer logs captured repeated crashes in `SubagentsPanel`. A transient record could omit `narrativeByMessage`, causing the panel to call `Object.values` with `undefined` or `null`.

## Key Changes
- Normalize nullish narrative data and pending persistence IDs at the thread-record boundary with stable empty values.
- Add real-store regression coverage for both `undefined` and `null` partial records.
- Verify the actual Subagents panel and Zustand stores in the running web app with no page or console errors.

Verification: 12 Subagents tests pass, 24 record-cache tests pass, typecheck passes, and lint passes. The related web gate passed 1,535 tests before one unrelated PR-summary test timed out; that test passed immediately in isolation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788126755&installation_model_id=20477&pr_number=1036&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1036&signature=7e661b5df4b1392ff8bf28fc1a0d13637e048b376dd6f214063c87272f851138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading older or incomplete thread records.
  - Missing narrative and pending persistence data now display safely with empty defaults.
  - Prevented issues in the Subagents panel when thread data is unavailable or still being saved.

- **Tests**
  - Added integration coverage for incomplete, null, and pending thread data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->