### PR TITLE
refactor(browser): establish BrowserSessionDriver seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -961,6 +961,16 @@ automation. A host advertises only tabs that it currently owns and can stop
 advertising a tab when that page is replaced, discarded, or closed.
 _Avoid_: treating a saved Preview tab record as a live automation target
 
+The host routes every Browser v1 command through one client-side
+`BrowserSessionDriver`. The driver selects the web or Electron runtime adapter;
+the adapter owns runtime execution while the Electron kernel retains Chromium
+and CDP mechanics. `BrowserTargetRegistry` owns logical target identity outside
+React. React attaches or detaches runtime handles and projects registry state;
+ordinary remounts do not release a logical target. Authoritative tab, thread,
+and workspace deletion releases the record. The broker remains responsible for
+credentials, routing, cancellation, capacity, and liveness, while MCP remains
+schema and authority translation.
+
 ### Browser controller
 The current actor with control of a Preview tab: the user, an agent, or neither.
 Direct user input takes control from the agent and stops the active Browser

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -1217,10 +1217,10 @@ export function BrowserAutomationHost() {
           lease.generation,
           failureResponse(request, "TAB_UNAVAILABLE", cause instanceof Error ? cause.message : "Browser open failed"),
         );
-      }).finally(() => {
-        void restoreBackgroundContext();
+      }).finally(async () => {
+        await restoreBackgroundContext();
         if (createdTabId && !bootstrapSucceeded) {
-          void window.desktopBridge?.preview?.tabs.close?.(request.threadId, createdTabId);
+          await usePreviewTabsStore.getState().closePage(request.threadId, createdTabId);
         }
         window.clearTimeout(deadlineTimer);
         if (bootstrapAbortRef.current.get(key) === controller) bootstrapAbortRef.current.delete(key);

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -1218,9 +1218,17 @@ export function BrowserAutomationHost() {
           failureResponse(request, "TAB_UNAVAILABLE", cause instanceof Error ? cause.message : "Browser open failed"),
         );
       }).finally(async () => {
-        await restoreBackgroundContext();
+        try {
+          await restoreBackgroundContext();
+        } catch {
+          // Restoration failure must not skip closing a tab created for this bootstrap.
+        }
         if (createdTabId && !bootstrapSucceeded) {
-          await usePreviewTabsStore.getState().closePage(request.threadId, createdTabId);
+          try {
+            await usePreviewTabsStore.getState().closePage(request.threadId, createdTabId);
+          } catch {
+            // Keep finalizer cleanup settled; closePage preserves logical records on physical failure.
+          }
         }
         window.clearTimeout(deadlineTimer);
         if (bootstrapAbortRef.current.get(key) === controller) bootstrapAbortRef.current.delete(key);

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -28,8 +28,6 @@ import { useDiffStore } from "@/stores/diffStore";
 import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { BrowserAutomationRecorder } from "./browserAutomationRecorder";
 import {
-  executeWebInteraction,
-  observeWebHumanInput,
   resolveSameOriginFrame,
 } from "./webBrowserInteractionExecutor";
 import { PreviewPanel, WEB_RUNTIME_PREVIEW_TAB_ID } from "./PreviewPanel";
@@ -40,6 +38,8 @@ import {
 } from "./browserAutomationRuntime";
 import { executeWebBrowserDispatch } from "./browserAutomationWebExecutor";
 import { captureVisibleWebLocation, sanitizeWebLocation } from "./web-browser-automation/capture";
+import { BrowserSessionDriver, ElectronBrowserSessionAdapter } from "@/services/browser-automation/browserSessionDriver";
+import { WebBrowserSessionAdapter } from "@/services/browser-automation/webBrowserSessionAdapter";
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
 const UNAVAILABLE_OPERATIONS = new Map<BrowserAutomationOperation, string>([
@@ -486,6 +486,7 @@ export function BrowserAutomationHost() {
   const requestAbortRef = useRef(new Map<string, AbortController>());
   const webAbortRef = useRef(new Map<string, AbortController>());
   const webObserverRef = useRef(new Map<string, () => void>());
+  const webHumanCancelRef = useRef(new Map<string, () => void>());
   const webNavigationRef = useRef(new Map<string, WebNavigationExpectation>());
   const bootstrapPendingRef = useRef(new Set<string>());
   const bootstrapAbortRef = useRef(new Map<string, AbortController>());
@@ -493,6 +494,37 @@ export function BrowserAutomationHost() {
   const priorLiveTargetKeysRef = useRef(new Set<string>());
   const priorLiveTargetRevisionsRef = useRef(new Map<string, number>());
   const cancelledRef = useRef(new Set<string>());
+  const sessionDriverRef = useRef<BrowserSessionDriver | null>(null);
+  if (!sessionDriverRef.current) {
+    const webAdapter = new WebBrowserSessionAdapter({
+      resolveDocument: (dispatch) => {
+        const selector = `iframe[data-thread-id="${escapeWebSelector(dispatch.target.threadId)}"][data-tab-id="${escapeWebSelector(dispatch.target.tabId)}"]`;
+        for (const iframe of document.querySelectorAll<HTMLIFrameElement>(selector)) {
+          const resolved = resolveSameOriginFrame(iframe);
+          if (resolved) return resolved.document;
+        }
+        return null;
+      },
+      resolveSignal: (dispatch, signal) => webAbortRef.current.get(browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence))?.signal ?? signal,
+      getControlEpoch: (dispatch) => {
+        const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+        return useBrowserAutomationStore.getState().controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch;
+      },
+      getTargetGeneration: (dispatch) => {
+        const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+        return useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision ?? 0;
+      },
+      onHumanInput: (dispatch) => webHumanCancelRef.current.get(browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence))?.(),
+      onObserver: (dispatch, dispose) => webObserverRef.current.set(browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence), dispose),
+      executeNonInteraction: (dispatch, signal) => executeBrowserDispatch(undefined, recorderRef.current, dispatch, signal),
+    });
+    sessionDriverRef.current = new BrowserSessionDriver({
+      web: webAdapter,
+      electron: new ElectronBrowserSessionAdapter(
+        (dispatch, signal) => executeBrowserDispatch(window.desktopBridge?.preview?.automation, recorderRef.current, dispatch, signal),
+      ),
+    });
+  }
   const stableHostId = useMemo(hostId, []);
   const [backgroundScopes, setBackgroundScopes] = useState<readonly BackgroundBrowserScope[]>([]);
   const backgroundScopesRef = useRef<readonly BackgroundBrowserScope[]>([]);
@@ -819,31 +851,21 @@ export function BrowserAutomationHost() {
           "human-interrupted",
         ).catch(() => undefined);
       };
+      if (webDispatch) webHumanCancelRef.current.set(key, cancelForHuman);
       const executeWeb = async (): Promise<BrowserAutomationResponse> => {
         if (staleAtStart) {
           return failureResponse(dispatch.request, !liveTarget || liveTarget.revision !== dispatch.target.targetGeneration ? "STALE_TARGET_GENERATION" : "STALE_CONTROL_EPOCH", "Browser operation is stale");
         }
         if (!operationAbort) return failureResponse(dispatch.request, "TAB_UNAVAILABLE", "Browser target is unavailable");
-        const selector = `iframe[data-thread-id="${escapeWebSelector(dispatch.target.threadId)}"][data-tab-id="${escapeWebSelector(dispatch.target.tabId)}"]`;
-        const targetDocument = resolveSameOriginFrame(document.querySelector<HTMLIFrameElement>(selector));
-        if (!targetDocument) return failureResponse(dispatch.request, "TAB_UNAVAILABLE", "Browser target is unavailable");
-        webObserverRef.current.set(key, observeWebHumanInput(targetDocument.document, cancelForHuman));
-        return executeWebInteraction(targetDocument.document, dispatch, {
-          signal: operationAbort.signal,
-          deadline: dispatch.request.deadline,
-          expectedControlEpoch: dispatch.request.expectedControlEpoch,
-          targetGeneration: dispatch.target.targetGeneration,
-          getControlEpoch: () => useBrowserAutomationStore.getState().controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch,
-          getTargetGeneration: () => useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision ?? 0,
-        });
+        return sessionDriverRef.current!.execute(dispatch, controller.signal);
       };
       const executeWebOpen = async (): Promise<BrowserAutomationResponse> => {
         if (!webOpenRequest || dispatch.request.operation !== "open" || !dispatch.request.args.url) {
-          return executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal);
+          return sessionDriverRef.current!.execute(dispatch, controller.signal);
         }
         const requestedUrl = normalizeWebPreviewUrl(dispatch.request.args.url);
         if (!requestedUrl || !isSameOriginWebPreviewUrl(requestedUrl)) {
-          return executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal);
+          return sessionDriverRef.current!.execute(dispatch, controller.signal);
         }
         const currentTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
         if (!currentTarget || currentTarget.revision !== dispatch.target.targetGeneration) {
@@ -896,14 +918,14 @@ export function BrowserAutomationHost() {
             args: { activate: dispatch.request.args.activate },
           },
         };
-        return executeBrowserDispatch(bridge, recorderRef.current, executionDispatch, controller.signal);
+        return sessionDriverRef.current!.execute(executionDispatch, controller.signal);
       };
       const operation = webDispatch
         ? executeWeb()
         : webOpenRequest
           ? executeWebOpen()
         : bridge || webExecutorDispatch
-          ? executeBrowserDispatch(bridge, recorderRef.current, dispatch, controller.signal)
+          ? sessionDriverRef.current!.execute(dispatch, controller.signal)
           : Promise.resolve(failureResponse(dispatch.request, "UNSUPPORTED_OPERATION", WEB_AUTOMATION_UNAVAILABLE_REASON));
       const guardedOperation = operation.then((response) => {
         if (!bridge && webAutomationEnabled && (webDispatch || webOpenRequest || webNavigateRequest)) {
@@ -947,6 +969,7 @@ export function BrowserAutomationHost() {
       }).catch(() => undefined).finally(() => {
         webObserverRef.current.get(key)?.();
         webObserverRef.current.delete(key);
+        webHumanCancelRef.current.delete(key);
         webAbortRef.current.delete(key);
         webNavigationRef.current.delete(key);
         if (inFlightRef.current.get(key) === dispatch) inFlightRef.current.delete(key);
@@ -1176,7 +1199,7 @@ export function BrowserAutomationHost() {
               },
             }
           : dispatch;
-        const response = await executeBrowserDispatch(bridge, recorderRef.current, executionDispatch, controller.signal);
+        const response = await sessionDriverRef.current!.execute(executionDispatch, controller.signal);
         await restoreBackgroundContext();
         if (leaseRef.current === lease && !cancelledRef.current.has(key)) {
           await getTransport().respondToBrowserAutomationRequest(
@@ -1307,6 +1330,7 @@ export function BrowserAutomationHost() {
     for (const dispose of webObserverRef.current.values()) dispose();
     webAbortRef.current.clear();
     webObserverRef.current.clear();
+    webHumanCancelRef.current.clear();
   }, []);
 
   return backgroundScopes.map((scope) => (

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1559,7 +1559,7 @@ function WebRuntimePreview({
       WEB_RUNTIME_PREVIEW_TAB_ID,
     );
     return () => {
-      useBrowserAutomationStore.getState().unregisterTarget(
+      useBrowserAutomationStore.getState().detachTarget(
         threadId,
         WEB_RUNTIME_PREVIEW_TAB_ID,
       );

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -274,7 +274,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       el.addEventListener("load", onLoad);
       return () => {
         el.removeEventListener("load", onLoad);
-        useBrowserAutomationStore.getState().unregisterTarget(threadId, tabId);
+        useBrowserAutomationStore.getState().detachTarget(threadId, tabId);
       };
     }
     if (!window.desktopBridge?.preview?.adoptWebview) return;
@@ -307,7 +307,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       } catch {
         /* webview gone */
       }
-      useBrowserAutomationStore.getState().unregisterTarget(threadId, tabId);
+      useBrowserAutomationStore.getState().detachTarget(threadId, tabId);
       void window.desktopBridge?.preview?.releaseWebview?.({ threadId, tabId });
     };
   }, [threadId, tabId, workspaceId]);

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -15,6 +15,7 @@ import {
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore } from "@/stores/diffStore";
 import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import { browserTargetRegistry } from "@/services/browser-automation/browserTargetRegistry";
 
 const harness = vi.hoisted(() => {
   const listeners = new Map<string, Set<(payload: unknown) => void>>();
@@ -236,6 +237,7 @@ describe("BrowserAutomationHost", () => {
       hostedScopeIds: new Set(),
     });
     usePreviewTabsStore.setState({ tabSetByScope: {}, liveChromeByScope: {} });
+    browserTargetRegistry.clear();
     useBrowserAutomationStore.getState().registerTarget(
       "workspace-1",
       "thread-1",
@@ -1505,6 +1507,35 @@ describe("BrowserAutomationHost", () => {
     await act(async () => executing.promise);
     expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
     await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "created-tab"));
+    expect(browserTargetRegistry.get("thread-1", "created-tab")).toBeNull();
+    view.unmount();
+  });
+
+  it("releases a bootstrap-created target when bootstrap fails before execution", async () => {
+    useBrowserAutomationStore.setState({ liveTargets: new Map() });
+    createTab.mockImplementation(async (threadId: string) => {
+      useBrowserAutomationStore.getState().registerTarget("workspace-1", threadId, "failed-tab");
+      return {
+        ok: true,
+        data: {
+          tabId: "failed-tab",
+          tabs: { threadId, activeTabId: "failed-tab", tabs: [{ id: "failed-tab", threadId, url: null, title: null, faviconUrl: null, warm: true }] },
+        },
+      };
+    });
+    describeTarget.mockImplementation(async ({ tabId }: { readonly tabId: string }) =>
+      tabId === "failed-tab"
+        ? { ok: false, error: "target unavailable" }
+        : { ok: true, target: { windowId: 7, threadId: "thread-1", tabId, targetGeneration: 3, active: true, focused: true, lastUsedAt: 10 } },
+    );
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const request = dispatch(1, 13).request;
+    const openRequest = { ...request, operation: "open" as const, args: { url: "https://example.com/", activate: true } };
+    act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
+    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "failed-tab"));
+    expect(browserTargetRegistry.get("thread-1", "failed-tab")).toBeNull();
     view.unmount();
   });
 

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -1539,6 +1539,74 @@ describe("BrowserAutomationHost", () => {
     view.unmount();
   });
 
+  it("attempts created-tab close when background restoration rejects", async () => {
+    useBrowserAutomationStore.setState({ liveTargets: new Map() });
+    usePreviewTabsStore.setState({
+      tabSetByScope: {
+        "thread-1": {
+          threadId: "thread-1",
+          activeTabId: "previous-tab",
+          tabs: [{ id: "previous-tab", threadId: "thread-1", url: null, title: null, faviconUrl: null, warm: true, active: true }],
+        },
+      },
+    });
+    createTab.mockImplementation(async (threadId: string) => {
+      useBrowserAutomationStore.getState().registerTarget("workspace-1", threadId, "restore-failure-tab");
+      return {
+        ok: true,
+        data: {
+          tabId: "restore-failure-tab",
+          tabs: { threadId, activeTabId: "restore-failure-tab", tabs: [{ id: "restore-failure-tab", threadId, url: null, title: null, faviconUrl: null, warm: true }] },
+        },
+      };
+    });
+    describeTarget.mockImplementation(async ({ tabId }: { readonly tabId: string }) => ({
+      ok: true,
+      target: { windowId: 7, threadId: "thread-1", tabId, targetGeneration: 1, active: true, focused: true, lastUsedAt: 10 },
+    }));
+    execute.mockRejectedValueOnce(new Error("bootstrap execution failed"));
+    const activatePage = vi.fn().mockRejectedValue(new Error("restore activation failed"));
+    usePreviewTabsStore.setState({ activatePage });
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const request = dispatch(1, 15).request;
+    const openRequest = { ...request, operation: "open" as const, args: { url: "https://example.com/", activate: false } };
+    act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
+    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "restore-failure-tab"));
+    expect(activatePage).toHaveBeenCalledWith("thread-1", "previous-tab");
+    expect(browserTargetRegistry.get("thread-1", "restore-failure-tab")).toBeNull();
+    view.unmount();
+  });
+
+  it("retains logical target when created-tab physical close fails", async () => {
+    useBrowserAutomationStore.setState({ liveTargets: new Map() });
+    createTab.mockImplementation(async (threadId: string) => {
+      useBrowserAutomationStore.getState().registerTarget("workspace-1", threadId, "close-failure-tab");
+      return {
+        ok: true,
+        data: {
+          tabId: "close-failure-tab",
+          tabs: { threadId, activeTabId: "close-failure-tab", tabs: [{ id: "close-failure-tab", threadId, url: null, title: null, faviconUrl: null, warm: true }] },
+        },
+      };
+    });
+    describeTarget.mockResolvedValue({
+      ok: false,
+      error: "target unavailable",
+    });
+    closeTab.mockResolvedValueOnce({ ok: false, error: "physical close failed" });
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const request = dispatch(1, 17).request;
+    const openRequest = { ...request, operation: "open" as const, args: { url: "https://example.com/", activate: true } };
+    act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
+    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "close-failure-tab"));
+    expect(browserTargetRegistry.get("thread-1", "close-failure-tab")).not.toBeNull();
+    view.unmount();
+  });
+
   it("does not mutate the renderer when its desktop operation lease is stale", async () => {
     beginRendererOperation.mockResolvedValueOnce({
       ok: false,

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -74,6 +74,7 @@ vi.mock("../webBrowserInteractionExecutor", async (importOriginal) => {
 
 import { BrowserAutomationHost, isBrowserAutomationWebRuntimeEnabled } from "../BrowserAutomationHost";
 import { BrowserAutomationRecorder } from "../browserAutomationRecorder";
+import { BrowserSessionDriver } from "@/services/browser-automation/browserSessionDriver";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -246,6 +247,36 @@ describe("BrowserAutomationHost", () => {
     expect(isBrowserAutomationWebRuntimeEnabled({})).toBe(false);
     expect(isBrowserAutomationWebRuntimeEnabled({ VITE_MCODE_WEB_AUTOMATION: "0" })).toBe(false);
     expect(isBrowserAutomationWebRuntimeEnabled({ VITE_MCODE_WEB_AUTOMATION: "1" })).toBe(true);
+  });
+
+  it("enters BrowserSessionDriver for broker-dispatched web and Electron commands", async () => {
+    execute.mockResolvedValue(successResponse(dispatch(1, 91).request));
+    const driverExecute = vi.spyOn(BrowserSessionDriver.prototype, "execute");
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: dispatch(1, 91) }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(driverExecute).toHaveBeenCalledWith(expect.objectContaining({ request: expect.objectContaining({ operation: "status" }) }), expect.any(AbortSignal));
+    view.unmount();
+    driverExecute.mockRestore();
+    execute.mockReset();
+  });
+
+  it("enters BrowserSessionDriver before web adapter dispatch", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    const driverExecute = vi.spyOn(BrowserSessionDriver.prototype, "execute");
+    webExecutor.executeWebBrowserDispatch.mockResolvedValue(successResponse(dispatch(1, 92).request));
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: dispatch(1, 92) }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(driverExecute).toHaveBeenCalledWith(expect.objectContaining({ request: expect.objectContaining({ operation: "status" }) }), expect.any(AbortSignal));
+    view.unmount();
+    driverExecute.mockRestore();
+    webExecutor.executeWebBrowserDispatch.mockReset();
   });
 
   it("carries an initial web open URL into the visible preview state", async () => {

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserAutomationHostDispatch, BrowserAutomationResponse } from "@mcode/contracts";
+import { BrowserSessionDriver, ElectronBrowserSessionAdapter } from "./browserSessionDriver";
+import { WebBrowserSessionAdapter } from "./webBrowserSessionAdapter";
+
+const response = {} as BrowserAutomationResponse;
+const dispatch = {} as BrowserAutomationHostDispatch;
+
+describe("BrowserSessionDriver", () => {
+  it("routes the same command boundary to each runtime adapter", async () => {
+    const web = vi.fn().mockResolvedValue(response);
+    const electron = vi.fn().mockResolvedValue(response);
+    let electronRuntime = false;
+    const driver = new BrowserSessionDriver({
+      web: { execute: web },
+      electron: { execute: electron },
+      isElectron: () => electronRuntime,
+    });
+    const signal = new AbortController().signal;
+
+    await driver.execute(dispatch, signal);
+    electronRuntime = true;
+    await driver.execute(dispatch, signal);
+
+    expect(web).toHaveBeenCalledWith(dispatch, signal);
+    expect(electron).toHaveBeenCalledWith(dispatch, signal);
+  });
+
+  it("runs one Browser v1 click case through web and Electron adapter contracts", async () => {
+    const webButton = document.createElement("button");
+    webButton.id = "save";
+    webButton.textContent = "Save";
+    document.body.append(webButton);
+    Object.defineProperty(webButton, "getBoundingClientRect", { value: () => ({ width: 80, height: 20 }) });
+    const webAdapter = new WebBrowserSessionAdapter({
+      resolveDocument: () => document,
+      resolveSignal: (_dispatch, signal) => signal,
+      getControlEpoch: () => 0,
+      getTargetGeneration: () => 1,
+      onHumanInput: vi.fn(),
+      onObserver: (_dispatch, dispose) => dispose,
+      executeNonInteraction: vi.fn(),
+    });
+    const electronExecute = vi.fn().mockResolvedValue({ ok: true } as BrowserAutomationResponse);
+    const electronAdapter = new ElectronBrowserSessionAdapter(electronExecute);
+    const driver = new BrowserSessionDriver({ web: webAdapter, electron: electronAdapter, isElectron: () => false });
+    const clickDispatch = {
+      request: { operation: "click", deadline: Date.now() + 1_000, expectedControlEpoch: 0, args: { target: { cssSelector: "#save" }, button: "left", clickCount: 1 } },
+      target: { targetGeneration: 1, threadId: "thread", tabId: "tab" },
+    } as unknown as BrowserAutomationHostDispatch;
+    const webResponse = await driver.execute(clickDispatch, new AbortController().signal);
+    expect(webResponse.ok).toBe(true);
+    expect(electronExecute).not.toHaveBeenCalled();
+    const electronDriver = new BrowserSessionDriver({ web: webAdapter, electron: electronAdapter, isElectron: () => true });
+    await electronDriver.execute(clickDispatch, new AbortController().signal);
+    expect(electronExecute).toHaveBeenCalledWith(clickDispatch, expect.any(AbortSignal));
+    document.body.removeChild(webButton);
+  });
+});

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -1,0 +1,55 @@
+import type {
+  BrowserAutomationHostDispatch,
+  BrowserAutomationResponse,
+} from "@mcode/contracts";
+
+/** Runtime implementation used by the client BrowserSessionDriver. */
+export interface BrowserSessionRuntimeAdapter {
+  execute(
+    dispatch: BrowserAutomationHostDispatch,
+    signal: AbortSignal,
+  ): Promise<BrowserAutomationResponse>;
+}
+
+/** Renderer-side adapter that forwards Browser v1 commands to Electron preload. */
+export class ElectronBrowserSessionAdapter implements BrowserSessionRuntimeAdapter {
+  constructor(
+    private readonly executeRequest: (
+      dispatch: BrowserAutomationHostDispatch,
+      signal: AbortSignal,
+    ) => Promise<BrowserAutomationResponse>,
+  ) {}
+
+  execute(dispatch: BrowserAutomationHostDispatch, signal: AbortSignal): Promise<BrowserAutomationResponse> {
+    return this.executeRequest(dispatch, signal);
+  }
+}
+
+/** Runtime selection inputs for the single Browser v1 command boundary. */
+export interface BrowserSessionDriverOptions {
+  readonly web: BrowserSessionRuntimeAdapter;
+  readonly electron: BrowserSessionRuntimeAdapter;
+  readonly isElectron?: () => boolean;
+}
+
+/**
+ * Client orchestration boundary for Browser v1 commands. The driver chooses
+ * the active runtime adapter; broker transport and native Electron mechanics
+ * stay outside this class.
+ */
+export class BrowserSessionDriver {
+  private readonly isElectron: () => boolean;
+
+  constructor(private readonly options: BrowserSessionDriverOptions) {
+    this.isElectron = options.isElectron ?? (() => typeof window !== "undefined" && typeof window.desktopBridge?.preview === "object");
+  }
+
+  /** Dispatch one broker-authorized Browser v1 command through the active runtime adapter. */
+  execute(
+    dispatch: BrowserAutomationHostDispatch,
+    signal: AbortSignal,
+  ): Promise<BrowserAutomationResponse> {
+    return (this.isElectron() ? this.options.electron : this.options.web).execute(dispatch, signal);
+  }
+
+}

--- a/apps/web/src/services/browser-automation/browserTargetRegistry.test.ts
+++ b/apps/web/src/services/browser-automation/browserTargetRegistry.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { BrowserTargetRegistry } from "./browserTargetRegistry";
+
+describe("BrowserTargetRegistry", () => {
+  let registry: BrowserTargetRegistry;
+
+  beforeEach(() => {
+    registry = new BrowserTargetRegistry();
+  });
+
+  it("retains the logical record across detach and reattach", () => {
+    const first = registry.register("workspace", "thread", "tab");
+    registry.detach("thread", "tab");
+    const second = registry.register("workspace", "thread", "tab");
+
+    expect(second.revision).toBe(first.revision);
+    expect(registry.get("thread", "tab")?.attached).toBe(true);
+  });
+
+  it("releases records only for authoritative scopes", () => {
+    registry.register("workspace-a", "thread-a", "tab-a");
+    registry.register("workspace-b", "thread-b", "tab-b");
+    registry.detach("thread-a", "tab-a");
+    expect(registry.get("thread-a", "tab-a")).not.toBeNull();
+
+    registry.releaseThread("thread-a");
+    expect(registry.get("thread-a", "tab-a")).toBeNull();
+    expect(registry.get("thread-b", "tab-b")).not.toBeNull();
+
+    registry.releaseWorkspace("workspace-b");
+    expect(registry.get("thread-b", "tab-b")).toBeNull();
+  });
+});

--- a/apps/web/src/services/browser-automation/browserTargetRegistry.ts
+++ b/apps/web/src/services/browser-automation/browserTargetRegistry.ts
@@ -1,0 +1,90 @@
+/** Logical Browser target retained independently from React component lifetime. */
+export interface BrowserTargetRecord {
+  readonly workspaceId: string;
+  readonly threadId: string;
+  readonly tabId: string;
+  readonly revision: number;
+  readonly lastUsedAt: number;
+  readonly attached: boolean;
+}
+
+function key(threadId: string, tabId: string): string {
+  return JSON.stringify([threadId, tabId]);
+}
+
+/**
+ * Owns Browser target identity and lifetime. Detaching a renderer handle keeps
+ * the logical record warm; only an explicit scope release removes it.
+ */
+export class BrowserTargetRegistry {
+  private readonly records = new Map<string, BrowserTargetRecord>();
+
+  register(workspaceId: string, threadId: string, tabId: string): BrowserTargetRecord {
+    const targetKey = key(threadId, tabId);
+    const current = this.records.get(targetKey);
+    const next: BrowserTargetRecord = {
+      workspaceId,
+      threadId,
+      tabId,
+      revision: current?.revision ?? 1,
+      lastUsedAt: Date.now(),
+      attached: true,
+    };
+    this.records.set(targetKey, next);
+    return next;
+  }
+
+  /** Attach a runtime handle to an existing logical target, or create it. */
+  attach(workspaceId: string, threadId: string, tabId: string): BrowserTargetRecord {
+    return this.register(workspaceId, threadId, tabId);
+  }
+
+  refresh(threadId: string, tabId: string): BrowserTargetRecord | null {
+    const targetKey = key(threadId, tabId);
+    const current = this.records.get(targetKey);
+    if (!current) return null;
+    const next = { ...current, revision: current.revision + 1, lastUsedAt: Date.now(), attached: true };
+    this.records.set(targetKey, next);
+    return next;
+  }
+
+  detach(threadId: string, tabId: string): BrowserTargetRecord | null {
+    const targetKey = key(threadId, tabId);
+    const current = this.records.get(targetKey);
+    if (!current) return null;
+    const next = { ...current, attached: false };
+    this.records.set(targetKey, next);
+    return next;
+  }
+
+  releaseTarget(threadId: string, tabId: string): void {
+    this.records.delete(key(threadId, tabId));
+  }
+
+  releaseThread(threadId: string): void {
+    for (const [targetKey, target] of this.records) {
+      if (target.threadId === threadId) this.records.delete(targetKey);
+    }
+  }
+
+  releaseWorkspace(workspaceId: string): void {
+    for (const [targetKey, target] of this.records) {
+      if (target.workspaceId === workspaceId) this.records.delete(targetKey);
+    }
+  }
+
+  get(threadId: string, tabId: string): BrowserTargetRecord | null {
+    return this.records.get(key(threadId, tabId)) ?? null;
+  }
+
+  attached(): BrowserTargetRecord[] {
+    return [...this.records.values()].filter((target) => target.attached);
+  }
+
+  clear(): void {
+    this.records.clear();
+  }
+}
+
+/** Process-local logical Browser target registry. */
+export const browserTargetRegistry = new BrowserTargetRegistry();

--- a/apps/web/src/services/browser-automation/index.ts
+++ b/apps/web/src/services/browser-automation/index.ts
@@ -1,0 +1,2 @@
+export * from "./browserSessionDriver";
+export * from "./browserTargetRegistry";

--- a/apps/web/src/services/browser-automation/webBrowserSessionAdapter.ts
+++ b/apps/web/src/services/browser-automation/webBrowserSessionAdapter.ts
@@ -1,0 +1,67 @@
+import type {
+  BrowserAutomationHostDispatch,
+  BrowserAutomationResponse,
+} from "@mcode/contracts";
+import {
+  executeWebInteraction,
+  observeWebHumanInput,
+  type WebInteractionGuard,
+} from "@/components/panels/webBrowserInteractionExecutor";
+import type {
+  BrowserSessionRuntimeAdapter,
+} from "./browserSessionDriver";
+
+export interface WebBrowserSessionAdapterOptions {
+  resolveDocument: (dispatch: BrowserAutomationHostDispatch) => Document | null;
+  resolveSignal: (dispatch: BrowserAutomationHostDispatch, signal: AbortSignal) => AbortSignal;
+  getControlEpoch: (dispatch: BrowserAutomationHostDispatch) => number;
+  getTargetGeneration: (dispatch: BrowserAutomationHostDispatch) => number;
+  onHumanInput: (dispatch: BrowserAutomationHostDispatch) => void;
+  onObserver: (dispatch: BrowserAutomationHostDispatch, dispose: () => void) => void;
+  executeNonInteraction: (dispatch: BrowserAutomationHostDispatch, signal: AbortSignal) => Promise<BrowserAutomationResponse>;
+}
+
+function failureResponse(
+  dispatch: BrowserAutomationHostDispatch,
+  code: "TAB_UNAVAILABLE" | "UNSUPPORTED_OPERATION",
+  message: string,
+): BrowserAutomationResponse {
+  return {
+    contractVersion: dispatch.request.contractVersion,
+    requestId: dispatch.request.requestId,
+    sequence: dispatch.request.sequence,
+    ok: false,
+    error: { code, message, retryable: true },
+  };
+}
+
+/** Web runtime adapter for every Browser v1 command, including DOM interaction. */
+export class WebBrowserSessionAdapter implements BrowserSessionRuntimeAdapter {
+  constructor(private readonly options: WebBrowserSessionAdapterOptions) {}
+
+  async execute(
+    dispatch: BrowserAutomationHostDispatch,
+    signal: AbortSignal,
+  ): Promise<BrowserAutomationResponse> {
+    const operation = dispatch.request.operation;
+    if (operation !== "click" && operation !== "type") {
+      return this.options.executeNonInteraction(dispatch, signal);
+    }
+    const ownerDocument = this.options.resolveDocument(dispatch);
+    if (!ownerDocument) return failureResponse(dispatch, "TAB_UNAVAILABLE", "Browser target is unavailable");
+    const operationSignal = this.options.resolveSignal(dispatch, signal);
+    const guard: WebInteractionGuard = {
+      signal: operationSignal,
+      deadline: dispatch.request.deadline,
+      expectedControlEpoch: dispatch.request.expectedControlEpoch,
+      targetGeneration: dispatch.target.targetGeneration,
+      getControlEpoch: () => this.options.getControlEpoch(dispatch),
+      getTargetGeneration: () => this.options.getTargetGeneration(dispatch),
+    };
+    this.options.onObserver(
+      dispatch,
+      observeWebHumanInput(ownerDocument, () => this.options.onHumanInput(dispatch)),
+    );
+    return executeWebInteraction(ownerDocument, dispatch, guard);
+  }
+}

--- a/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
+++ b/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../browserAutomationStore";
 import { selectBrowserAutomationWorkspaceIds } from "@/components/panels/BrowserAutomationHost";
 import { reconcileWarmPreviewScopes } from "@/components/panels/RightPanel";
+import { browserTargetRegistry } from "@/services/browser-automation/browserTargetRegistry";
 
 function target(
   workspaceId: string,
@@ -127,6 +128,32 @@ describe("browser automation renderer scope", () => {
     expect(useBrowserAutomationStore.getState().activeRequests.has(
       browserAutomationRequestKey(newestRequestId, BROWSER_AUTOMATION_MAX_PENDING_REQUESTS),
     )).toBe(false);
+  });
+
+  it("does not reattach a detached target after a late refresh", () => {
+    const workspaceId = "workspace-late-refresh";
+    const threadId = "thread-late-refresh";
+    const tabId = "tab-late-refresh";
+    const key = browserAutomationTargetKey(threadId, tabId);
+    const store = useBrowserAutomationStore.getState();
+
+    store.unregisterTarget(threadId, tabId);
+    store.registerTarget(workspaceId, threadId, tabId);
+    const attachedRevision = useBrowserAutomationStore.getState().liveTargets.get(key)?.revision;
+    expect(attachedRevision).toBeDefined();
+
+    store.refreshTarget(threadId, tabId);
+    expect(useBrowserAutomationStore.getState().liveTargets.get(key)?.revision).toBe(
+      attachedRevision! + 1,
+    );
+
+    store.detachTarget(threadId, tabId);
+    store.refreshTarget(threadId, tabId);
+
+    expect(useBrowserAutomationStore.getState().liveTargets.has(key)).toBe(false);
+    expect(browserTargetRegistry.get(threadId, tabId)?.attached).toBe(false);
+
+    store.unregisterTarget(threadId, tabId);
   });
 
   it("routes authoritative thread and workspace cleanup to exact host scopes", () => {

--- a/apps/web/src/stores/__tests__/previewTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewTabsStore.test.ts
@@ -6,6 +6,8 @@ import {
   type PreviewLiveChrome,
 } from "../previewTabsStore";
 import { usePreviewFocusStore } from "../previewFocusStore";
+import { useBrowserAutomationStore } from "../browserAutomationStore";
+import { browserTargetRegistry } from "@/services/browser-automation/browserTargetRegistry";
 
 const SCOPE = "thread-1";
 
@@ -31,6 +33,7 @@ function mockBridge(handlers: {
   create?: BrowserTabSet;
   activate?: BrowserTabSet;
   close?: BrowserTabSet;
+  closeScope?: BrowserTabSet;
 }) {
   const create = vi.fn(async () => ({
     ok: true as const,
@@ -44,11 +47,17 @@ function mockBridge(handlers: {
     ok: true as const,
     data: handlers.close ?? set("a", [page("a")]),
   }));
+  const closeScope = vi.fn(async (): Promise<
+    { ok: true; data: BrowserTabSet } | { ok: false; error: string }
+  > => ({
+    ok: true as const,
+    data: handlers.closeScope ?? set(null, []),
+  }));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).desktopBridge = {
-    preview: { tabs: { create, activate, close, list: vi.fn(), onUpdated: vi.fn() } },
+    preview: { tabs: { create, activate, close, closeScope, list: vi.fn(), onUpdated: vi.fn() } },
   };
-  return { create, activate, close };
+  return { create, activate, close, closeScope };
 }
 
 describe("overlayDisplaySet", () => {
@@ -91,6 +100,7 @@ describe("previewTabsStore", () => {
   beforeEach(() => {
     usePreviewTabsStore.setState({ tabSetByScope: {}, liveChromeByScope: {} });
     usePreviewFocusStore.setState({ omniboxFocusTick: 0 });
+    browserTargetRegistry.clear();
   });
 
   afterEach(() => {
@@ -147,6 +157,29 @@ describe("previewTabsStore", () => {
     // The host recreates a blank fallback, but the Browser tab is gone; the
     // scope's set must clear rather than retain a phantom page.
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
+  });
+
+  it("clearScope releases every target after a successful scope close", async () => {
+    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "a");
+    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "b");
+    useBrowserAutomationStore.getState().registerTarget("workspace-1", "thread-2", "other");
+    const { closeScope } = mockBridge({});
+
+    await usePreviewTabsStore.getState().clearScope(SCOPE);
+
+    expect(closeScope).toHaveBeenCalledWith(SCOPE);
+    expect(browserTargetRegistry.get(SCOPE, "a")).toBeNull();
+    expect(browserTargetRegistry.get(SCOPE, "b")).toBeNull();
+    expect(browserTargetRegistry.get("thread-2", "other")).not.toBeNull();
+  });
+
+  it("clearScope retains targets when the physical scope close fails", async () => {
+    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "a");
+    const { closeScope } = mockBridge({});
+    closeScope.mockResolvedValueOnce({ ok: false, error: "scope close failed" });
+
+    await expect(usePreviewTabsStore.getState().clearScope(SCOPE)).rejects.toThrow("scope close failed");
+    expect(browserTargetRegistry.get(SCOPE, "a")).not.toBeNull();
   });
 
   it("setLiveChrome keeps the same reference when the chrome is unchanged", () => {

--- a/apps/web/src/stores/browserAutomationStore.ts
+++ b/apps/web/src/stores/browserAutomationStore.ts
@@ -4,6 +4,7 @@ import type {
 } from "@mcode/contracts";
 import { BROWSER_AUTOMATION_MAX_PENDING_REQUESTS } from "@mcode/contracts";
 import { create } from "zustand";
+import { browserTargetRegistry } from "@/services/browser-automation/browserTargetRegistry";
 
 /** Maximum number of inactive, non-busy Browser targets retained warm. */
 export const BROWSER_AUTOMATION_WARM_TARGET_LIMIT = 3;
@@ -36,7 +37,10 @@ interface BrowserAutomationState {
   readonly hostedScopeIds: ReadonlySet<string>;
   registerTarget: (workspaceId: string, threadId: string, tabId: string) => void;
   refreshTarget: (threadId: string, tabId: string) => void;
+  detachTarget: (threadId: string, tabId: string) => void;
   unregisterTarget: (threadId: string, tabId: string) => void;
+  releaseThreadTargets: (threadId: string) => void;
+  releaseWorkspaceTargets: (workspaceId: string) => void;
   setController: (state: BrowserAutomationControllerState) => void;
   setControllerForTarget: (
     threadId: string,
@@ -82,31 +86,37 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set) =>
   registerTarget: (workspaceId, threadId, tabId) =>
     set((state) => {
       const key = browserAutomationTargetKey(threadId, tabId);
-      const current = state.liveTargets.get(key);
+      const previous = browserTargetRegistry.get(threadId, tabId);
+      if (previous?.attached && !state.liveTargets.has(key)) {
+        browserTargetRegistry.releaseTarget(threadId, tabId);
+      }
+      const current = browserTargetRegistry.register(workspaceId, threadId, tabId);
       const liveTargets = new Map(state.liveTargets);
       liveTargets.set(key, {
         workspaceId,
         threadId,
         tabId,
-        revision: (current?.revision ?? 0) + 1,
-        lastUsedAt: Date.now(),
+        revision: current.revision,
+        lastUsedAt: current.lastUsedAt,
       });
       return { liveTargets };
     }),
   refreshTarget: (threadId, tabId) =>
     set((state) => {
       const key = browserAutomationTargetKey(threadId, tabId);
-      const current = state.liveTargets.get(key);
+      if (!state.liveTargets.has(key)) return state;
+      const current = browserTargetRegistry.refresh(threadId, tabId);
       if (!current) return state;
       const liveTargets = new Map(state.liveTargets);
       liveTargets.set(key, {
         ...current,
-        revision: current.revision + 1,
+        revision: current.revision,
         lastUsedAt: Date.now(),
       });
       return { liveTargets };
     }),
-  unregisterTarget: (threadId, tabId) =>
+  detachTarget: (threadId, tabId) => {
+    browserTargetRegistry.detach(threadId, tabId);
     set((state) => {
       const key = browserAutomationTargetKey(threadId, tabId);
       if (!state.liveTargets.has(key)) return state;
@@ -117,7 +127,54 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set) =>
       const viewportByTarget = new Map(state.viewportByTarget);
       viewportByTarget.delete(key);
       return { liveTargets, controllers, viewportByTarget };
-    }),
+    });
+  },
+  unregisterTarget: (threadId, tabId) => {
+    browserTargetRegistry.releaseTarget(threadId, tabId);
+    set((state) => {
+      const key = browserAutomationTargetKey(threadId, tabId);
+      if (!state.liveTargets.has(key)) return state;
+      const liveTargets = new Map(state.liveTargets);
+      liveTargets.delete(key);
+      const controllers = new Map(state.controllers);
+      controllers.delete(key);
+      const viewportByTarget = new Map(state.viewportByTarget);
+      viewportByTarget.delete(key);
+      return { liveTargets, controllers, viewportByTarget };
+    });
+  },
+  releaseThreadTargets: (threadId) => {
+    browserTargetRegistry.releaseThread(threadId);
+    set((state) => {
+      const liveTargets = new Map(state.liveTargets);
+      const controllers = new Map(state.controllers);
+      const viewportByTarget = new Map(state.viewportByTarget);
+      for (const target of state.liveTargets.values()) {
+        if (target.threadId !== threadId) continue;
+        const key = browserAutomationTargetKey(target.threadId, target.tabId);
+        liveTargets.delete(key);
+        controllers.delete(key);
+        viewportByTarget.delete(key);
+      }
+      return { liveTargets, controllers, viewportByTarget };
+    });
+  },
+  releaseWorkspaceTargets: (workspaceId) => {
+    browserTargetRegistry.releaseWorkspace(workspaceId);
+    set((state) => {
+      const liveTargets = new Map(state.liveTargets);
+      const controllers = new Map(state.controllers);
+      const viewportByTarget = new Map(state.viewportByTarget);
+      for (const target of state.liveTargets.values()) {
+        if (target.workspaceId !== workspaceId) continue;
+        const key = browserAutomationTargetKey(target.threadId, target.tabId);
+        liveTargets.delete(key);
+        controllers.delete(key);
+        viewportByTarget.delete(key);
+      }
+      return { liveTargets, controllers, viewportByTarget };
+    });
+  },
   setController: (controller) =>
     set((state) => {
       const target = resolveBrowserAutomationControllerTarget(state.liveTargets.values(), controller);
@@ -192,11 +249,13 @@ export function onBrowserAutomationScopeRelease(listener: ScopeReleaseListener):
 
 /** Release the persistent Browser surface owned by one deleted thread. */
 export function releaseBrowserAutomationThreadScope(threadId: string): void {
+  useBrowserAutomationStore.getState().releaseThreadTargets(threadId);
   for (const listener of scopeReleaseListeners) listener({ threadId });
 }
 
 /** Release all persistent Browser surfaces owned by one deleted workspace. */
 export function releaseBrowserAutomationWorkspaceScopes(workspaceId: string): void {
+  useBrowserAutomationStore.getState().releaseWorkspaceTargets(workspaceId);
   for (const listener of scopeReleaseListeners) listener({ workspaceId });
 }
 

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -213,6 +213,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     const tabs = bridgeTabs();
     const r = await tabs?.closeScope?.(scopeId);
     if (r && !r.ok) throw new Error(r.error);
+    useBrowserAutomationStore.getState().releaseThreadTargets(scopeId);
     set((s) => {
       const tabSetByScope = { ...s.tabSetByScope };
       const liveChromeByScope = { ...s.liveChromeByScope };

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -201,6 +201,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     get().setLiveChrome(scopeId, null);
     const r = await tabs.close(scopeId, tabId);
     if (!r.ok) return;
+    useBrowserAutomationStore.getState().unregisterTarget(scopeId, tabId);
     // Closing the last page collapses the Browser tab. The host always recreates
     // a blank fallback page in its returned set, but the tab is gone from the
     // rail, so drop the scope's set rather than leave that fallback as a phantom

--- a/docs/specs/2026-07-28-browser-automation-web-dev.md
+++ b/docs/specs/2026-07-28-browser-automation-web-dev.md
@@ -17,6 +17,11 @@ makes web development mode behave differently from the desktop path.
 The solution must keep one shared page state for the user and the agent. It must
 also preserve the existing Electron control path, broker authority, security
 boundaries, tab identity, cancellation behavior, and bounded browser payloads.
+The client boundary is shared by both runtimes: `BrowserSessionDriver` is the
+single Browser v1 command entry, `BrowserTargetRegistry` owns logical target
+lifetime outside React, and web and Electron provide one runtime-adapter
+contract. React only projects registry state and attaches or detaches runtime
+handles. Broker and MCP ownership remain unchanged.
 
 ## Solution
 
@@ -161,19 +166,24 @@ or extension bridge if product requirements justify that boundary.
 13. **Electron preservation.** The Electron path keeps its current visible
     preview, adoption, CDP, capture, and security behavior. Web mode selects a
     different executor behind the host capability boundary.
-14. **Contract compatibility.** Shared schemas remain provider-neutral. Any new
+14. **Client ownership.** `BrowserSessionDriver` selects the runtime adapter for
+    every Browser v1 dispatch. `BrowserTargetRegistry` retains logical records
+    across panel hiding, tab changes, thread switches, and ordinary remounts;
+    explicit tab, thread, or workspace deletion releases them. React does not
+    own target existence.
+15. **Contract compatibility.** Shared schemas remain provider-neutral. Any new
     web capability or error is added as a discriminated, bounded contract and
     consumed by every importing package.
-15. **UI behavior.** The Browser panel exposes a clear unavailable or disabled
+16. **UI behavior.** The Browser panel exposes a clear unavailable or disabled
     state in web mode and does not imply arbitrary browsing support.
-16. **Code structure phase.** After web behavior reaches a stable release
+17. **Code structure phase.** After web behavior reaches a stable release
     candidate, extract duplicated provider credential and browser-session
     lifecycle into a `BrowserAutomationSessionLease` service. The lease owns
     issue, refresh, expiry, revocation, pending cleanup, and shutdown release.
-17. **Provider boundaries.** The lease does not own provider-specific transport,
+18. **Provider boundaries.** The lease does not own provider-specific transport,
     restart or resume policy, environment overrides, MCP descriptor format, or
     provider event mapping.
-18. **Refactor sequence.** Add the lease and tests without callers, migrate one
+19. **Refactor sequence.** Add the lease and tests without callers, migrate one
     provider, verify, then migrate the remaining providers incrementally. Do not
     combine this extraction with the first web executor change.
 


### PR DESCRIPTION
## What

Routes the visible Preview Browser v1 workflow through a client-side `BrowserSessionDriver`, one logical target registry, and runtime adapters for web and Electron.

This PR remains draft because the current environment could not complete the required post-repair visible Electron close oracle.

## Why

Browser orchestration and target lifecycle policy were mixed into React host code. The new seam gives later Browser work one provider-neutral boundary while preserving the existing Browser v1 contract.

## Key Changes

- Adds the driver, logical registry, and web runtime adapter with focused compatibility tests.
- Preserves targets across hide, tab switch, thread switch, and ordinary remount flows.
- Releases targets only after authoritative tab or scope closes succeed.
- Keeps failed physical closes registered and settles bootstrap cleanup failures.
- Updates Browser automation ownership documentation.

Closes #1043

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788193697&installation_model_id=20477&pr_number=1059&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1059&signature=2ed6ad658ca741f060dfc7e43f49d357da499154fc8e1129e5d4969068a27ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Browser automation now uses a shared execution flow across web and Electron environments.
  - Improved support for browser interactions such as clicking and typing in web previews.
  - Browser targets now persist reliably across preview lifecycle changes.

- **Bug Fixes**
  - Prevented stale or detached browser targets from being recreated.
  - Improved cleanup when closing tabs, previews, threads, and workspaces.
  - Added safer recovery when automation or tab cleanup encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->