### PR TITLE
feat(browser): implement browser open vertical slice

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
@@ -350,6 +350,20 @@ describe("BrowserAutomationKernel", () => {
     });
   });
 
+  it("describes a native background tab without renderer adoption", () => {
+    const native = new FakeWebContents(9);
+    fakePreviewSession.tabsByThread.set("native-thread", {
+      threadId: "native-thread",
+      activeTabId: "native-tab",
+      tabs: [{ id: "native-tab", threadId: "native-thread", view: { webContents: native } as never }],
+    });
+    adoptedWebContents.set(JSON.stringify(["native-thread", "native-tab"]), null);
+    expect(kernel.describeTarget(event(), { threadId: "native-thread", tabId: "native-tab" })).toMatchObject({
+      ok: true,
+      target: { threadId: "native-thread", tabId: "native-tab" },
+    });
+  });
+
   it("issues media source ids only for the current exact adopted target", () => {
     expect(kernel.getMediaSourceId(event(), {
       windowId: 7,

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -1104,6 +1104,29 @@ describe("preview-browser", () => {
       expect(activated.data.activeTabId).toBe(created.data.tabId);
     });
 
+    it("warms an inactive-thread tab when activation is disabled", async () => {
+      const win = createWindow();
+      await showPreview(win, { threadId: "thread-A" });
+      const activeView = createdViews[0]!;
+      const viewsBeforeCreate = createdViews.length;
+
+      const created = callTabs<{
+        tabId: string;
+        tabs: { activeTabId: string | null; tabs: { id: string; warm: boolean }[] };
+      }>(win, "preview:tabs.create", {
+        threadId: "thread-B",
+        activate: false,
+      });
+
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+      expect(created.data.tabs.activeTabId).not.toBe(created.data.tabId);
+      expect(created.data.tabs.tabs.find((tab) => tab.id === created.data.tabId)?.warm).toBe(true);
+      expect(createdViews).toHaveLength(viewsBeforeCreate + 1);
+      expect(win.contentView.addChildView).toHaveBeenCalledTimes(1);
+      expect(win.contentView.children).toEqual([activeView]);
+    });
+
     it("tabs.close promotes a sibling when the active tab is removed", async () => {
       const win = createWindow();
       await showPreview(win, { threadId: "thread-A" });

--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -792,7 +792,10 @@ export class BrowserAutomationKernel {
       return { ok: false, error: "invalid-target" };
     }
     try {
-      const resolved = this.resolveCurrentTarget(event, threadId, tabId, true);
+      // Bootstrap-created native tabs are owned by main and are not renderer
+      // adopted webviews. Resolve their native WebContents so targetless opens
+      // can describe and dispatch without activating the visible panel.
+      const resolved = this.resolveCurrentTarget(event, threadId, tabId, false);
       const tabSet = getSession(resolved.window).tabsByThread.get(threadId);
       const tab = tabSet?.tabs.find((candidate) => candidate.id === tabId);
       return {
@@ -1232,7 +1235,11 @@ export class BrowserAutomationKernel {
             state.automationNavigationDepth -= 1;
           }
         }
-        return { operation: request.operation, ...base() };
+        return {
+          operation: request.operation,
+          ...base(),
+          ...(request.operation === "open" ? { observationRef: randomUUID() } : {}),
+        };
       }
       case "resize":
         throw new KernelError("UNSUPPORTED_OPERATION", "Renderer-hosted browser resize is unavailable", false);
@@ -1918,7 +1925,15 @@ export class BrowserAutomationKernel {
       requestId: request?.requestId ?? "invalid-request",
       sequence: request?.sequence ?? 0,
       ok: false,
-      error: { code: mapped.code, message: redactBrowserText(mapped.message), retryable: mapped.retryable },
+      error: {
+        code: mapped.code,
+        message: redactBrowserText(mapped.message),
+        retryable: mapped.retryable,
+        stage: mapped.code === "TAB_UNAVAILABLE" ? "allocation" : "effect",
+        effect: mapped.code === "TAB_UNAVAILABLE" ? "unknown" : "none",
+        recovery: mapped.retryable ? "retry" : "manual",
+        correlationId: randomUUID(),
+      },
     };
   }
 }

--- a/apps/desktop/src/main/preview/preview-tabs.ts
+++ b/apps/desktop/src/main/preview/preview-tabs.ts
@@ -182,6 +182,12 @@ export function registerTabHandlers(): void {
         activateTabView(win, s, newTab);
       } else if (activate) {
         set.activeTabId = tabId;
+      } else if (!activate) {
+        // Agent-owned tabs stay warm without mounting or selecting their view,
+        // including tabs created for an inactive thread. This preserves the
+        // user's visible page while allowing the automation kernel to attach
+        // to the newly-created target immediately.
+        ensureTabView(win, s, set.tabs[set.tabs.length - 1]!);
       }
 
       const tabs = buildTabSet(s, tid);

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -1002,6 +1002,250 @@ describe("BrowserAutomationBroker", () => {
     await expect(status).resolves.toMatchObject({ ok: true });
   });
 
+  it("creates one fresh target per keyed open while replaying duplicates", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        deliveries.push({ channel, data });
+        return true;
+      },
+    }));
+    const hostSocket = socket("fresh-open");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("fresh-open", "workspace-a"),
+      capabilities: [{ operation: "open", available: true }],
+    }, authorization("fresh-open")).generation;
+    const scope = {
+      ...claims("thread-a", "workspace-a"),
+      allowedOperations: ["open" as const],
+    };
+    const open = (requestId: string, sequence: number, key: string, url: string) => broker.execute(scope, {
+      ...request(scope, sequence),
+      requestId,
+      operation: "open",
+      args: { activate: false, idempotencyKey: key, url },
+    });
+    const first = open("open-a", 1, "key-a", "https://example.test/a");
+    const firstBootstrap = deliveries[0]!;
+    const firstTarget = {
+      desktopInstanceId: "desktop-fresh-open",
+      windowId: 1,
+      connectionGeneration: generation,
+      threadId: "thread-a",
+      tabId: "tab-a",
+      targetGeneration: 1,
+      active: false,
+      focused: false,
+      lastUsedAt: 10,
+    };
+    broker.respond(hostSocket, "fresh-open", generation, {
+      contractVersion: 1,
+      requestId: firstBootstrap.data.request.requestId,
+      sequence: firstBootstrap.data.request.sequence,
+      ok: true,
+      result: { operation: "open", url: "https://example.test/a", title: "A", controlEpoch: 0, observationRef: "obs-a" },
+    }, firstTarget);
+    await expect(first).resolves.toMatchObject({ ok: true, result: { observationRef: "obs-a" } });
+
+    const replay = await open("open-a-replay", 2, "key-a", "https://example.test/a");
+    expect(replay).toMatchObject({ ok: true, requestId: "open-a-replay", sequence: 2, result: { observationRef: "obs-a" } });
+    expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(1);
+
+    const second = open("open-b", 3, "key-b", "https://example.test/b");
+    const secondBootstrap = deliveries[1]!;
+    const secondTarget = { ...firstTarget, tabId: "tab-b", lastUsedAt: 11 };
+    broker.respond(hostSocket, "fresh-open", generation, {
+      contractVersion: 1,
+      requestId: secondBootstrap.data.request.requestId,
+      sequence: secondBootstrap.data.request.sequence,
+      ok: true,
+      result: { operation: "open", url: "https://example.test/b", title: "B", controlEpoch: 0, observationRef: "obs-b" },
+    }, secondTarget);
+    await expect(second).resolves.toMatchObject({ ok: true, result: { observationRef: "obs-b" } });
+    expect(secondBootstrap.data.request.args.url).toBe("https://example.test/b");
+    expect(secondTarget.tabId).not.toBe(firstTarget.tabId);
+    const bootstrapKeys = deliveries
+      .filter(({ channel }) => channel === "browserAutomation.bootstrap")
+      .map(({ data }) => data.request.args.idempotencyKey);
+    expect(bootstrapKeys).toEqual(["key-a", "key-b"]);
+
+    broker.updateTargets(hostSocket, "fresh-open", generation, []);
+    const afterClose = open("open-a-after-close", 4, "key-a", "https://example.test/a");
+    const afterCloseBootstrap = deliveries[2]!;
+    const replacementTarget = { ...firstTarget, tabId: "tab-c" };
+    broker.respond(hostSocket, "fresh-open", generation, {
+      contractVersion: 1,
+      requestId: afterCloseBootstrap.data.request.requestId,
+      sequence: afterCloseBootstrap.data.request.sequence,
+      ok: true,
+      result: { operation: "open", url: "https://example.test/a", title: "A2", controlEpoch: 0, observationRef: "obs-a2" },
+    }, replacementTarget);
+    await expect(afterClose).resolves.toMatchObject({ ok: true, result: { observationRef: "obs-a2" } });
+    expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(3);
+  });
+
+  it("drops keyed open replay when its host reconnects", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        deliveries.push({ channel, data });
+        return true;
+      },
+    }));
+    const firstSocket = socket("reconnect-first");
+    const firstGeneration = broker.registerHost(firstSocket, {
+      ...registration("reconnect-first", "workspace-a"),
+      capabilities: [{ operation: "open", available: true }],
+    }, authorization("reconnect-first")).generation;
+    const scope = { ...claims("thread-a", "workspace-a"), allowedOperations: ["open" as const] };
+    const open = (requestId: string, sequence: number) => broker.execute(scope, {
+      ...request(scope, sequence),
+      requestId,
+      operation: "open",
+      args: { activate: false, idempotencyKey: "reconnect-key", url: "https://example.test/reconnect" },
+    });
+    const first = open("reconnect-open-1", 1);
+    const firstBootstrap = deliveries[0]!;
+    const firstTarget = {
+      desktopInstanceId: "desktop-reconnect-first",
+      windowId: 1,
+      connectionGeneration: firstGeneration,
+      threadId: "thread-a",
+      tabId: "tab-first",
+      targetGeneration: 1,
+      active: false,
+      focused: false,
+      lastUsedAt: 10,
+    };
+    broker.respond(firstSocket, "reconnect-first", firstGeneration, {
+      contractVersion: 1,
+      requestId: firstBootstrap.data.request.requestId,
+      sequence: firstBootstrap.data.request.sequence,
+      ok: true,
+      result: { operation: "open", url: "https://example.test/reconnect", title: "First", controlEpoch: 0, observationRef: "obs-first" },
+    }, firstTarget);
+    await expect(first).resolves.toMatchObject({ ok: true, result: { observationRef: "obs-first" } });
+
+    broker.disconnect(firstSocket);
+    const replacementSocket = socket("reconnect-first");
+    const replacementGeneration = broker.registerHost(replacementSocket, {
+      ...registration("reconnect-first", "workspace-a"),
+      capabilities: [{ operation: "open", available: true }],
+    }, authorization("reconnect-first")).generation;
+    const second = open("reconnect-open-2", 2);
+    const secondBootstrap = deliveries[1]!;
+    const secondTarget = { ...firstTarget, connectionGeneration: replacementGeneration, tabId: "tab-second" };
+    broker.respond(replacementSocket, "reconnect-first", replacementGeneration, {
+      contractVersion: 1,
+      requestId: secondBootstrap.data.request.requestId,
+      sequence: secondBootstrap.data.request.sequence,
+      ok: true,
+      result: { operation: "open", url: "https://example.test/reconnect", title: "Second", controlEpoch: 0, observationRef: "obs-second" },
+    }, secondTarget);
+    await expect(second).resolves.toMatchObject({ ok: true, result: { observationRef: "obs-second" } });
+    expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(2);
+  });
+
+  it("retries a keyed open after a failed bootstrap", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        deliveries.push({ channel, data });
+        return true;
+      },
+    }));
+    const hostSocket = socket("failed-open");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("failed-open", "workspace-a"),
+      capabilities: [{ operation: "open", available: true }],
+    }, authorization("failed-open")).generation;
+    const scope = { ...claims("thread-a", "workspace-a"), allowedOperations: ["open" as const] };
+    const open = (requestId: string, sequence: number) => broker.execute(scope, {
+      ...request(scope, sequence),
+      requestId,
+      operation: "open",
+      args: { activate: false, idempotencyKey: "failed-key", url: "https://example.test/failed" },
+    });
+    const first = open("failed-open-1", 1);
+    const firstBootstrap = deliveries[0]!;
+    broker.respond(hostSocket, "failed-open", generation, {
+      contractVersion: 1,
+      requestId: firstBootstrap.data.request.requestId,
+      sequence: firstBootstrap.data.request.sequence,
+      ok: false,
+      error: { code: "HOST_UNAVAILABLE", message: "bootstrap failed", retryable: true },
+    });
+    await expect(first).resolves.toMatchObject({ ok: false, error: { code: "HOST_UNAVAILABLE" } });
+
+    const retry = open("failed-open-2", 2);
+    expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(2);
+    const retryBootstrap = deliveries[1]!;
+    broker.respond(hostSocket, "failed-open", generation, {
+      contractVersion: 1,
+      requestId: retryBootstrap.data.request.requestId,
+      sequence: retryBootstrap.data.request.sequence,
+      ok: false,
+      error: { code: "HOST_UNAVAILABLE", message: "retry failed", retryable: true },
+    });
+    await expect(retry).resolves.toMatchObject({ ok: false, error: { code: "HOST_UNAVAILABLE" } });
+  });
+
+  it("retries a pending keyed open after host disconnect", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        deliveries.push({ channel, data });
+        return true;
+      },
+    }));
+    const hostSocket = socket("pending-open");
+    broker.registerHost(hostSocket, {
+      ...registration("pending-open", "workspace-a"),
+      capabilities: [{ operation: "open", available: true }],
+    }, authorization("pending-open")).generation;
+    const scope = { ...claims("thread-a", "workspace-a"), allowedOperations: ["open" as const] };
+    const input = (requestId: string, sequence: number) => ({
+      ...request(scope, sequence),
+      requestId,
+      operation: "open" as const,
+      args: { activate: false, idempotencyKey: "pending-key", url: "https://example.test/pending" },
+    });
+    const first = broker.execute(scope, input("pending-open-1", 1));
+    broker.disconnect(hostSocket);
+    await expect(first).resolves.toMatchObject({ ok: false, error: { code: "HOST_UNAVAILABLE" } });
+
+    const replacementSocket = socket("pending-open-replacement");
+    const replacementGeneration = broker.registerHost(replacementSocket, {
+      ...registration("pending-open-replacement", "workspace-a"),
+      capabilities: [{ operation: "open", available: true }],
+    }, authorization("pending-open-replacement")).generation;
+    const retry = broker.execute(scope, input("pending-open-2", 2));
+    expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(2);
+    const retryBootstrap = deliveries[1]!;
+    broker.respond(replacementSocket, "pending-open-replacement", replacementGeneration, {
+      contractVersion: 1,
+      requestId: retryBootstrap.data.request.requestId,
+      sequence: retryBootstrap.data.request.sequence,
+      ok: true,
+      result: { operation: "open", url: "https://example.test/pending", title: "Retry", controlEpoch: 0 },
+    }, {
+      desktopInstanceId: "desktop-pending-open-replacement",
+      windowId: 1,
+      connectionGeneration: replacementGeneration,
+      threadId: "thread-a",
+      tabId: "tab-retry",
+      targetGeneration: 1,
+      active: false,
+      focused: false,
+      lastUsedAt: 10,
+    });
+    await expect(retry).resolves.toMatchObject({ ok: true });
+  });
+
   it("selects focused, then active, then most recently used matching targets", async () => {
     const deliveries: Array<{ socket: WebSocket; data: any }> = [];
     const broker = new BrowserAutomationBroker(options({

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -1,4 +1,5 @@
 import type { WebSocket } from "ws";
+import { randomUUID } from "node:crypto";
 import {
   BROWSER_AUTOMATION_CONTRACT_VERSION,
   BROWSER_AUTOMATION_MAX_PENDING_REQUESTS,
@@ -37,6 +38,14 @@ interface PendingRequest {
   resolve: (response: BrowserAutomationResponse) => void;
   timer: ReturnType<typeof setTimeout>;
   startedAt: number;
+}
+
+interface OpenReplayRecord {
+  readonly fingerprint: string;
+  readonly promise: Promise<BrowserAutomationResponse>;
+  host?: RegisteredHost;
+  target?: BrowserAutomationHostDispatchTarget;
+  lastUsedAt: number;
 }
 
 /** Content-free reliability counters for the browser automation broker. */
@@ -92,7 +101,15 @@ function failure(
     requestId: request.requestId,
     sequence: request.sequence,
     ok: false,
-    error: { code, message, retryable },
+    error: {
+      code,
+      message,
+      retryable,
+      stage: code === "TAB_UNAVAILABLE" ? "allocation" : "transport",
+      effect: code === "TAB_UNAVAILABLE" ? "unknown" : "none",
+      recovery: retryable ? "retry" : "manual",
+      correlationId: randomUUID(),
+    },
   };
 }
 
@@ -128,6 +145,17 @@ function pendingKey(host: RegisteredHost, requestId: string, sequence: number): 
 
 function targetKey(target: Pick<BrowserAutomationHostDispatchTarget, "threadId" | "tabId">): string {
   return JSON.stringify([target.threadId, target.tabId]);
+}
+
+function openReplayKey(
+  providerId: string,
+  request: Pick<BrowserAutomationRequest, "providerSessionId" | "workspaceId" | "threadId"> & {
+    args?: { idempotencyKey?: string };
+  },
+): string | null {
+  const key = request.args?.idempotencyKey;
+  if (!key) return null;
+  return JSON.stringify([providerId, request.providerSessionId, request.workspaceId, request.threadId, key]);
 }
 
 function targetsMatch(
@@ -197,6 +225,7 @@ export class BrowserAutomationBroker {
   private readonly hostHeartbeatTimeoutMs: number;
   private readonly maxHosts: number;
   private readonly maxTargets: number;
+  private readonly openReplay = new Map<string, OpenReplayRecord>();
   private nextGeneration = 1;
   private readonly reliability: BrowserAutomationReliabilityCounters = {
     dispatched: 0,
@@ -427,6 +456,16 @@ export class BrowserAutomationBroker {
         this.settle(key, pending, failure(pending.request, "INVALID_REQUEST", targetError, false));
         return;
       }
+      if (pending.request.operation === "open") {
+        const replayKey = openReplayKey(pending.providerId, pending.request);
+        if (replayKey) {
+          const replay = this.openReplay.get(replayKey);
+          if (replay) {
+            replay.host = pending.host;
+            replay.target = responseTarget;
+          }
+        }
+      }
     } else if (responseTarget && pending.target && !targetsMatch(responseTarget, pending.target)) {
       this.settle(
         key,
@@ -506,6 +545,53 @@ export class BrowserAutomationBroker {
 
   /** Executes one validated request under credential and host scope constraints. */
   execute(claims: BrowserAutomationCredentialClaims, input: unknown): Promise<BrowserAutomationResponse> {
+    const cutoff = this.now() - 30 * 60_000;
+    for (const [replayKey, record] of this.openReplay) {
+      if (record.lastUsedAt < cutoff) this.openReplay.delete(replayKey);
+    }
+    const parsed = BrowserAutomationRequestSchema().safeParse(input);
+    if (!parsed.success || parsed.data.operation !== "open") return this.executeInternal(claims, input);
+    const request = parsed.data;
+    const key = request.args.idempotencyKey;
+    if (!key) return this.executeInternal(claims, input);
+    const replayKey = openReplayKey(claims.providerId, request);
+    if (!replayKey) return this.executeInternal(claims, request);
+    const fingerprint = JSON.stringify({ url: request.args.url ?? null });
+    const existing = this.openReplay.get(replayKey);
+    if (existing) {
+      existing.lastUsedAt = this.now();
+      if (existing.fingerprint !== fingerprint) {
+        return Promise.resolve(failure(request, "IDEMPOTENCY_CONFLICT", "The idempotency key was already used with different browser_open arguments", false));
+      }
+      return existing.promise.then((response) => ({ ...response, requestId: request.requestId, sequence: request.sequence }));
+    }
+    const bootstrapHost = this.resolveBootstrapHost(claims, request);
+    if (!bootstrapHost) return this.executeInternal(claims, request);
+    let resolveReplay!: (response: BrowserAutomationResponse) => void;
+    const replayPromise = new Promise<BrowserAutomationResponse>((resolve) => {
+      resolveReplay = resolve;
+    });
+    const replayRecord: OpenReplayRecord = {
+      fingerprint,
+      promise: replayPromise,
+      host: bootstrapHost,
+      lastUsedAt: this.now(),
+    };
+    this.openReplay.set(replayKey, replayRecord);
+    while (this.openReplay.size > 256) {
+      const oldest = this.openReplay.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.openReplay.delete(oldest);
+    }
+    const promise = this.executeInternal(claims, request);
+    void promise.then((response) => {
+      resolveReplay(response);
+      if (!response.ok && this.openReplay.get(replayKey) === replayRecord) this.openReplay.delete(replayKey);
+    });
+    return promise;
+  }
+
+  private executeInternal(claims: BrowserAutomationCredentialClaims, input: unknown): Promise<BrowserAutomationResponse> {
     this.pruneExpiredState();
     const parsed = BrowserAutomationRequestSchema().safeParse(input);
     if (!parsed.success) {
@@ -540,7 +626,12 @@ export class BrowserAutomationBroker {
       return finishImmediately(failure(request, "HOST_UNAVAILABLE", "Browser request capacity is exhausted", true));
     }
 
-    const assignment = this.resolveAssignment(claims, request);
+    // Each fresh keyed browser_open owns a new tab. Duplicate keys are
+    // handled by openReplay before this path and continue to reuse the
+    // original target.
+    const assignment = request.operation === "open" && request.args.idempotencyKey !== undefined
+      ? undefined
+      : this.resolveAssignment(claims, request);
     if (!assignment) {
       if (request.operation === "open") {
         const host = this.resolveBootstrapHost(claims, request);
@@ -632,6 +723,9 @@ export class BrowserAutomationBroker {
     if (!host) return;
     this.hostsBySocket.delete(socket);
     clearTimeout(host.heartbeatTimer);
+    for (const [replayKey, record] of this.openReplay) {
+      if (record.host === host) this.openReplay.delete(replayKey);
+    }
     for (const [key, assigned] of this.assignments) {
       if (assigned.host === host) this.assignments.delete(key);
     }
@@ -702,6 +796,10 @@ export class BrowserAutomationBroker {
         pending,
         failure(pending.request, "OPERATION_CANCELLED", "Browser credential was revoked", false),
       );
+    }
+    for (const key of this.openReplay.keys()) {
+      const parts = JSON.parse(key) as string[];
+      if (parts[0] === providerId && parts[1] === providerSessionId) this.openReplay.delete(key);
     }
     return removed;
   }
@@ -931,6 +1029,11 @@ export class BrowserAutomationBroker {
     removedTargetKey: string,
     preserveTargetTransition = false,
   ): void {
+    for (const [replayKey, record] of this.openReplay) {
+      if (record.host === host && record.target && targetKey(record.target) === removedTargetKey) {
+        this.openReplay.delete(replayKey);
+      }
+    }
     for (const [key, assignment] of this.assignments) {
       if (assignment.host === host && assignment.targetKey === removedTargetKey) this.assignments.delete(key);
     }

--- a/apps/server/src/services/browser-automation/mcp-handler.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.ts
@@ -106,7 +106,10 @@ const commonProperties = {
 function inputSchema(operation: BrowserAutomationOperation): Record<string, unknown> {
   const schemas: Record<BrowserAutomationOperation, Record<string, unknown>> = {
     status: {},
-    open: { url: { type: "string", format: "uri" }, activate: { type: "boolean", default: true } },
+    open: {
+      url: { type: "string", format: "uri" },
+      idempotencyKey: { type: "string", minLength: 1, maxLength: 256 },
+    },
     navigate: { url: { type: "string", format: "uri" } },
     resize: { width: { type: "integer", minimum: 320, maximum: 7680 }, height: { type: "integer", minimum: 240, maximum: 4320 } },
     snapshot: { includeScreenshot: { type: "boolean", default: true }, timeoutMs: { type: "integer", minimum: 1, maximum: 60000 } },
@@ -125,7 +128,7 @@ function inputSchema(operation: BrowserAutomationOperation): Record<string, unkn
     recordingStop: {},
   };
   const requiredByOperation: Partial<Record<BrowserAutomationOperation, string[]>> = {
-    navigate: ["url"], resize: ["width", "height"], click: ["target"], type: ["text"], press: ["key"], scroll: ["deltaY"], evaluate: ["expression"],
+    open: ["idempotencyKey"], navigate: ["url"], resize: ["width", "height"], click: ["target"], type: ["text"], press: ["key"], scroll: ["deltaY"], evaluate: ["expression"],
   };
   return {
     type: "object",

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -86,7 +86,15 @@ function failureResponse(
     requestId: request.requestId,
     sequence: request.sequence,
     ok: false,
-    error: { code, message, retryable: code !== "INVALID_REQUEST" },
+    error: {
+      code,
+      message,
+      retryable: code !== "INVALID_REQUEST",
+      stage: code === "TAB_UNAVAILABLE" ? "allocation" : "effect",
+      effect: code === "TAB_UNAVAILABLE" ? "unknown" : "none",
+      recovery: code === "TAB_UNAVAILABLE" ? "reopen" : "manual",
+      correlationId: globalThis.crypto.randomUUID(),
+    },
   };
 }
 
@@ -381,6 +389,13 @@ interface BackgroundBrowserScope {
   readonly workspaceId: string;
 }
 
+interface PersistentAutomationWebTab {
+  readonly threadId: string;
+  readonly workspaceId: string;
+  readonly tabId: string;
+  readonly url: string;
+}
+
 interface PersistentSurfaceLayout {
   readonly visible: boolean;
   readonly left: number;
@@ -397,7 +412,40 @@ function findAutomationDock(threadId: string): HTMLElement | null {
 }
 
 /** Keeps one exact automation PreviewPanel mounted while moving it into its visible dock. */
-function PersistentAutomationPreviewSurface({ scope }: { readonly scope: BackgroundBrowserScope }) {
+function PersistentAutomationWebTab({ tab }: { readonly tab: PersistentAutomationWebTab }) {
+  useEffect(() => {
+    useBrowserAutomationStore.getState().registerTarget(tab.workspaceId, tab.threadId, tab.tabId);
+    return () => useBrowserAutomationStore.getState().detachTarget(tab.threadId, tab.tabId);
+  }, [tab.tabId, tab.threadId, tab.workspaceId]);
+
+  return (
+    <iframe
+      title="Browser automation page"
+      src={tab.url}
+      data-thread-id={tab.threadId}
+      data-tab-id={tab.tabId}
+      onLoad={() => useBrowserAutomationStore.getState().refreshTarget(tab.threadId, tab.tabId)}
+      style={{
+        position: "fixed",
+        left: -20_000,
+        top: 0,
+        width: 1_280,
+        height: 720,
+        border: 0,
+        pointerEvents: "none",
+      }}
+      referrerPolicy="no-referrer"
+    />
+  );
+}
+
+function PersistentAutomationPreviewSurface({
+  scope,
+  webTabs,
+}: {
+  readonly scope: BackgroundBrowserScope;
+  readonly webTabs: readonly PersistentAutomationWebTab[];
+}) {
   const [layout, setLayout] = useState<PersistentSurfaceLayout>({
     visible: false,
     left: -20_000,
@@ -464,6 +512,9 @@ function PersistentAutomationPreviewSurface({ scope }: { readonly scope: Backgro
         workspaceId={scope.workspaceId}
         automationOnly={!layout.visible}
       />
+      {webTabs
+        .filter((tab) => tab.threadId === scope.threadId)
+        .map((tab) => <PersistentAutomationWebTab key={tab.tabId} tab={tab} />)}
     </div>
   );
 }
@@ -494,6 +545,9 @@ export function BrowserAutomationHost() {
   const priorLiveTargetKeysRef = useRef(new Set<string>());
   const priorLiveTargetRevisionsRef = useRef(new Map<string, number>());
   const cancelledRef = useRef(new Set<string>());
+  const persistentWebTabsRef = useRef(new Map<string, PersistentAutomationWebTab>());
+  const agentOpenTabsRef = useRef(new Map<string, string>());
+  const [, setPersistentWebTabsRevision] = useState(0);
   const sessionDriverRef = useRef<BrowserSessionDriver | null>(null);
   if (!sessionDriverRef.current) {
     const webAdapter = new WebBrowserSessionAdapter({
@@ -525,6 +579,20 @@ export function BrowserAutomationHost() {
       ),
     });
   }
+  const addPersistentWebTab = (tab: PersistentAutomationWebTab): void => {
+    persistentWebTabsRef.current.set(tab.tabId, tab);
+    setPersistentWebTabsRevision((value) => value + 1);
+  };
+  const removePersistentWebTab = (tabId: string): void => {
+    const tab = persistentWebTabsRef.current.get(tabId);
+    if (!tab) return;
+    persistentWebTabsRef.current.delete(tabId);
+    for (const [key, value] of agentOpenTabsRef.current) {
+      if (value === tabId) agentOpenTabsRef.current.delete(key);
+    }
+    useBrowserAutomationStore.getState().unregisterTarget(tab.threadId, tabId);
+    setPersistentWebTabsRevision((value) => value + 1);
+  };
   const stableHostId = useMemo(hostId, []);
   const [backgroundScopes, setBackgroundScopes] = useState<readonly BackgroundBrowserScope[]>([]);
   const backgroundScopesRef = useRef<readonly BackgroundBrowserScope[]>([]);
@@ -665,6 +733,8 @@ export function BrowserAutomationHost() {
         }
         registrationEpochRef.current += 1;
         leaseRef.current = null;
+        sessionDriverRef.current?.clearIdempotency();
+        agentOpenTabsRef.current.clear();
         useBrowserAutomationStore.getState().setRegistered(false);
         useBrowserAutomationStore.getState().setStatus("unavailable");
       }
@@ -746,6 +816,10 @@ export function BrowserAutomationHost() {
     for (const removed of priorLiveTargetKeysRef.current) {
       if (next.has(removed)) continue;
       const [threadId, tabId] = JSON.parse(removed) as [string, string];
+      sessionDriverRef.current?.clearIdempotencyForTarget(threadId, tabId);
+      for (const [openKey, mappedTabId] of agentOpenTabsRef.current) {
+        if (mappedTabId === tabId) agentOpenTabsRef.current.delete(openKey);
+      }
       recorderRef.current.disposeTarget(threadId, tabId);
       for (const [key, dispatch] of inFlightRef.current) {
         if (dispatch.target.threadId !== threadId || dispatch.target.tabId !== tabId) continue;
@@ -1023,6 +1097,7 @@ export function BrowserAutomationHost() {
         !parsed.success || parsed.data.operation !== "open"
       ) return;
       const request = parsed.data;
+      const agentOwnedOpen = request.args.idempotencyKey !== undefined;
       const key = browserAutomationRequestKey(request.requestId, request.sequence);
       if (inFlightRef.current.has(key) || bootstrapPendingRef.current.has(key)) return;
       bootstrapPendingRef.current.add(key);
@@ -1037,10 +1112,14 @@ export function BrowserAutomationHost() {
       const previousPanel = useDiffStore.getState().getRightPanel(request.workspaceId, request.threadId);
       let backgroundContextRestored = false;
       let createdTabId: string | null = null;
+      let createdWebTabId: string | undefined;
+      const agentOpenKey = agentOwnedOpen
+        ? JSON.stringify([request.providerSessionId, request.providerInstanceId, request.workspaceId, request.threadId, request.args.idempotencyKey])
+        : null;
       let bootstrapSucceeded = false;
       let visibleContextModified = false;
       const restoreBackgroundContext = async () => {
-        if (request.args.activate || backgroundContextRestored) return;
+        if (agentOwnedOpen || request.args.activate || backgroundContextRestored) return;
         backgroundContextRestored = true;
         if (createdTabId && previousTabId && previousTabId !== createdTabId) {
           await usePreviewTabsStore.getState().activatePage(request.threadId, previousTabId);
@@ -1101,7 +1180,7 @@ export function BrowserAutomationHost() {
           );
           setBackgroundScopes(nextScopes);
         }
-        if (ownsVisibleContext) {
+        if (ownsVisibleContext && !agentOwnedOpen) {
           visibleContextModified = true;
           diff.showRightPanel(request.workspaceId, request.threadId);
           diff.setRightPanelTab(request.workspaceId, request.threadId, "preview");
@@ -1112,21 +1191,45 @@ export function BrowserAutomationHost() {
           usePreviewTabsStore.getState().setTabSet(request.threadId, listed.data);
         }
         const existingSet = usePreviewTabsStore.getState().tabSetByScope[request.threadId];
-        let tabId = existingSet?.activeTabId || existingSet?.tabs[0]?.id ||
-          (!bridge ? WEB_RUNTIME_PREVIEW_TAB_ID : null);
-        if (!tabId) {
-          tabId = await usePreviewTabsStore.getState().createPage(request.threadId, {
-            focusOmnibox: ownsVisibleContext && request.args.activate,
-          });
-          if (tabId) createdTabId = tabId;
-        }
-        if (!tabId) throw new Error("Browser tab could not be created or restored");
-        const selectedTab = existingSet?.tabs.find((tab) => tab.id === tabId);
         const requestedWebUrl = !bridge && request.args.url
           ? normalizeWebPreviewUrl(request.args.url)
           : undefined;
+        let tabId = agentOwnedOpen
+          ? (agentOpenKey ? agentOpenTabsRef.current.get(agentOpenKey) ?? null : null)
+          : existingSet?.activeTabId || existingSet?.tabs[0]?.id ||
+            (!bridge ? WEB_RUNTIME_PREVIEW_TAB_ID : null);
+        if (!bridge && agentOwnedOpen && !tabId) {
+          const webTabId = `web-agent-${globalThis.crypto.randomUUID()}`;
+          const webTabUrl = requestedWebUrl ?? `${window.location.origin}/browser-automation-fixture.html`;
+          createdWebTabId = webTabId;
+          if (agentOpenKey) agentOpenTabsRef.current.set(agentOpenKey, webTabId);
+          addPersistentWebTab({
+            threadId: request.threadId,
+            workspaceId: request.workspaceId,
+            tabId: webTabId,
+            url: webTabUrl,
+          });
+          tabId = webTabId;
+        }
+        if (!tabId) {
+          tabId = await usePreviewTabsStore.getState().createPage(request.threadId, {
+            activate: !agentOwnedOpen,
+            focusOmnibox: ownsVisibleContext && request.args.activate && !agentOwnedOpen,
+          });
+          if (tabId) {
+            createdTabId = tabId;
+            if (agentOpenKey) agentOpenTabsRef.current.set(agentOpenKey, tabId);
+            useBrowserAutomationStore.getState().registerTarget(
+              request.workspaceId,
+              request.threadId,
+              tabId,
+            );
+          }
+        }
+        if (!tabId) throw new Error("Browser tab could not be created or restored");
+        const selectedTab = existingSet?.tabs.find((tab) => tab.id === tabId);
         const initialUrl = requestedWebUrl ?? selectedTab?.url ?? "about:blank";
-        if (!selectedTab?.url || requestedWebUrl) {
+        if (!agentOwnedOpen && (!selectedTab?.url || requestedWebUrl)) {
           usePreviewTabsStore.getState().updateTabChrome(request.threadId, tabId, {
             title: null,
             url: initialUrl,
@@ -1160,8 +1263,8 @@ export function BrowserAutomationHost() {
                 targetGeneration: useBrowserAutomationStore.getState().liveTargets.get(
                   browserAutomationTargetKey(request.threadId, tabId),
                 )?.revision ?? 1,
-                active: true,
-                focused: true,
+                active: !agentOwnedOpen,
+                focused: !agentOwnedOpen,
                 lastUsedAt: Date.now(),
               },
             };
@@ -1195,7 +1298,10 @@ export function BrowserAutomationHost() {
               ...dispatch,
               request: {
                 ...dispatch.request,
-                args: { activate: request.args.activate },
+                args: {
+                  activate: request.args.activate,
+                  ...(request.args.idempotencyKey ? { idempotencyKey: request.args.idempotencyKey } : {}),
+                },
               },
             }
           : dispatch;
@@ -1230,6 +1336,8 @@ export function BrowserAutomationHost() {
             // Keep finalizer cleanup settled; closePage preserves logical records on physical failure.
           }
         }
+        if (createdWebTabId && !bootstrapSucceeded) removePersistentWebTab(createdWebTabId);
+        if (!bootstrapSucceeded && agentOpenKey) agentOpenTabsRef.current.delete(agentOpenKey);
         window.clearTimeout(deadlineTimer);
         if (bootstrapAbortRef.current.get(key) === controller) bootstrapAbortRef.current.delete(key);
         bootstrapPendingRef.current.delete(key);
@@ -1287,6 +1395,9 @@ export function BrowserAutomationHost() {
         new Set(nextScopes.map((scope) => scope.threadId)),
       );
     }
+    for (const tab of persistentWebTabsRef.current.values()) {
+      if (matches(tab.threadId, tab.workspaceId)) removePersistentWebTab(tab.tabId);
+    }
     const lease = leaseRef.current;
     for (const [key, request] of bootstrapRequestRef.current) {
       if (!matches(request.threadId, request.workspaceId)) continue;
@@ -1339,9 +1450,16 @@ export function BrowserAutomationHost() {
     webAbortRef.current.clear();
     webObserverRef.current.clear();
     webHumanCancelRef.current.clear();
+    persistentWebTabsRef.current.clear();
+    sessionDriverRef.current?.clearIdempotency();
+    agentOpenTabsRef.current.clear();
   }, []);
 
   return backgroundScopes.map((scope) => (
-    <PersistentAutomationPreviewSurface key={scope.threadId} scope={scope} />
+    <PersistentAutomationPreviewSurface
+      key={scope.threadId}
+      scope={scope}
+      webTabs={[...persistentWebTabsRef.current.values()]}
+    />
   ));
 }

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -166,6 +166,12 @@ function successResponse(request: BrowserAutomationHostDispatch["request"]): Bro
   };
 }
 
+function markIframeLoaded(iframe: HTMLIFrameElement): void {
+  if (iframe.contentDocument) {
+    Object.defineProperty(iframe.contentDocument, "readyState", { configurable: true, value: "complete" });
+  }
+}
+
 describe("BrowserAutomationHost", () => {
   const execute = vi.fn();
   const beginRendererOperation = vi.fn();
@@ -303,6 +309,7 @@ describe("BrowserAutomationHost", () => {
     iframe.dataset.threadId = "thread-1";
     iframe.dataset.tabId = "web-preview";
     document.body.append(iframe);
+    markIframeLoaded(iframe);
     window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalled());
     expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(`${window.location.origin}/fixture`);
@@ -334,12 +341,115 @@ describe("BrowserAutomationHost", () => {
     iframe.dataset.threadId = "thread-1";
     iframe.dataset.tabId = "web-preview";
     document.body.append(iframe);
+    markIframeLoaded(iframe);
     window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
     await waitFor(() => expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(
       expect.objectContaining({ request: expect.objectContaining({ args: { activate: true } }) }),
       expect.any(AbortSignal),
     ));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    iframe.remove();
+    view.unmount();
+  });
+
+  it("bootstraps the hidden dedicated web surface with its created tab id", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    useBrowserAutomationStore.setState({ liveTargets: new Map() });
+    webExecutor.executeWebBrowserDispatch.mockImplementation(async (value: BrowserAutomationHostDispatch) => ({
+      contractVersion: value.request.contractVersion,
+      requestId: value.request.requestId,
+      sequence: value.request.sequence,
+      ok: true as const,
+      result: {
+        operation: "open" as const,
+        url: value.request.args.url ?? `${window.location.origin}/browser-automation-fixture.html`,
+        title: "Fixture",
+        controlEpoch: 0,
+      },
+    }));
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    const openRequest = {
+      ...dispatch(1, 37).request,
+      operation: "open" as const,
+      args: {
+        url: `${window.location.origin}/browser-automation-fixture.html`,
+        idempotencyKey: "hidden-web-open",
+        activate: false,
+      },
+    };
+    act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
+    await waitFor(() => expect(useBrowserAutomationStore.getState().hostedScopeIds.has("thread-1")).toBe(true));
+    const surface = document.querySelector<HTMLElement>('[data-automation-persistent-scope="thread-1"]');
+    expect(surface).not.toBeNull();
+    let iframe!: HTMLIFrameElement;
+    await waitFor(() => {
+      const value = document.querySelector<HTMLIFrameElement>(
+        '[data-automation-persistent-scope="thread-1"] iframe[data-tab-id^="web-agent-"]',
+      );
+      expect(value).not.toBeNull();
+      iframe = value!;
+    });
+    expect(iframe.src).toBe(openRequest.args.url);
+    window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
+      hostId,
+      1,
+      expect.objectContaining({ ok: true }),
+      expect.objectContaining({ tabId: iframe.dataset.tabId }),
+    ));
+    const firstResponse = harness.transport.respondToBrowserAutomationRequest.mock.calls[0]?.[2];
+    expect(firstResponse.result.observationRef).toEqual(expect.any(String));
+    if (iframe.contentDocument) {
+      Object.defineProperty(iframe.contentDocument, "readyState", { configurable: true, value: "complete" });
+    }
+
+    const replayRequest = {
+      ...openRequest,
+      requestId: "request-38",
+      sequence: 38,
+    };
+    act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: replayRequest }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledTimes(2));
+    const replayResponse = harness.transport.respondToBrowserAutomationRequest.mock.calls[1]?.[2];
+    expect(replayResponse).toMatchObject({ ok: true, requestId: replayRequest.requestId, sequence: replayRequest.sequence });
+    expect(replayResponse.result.observationRef).toBe(firstResponse.result.observationRef);
+
+    const secondRequest = {
+      ...openRequest,
+      requestId: "request-39",
+      sequence: 39,
+      args: {
+        ...openRequest.args,
+        idempotencyKey: "hidden-web-open-2",
+        url: `${window.location.origin}/browser-automation-fixture-second.html`,
+      },
+    };
+    act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: secondRequest }));
+    let secondIframe!: HTMLIFrameElement;
+    await waitFor(() => {
+      const value = [...document.querySelectorAll<HTMLIFrameElement>(
+        '[data-automation-persistent-scope="thread-1"] iframe[data-tab-id^="web-agent-"]',
+      )].find((candidate) => candidate !== iframe);
+      expect(value).toBeDefined();
+      secondIframe = value!;
+    });
+    expect(secondIframe.dataset.tabId).not.toBe(iframe.dataset.tabId);
+    expect(secondIframe.src).toBe(secondRequest.args.url);
+    markIframeLoaded(secondIframe);
+    window.setTimeout(() => secondIframe.dispatchEvent(new Event("load")), 0);
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledTimes(3));
+    const secondResponse = harness.transport.respondToBrowserAutomationRequest.mock.calls[2]?.[2];
+    expect(secondResponse.result.observationRef).not.toBe(firstResponse.result.observationRef);
+    expect(harness.transport.respondToBrowserAutomationRequest.mock.calls[2]?.[3]).toMatchObject({
+      tabId: secondIframe.dataset.tabId,
+      active: false,
+      focused: false,
+    });
+
+    expect(surface).toHaveAttribute("aria-hidden", "true");
     iframe.remove();
     view.unmount();
   });
@@ -809,6 +919,7 @@ describe("BrowserAutomationHost", () => {
   });
 
   it("cancels an exact removed target and suppresses its late success response", async () => {
+    const clearTargetReplay = vi.spyOn(BrowserSessionDriver.prototype, "clearIdempotencyForTarget");
     const executing = deferred<BrowserAutomationResponse>();
     execute.mockReturnValueOnce(executing.promise);
     const view = render(<BrowserAutomationHost />);
@@ -824,6 +935,7 @@ describe("BrowserAutomationHost", () => {
 
     act(() => useBrowserAutomationStore.getState().unregisterTarget("thread-1", "tab-1"));
     await waitFor(() => expect(cancel).toHaveBeenCalledWith(activeDispatch.request.requestId));
+    expect(clearTargetReplay).toHaveBeenCalledWith("thread-1", "tab-1");
     expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(
       hostId,
       1,
@@ -836,6 +948,7 @@ describe("BrowserAutomationHost", () => {
     executing.resolve(successResponse(activeDispatch.request));
     await act(async () => executing.promise);
     expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
+    clearTargetReplay.mockRestore();
     view.unmount();
   });
 

--- a/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
@@ -38,6 +38,18 @@ function iframe(): HTMLIFrameElement {
   return element;
 }
 
+function expectTypedFailure(result: unknown): void {
+  expect(result).toMatchObject({
+    ok: false,
+    error: {
+      stage: expect.any(String),
+      effect: expect.any(String),
+      recovery: expect.any(String),
+      correlationId: expect.any(String),
+    },
+  });
+}
+
 describe("web browser automation executor", () => {
   it("navigates the visible iframe and snapshots bounded semantic content", async () => {
     const target = iframe();
@@ -157,17 +169,45 @@ describe("web browser automation executor", () => {
     target.parentElement?.setAttribute("aria-hidden", "true");
     const result = await executeWebBrowserDispatch(dispatch("snapshot", { includeScreenshot: false }), new AbortController().signal);
     expect(result).toMatchObject({ ok: false, error: { code: "TAB_UNAVAILABLE" } });
+    expectTypedFailure(result);
     target.parentElement?.removeAttribute("aria-hidden");
     target.remove();
+  });
+
+  it("accepts a hidden iframe only inside the dedicated automation surface", async () => {
+    const surface = document.createElement("div");
+    surface.dataset.automationPersistentScope = "thread-1";
+    surface.setAttribute("aria-hidden", "true");
+    surface.setAttribute("inert", "");
+    const target = document.createElement("iframe");
+    target.dataset.threadId = "thread-1";
+    target.dataset.tabId = "web-preview";
+    target.src = "about:blank";
+    surface.append(target);
+    document.body.append(surface);
+    const page = document.implementation.createHTMLDocument("Fixture");
+    page.title = "Fixture";
+    Object.defineProperty(target, "contentDocument", { configurable: true, value: page });
+    const openDispatch = dispatch("open", { url: `${window.location.origin}/browser-automation-fixture.html` });
+    openDispatch.target = { ...openDispatch.target, tabId: "web-preview" };
+    const opening = executeWebBrowserDispatch(
+      openDispatch,
+      new AbortController().signal,
+    );
+    window.setTimeout(() => target.dispatchEvent(new Event("load")), 0);
+    await expect(opening).resolves.toMatchObject({ ok: true, result: { operation: "open" } });
+    surface.remove();
   });
 
   it("rejects cross-origin navigation and DOM access with a typed error", async () => {
     const target = iframe();
     const rejected = await executeWebBrowserDispatch(dispatch("navigate", { url: "https://other.example/" }), new AbortController().signal);
     expect(rejected).toMatchObject({ ok: false, error: { code: "CROSS_ORIGIN" } });
+    expectTypedFailure(rejected);
     Object.defineProperty(target, "contentDocument", { configurable: true, get: () => null });
     const snapshot = await executeWebBrowserDispatch(dispatch("snapshot", { includeScreenshot: false }), new AbortController().signal);
     expect(snapshot).toMatchObject({ ok: false, error: { code: "CROSS_ORIGIN" } });
+    expectTypedFailure(snapshot);
     target.remove();
   });
 
@@ -177,8 +217,10 @@ describe("web browser automation executor", () => {
     controller.abort();
     const cancelled = await executeWebBrowserDispatch(dispatch("snapshot", { includeScreenshot: false }), controller.signal);
     expect(cancelled).toMatchObject({ ok: false, error: { code: "OPERATION_CANCELLED" } });
+    expectTypedFailure(cancelled);
     const expired = await executeWebBrowserDispatch(dispatch("snapshot", { includeScreenshot: false }, Date.now() - 1), new AbortController().signal);
     expect(expired).toMatchObject({ ok: false, error: { code: "DEADLINE_EXCEEDED" } });
+    expectTypedFailure(expired);
     target.remove();
   });
 
@@ -220,6 +262,7 @@ describe("web browser automation executor", () => {
       ok: false,
       error: { code: "UNSUPPORTED_OPERATION" },
     });
+    expectTypedFailure(result);
     expect(captureVisibleWebScreenshot).not.toHaveBeenCalled();
     target.remove();
   });

--- a/apps/web/src/components/panels/browserAutomationWebExecutor.ts
+++ b/apps/web/src/components/panels/browserAutomationWebExecutor.ts
@@ -47,6 +47,33 @@ function popSnapshotNode(stack: SnapshotNode[], budget: SnapshotBudget): Snapsho
 
 type WebIframe = HTMLIFrameElement & { dataset: DOMStringMap };
 
+type WebFailureCode =
+  | "CROSS_ORIGIN"
+  | "DEADLINE_EXCEEDED"
+  | "INTERNAL_ERROR"
+  | "NAVIGATION_FAILED"
+  | "OPERATION_CANCELLED"
+  | "RESULT_TOO_LARGE"
+  | "TAB_UNAVAILABLE"
+  | "UNSUPPORTED_OPERATION";
+
+type WebFailureMetadata = {
+  stage: "validation" | "allocation" | "observation" | "effect" | "recovery" | "transport";
+  effect: "none" | "created" | "closed" | "preserved" | "unknown";
+  recovery: "none" | "retry" | "refresh" | "reopen" | "manual";
+};
+
+const WEB_FAILURE_METADATA: Record<WebFailureCode, WebFailureMetadata> = {
+  CROSS_ORIGIN: { stage: "observation", effect: "none", recovery: "manual" },
+  DEADLINE_EXCEEDED: { stage: "recovery", effect: "unknown", recovery: "retry" },
+  INTERNAL_ERROR: { stage: "transport", effect: "unknown", recovery: "retry" },
+  NAVIGATION_FAILED: { stage: "effect", effect: "unknown", recovery: "retry" },
+  OPERATION_CANCELLED: { stage: "recovery", effect: "preserved", recovery: "none" },
+  RESULT_TOO_LARGE: { stage: "observation", effect: "none", recovery: "retry" },
+  TAB_UNAVAILABLE: { stage: "allocation", effect: "unknown", recovery: "retry" },
+  UNSUPPORTED_OPERATION: { stage: "validation", effect: "none", recovery: "manual" },
+};
+
 function response(
   dispatch: BrowserAutomationHostDispatch,
   result: BrowserAutomationResult,
@@ -62,21 +89,37 @@ function response(
 
 function failure(
   dispatch: BrowserAutomationHostDispatch,
-  code: "CROSS_ORIGIN" | "DEADLINE_EXCEEDED" | "INTERNAL_ERROR" | "NAVIGATION_FAILED" | "OPERATION_CANCELLED" | "RESULT_TOO_LARGE" | "TAB_UNAVAILABLE" | "UNSUPPORTED_OPERATION",
+  code: WebFailureCode,
   message: string,
 ): BrowserAutomationResponse {
+  const metadata = WEB_FAILURE_METADATA[code];
   return {
     contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
     requestId: dispatch.request.requestId,
     sequence: dispatch.request.sequence,
     ok: false,
-    error: { code, message, retryable: code !== "CROSS_ORIGIN" && code !== "UNSUPPORTED_OPERATION" },
+    error: {
+      code,
+      message,
+      retryable: code !== "CROSS_ORIGIN" && code !== "UNSUPPORTED_OPERATION",
+      ...metadata,
+      correlationId: globalThis.crypto.randomUUID(),
+    },
   };
 }
 
 function findIframe(dispatch: BrowserAutomationHostDispatch): WebIframe | null {
   const candidates = [...document.querySelectorAll<HTMLIFrameElement>("iframe")]
     .filter((candidate) => candidate.dataset.threadId === dispatch.target.threadId && candidate.dataset.tabId === dispatch.target.tabId);
+  const automationSurface = candidates.find((candidate) => {
+    let node: Element | null = candidate.parentElement;
+    while (node) {
+      if (node.getAttribute("data-automation-persistent-scope") === dispatch.target.threadId) return true;
+      node = node.parentElement;
+    }
+    return false;
+  });
+  if (automationSurface) return automationSurface as WebIframe;
   const visible = candidates.find((candidate) => {
     let node: HTMLElement | null = candidate;
     let depth = 0;

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -56,4 +56,52 @@ describe("BrowserSessionDriver", () => {
     expect(electronExecute).toHaveBeenCalledWith(clickDispatch, expect.any(AbortSignal));
     document.body.removeChild(webButton);
   });
+
+  it("joins idempotent opens, returns an observation reference, and rejects conflicts", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      contractVersion: 1,
+      requestId: "first",
+      sequence: 1,
+      ok: true,
+      result: { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+    } as BrowserAutomationResponse);
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+    });
+    const makeDispatch = (requestId: string, url: string, targetGeneration = 1, windowId = 1): BrowserAutomationHostDispatch => ({
+      request: {
+        contractVersion: 1,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId,
+        sequence: 1,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "open",
+        args: { url, idempotencyKey: "open-key" },
+      },
+      target: { threadId: "thread", tabId: "tab", windowId, targetGeneration },
+    } as unknown as BrowserAutomationHostDispatch);
+    const first = await driver.execute(makeDispatch("first", "https://example.test/"), new AbortController().signal);
+    const replay = await driver.execute(makeDispatch("replay", "https://example.test/"), new AbortController().signal);
+    const conflict = await driver.execute(makeDispatch("conflict", "https://other.test/"), new AbortController().signal);
+    expect(execute).toHaveBeenCalledOnce();
+    expect(first).toMatchObject({ ok: true, result: { operation: "open", observationRef: expect.any(String) } });
+    expect(replay).toMatchObject({ ok: true, requestId: "replay", result: { operation: "open" } });
+    expect(conflict).toMatchObject({ ok: false, error: { code: "IDEMPOTENCY_CONFLICT" } });
+
+    await driver.execute(makeDispatch("window-bump", "https://example.test/", 1, 2), new AbortController().signal);
+    expect(execute).toHaveBeenCalledTimes(2);
+
+    await driver.execute(makeDispatch("generation-bump", "https://example.test/", 2), new AbortController().signal);
+    expect(execute).toHaveBeenCalledTimes(3);
+
+    driver.clearIdempotencyForTarget("thread", "tab");
+    await driver.execute(makeDispatch("fresh", "https://example.test/", 2), new AbortController().signal);
+    expect(execute).toHaveBeenCalledTimes(4);
+  });
 });

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -3,6 +3,20 @@ import type {
   BrowserAutomationResponse,
 } from "@mcode/contracts";
 
+const MAX_IDEMPOTENCY_RECORDS = 256;
+const IDEMPOTENCY_TTL_MS = 30 * 60_000;
+
+type OpenDispatch = BrowserAutomationHostDispatch & {
+  request: Extract<BrowserAutomationHostDispatch["request"], { operation: "open" }>;
+};
+
+interface IdempotencyRecord {
+  readonly fingerprint: string;
+  readonly target: { threadId: string; tabId: string; windowId: number; targetGeneration: number };
+  lastUsedAt: number;
+  readonly promise: Promise<BrowserAutomationResponse>;
+}
+
 /** Runtime implementation used by the client BrowserSessionDriver. */
 export interface BrowserSessionRuntimeAdapter {
   execute(
@@ -39,6 +53,7 @@ export interface BrowserSessionDriverOptions {
  */
 export class BrowserSessionDriver {
   private readonly isElectron: () => boolean;
+  private readonly idempotency = new Map<string, IdempotencyRecord>();
 
   constructor(private readonly options: BrowserSessionDriverOptions) {
     this.isElectron = options.isElectron ?? (() => typeof window !== "undefined" && typeof window.desktopBridge?.preview === "object");
@@ -49,7 +64,114 @@ export class BrowserSessionDriver {
     dispatch: BrowserAutomationHostDispatch,
     signal: AbortSignal,
   ): Promise<BrowserAutomationResponse> {
-    return (this.isElectron() ? this.options.electron : this.options.web).execute(dispatch, signal);
+    if (dispatch.request?.operation !== "open") {
+      return (this.isElectron() ? this.options.electron : this.options.web).execute(dispatch, signal);
+    }
+
+    // Legacy/internal bootstrap callers without the v2 key retain the exact
+    // dispatch object and adapter contract. Authenticated MCP opens always
+    // carry idempotencyKey and enter the v2 lifecycle below.
+    if (dispatch.request.args.idempotencyKey === undefined) {
+      return (this.isElectron() ? this.options.electron : this.options.web).execute(dispatch, signal);
+    }
+
+    this.pruneIdempotency();
+    const request = dispatch.request;
+    const key = request.args.idempotencyKey;
+    const scopeKey = JSON.stringify([request.providerSessionId, request.providerInstanceId, key]);
+    const fingerprint = JSON.stringify({
+      url: request.args.url ?? null,
+      workspaceId: request.workspaceId,
+      threadId: request.threadId,
+    });
+    const existing = this.idempotency.get(scopeKey);
+    if (existing) {
+      const sameTarget = existing.target.threadId === request.threadId &&
+        existing.target.tabId === dispatch.target.tabId &&
+        existing.target.windowId === dispatch.target.windowId &&
+        existing.target.targetGeneration === dispatch.target.targetGeneration;
+      if (!sameTarget) {
+        this.idempotency.delete(scopeKey);
+      } else {
+        existing.lastUsedAt = Date.now();
+        if (existing.fingerprint !== fingerprint) {
+          return Promise.resolve({
+            contractVersion: request.contractVersion,
+            requestId: request.requestId,
+            sequence: request.sequence,
+            ok: false,
+            error: {
+              code: "IDEMPOTENCY_CONFLICT",
+              message: "The idempotency key was already used with different browser_open arguments",
+              retryable: false,
+              stage: "validation",
+              effect: "none",
+              recovery: "manual",
+            },
+          });
+        }
+        return existing.promise.then((response) => ({
+          ...response,
+          requestId: request.requestId,
+          sequence: request.sequence,
+        }));
+      }
+    }
+
+    const normalized = {
+      ...dispatch,
+      request: {
+        ...request,
+        args: {
+          ...(request.args.url ? { url: request.args.url } : {}),
+          idempotencyKey: key,
+        },
+      },
+    } as OpenDispatch;
+    const promise = (this.isElectron() ? this.options.electron : this.options.web)
+      .execute(normalized, signal)
+      .then((response) => this.withObservationRef(response));
+    this.idempotency.set(scopeKey, {
+      fingerprint,
+      target: {
+        threadId: request.threadId,
+        tabId: dispatch.target.tabId,
+        windowId: dispatch.target.windowId,
+        targetGeneration: dispatch.target.targetGeneration,
+      },
+      lastUsedAt: Date.now(),
+      promise,
+    });
+    while (this.idempotency.size > MAX_IDEMPOTENCY_RECORDS) {
+      const oldest = this.idempotency.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.idempotency.delete(oldest);
+    }
+    return promise;
+  }
+
+  /** Clears bounded replay state when a provider session or host is released. */
+  clearIdempotency(): void {
+    this.idempotency.clear();
+  }
+
+  /** Clears replay state bound to one browser target after that target closes or is replaced. */
+  clearIdempotencyForTarget(threadId: string, tabId: string): void {
+    for (const [key, record] of this.idempotency) {
+      if (record.target.threadId === threadId && record.target.tabId === tabId) this.idempotency.delete(key);
+    }
+  }
+
+  private withObservationRef(response: BrowserAutomationResponse): BrowserAutomationResponse {
+    if (!response.ok || response.result.operation !== "open" || response.result.observationRef) return response;
+    return { ...response, result: { ...response.result, observationRef: globalThis.crypto.randomUUID() } };
+  }
+
+  private pruneIdempotency(): void {
+    const cutoff = Date.now() - IDEMPOTENCY_TTL_MS;
+    for (const [key, record] of this.idempotency) {
+      if (record.lastUsedAt < cutoff) this.idempotency.delete(key);
+    }
   }
 
 }

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -89,7 +89,7 @@ interface PreviewTabsState {
   updateTabChrome: (scopeId: string, tabId: string, chrome: PreviewLiveChrome) => void;
 
   /** Create a new page and optionally suppress human-focused omnibox behavior. */
-  createPage: (scopeId: string, options?: { readonly focusOmnibox?: boolean }) => Promise<string | null>;
+  createPage: (scopeId: string, options?: { readonly focusOmnibox?: boolean; readonly activate?: boolean }) => Promise<string | null>;
   /** Activate (switch to) a page within the scope's browser. */
   activatePage: (scopeId: string, tabId: string) => Promise<void>;
   /**
@@ -167,13 +167,15 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
   createPage: async (scopeId, options) => {
     const tabs = bridgeTabs();
     if (!tabs) return null;
-    const r = await tabs.create(scopeId, true);
+    const r = await tabs.create(scopeId, options?.activate ?? true);
     if (r.ok) {
       get().setTabSet(scopeId, r.data.tabs);
       useBrowserAutomationStore.getState().refreshTarget(scopeId, r.data.tabId);
       // A freshly-created page is empty; drop the cursor into the URL field so
       // the user can type immediately (matches the panel-open shortcut's UX).
-      if (options?.focusOmnibox !== false) usePreviewFocusStore.getState().requestOmniboxFocus();
+      if (options?.focusOmnibox !== false && (options?.activate ?? true)) {
+        usePreviewFocusStore.getState().requestOmniboxFocus();
+      }
       return r.data.tabId;
     }
     return null;

--- a/packages/contracts/src/models/__tests__/browser-automation.test.ts
+++ b/packages/contracts/src/models/__tests__/browser-automation.test.ts
@@ -236,6 +236,22 @@ describe("browser automation operation contract", () => {
       ).toBe(false);
     }
   });
+
+  it("accepts bounded browser_open idempotency and opaque observation references", () => {
+    const parsed = BrowserAutomationRequestSchema().parse({
+      ...requestBase,
+      operation: "open",
+      args: { idempotencyKey: "open-key" },
+    });
+    expect(parsed.args).toEqual({ idempotencyKey: "open-key" });
+    expect(BrowserAutomationResultSchema().parse({
+      operation: "open",
+      url: "about:blank",
+      title: "",
+      controlEpoch: 0,
+      observationRef: "observation-1",
+    })).toMatchObject({ observationRef: "observation-1" });
+  });
 });
 
 describe("browser automation boundaries", () => {

--- a/packages/contracts/src/models/browser-automation.ts
+++ b/packages/contracts/src/models/browser-automation.ts
@@ -41,6 +41,7 @@ const RECORDING_MAX_BASE64_CHARS =
   Math.ceil(BROWSER_AUTOMATION_MAX_RECORDING_BYTES / 3) * 4;
 
 const idSchema = z.string().trim().min(1).max(ID_MAX);
+const idempotencyKeySchema = z.string().trim().min(1).max(ID_MAX);
 const timeoutSchema = z
   .number()
   .int()
@@ -824,7 +825,13 @@ export const BrowserAutomationRequestSchema = lazySchema(() =>
     requestVariant("status", emptyArgs),
     requestVariant(
       "open",
-      z.object({ url: BrowserAutomationUrlSchema().optional(), activate: z.boolean().default(true) }).strict(),
+      z.object({
+        url: BrowserAutomationUrlSchema().optional(),
+        // `activate` is retained as an ignored wire field for older clients;
+        // BrowserSessionDriver never uses it to change visible selection.
+        activate: z.boolean().optional(),
+        idempotencyKey: idempotencyKeySchema.optional(),
+      }).strict(),
     ),
     requestVariant("navigate", urlArgs),
     requestVariant(
@@ -917,7 +924,13 @@ export const BrowserAutomationResultSchema = lazySchema(() =>
       controller: BrowserAutomationControllerStateSchema().optional(),
       capabilities: z.array(z.enum(BROWSER_AUTOMATION_OPERATIONS)).max(BROWSER_AUTOMATION_OPERATIONS.length),
     }).strict(),
-    actionResult("open"),
+    z.object({
+      operation: z.literal("open"),
+      url: BrowserAutomationOutputLocationSchema(),
+      title: z.string().max(4_096),
+      controlEpoch: z.number().int().nonnegative(),
+      observationRef: idSchema.optional(),
+    }).strict(),
     actionResult("navigate"),
     z.object({ operation: z.literal("resize"), width: z.number().int().positive(), height: z.number().int().positive(), controlEpoch: z.number().int().nonnegative() }).strict(),
     z.object({ operation: z.literal("snapshot"), snapshot: BrowserAutomationSnapshotSchema(), controlEpoch: z.number().int().nonnegative() }).strict(),
@@ -956,6 +969,7 @@ export type BrowserAutomationResult = z.infer<ReturnType<typeof BrowserAutomatio
 /** Stable browser automation error codes returned across process boundaries. */
 export const BROWSER_AUTOMATION_ERROR_CODES = [
   "INVALID_REQUEST",
+  "IDEMPOTENCY_CONFLICT",
   "UNAUTHORIZED",
   "FORBIDDEN",
   "UNSUPPORTED_OPERATION",
@@ -987,6 +1001,10 @@ export const BrowserAutomationErrorSchema = lazySchema(() =>
       code: z.enum(BROWSER_AUTOMATION_ERROR_CODES),
       message: z.string().min(1).max(SHORT_TEXT_MAX),
       retryable: z.boolean(),
+      stage: z.enum(["validation", "authorization", "allocation", "observation", "effect", "recovery", "transport"]).optional(),
+      effect: z.enum(["none", "created", "closed", "preserved", "unknown"]).optional(),
+      recovery: z.enum(["none", "retry", "refresh", "reopen", "manual"]).optional(),
+      correlationId: idSchema.optional(),
     })
     .strict(),
 );


### PR DESCRIPTION
## What

Implement `browser_open` as a complete provider-to-Preview Browser v2 path for web and Electron runtimes.

## Why

Agents need a reliable way to create a background browser target, receive its initial observation, and continue against the same target without changing the user's active panel, thread, or workspace.

## Key Changes

- Route `browser_open` through the MCP adapter, broker, session driver, target registry, and both runtime adapters.
- Create one agent-owned background tab for each new idempotency key and replay the original result for matching requests.
- Reject conflicting keyed requests and return typed failure metadata for stage, effect, recovery, and correlation identity.
- Clear replay and target state after failures, disconnects, target closure, host replacement, or target generation changes.
- Cover contracts, broker lifecycle, session targeting, web execution, host cleanup, and Electron preview behavior with focused tests.
- Verify live web and Electron flows preserve the user's visible panel and focus.

## Verification

- Web live check: matching replay returned the original observation; a new key created a second hidden target; the Browser panel remained hidden.
- Electron live check: matching replay returned the original observation; a new key created a second background target; the Browser panel remained hidden.
- Focused suites: 372 tests passed across contracts, broker, session driver, web executor, host, kernel, and preview browser coverage.
- Frontend suite: 304 files and 2,874 tests passed.
- Typecheck and lint passed. The combined repository wrapper exceeded its fixed 10-minute unit-test phase while the isolated suites completed successfully.

Closes #1044

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788223701&installation_model_id=20477&pr_number=1060&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1060&signature=1015e71c2464f91653338880df98d830b7a64c5207c7bfa46f2852a44dcc381e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser automation can now open and prepare background tabs without changing the visible page.
  * Repeated open requests are safely replayed, while conflicting requests are clearly identified.
  * Successful opens provide an observation reference for follow-up actions.
* **Bug Fixes**
  * Improved handling of hidden and inactive browser targets across desktop and web.
  * Automation failures now provide clearer status, recovery guidance, and correlation details.
* **Tests**
  * Added coverage for background tabs, request replay, target cleanup, and structured error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->