### PR TITLE
fix(desktop): extend Rosetta smoke startup budget

### DIFF
--- a/apps/desktop/scripts/__tests__/smoke-test-config.test.mjs
+++ b/apps/desktop/scripts/__tests__/smoke-test-config.test.mjs
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifySmokeOutcome,
+  getSmokeTimeoutMs,
+} from "../smoke-test-config.mjs";
+
+describe("getSmokeTimeoutMs", () => {
+  it("keeps the default budget for native and non-macOS targets", () => {
+    expect(getSmokeTimeoutMs({
+      hostPlatform: "linux",
+      hostArch: "x64",
+      targetPlatform: "linux",
+      targetArch: "x64",
+    })).toBe(30_000);
+    expect(getSmokeTimeoutMs({
+      hostPlatform: "darwin",
+      hostArch: "arm64",
+      targetPlatform: "darwin",
+      targetArch: "arm64",
+    })).toBe(30_000);
+  });
+
+  it("extends the budget only for an Apple Silicon host running x64 macOS", () => {
+    expect(getSmokeTimeoutMs({
+      hostPlatform: "darwin",
+      hostArch: "arm64",
+      targetPlatform: "darwin",
+      targetArch: "x64",
+    })).toBe(60_000);
+    expect(getSmokeTimeoutMs({
+      hostPlatform: "darwin",
+      hostArch: "x64",
+      targetPlatform: "darwin",
+      targetArch: "x64",
+    })).toBe(30_000);
+  });
+});
+
+describe("classifySmokeOutcome", () => {
+  it("preserves a deadline miss after cleanup observes the SIGTERM exit", () => {
+    let exited = false;
+    const outcomeAtDeadline = classifySmokeOutcome({
+      healthy: false,
+      exitedAtDeadline: exited,
+    });
+    exited = true;
+
+    expect(outcomeAtDeadline).toBe("timed-out");
+    expect(exited).toBe(true);
+  });
+
+  it("classifies a child that exited before readiness as crashed", () => {
+    expect(classifySmokeOutcome({
+      healthy: false,
+      exitedAtDeadline: true,
+    })).toBe("crashed");
+  });
+
+  it("classifies a healthy response as success", () => {
+    expect(classifySmokeOutcome({
+      healthy: true,
+      exitedAtDeadline: false,
+    })).toBe("healthy");
+  });
+});

--- a/apps/desktop/scripts/smoke-test-config.mjs
+++ b/apps/desktop/scripts/smoke-test-config.mjs
@@ -1,0 +1,29 @@
+const DEFAULT_SMOKE_TIMEOUT_MS = 30_000;
+const ROSETTA_SMOKE_TIMEOUT_MS = 60_000;
+
+/**
+ * Select the packaged-server startup budget for the current host and target.
+ *
+ * @param {{hostPlatform: string, hostArch: string, targetPlatform: string, targetArch: string}} input
+ * @returns {number}
+ */
+export function getSmokeTimeoutMs({ hostPlatform, hostArch, targetPlatform, targetArch }) {
+  const isRosettaTarget = hostPlatform === "darwin"
+    && hostArch === "arm64"
+    && targetPlatform === "darwin"
+    && targetArch === "x64";
+  return isRosettaTarget ? ROSETTA_SMOKE_TIMEOUT_MS : DEFAULT_SMOKE_TIMEOUT_MS;
+}
+
+/**
+ * Classify the readiness result captured when polling reaches its deadline.
+ *
+ * @param {{healthy: boolean, exitedAtDeadline: boolean}} input
+ * @returns {"healthy" | "crashed" | "timed-out"}
+ */
+export function classifySmokeOutcome({ healthy, exitedAtDeadline }) {
+  if (healthy) {
+    return "healthy";
+  }
+  return exitedAtDeadline ? "crashed" : "timed-out";
+}

--- a/apps/desktop/scripts/smoke-test.mjs
+++ b/apps/desktop/scripts/smoke-test.mjs
@@ -29,6 +29,10 @@ import {
   findClaudeSdkCliPath,
   expectedClaudeSdkCliPath,
 } from "../../../scripts/build-server-dev-bundle.mjs";
+import {
+  classifySmokeOutcome,
+  getSmokeTimeoutMs,
+} from "./smoke-test-config.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
@@ -37,7 +41,6 @@ const desktopRequire = createRequire(resolve(desktopRoot, "package.json"));
 const serverRequire = createRequire(resolve(desktopRoot, "..", "server", "package.json"));
 
 const SMOKE_PORT = 19899;
-const TIMEOUT_MS = 30_000;
 const POLL_INTERVAL_MS = 300;
 
 // ---------------------------------------------------------------------------
@@ -176,6 +179,16 @@ if (found.binding) {
   console.log(`[smoke-test] SQLite binding: ${found.binding}`);
 }
 
+const sdkTarget = bundleOnly
+  ? { platform: process.platform, arch: process.arch }
+  : inferPackagedSdkTarget(found.server);
+const timeoutMs = getSmokeTimeoutMs({
+  hostPlatform: process.platform,
+  hostArch: process.arch,
+  targetPlatform: sdkTarget.platform,
+  targetArch: sdkTarget.arch,
+});
+
 if (!bundleOnly) {
   if (!found.koffi || !existsSync(found.koffi)) {
     console.error(`[smoke-test] ERROR: koffi native module missing at ${found.koffi}`);
@@ -184,7 +197,6 @@ if (!bundleOnly) {
   }
   console.log(`[smoke-test] koffi module: ${found.koffi}`);
 
-  const sdkTarget = inferPackagedSdkTarget(found.server);
   const claudeCli = findClaudeSdkCliPath(found.server, sdkTarget.platform, sdkTarget.arch);
   if (!claudeCli) {
     const expected = expectedClaudeSdkCliPath(found.server, sdkTarget.platform, sdkTarget.arch);
@@ -345,7 +357,7 @@ const exitPromise = new Promise((resolve) => {
   });
 });
 
-const deadline = Date.now() + TIMEOUT_MS;
+const deadline = Date.now() + timeoutMs;
 let healthy = false;
 
 while (Date.now() < deadline && !exited) {
@@ -360,6 +372,11 @@ while (Date.now() < deadline && !exited) {
   }
   await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
 }
+
+const outcome = classifySmokeOutcome({
+  healthy,
+  exitedAtDeadline: exited,
+});
 
 // ---------------------------------------------------------------------------
 // Report and cleanup
@@ -377,17 +394,17 @@ await exitPromise;
 // Clean up temp data directory
 try { rmSync(dataDir, { recursive: true, force: true }); } catch { /* ok */ }
 
-if (healthy) {
+if (outcome === "healthy") {
   console.log("[smoke-test] PASS: Server started and /health returned 200.");
   process.exit(0);
-} else if (exited) {
+} else if (outcome === "crashed") {
   console.error("[smoke-test] FAIL: Server crashed before becoming ready.");
   if (serverStderr) {
     console.error("[smoke-test] Last stderr output:\n" + serverStderr.slice(-2000));
   }
   process.exit(1);
 } else {
-  console.error(`[smoke-test] FAIL: Server did not respond within ${TIMEOUT_MS / 1000}s.`);
+  console.error(`[smoke-test] FAIL: Server did not respond within ${timeoutMs / 1000}s.`);
   if (serverStderr) {
     console.error("[smoke-test] Last stderr output:\n" + serverStderr.slice(-2000));
   }


### PR DESCRIPTION
## What
Extend the packaged-server smoke startup budget only for x64 macOS targets running under Rosetta, and preserve the readiness result captured before cleanup.

## Why
Two consecutive nightly runs failed at the fixed 30-second boundary while the x64 server was still completing normal startup under Rosetta. The smoke script then sent SIGTERM and mislabeled that timeout as a crash.

## Key Changes
- Keep the default and native startup budget at 30 seconds.
- Use 60 seconds only for an Apple Silicon macOS host testing an x64 macOS package.
- Classify readiness before cleanup so a deadline miss remains a timeout.
- Add focused tests for timeout selection and outcome classification.

## Verification
- `bun test apps/desktop/scripts/__tests__/smoke-test-config.test.mjs`: 5 passed.
- Typecheck and lint passed in the full verification gate.
- Independent high-risk review returned no findings.
- The local full unit phase exceeded the repository's 10-minute bound without a candidate-related failure. Hosted CI is the release gate.

Related to https://github.com/Mzeey-Empire/mcode/actions/runs/30738784853

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788291530&installation_model_id=20477&pr_number=1062&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1062&signature=a885fdbc06040b5c71a557d2099287b6095109832700ec5ae2188cb7ebc9b0fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop smoke-test reliability for Apple Silicon hosts running x64 macOS.
  * Smoke tests now apply appropriate timeouts based on the target platform and architecture.
  * Test results more clearly distinguish healthy, crashed, and timed-out outcomes while preserving diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->