### PR TITLE
feat(browser): execute bounded Browser action batches

### DIFF
--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -1120,7 +1120,7 @@ export class BrowserAutomationKernel {
       tabId: state.tabId,
       controller,
       controlEpoch: state.controlEpoch,
-      ...(request && request.operation !== "inspect" ? { providerSessionId: request.providerSessionId, operation: request.operation } : {}),
+      ...(request && request.operation !== "inspect" && request.operation !== "act" ? { providerSessionId: request.providerSessionId, operation: request.operation } : {}),
       ...(pointer ? { pointer } : {}),
     };
     state.controller = payload;

--- a/apps/server/src/__tests__/copilot-provider.test.ts
+++ b/apps/server/src/__tests__/copilot-provider.test.ts
@@ -287,7 +287,7 @@ describe("CopilotProvider bootstrap", () => {
       url: "http://127.0.0.1:19400/mcp",
       headers: { Authorization: expect.stringMatching(/^Bearer [A-Za-z0-9_-]{40,}$/) },
     });
-    expect(config.mcpServers["mcode-browser"].tools).toHaveLength(17);
+    expect(config.mcpServers["mcode-browser"].tools).toEqual(expect.arrayContaining(["browser_inspect", "browser_act"]));
     expect(config.mcpServers["mcode-browser"].tools).not.toContain("browser_evaluate");
     expect(lease.status()).toEqual({ active: 1, pending: 0 });
     await provider.stopSession("mcode-browser-copilot");

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -1297,6 +1297,34 @@ describe("BrowserAutomationBroker", () => {
     expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(3);
   });
 
+  it("serializes browser_act per provider session and joins exact duplicates", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({ now: () => 10, send: (_socket, channel, data) => { deliveries.push({ channel, data }); return true; } }));
+    const hostSocket = socket("act-lock");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("act-lock", "workspace-a"),
+      executorDescriptor: { ...registration("act-lock", "workspace-a").executorDescriptor, operations: ["inspect", "act"] },
+      capabilities: [{ operation: "act", available: true }],
+    }, authorization("act-lock")).generation;
+    broker.updateTargets(hostSocket, "act-lock", generation, [statusTarget("act-lock", generation)]);
+    const scope = { ...claims("thread-a", "workspace-a"), permissionCapability: "interact" as const, allowedOperations: ["act" as const] };
+    const makeAct = (requestId: string, key: string, sequence: number) => broker.execute(scope, {
+      ...request(scope, sequence), requestId, operation: "act", args: { idempotencyKey: key, observationRef: "obs", deadlineMs: 10_000, steps: [{ operation: "click", target: { role: "button", accessibleName: "Save" } }] },
+    });
+    const first = makeAct("act-1", "same", 1);
+    const joined = makeAct("act-2", "same", 2);
+    const busy = makeAct("act-3", "different", 3);
+    await expect(busy).resolves.toMatchObject({ ok: false, error: { code: "BROWSER_BUSY", effect: "none", recovery: "wait" } });
+    const delivery = deliveries.find(({ channel }) => channel === "browserAutomation.request")!;
+    broker.respond(hostSocket, "act-lock", generation, {
+      contractVersion: 1, requestId: delivery.data.dispatch.request.requestId, sequence: delivery.data.dispatch.request.sequence, ok: true,
+      result: { operation: "act", outcome: "completed", stoppingPosition: 1, effect: "complete", recovery: "inspect", receipts: [{ index: 0, operation: "click", status: "applied" }], finalObservation: { observationRef: "next", hostRevision: generation, documentRevision: 0, controlRevision: 0, capabilityRevision: 1, observationRevision: 1 }, nextObservationRef: "next" },
+    }, delivery.data.dispatch.target);
+    await expect(first).resolves.toMatchObject({ ok: true });
+    await expect(joined).resolves.toMatchObject({ ok: true, requestId: "act-2" });
+    expect(deliveries.filter(({ channel }) => channel === "browserAutomation.request")).toHaveLength(1);
+  });
+
   it("drops keyed open replay when its host reconnects", async () => {
     const deliveries: Array<{ channel: string; data: any }> = [];
     const broker = new BrowserAutomationBroker(options({

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -205,6 +205,7 @@ describe("BrowserAutomationBroker", () => {
       ok: true,
       result: {
         operation: "inspect",
+        observationRef: "driver-issued",
         tabs: [target, { ...target, tabId: "extra-tab" }],
         snapshot: {
           url: "https://example.test/",
@@ -231,9 +232,45 @@ describe("BrowserAutomationBroker", () => {
         capabilities: ["inspect", "status"],
         capabilityRevision: 1,
         guidance: expect.stringContaining("electron"),
-        observationRef: expect.any(String),
+        observationRef: "driver-issued",
       },
     });
+  });
+
+  it("does not advertise act when an act-capable host omits its observation reference", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({ now: () => 10, send: (_socket, channel, data) => {
+      deliveries.push({ channel, data });
+      return true;
+    } }));
+    const hostSocket = socket("act-without-observation");
+    const base = registration("act-without-observation", "workspace-a");
+    const generation = broker.registerHost(hostSocket, {
+      ...base,
+      executorDescriptor: { ...base.executorDescriptor, operations: ["inspect", "act"] },
+      capabilities: [
+        { operation: "inspect", available: true },
+        { operation: "act", available: true },
+      ],
+    }, authorization("act-without-observation")).generation;
+    updateTargets(broker, hostSocket, "act-without-observation", generation, ["thread-a"]);
+    const scope = { ...claims("thread-a", "workspace-a"), permissionCapability: "interact" as const, allowedOperations: ["inspect", "act"] as const };
+    const pending = broker.execute(scope, { ...request(scope), operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const dispatch = deliveries.find((delivery) => delivery.channel === "browserAutomation.request")!.data.dispatch;
+    const target = dispatch.target;
+    broker.respond(hostSocket, "act-without-observation", generation, {
+      contractVersion: 1,
+      requestId: dispatch.request.requestId,
+      sequence: dispatch.request.sequence,
+      ok: true,
+      result: { operation: "inspect", tabs: [target] },
+    });
+    await expect(pending).resolves.toMatchObject({
+      ok: true,
+      result: { operation: "inspect", capabilities: ["inspect"] },
+    });
+    await expect(pending).resolves.not.toHaveProperty("result.observationRef");
   });
 
   it("restricts browser_status to descriptor, credential, host, and controller state", async () => {

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -50,6 +50,12 @@ interface OpenReplayRecord {
   lastUsedAt: number;
 }
 
+interface ActReplayRecord {
+  readonly fingerprint: string;
+  readonly promise: Promise<BrowserAutomationResponse>;
+  lastUsedAt: number;
+}
+
 /** Content-free reliability counters for the browser automation broker. */
 export interface BrowserAutomationReliabilityCounters {
   dispatched: number;
@@ -107,9 +113,9 @@ function failure(
       code,
       message,
       retryable,
-      stage: code === "TAB_UNAVAILABLE" ? "allocation" : "transport",
+      stage: code === "TAB_UNAVAILABLE" || code === "BROWSER_BUSY" ? "allocation" : "transport",
       effect: code === "TAB_UNAVAILABLE" ? "unknown" : "none",
-      recovery: code === "CAPABILITY_CHANGED" ? "inspect" : retryable ? "retry" : "manual",
+      recovery: code === "BROWSER_BUSY" ? "wait" : code === "CAPABILITY_CHANGED" ? "inspect" : retryable ? "retry" : "manual",
       correlationId: randomUUID(),
     },
   };
@@ -158,6 +164,10 @@ function openReplayKey(
   const key = request.args?.idempotencyKey;
   if (!key) return null;
   return JSON.stringify([providerId, request.providerSessionId, request.workspaceId, request.threadId, key]);
+}
+
+function actReplayKey(providerId: string, request: Extract<BrowserAutomationRequest, { operation: "act" }>): string {
+  return JSON.stringify([providerId, request.providerSessionId, request.workspaceId, request.threadId, request.args.idempotencyKey]);
 }
 
 function targetsMatch(
@@ -296,6 +306,8 @@ export class BrowserAutomationBroker {
   private readonly maxHosts: number;
   private readonly maxTargets: number;
   private readonly openReplay = new Map<string, OpenReplayRecord>();
+  private readonly actReplay = new Map<string, ActReplayRecord>();
+  private readonly actMutations = new Map<string, string>();
   private nextGeneration = 1;
   private readonly reliability: BrowserAutomationReliabilityCounters = {
     dispatched: 0,
@@ -633,7 +645,9 @@ export class BrowserAutomationBroker {
       if (record.lastUsedAt < cutoff) this.openReplay.delete(replayKey);
     }
     const parsed = BrowserAutomationRequestSchema().safeParse(input);
-    if (!parsed.success || parsed.data.operation !== "open") return this.executeInternal(claims, input);
+    if (!parsed.success) return this.executeInternal(claims, input);
+    if (parsed.data.operation === "act") return this.executeAct(claims, parsed.data);
+    if (parsed.data.operation !== "open") return this.executeInternal(claims, input);
     const request = parsed.data;
     const key = request.args.idempotencyKey;
     if (!key) return this.executeInternal(claims, input);
@@ -671,6 +685,48 @@ export class BrowserAutomationBroker {
       resolveReplay(response);
       if (!response.ok && this.openReplay.get(replayKey) === replayRecord) this.openReplay.delete(replayKey);
     });
+    return promise;
+  }
+
+  private executeAct(
+    claims: BrowserAutomationCredentialClaims,
+    request: Extract<BrowserAutomationRequest, { operation: "act" }>,
+  ): Promise<BrowserAutomationResponse> {
+    const cutoff = this.now() - 30 * 60_000;
+    for (const [key, record] of this.actReplay) {
+      if (record.lastUsedAt < cutoff) this.actReplay.delete(key);
+    }
+    const replayKey = actReplayKey(claims.providerId, request);
+    const fingerprint = JSON.stringify({
+      observationRef: request.args.observationRef,
+      deadlineMs: request.args.deadlineMs,
+      steps: request.args.steps,
+    });
+    const existing = this.actReplay.get(replayKey);
+    if (existing) {
+      existing.lastUsedAt = this.now();
+      if (existing.fingerprint !== fingerprint) {
+        return Promise.resolve(failure(request, "IDEMPOTENCY_CONFLICT", "The idempotency key was already used with different browser_act arguments", false));
+      }
+      return existing.promise.then((response) => ({ ...response, requestId: request.requestId, sequence: request.sequence }));
+    }
+    const sessionKey = JSON.stringify([claims.providerId, claims.providerSessionId]);
+    if (this.actMutations.has(sessionKey)) {
+      return Promise.resolve(failure(request, "BROWSER_BUSY", "Another browser mutation is active for this provider session", true));
+    }
+    const token = randomUUID();
+    this.actMutations.set(sessionKey, token);
+    const promise = this.executeInternal(claims, request)
+      .catch(() => failure(request, "INTERNAL_ERROR", "Browser mutation failed before a terminal result was produced", false))
+      .finally(() => {
+        if (this.actMutations.get(sessionKey) === token) this.actMutations.delete(sessionKey);
+      });
+    this.actReplay.set(replayKey, { fingerprint, promise, lastUsedAt: this.now() });
+    while (this.actReplay.size > 256) {
+      const oldest = this.actReplay.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.actReplay.delete(oldest);
+    }
     return promise;
   }
 
@@ -842,6 +898,8 @@ export class BrowserAutomationBroker {
       );
     }
     this.pending.clear();
+    this.actReplay.clear();
+    this.actMutations.clear();
   }
 
   /** Returns bounded broker counts for status and tests. */
@@ -891,6 +949,11 @@ export class BrowserAutomationBroker {
       const parts = JSON.parse(key) as string[];
       if (parts[0] === providerId && parts[1] === providerSessionId) this.openReplay.delete(key);
     }
+    for (const key of this.actReplay.keys()) {
+      const parts = JSON.parse(key) as string[];
+      if (parts[0] === providerId && parts[1] === providerSessionId) this.actReplay.delete(key);
+    }
+    this.actMutations.delete(JSON.stringify([providerId, providerSessionId]));
     return removed;
   }
 

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -240,10 +240,17 @@ function shapeNegotiatedResponse(
     allowed.has(operation) && liveHostCapabilities.has(operation),
   );
   if (response.result.operation === "inspect") {
+    const hostObservationRef = typeof response.result.observationRef === "string" && response.result.observationRef.length > 0
+      ? response.result.observationRef
+      : undefined;
+    const actReady = hostObservationRef !== undefined;
+    const advertisedCapabilities = actReady || !negotiatedCapabilities.includes("act")
+      ? negotiatedCapabilities
+      : negotiatedCapabilities.filter((operation) => operation !== "act");
     const targetReady = pending.target !== undefined;
     const guidance = pending.target?.controller?.controller === "human"
       ? "Visible Preview under human control. Yield to user before effects."
-      : `Visible browser executor (${descriptor.runtime}) supports: ${negotiatedCapabilities.join(", ") || "none"}.`;
+      : `Visible browser executor (${descriptor.runtime}) supports: ${advertisedCapabilities.join(", ") || "none"}.`;
     const snapshot = response.result.snapshot && response.result.snapshot.visibleText.length > descriptor.constraints.maxSnapshotChars
       ? {
           ...response.result.snapshot,
@@ -271,8 +278,12 @@ function shapeNegotiatedResponse(
         tabs: (pending.target ? [pending.target] : response.result.tabs).slice(0, descriptor.constraints.maxTabs),
         snapshot,
         ...(diagnostics ? { diagnostics } : {}),
-        observationRef: randomUUID(),
-        capabilities: negotiatedCapabilities,
+        ...(hostObservationRef
+          ? { observationRef: hostObservationRef }
+          : !negotiatedCapabilities.includes("act")
+            ? { observationRef: randomUUID() }
+            : {}),
+        capabilities: advertisedCapabilities,
         capabilityRevision: descriptor.capabilityRevision,
         guidance: guidance.slice(0, 4_000),
       },

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { BROWSER_AUTOMATION_OPERATIONS } from "@mcode/contracts";
 import {
   BrowserAutomationSessionLease,
   type BrowserAutomationSessionLeaseScope,
@@ -56,6 +57,24 @@ describe("BrowserAutomationSessionLease", () => {
     expect(lease.credentials.authenticate(second.token)?.threadId).toBe("thread-b");
     expect(lease.credentials.authenticate(rotated.token)?.allowedOperations).toContain("evaluate");
     expect(lease.status()).toEqual({ active: 2, pending: 0 });
+  });
+
+  it("grants inspect before act for mutation-capable leases without duplicates", () => {
+    const lease = configuredLease();
+    const interact = lease.issue(scope({ permissionCapability: "interact" }))!;
+    const privileged = lease.issue(scope({
+      permissionCapability: "privileged",
+      providerId: "privileged-provider",
+      mcodeSessionId: "privileged-mcode",
+    }))!;
+
+    expect(interact.allowedOperations.slice(0, 2)).toEqual(["inspect", "act"]);
+    expect(interact.allowedOperations).not.toContain("evaluate");
+    expect(new Set(interact.allowedOperations).size).toBe(interact.allowedOperations.length);
+    expect(privileged.allowedOperations.slice(0, 2)).toEqual(["inspect", "act"]);
+    expect(privileged.allowedOperations).toContain("evaluate");
+    expect(privileged.allowedOperations).toEqual(["inspect", "act", ...BROWSER_AUTOMATION_OPERATIONS]);
+    expect(new Set(privileged.allowedOperations).size).toBe(privileged.allowedOperations.length);
   });
 
   it("cleans a staged scope when registry issuance fails", () => {

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
@@ -101,9 +101,9 @@ function allowedOperations(
     return ["inspect", ...BROWSER_AUTOMATION_OPERATIONS.filter((operation) => OBSERVE_OPERATIONS.has(operation))];
   }
   if (capability === "interact") {
-    return BROWSER_AUTOMATION_OPERATIONS.filter((operation) => operation !== "evaluate");
+    return ["act", ...BROWSER_AUTOMATION_OPERATIONS.filter((operation) => operation !== "evaluate")];
   }
-  return [...BROWSER_AUTOMATION_OPERATIONS];
+  return ["act", ...BROWSER_AUTOMATION_OPERATIONS];
 }
 
 function validateConfiguration(configuration: BrowserAutomationSessionLeaseConfiguration): void {

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
@@ -101,9 +101,9 @@ function allowedOperations(
     return ["inspect", ...BROWSER_AUTOMATION_OPERATIONS.filter((operation) => OBSERVE_OPERATIONS.has(operation))];
   }
   if (capability === "interact") {
-    return ["act", ...BROWSER_AUTOMATION_OPERATIONS.filter((operation) => operation !== "evaluate")];
+    return ["inspect", "act", ...BROWSER_AUTOMATION_OPERATIONS.filter((operation) => operation !== "evaluate")];
   }
-  return ["act", ...BROWSER_AUTOMATION_OPERATIONS];
+  return ["inspect", "act", ...BROWSER_AUTOMATION_OPERATIONS];
 }
 
 function validateConfiguration(configuration: BrowserAutomationSessionLeaseConfiguration): void {

--- a/apps/server/src/services/browser-automation/credential-registry.ts
+++ b/apps/server/src/services/browser-automation/credential-registry.ts
@@ -84,10 +84,10 @@ function validateScope(scope: BrowserAutomationCredentialScope): void {
   if (ids.some((value) => value.length < 1 || value.length > 256)) {
     throw new Error("Browser automation credential scope contains an invalid identifier");
   }
-  const supported = new Set<BrowserAutomationOperation>([...BROWSER_AUTOMATION_OPERATIONS, "inspect"]);
+  const supported = new Set<BrowserAutomationOperation>([...BROWSER_AUTOMATION_OPERATIONS, "inspect", "act"]);
   if (
     scope.allowedOperations.length < 1 ||
-    scope.allowedOperations.length > BROWSER_AUTOMATION_OPERATIONS.length + 1 ||
+    scope.allowedOperations.length > BROWSER_AUTOMATION_OPERATIONS.length + 2 ||
     new Set(scope.allowedOperations).size !== scope.allowedOperations.length ||
     scope.allowedOperations.some((operation) => !supported.has(operation))
   ) {

--- a/apps/server/src/services/browser-automation/mcp-handler.test.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.test.ts
@@ -85,6 +85,31 @@ describe("BrowserAutomationMcpHandler", () => {
     });
   });
 
+  it("discovers browser_act with bounded required arguments and rejects invalid batches before broker execution", async () => {
+    const act = credentials.issue({
+      providerId: "cursor",
+      providerSessionId: "act-provider",
+      mcodeSessionId: "act-mcode",
+      threadId: "thread-act",
+      workspaceId: "workspace-a",
+      worktreeIdentity: "worktree-a",
+      permissionCapability: "interact",
+      allowedOperations: ["act"],
+    });
+    const listed = await post(JSON.stringify({ jsonrpc: "2.0", id: 10, method: "tools/list", params: {} }), `Bearer ${act.token}`);
+    const tool = (await listed.json() as any).result.tools[0];
+    expect(tool.name).toBe("browser_act");
+    expect(tool.inputSchema.required).toEqual(expect.arrayContaining(["idempotencyKey", "observationRef", "deadlineMs", "steps"]));
+    const invalid = await post(JSON.stringify({
+      jsonrpc: "2.0", id: 11, method: "tools/call", params: {
+        name: "browser_act",
+        arguments: { idempotencyKey: "key", observationRef: "obs", deadlineMs: 1_000, steps: [] },
+      },
+    }), `Bearer ${act.token}`);
+    expect((await invalid.json() as any).error.code).toBe(-32602);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("advertises only the operations allowed by the authenticated credential", async () => {
     const observe = credentials.issue({
       providerId: "cursor",

--- a/apps/server/src/services/browser-automation/mcp-handler.test.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.test.ts
@@ -100,6 +100,23 @@ describe("BrowserAutomationMcpHandler", () => {
     const tool = (await listed.json() as any).result.tools[0];
     expect(tool.name).toBe("browser_act");
     expect(tool.inputSchema.required).toEqual(expect.arrayContaining(["idempotencyKey", "observationRef", "deadlineMs", "steps"]));
+    expect(tool.inputSchema.properties.deadlineMs).toMatchObject({ type: "integer", maximum: 60_000 });
+    expect(tool.inputSchema.properties.steps).toMatchObject({ type: "array", minItems: 1, maxItems: 8 });
+    const variants = tool.inputSchema.properties.steps.items.oneOf;
+    const click = variants.find((variant: any) => variant.properties.operation.const === "click");
+    expect(click).toMatchObject({
+      required: ["operation", "target"],
+      additionalProperties: false,
+      properties: { operation: { const: "click" }, target: { oneOf: expect.any(Array) } },
+    });
+    expect(click.properties.target.oneOf).toHaveLength(4);
+    const wait = variants.find((variant: any) => variant.properties.operation.const === "wait");
+    expect(wait).toMatchObject({
+      required: ["operation", "durationMs"],
+      additionalProperties: false,
+      properties: { operation: { const: "wait" }, durationMs: { type: "integer", minimum: 1, maximum: 60_000 } },
+    });
+    expect(variants).toHaveLength(15);
     const invalid = await post(JSON.stringify({
       jsonrpc: "2.0", id: 11, method: "tools/call", params: {
         name: "browser_act",

--- a/apps/server/src/services/browser-automation/mcp-handler.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.ts
@@ -18,6 +18,7 @@ const MAX_BODY_BYTES = 256 * 1_024;
 const MCP_PROTOCOL_VERSIONS = ["2025-03-26", "2024-11-05"] as const;
 const TOOL_NAME_TO_OPERATION = new Map<string, BrowserAutomationOperation>([
   ["browser_inspect", "inspect" as BrowserAutomationOperation],
+  ["browser_act", "act" as BrowserAutomationOperation],
   ...BROWSER_AUTOMATION_OPERATIONS.map((operation) => [
     BROWSER_AUTOMATION_OPERATION_METADATA[operation].mcpName,
     operation,
@@ -107,6 +108,12 @@ const commonProperties = {
 function inputSchema(operation: BrowserAutomationOperation): Record<string, unknown> {
   const schemas: Record<BrowserAutomationOperation, Record<string, unknown>> = {
     inspect: { includeScreenshot: { type: "boolean", default: false }, includeDiagnostics: { type: "boolean", default: false } },
+    act: {
+      idempotencyKey: { type: "string", minLength: 1, maxLength: 256 },
+      observationRef: { type: "string", minLength: 1, maxLength: 256 },
+      deadlineMs: { type: "integer", minimum: 1, maximum: 60000 },
+      steps: { type: "array", minItems: 1, maxItems: 8, items: { type: "object" } },
+    },
     status: {},
     open: {
       url: { type: "string", format: "uri" },
@@ -130,7 +137,7 @@ function inputSchema(operation: BrowserAutomationOperation): Record<string, unkn
     recordingStop: {},
   };
   const requiredByOperation: Partial<Record<BrowserAutomationOperation, string[]>> = {
-    open: ["idempotencyKey"], navigate: ["url"], resize: ["width", "height"], click: ["target"], type: ["text"], press: ["key"], scroll: ["deltaY"], evaluate: ["expression"],
+    open: ["idempotencyKey"], act: ["idempotencyKey", "observationRef", "deadlineMs", "steps"], navigate: ["url"], resize: ["width", "height"], click: ["target"], type: ["text"], press: ["key"], scroll: ["deltaY"], evaluate: ["expression"],
   };
   return {
     type: "object",

--- a/apps/server/src/services/browser-automation/mcp-handler.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.ts
@@ -105,6 +105,50 @@ const commonProperties = {
   expectedControlEpoch: { type: "integer", minimum: 0, description: "Control epoch returned by browser_status." },
 } as const;
 
+const actTargetSchema = {
+  oneOf: [
+    { type: "object", properties: { semanticId: { type: "string", minLength: 1, maxLength: 1_024 } }, required: ["semanticId"], additionalProperties: false },
+    { type: "object", properties: { role: { type: "string", minLength: 1, maxLength: 128 }, accessibleName: { type: "string", minLength: 1, maxLength: 1_024 } }, required: ["role", "accessibleName"], additionalProperties: false },
+    { type: "object", properties: { cssSelector: { type: "string", minLength: 1, maxLength: 4_096 } }, required: ["cssSelector"], additionalProperties: false },
+    { type: "object", properties: { x: { type: "number", minimum: 0, maximum: 100_000 }, y: { type: "number", minimum: 0, maximum: 100_000 } }, required: ["x", "y"], additionalProperties: false },
+  ],
+} as const;
+
+const actTimeoutSchema = { type: "integer", minimum: 1, maximum: 60_000 } as const;
+
+function actStepSchema(
+  operation: string,
+  properties: Record<string, unknown>,
+  required: readonly string[] = [],
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: { operation: { const: operation }, ...properties },
+    required: ["operation", ...required],
+    additionalProperties: false,
+    ...extra,
+  };
+}
+
+const actStepVariants = [
+  actStepSchema("navigate", { url: { type: "string", format: "uri", minLength: 1, maxLength: 2_048 } }, ["url"]),
+  actStepSchema("back", {}),
+  actStepSchema("forward", {}),
+  actStepSchema("reload", {}),
+  actStepSchema("resize", { width: { type: "integer", minimum: 320, maximum: 7_680 }, height: { type: "integer", minimum: 240, maximum: 4_320 } }, ["width", "height"]),
+  actStepSchema("hover", { target: actTargetSchema, timeoutMs: actTimeoutSchema }, ["target"]),
+  actStepSchema("click", { target: actTargetSchema, button: { enum: ["left", "middle", "right"], default: "left" }, clickCount: { enum: [1, 2], default: 1 }, timeoutMs: actTimeoutSchema }, ["target"]),
+  actStepSchema("drag", { source: actTargetSchema, target: actTargetSchema, timeoutMs: actTimeoutSchema }, ["source", "target"]),
+  actStepSchema("type", { target: actTargetSchema, text: { type: "string", maxLength: 16_384 }, clear: { type: "boolean", default: false }, submit: { type: "boolean", default: false }, timeoutMs: actTimeoutSchema }, ["text"]),
+  actStepSchema("press", { key: { type: "string", minLength: 1, maxLength: 64 }, modifiers: { type: "array", items: { enum: ["Alt", "Control", "Meta", "Shift"] }, maxItems: 4, default: [] }, timeoutMs: actTimeoutSchema }, ["key"]),
+  actStepSchema("scroll", { target: actTargetSchema, deltaX: { type: "number", minimum: -100_000, maximum: 100_000, default: 0 }, deltaY: { type: "number", minimum: -100_000, maximum: 100_000 }, timeoutMs: actTimeoutSchema }, ["deltaY"]),
+  actStepSchema("wait", { durationMs: { type: "integer", minimum: 1, maximum: 60_000 } }, ["durationMs"]),
+  actStepSchema("assert", { target: actTargetSchema, text: { type: "string", minLength: 1, maxLength: 1_024 }, url: { type: "string", format: "uri", minLength: 1, maxLength: 2_048 } }, [], { anyOf: [{ required: ["target"] }, { required: ["text"] }, { required: ["url"] }] }),
+  actStepSchema("recordingStart", {}),
+  actStepSchema("recordingStop", {}),
+];
+
 function inputSchema(operation: BrowserAutomationOperation): Record<string, unknown> {
   const schemas: Record<BrowserAutomationOperation, Record<string, unknown>> = {
     inspect: { includeScreenshot: { type: "boolean", default: false }, includeDiagnostics: { type: "boolean", default: false } },
@@ -112,7 +156,7 @@ function inputSchema(operation: BrowserAutomationOperation): Record<string, unkn
       idempotencyKey: { type: "string", minLength: 1, maxLength: 256 },
       observationRef: { type: "string", minLength: 1, maxLength: 256 },
       deadlineMs: { type: "integer", minimum: 1, maximum: 60000 },
-      steps: { type: "array", minItems: 1, maxItems: 8, items: { type: "object" } },
+      steps: { type: "array", minItems: 1, maxItems: 8, items: { oneOf: actStepVariants } },
     },
     status: {},
     open: {

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -1039,20 +1039,17 @@ export function BrowserAutomationHost() {
       });
       void guardedOperation.then((response) => {
         if (leaseRef.current !== lease || cancelledRef.current.has(key)) return;
-        const outboundResponse = response.ok && response.result.operation === "inspect" && !response.result.observationRef
-          ? { ...response, result: { ...response.result, observationRef: globalThis.crypto.randomUUID() } }
-          : response;
         return webDispatch || webNavigateRequest || (!bridge && webAutomationEnabled && dispatch.request.operation === "screenshot")
           ? getTransport().respondToBrowserAutomationRequest(
             lease.hostId,
             lease.generation,
-            outboundResponse,
+            response,
             dispatch.target,
           )
           : getTransport().respondToBrowserAutomationRequest(
             lease.hostId,
             lease.generation,
-            outboundResponse,
+            response,
           );
       }).catch(() => undefined).finally(() => {
         webObserverRef.current.get(key)?.();

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -584,6 +584,9 @@ export function BrowserAutomationHost() {
       electron: new ElectronBrowserSessionAdapter(
         (dispatch, signal) => executeBrowserDispatch(window.desktopBridge?.preview?.automation, recorderRef.current, dispatch, signal),
       ),
+      supportedActOperations: window.desktopBridge?.preview?.automation
+        ? ["navigate", "click", "type", "press", "scroll"]
+        : ["navigate", "click", "type"],
     });
   }
   const addPersistentWebTab = (tab: PersistentAutomationWebTab): void => {

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -533,7 +533,7 @@ export function BrowserAutomationHost() {
   const shutdownLeaseRef = useRef<HostLease | null>(null);
   const executorDescriptor = useMemo(() => ({
     runtime: window.desktopBridge?.preview?.automation ? "electron" as const : "web" as const,
-    operations: ["inspect", ...BROWSER_AUTOMATION_OPERATIONS] as BrowserAutomationOperation[],
+    operations: ["inspect", "act", ...BROWSER_AUTOMATION_OPERATIONS] as BrowserAutomationOperation[],
     constraints: { maxTabs: 32, maxSnapshotChars: 20_000, maxDiagnostics: 200 },
     capabilityRevision: 1,
   }), []);
@@ -682,7 +682,7 @@ export function BrowserAutomationHost() {
         targetIdentity: webTargetIdentity(worktreeIdentity, "pending-desktop", activeTarget),
       } : {}),
       executorDescriptor,
-      capabilities: [{ operation: "inspect", available: true }, ...BROWSER_AUTOMATION_OPERATIONS.map((operation) => {
+      capabilities: [{ operation: "inspect", available: true }, { operation: "act", available: true }, ...BROWSER_AUTOMATION_OPERATIONS.map((operation) => {
         if (!desktopAutomation) {
           const available = operation === "click" || operation === "type" ||
             operation === "status" || operation === "open" || operation === "navigate" ||
@@ -1039,17 +1039,20 @@ export function BrowserAutomationHost() {
       });
       void guardedOperation.then((response) => {
         if (leaseRef.current !== lease || cancelledRef.current.has(key)) return;
+        const outboundResponse = response.ok && response.result.operation === "inspect" && !response.result.observationRef
+          ? { ...response, result: { ...response.result, observationRef: globalThis.crypto.randomUUID() } }
+          : response;
         return webDispatch || webNavigateRequest || (!bridge && webAutomationEnabled && dispatch.request.operation === "screenshot")
           ? getTransport().respondToBrowserAutomationRequest(
             lease.hostId,
             lease.generation,
-            response,
+            outboundResponse,
             dispatch.target,
           )
           : getTransport().respondToBrowserAutomationRequest(
             lease.hostId,
             lease.generation,
-            response,
+            outboundResponse,
           );
       }).catch(() => undefined).finally(() => {
         webObserverRef.current.get(key)?.();

--- a/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
@@ -93,8 +93,11 @@ describe("web browser automation executor", () => {
     const clicked = vi.fn();
     button.addEventListener("click", clicked);
     const snapshot = await executeWebBrowserDispatch(dispatch("snapshot", { includeScreenshot: false }), new AbortController().signal);
-    const semanticId = (snapshot as any).result.snapshot.elements[0].semanticId;
+    const snapshotData = snapshot.ok && snapshot.result.operation === "snapshot" ? snapshot.result.snapshot : null;
+    expect(snapshotData).not.toBeNull();
+    const semanticId = snapshotData?.elements[0]?.semanticId;
     expect(semanticId).toMatch(/^element-/);
+    if (!semanticId) throw new Error("Snapshot did not return a semantic element identity");
     const result = await executeWebInteraction(page, dispatch("click", {
       target: { semanticId }, button: "left", clickCount: 1, timeoutMs: 1_000,
     }), {

--- a/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/browserAutomationWebExecutor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { BROWSER_AUTOMATION_CONTRACT_VERSION, type BrowserAutomationHostDispatch } from "@mcode/contracts";
 import { captureVisibleWebScreenshot } from "../web-browser-automation/capture";
 import { executeWebBrowserDispatch } from "../browserAutomationWebExecutor";
+import { executeWebInteraction, resolveWebTarget } from "../webBrowserInteractionExecutor";
 
 vi.mock("../web-browser-automation/capture", () => ({ captureVisibleWebScreenshot: vi.fn() }));
 
@@ -77,6 +78,39 @@ describe("web browser automation executor", () => {
       elements: [{ semanticId: "save-button", role: "button", accessibleName: "Save" }],
     } } });
     target.remove();
+  });
+
+  it("reuses a synthetic snapshot semantic id for a native control click", async () => {
+    document.body.innerHTML = `<button>Save</button>`;
+    const target = document.createElement("iframe");
+    target.dataset.threadId = "thread-1";
+    target.dataset.tabId = "tab-1";
+    document.body.append(target);
+    Object.defineProperty(target, "contentDocument", { configurable: true, value: document });
+    const page = document;
+    const button = page.querySelector("button")!;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    const clicked = vi.fn();
+    button.addEventListener("click", clicked);
+    const snapshot = await executeWebBrowserDispatch(dispatch("snapshot", { includeScreenshot: false }), new AbortController().signal);
+    const semanticId = (snapshot as any).result.snapshot.elements[0].semanticId;
+    expect(semanticId).toMatch(/^element-/);
+    const result = await executeWebInteraction(page, dispatch("click", {
+      target: { semanticId }, button: "left", clickCount: 1, timeoutMs: 1_000,
+    }), {
+      signal: new AbortController().signal,
+      deadline: Date.now() + 1_000,
+      expectedControlEpoch: 0,
+      targetGeneration: 1,
+      getControlEpoch: () => 0,
+      getTargetGeneration: () => 1,
+    });
+    expect(result).toMatchObject({ ok: true });
+    expect(clicked).toHaveBeenCalledOnce();
+    button.remove();
+    expect(resolveWebTarget(page, { semanticId })).toMatchObject({ ok: false, code: "TARGET_NOT_FOUND" });
+    target.remove();
+    document.body.innerHTML = "";
   });
 
   it("scans hostile oversized DOM without whole-document query materialization", async () => {

--- a/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
+++ b/apps/web/src/components/panels/__tests__/webBrowserInteractionExecutor.test.ts
@@ -53,6 +53,13 @@ describe("web browser interaction executor", () => {
     expect(clicked).toHaveBeenCalledOnce();
   });
 
+  it("resolves native controls through their implicit role", () => {
+    document.body.innerHTML = "<button>Save</button>";
+    const button = document.querySelector("button")!;
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({ width: 80, height: 20 } as DOMRect);
+    expect(resolveWebTarget(document, { role: "button", accessibleName: "Save" })).toMatchObject({ ok: true, element: button });
+  });
+
   it("cancels click during the scheduling frame before dispatching events", async () => {
     document.body.innerHTML = '<button id="save">Save</button>';
     const button = document.querySelector("button") as HTMLButtonElement;

--- a/apps/web/src/components/panels/__tests__/webBrowserSemanticRegistry.test.ts
+++ b/apps/web/src/components/panels/__tests__/webBrowserSemanticRegistry.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { WebBrowserSemanticRegistry } from "../webBrowserSemanticRegistry";
+
+describe("WebBrowserSemanticRegistry", () => {
+  it("refreshes an evicted connected element identity without resolving stale ids", () => {
+    const registry = new WebBrowserSemanticRegistry();
+    const first = document.createElement("button");
+    document.body.replaceChildren(first);
+    const firstId = registry.register(document, first);
+    const otherElements = Array.from({ length: 256 }, () => document.createElement("button"));
+    document.body.append(...otherElements);
+    for (const element of otherElements) registry.register(document, element);
+
+    expect(registry.resolve(document, firstId)).toBeNull();
+    const refreshedId = registry.register(document, first);
+    expect(registry.resolve(document, refreshedId)).toBe(first);
+    document.body.replaceChildren();
+  });
+});

--- a/apps/web/src/components/panels/browserAutomationWebExecutor.ts
+++ b/apps/web/src/components/panels/browserAutomationWebExecutor.ts
@@ -8,6 +8,7 @@ import {
   type BrowserAutomationResponse,
 } from "@mcode/contracts";
 import { captureVisibleWebScreenshot } from "./web-browser-automation/capture";
+import { getWebBrowserSemanticRegistry } from "./webBrowserSemanticRegistry";
 
 const WEB_SNAPSHOT_MAX_SCAN_NODES = 8_192;
 const WEB_SNAPSHOT_MAX_ELEMENT_TEXT = 1_024;
@@ -326,8 +327,9 @@ function collectBoundedSnapshot(document: Document): BoundedSnapshotData {
         const bounds = (element as HTMLElement).getBoundingClientRect();
         const accessibleName = element.getAttribute("aria-label")?.slice(0, WEB_SNAPSHOT_MAX_ELEMENT_TEXT) || boundedElementText(element, WEB_SNAPSHOT_MAX_ELEMENT_TEXT, budget);
         if (typeof accessibleName !== "string" && accessibleName.budgetExhausted) scanLimitReached = true;
+        const preferredSemanticId = element.id || element.getAttribute("data-automation-id") || undefined;
         elements.push({
-          semanticId: element.id || `element-${elements.length + 1}`,
+          semanticId: getWebBrowserSemanticRegistry(document).register(document, element, preferredSemanticId),
           role: element.getAttribute("role")?.slice(0, 128) || element.tagName.toLowerCase(),
           accessibleName: typeof accessibleName === "string" ? accessibleName : accessibleName.text,
           ...(("value" in element && typeof (element as HTMLInputElement).value === "string" &&

--- a/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
+++ b/apps/web/src/components/panels/webBrowserInteractionExecutor.ts
@@ -4,6 +4,7 @@ import type {
   BrowserAutomationResponse,
   BrowserAutomationTarget,
 } from "@mcode/contracts";
+import { getWebBrowserSemanticRegistry } from "./webBrowserSemanticRegistry";
 
 const MAX_TARGET_SCAN = 1_024;
 const MAX_METADATA_CHARS = 2_048;
@@ -101,11 +102,13 @@ export function resolveWebTarget(ownerDocument: Document, target: BrowserAutomat
     } else if ("semanticId" in target) {
       element = ownerDocument.getElementById(target.semanticId);
       if (!element) element = ownerDocument.querySelector<HTMLElement>(`[data-automation-id="${escapeSelector(target.semanticId)}"]`);
+      if (!element) element = getWebBrowserSemanticRegistry(ownerDocument).resolve(ownerDocument, target.semanticId);
     } else if ("role" in target) {
       let scanned = 0;
-      for (const candidate of ownerDocument.querySelectorAll<HTMLElement>("[role]")) {
+      for (const candidate of ownerDocument.querySelectorAll<HTMLElement>("button,input,select,textarea,[role]")) {
         if (++scanned > MAX_TARGET_SCAN) break;
-        if (candidate.getAttribute("role") === target.role && accessibleName(candidate) === target.accessibleName) {
+        const role = candidate.getAttribute("role") || candidate.localName?.toLowerCase();
+        if (role === target.role && accessibleName(candidate) === target.accessibleName) {
           element = candidate;
           break;
         }

--- a/apps/web/src/components/panels/webBrowserSemanticRegistry.ts
+++ b/apps/web/src/components/panels/webBrowserSemanticRegistry.ts
@@ -10,7 +10,16 @@ export class WebBrowserSemanticRegistry {
   /** Returns a stable identity for one element, preferring its real DOM identity. */
   register(ownerDocument: Document, element: Element, preferredId?: string): string {
     const existing = this.idsByElement.get(element);
-    if (existing) return existing;
+    if (existing) {
+      const retained = this.elementsById.get(existing);
+      if (retained === element && element.ownerDocument === ownerDocument && element.isConnected) return existing;
+      if (!retained && element.ownerDocument === ownerDocument && element.isConnected) {
+        this.retain(existing, element);
+        return existing;
+      }
+      this.idsByElement.delete(element);
+      if (retained === element) this.elementsById.delete(existing);
+    }
     const usablePreferred = preferredId && preferredId.length <= MAX_SEMANTIC_ID_CHARS
       ? preferredId
       : undefined;
@@ -18,6 +27,11 @@ export class WebBrowserSemanticRegistry {
     const id = usablePreferred && (!preferredOwner || preferredOwner === element)
       ? usablePreferred
       : this.nextSyntheticIdFor(ownerDocument);
+    this.retain(id, element);
+    return id;
+  }
+
+  private retain(id: string, element: Element): void {
     this.idsByElement.set(element, id);
     this.elementsById.set(id, element);
     while (this.elementsById.size > MAX_REGISTERED_ELEMENTS) {
@@ -25,7 +39,6 @@ export class WebBrowserSemanticRegistry {
       if (oldest === undefined) break;
       this.elementsById.delete(oldest);
     }
-    return id;
   }
 
   /** Resolves a registry identity only while its element remains in the same document. */

--- a/apps/web/src/components/panels/webBrowserSemanticRegistry.ts
+++ b/apps/web/src/components/panels/webBrowserSemanticRegistry.ts
@@ -1,0 +1,64 @@
+const MAX_REGISTERED_ELEMENTS = 256;
+const MAX_SEMANTIC_ID_CHARS = 1_024;
+
+/** Retains bounded, document-scoped element identities without mutating page DOM. */
+export class WebBrowserSemanticRegistry {
+  private readonly idsByElement = new WeakMap<Element, string>();
+  private readonly elementsById = new Map<string, Element>();
+  private nextSyntheticId = 1;
+
+  /** Returns a stable identity for one element, preferring its real DOM identity. */
+  register(ownerDocument: Document, element: Element, preferredId?: string): string {
+    const existing = this.idsByElement.get(element);
+    if (existing) return existing;
+    const usablePreferred = preferredId && preferredId.length <= MAX_SEMANTIC_ID_CHARS
+      ? preferredId
+      : undefined;
+    const preferredOwner = usablePreferred ? this.elementsById.get(usablePreferred) : undefined;
+    const id = usablePreferred && (!preferredOwner || preferredOwner === element)
+      ? usablePreferred
+      : this.nextSyntheticIdFor(ownerDocument);
+    this.idsByElement.set(element, id);
+    this.elementsById.set(id, element);
+    while (this.elementsById.size > MAX_REGISTERED_ELEMENTS) {
+      const oldest = this.elementsById.keys().next().value;
+      if (oldest === undefined) break;
+      this.elementsById.delete(oldest);
+    }
+    return id;
+  }
+
+  /** Resolves a registry identity only while its element remains in the same document. */
+  resolve(ownerDocument: Document, id: string): HTMLElement | null {
+    const element = this.elementsById.get(id);
+    if (!element) return null;
+    if (element.ownerDocument !== ownerDocument || !element.isConnected) {
+      this.elementsById.delete(id);
+      return null;
+    }
+    return element as HTMLElement;
+  }
+
+  private nextSyntheticIdFor(ownerDocument: Document): string {
+    let id: string;
+    do {
+      id = `element-${this.nextSyntheticId++}`;
+    } while (
+      this.elementsById.has(id) ||
+      ownerDocument.getElementById(id) !== null ||
+      ownerDocument.querySelector(`[data-automation-id="${id}"]`) !== null
+    );
+    return id;
+  }
+}
+
+const registriesByDocument = new WeakMap<Document, WebBrowserSemanticRegistry>();
+
+/** Returns the bounded semantic registry associated with one document lifetime. */
+export function getWebBrowserSemanticRegistry(ownerDocument: Document): WebBrowserSemanticRegistry {
+  const existing = registriesByDocument.get(ownerDocument);
+  if (existing) return existing;
+  const registry = new WebBrowserSemanticRegistry();
+  registriesByDocument.set(ownerDocument, registry);
+  return registry;
+}

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -7,6 +7,83 @@ const response = {} as BrowserAutomationResponse;
 const dispatch = {} as BrowserAutomationHostDispatch;
 
 describe("BrowserSessionDriver", () => {
+  function actDispatch(observationRef: string, steps: unknown[], requestId = "act"): BrowserAutomationHostDispatch {
+    return {
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target: { threadId: "thread", tabId: "tab", targetGeneration: 1 },
+      request: {
+        contractVersion: 1,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId,
+        sequence: 1,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "act",
+        args: { idempotencyKey: `${requestId}-key`, observationRef, deadlineMs: 10_000, steps },
+      },
+    } as unknown as BrowserAutomationHostDispatch;
+  }
+
+  it("produces an observation in-driver and stops after a navigation boundary with receipts", async () => {
+    const calls: string[] = [];
+    const execute = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => {
+      calls.push(dispatch.request.operation);
+      if (dispatch.request.operation === "inspect") {
+        return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
+      }
+      return { ok: true, result: { operation: dispatch.request.operation } } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({ web: { execute }, electron: { execute }, isElectron: () => false, supportedActOperations: ["click", "navigate", "type"] });
+    const inspect = await driver.execute({
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target: { threadId: "thread", tabId: "tab", targetGeneration: 1 },
+      request: { contractVersion: 1, requestId: "inspect", sequence: 1, operation: "inspect", expectedControlEpoch: 0 },
+    } as unknown as BrowserAutomationHostDispatch, new AbortController().signal);
+    const observationRef = (inspect as { result?: { observationRef?: string } }).result?.observationRef;
+    expect(observationRef).toEqual(expect.any(String));
+    const result = await driver.execute(actDispatch(observationRef!, [
+      { operation: "click", target: { cssSelector: "#save" } },
+      { operation: "navigate", url: "https://example.test/next" },
+      { operation: "type", text: "secret" },
+    ]), new AbortController().signal);
+    expect(result).toMatchObject({ ok: true, result: { operation: "act", outcome: "completed", stoppingPosition: 2, effect: "complete", receipts: [
+      { index: 0, operation: "click", status: "applied" },
+      { index: 1, operation: "navigate", status: "applied" },
+      { index: 2, operation: "type", status: "skipped" },
+    ] } });
+    expect(calls).toEqual(["inspect", "click", "navigate"]);
+    const replay = await driver.execute(actDispatch(observationRef!, [{ operation: "click", target: { cssSelector: "#save" } }], "second"), new AbortController().signal);
+    expect(replay).toMatchObject({ ok: false, error: { code: "STALE_TARGET_GENERATION" } });
+  });
+
+  it("rejects unsupported steps before the first adapter effect", async () => {
+    const execute = vi.fn().mockResolvedValue({ ok: true, result: { operation: "click" } } as unknown as BrowserAutomationResponse);
+    const driver = new BrowserSessionDriver({ web: { execute }, electron: { execute }, isElectron: () => false, supportedActOperations: ["click"] });
+    const result = await driver.execute(actDispatch("observation", [
+      { operation: "click", target: { cssSelector: "#save" } },
+      { operation: "type", text: "secret" },
+    ]), new AbortController().signal);
+    expect(result).toMatchObject({ ok: false, error: { code: "UNSUPPORTED_OPERATION", effect: "none" } });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("stops before the next effect when control revision changes", async () => {
+    let controlRevision = 0;
+    const execute = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => {
+      if (dispatch.request.operation === "inspect") return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
+      controlRevision = 1;
+      return { ok: true, result: { operation: dispatch.request.operation } } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({ web: { execute }, electron: { execute }, isElectron: () => false, getControlRevision: () => controlRevision, supportedActOperations: ["click", "type"] });
+    const inspect = await driver.execute({ connection: { connectionGeneration: 1, capabilityRevision: 1 }, target: { threadId: "thread", tabId: "tab", targetGeneration: 1 }, request: { contractVersion: 1, requestId: "inspect", sequence: 1, operation: "inspect", expectedControlEpoch: 0 } } as unknown as BrowserAutomationHostDispatch, new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+    const result = await driver.execute(actDispatch(observationRef, [{ operation: "click", target: { cssSelector: "#save" } }, { operation: "type", text: "secret" }]), new AbortController().signal);
+    expect(result).toMatchObject({ ok: true, result: { outcome: "interrupted", effect: "partial", receipts: [{ index: 0, status: "applied" }, { index: 1, status: "interrupted" }] } });
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
   it("fails before adapter execution when descriptor revision drifts", async () => {
     const web = vi.fn().mockResolvedValue(response);
     const driver = new BrowserSessionDriver({

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -59,6 +59,25 @@ describe("BrowserSessionDriver", () => {
     expect(replay).toMatchObject({ ok: false, error: { code: "STALE_TARGET_GENERATION" } });
   });
 
+  it("preserves a host-issued observation reference for the next act", async () => {
+    const execute = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => {
+      if (dispatch.request.operation === "inspect") {
+        return { ok: true, result: { operation: "inspect", observationRef: "driver-issued" } } as unknown as BrowserAutomationResponse;
+      }
+      return { ok: true, result: { operation: dispatch.request.operation } } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({ web: { execute }, electron: { execute }, isElectron: () => false, supportedActOperations: ["click"] });
+    const inspect = await driver.execute({
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target: { threadId: "thread", tabId: "tab", targetGeneration: 1 },
+      request: { contractVersion: 1, requestId: "inspect-issued", sequence: 1, operation: "inspect", expectedControlEpoch: 0 },
+    } as unknown as BrowserAutomationHostDispatch, new AbortController().signal);
+    expect(inspect).toMatchObject({ ok: true, result: { observationRef: "driver-issued" } });
+    await expect(driver.execute(actDispatch("driver-issued", [{ operation: "click", target: { cssSelector: "#save" } }]), new AbortController().signal))
+      .resolves.toMatchObject({ ok: true, result: { outcome: "completed" } });
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects unsupported steps before the first adapter effect", async () => {
     const execute = vi.fn().mockResolvedValue({ ok: true, result: { operation: "click" } } as unknown as BrowserAutomationResponse);
     const driver = new BrowserSessionDriver({ web: { execute }, electron: { execute }, isElectron: () => false, supportedActOperations: ["click"] });

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -1,6 +1,7 @@
 import type {
   BrowserAutomationHostDispatch,
   BrowserAutomationResponse,
+  BrowserAutomationActStep,
 } from "@mcode/contracts";
 
 const MAX_IDEMPOTENCY_RECORDS = 256;
@@ -15,6 +16,13 @@ interface IdempotencyRecord {
   readonly target: { threadId: string; tabId: string; windowId: number; targetGeneration: number };
   lastUsedAt: number;
   readonly promise: Promise<BrowserAutomationResponse>;
+}
+
+interface ObservationRecord {
+  readonly targetGeneration: number;
+  readonly controlRevision: number;
+  readonly capabilityRevision: number;
+  observationRevision: number;
 }
 
 /** Runtime implementation used by the client BrowserSessionDriver. */
@@ -55,6 +63,7 @@ export interface BrowserSessionDriverOptions {
 export class BrowserSessionDriver {
   private readonly isElectron: () => boolean;
   private readonly idempotency = new Map<string, IdempotencyRecord>();
+  private readonly observations = new Map<string, ObservationRecord>();
 
   constructor(private readonly options: BrowserSessionDriverOptions) {
     this.isElectron = options.isElectron ?? (() => typeof window !== "undefined" && typeof window.desktopBridge?.preview === "object");
@@ -67,6 +76,7 @@ export class BrowserSessionDriver {
   ): Promise<BrowserAutomationResponse> {
     const initialDrift = this.revisionDrift(dispatch);
     if (initialDrift) return Promise.resolve(initialDrift);
+    if (dispatch.request?.operation === "act") return this.executeAct(dispatch, signal);
     if (dispatch.request?.operation !== "open") {
       return this.executeAdapter(dispatch, signal);
     }
@@ -175,7 +185,119 @@ export class BrowserSessionDriver {
   ): Promise<BrowserAutomationResponse> {
     const drift = this.revisionDrift(dispatch);
     if (drift) return Promise.resolve(drift);
-    return (this.isElectron() ? this.options.electron : this.options.web).execute(dispatch, signal);
+    return (this.isElectron() ? this.options.electron : this.options.web).execute(dispatch, signal)
+      .then((response) => this.rememberObservation(response, dispatch));
+  }
+
+  private executeAct(
+    dispatch: BrowserAutomationHostDispatch,
+    signal: AbortSignal,
+  ): Promise<BrowserAutomationResponse> {
+    const request = dispatch.request as Extract<BrowserAutomationHostDispatch["request"], { operation: "act" }>;
+    const observation = this.observations.get(request.args.observationRef);
+    const capabilityRevision = this.options.getCapabilityRevision?.() ?? dispatch.connection?.capabilityRevision ?? 1;
+    const baseObservation = observation ?? {
+      targetGeneration: dispatch.target.targetGeneration,
+      controlRevision: request.expectedControlEpoch,
+      capabilityRevision,
+      observationRevision: 0,
+    };
+    if (!observation || observation.targetGeneration !== dispatch.target.targetGeneration || observation.controlRevision !== request.expectedControlEpoch || observation.capabilityRevision !== capabilityRevision) {
+      return Promise.resolve(this.actFailure(dispatch, "STALE_TARGET_GENERATION", "Browser observation is stale; inspect before browser_act"));
+    }
+    const deadline = Math.min(dispatch.request.deadline, Date.now() + request.args.deadlineMs);
+    const receipts: Array<{ index: number; operation: string; status: "applied" | "satisfied" | "failed" | "interrupted" | "skipped"; message?: string }> = [];
+    const nextObservationRef = globalThis.crypto.randomUUID();
+    let effect: "none" | "partial" | "complete" = "none";
+    let outcome: "completed" | "failed" | "interrupted" = "completed";
+    let stoppingPosition = request.args.steps.length;
+    const run = async (): Promise<BrowserAutomationResponse> => {
+      for (let index = 0; index < request.args.steps.length; index += 1) {
+        const step = request.args.steps[index] as BrowserAutomationActStep;
+        if (signal.aborted || Date.now() >= deadline) {
+          outcome = "interrupted";
+          stoppingPosition = index;
+          receipts.push({ index, operation: step.operation, status: "interrupted", message: "Browser batch interrupted before the next effect" });
+          for (let skipped = index + 1; skipped < request.args.steps.length; skipped += 1) receipts.push({ index: skipped, operation: request.args.steps[skipped]!.operation, status: "skipped" });
+          break;
+        }
+        const drift = this.revisionDrift(dispatch);
+        if (drift) {
+          outcome = "interrupted";
+          stoppingPosition = index;
+          receipts.push({ index, operation: step.operation, status: "interrupted", message: "Browser capability revision changed" });
+          for (let skipped = index + 1; skipped < request.args.steps.length; skipped += 1) receipts.push({ index: skipped, operation: request.args.steps[skipped]!.operation, status: "skipped" });
+          break;
+        }
+        const stepDispatch = this.stepDispatch(dispatch, step, deadline, index);
+        const response = await this.executeAdapter(stepDispatch, signal);
+        if (!response.ok) {
+          outcome = response.error.code === "OPERATION_CANCELLED" || response.error.code === "HUMAN_INTERRUPTED" || response.error.code === "DEADLINE_EXCEEDED" ? "interrupted" : "failed";
+          stoppingPosition = index;
+          receipts.push({ index, operation: step.operation, status: outcome === "interrupted" ? "interrupted" : "failed", message: response.error.message });
+          for (let skipped = index + 1; skipped < request.args.steps.length; skipped += 1) receipts.push({ index: skipped, operation: request.args.steps[skipped]!.operation, status: "skipped" });
+          break;
+        }
+        receipts.push({ index, operation: step.operation, status: step.operation === "assert" || step.operation === "wait" ? "satisfied" : "applied" });
+        effect = "complete";
+        if (step.operation === "navigate" || step.operation === "back" || step.operation === "forward" || step.operation === "reload") {
+          stoppingPosition = index + 1;
+          for (let skipped = index + 1; skipped < request.args.steps.length; skipped += 1) receipts.push({ index: skipped, operation: request.args.steps[skipped]!.operation, status: "skipped" });
+          break;
+        }
+      }
+      if (outcome !== "completed" && effect === "complete") effect = "partial";
+      if (outcome === "completed" && stoppingPosition < request.args.steps.length) outcome = "completed";
+      const finalObservation = {
+        observationRef: nextObservationRef,
+        hostRevision: dispatch.target.targetGeneration,
+        documentRevision: dispatch.target.targetGeneration,
+        controlRevision: request.expectedControlEpoch,
+        capabilityRevision,
+        observationRevision: baseObservation.observationRevision + 1,
+      };
+      this.observations.set(nextObservationRef, { targetGeneration: finalObservation.hostRevision, controlRevision: finalObservation.controlRevision, capabilityRevision, observationRevision: finalObservation.observationRevision });
+      return {
+        contractVersion: request.contractVersion,
+        requestId: request.requestId,
+        sequence: request.sequence,
+        ok: true,
+        result: { operation: "act", outcome, stoppingPosition, effect, recovery: outcome === "interrupted" ? "inspect" : "inspect", receipts, finalObservation, nextObservationRef },
+      } as BrowserAutomationResponse;
+    };
+    return run();
+  }
+
+  private stepDispatch(dispatch: BrowserAutomationHostDispatch, step: BrowserAutomationActStep, deadline: number, index: number): BrowserAutomationHostDispatch {
+    const { operation, ...args } = step as unknown as Record<string, unknown>;
+    return {
+      ...dispatch,
+      request: {
+        ...dispatch.request,
+        requestId: `${dispatch.request.requestId}:step:${index}`,
+        sequence: dispatch.request.sequence + index,
+        deadline,
+        operation,
+        args,
+      },
+    } as unknown as BrowserAutomationHostDispatch;
+  }
+
+  private actFailure(dispatch: BrowserAutomationHostDispatch, code: "STALE_TARGET_GENERATION" | "CAPABILITY_CHANGED", message: string): BrowserAutomationResponse {
+    return { contractVersion: dispatch.request.contractVersion, requestId: dispatch.request.requestId, sequence: dispatch.request.sequence, ok: false, error: { code, message, retryable: false, stage: "observation", effect: "none", recovery: "inspect" } };
+  }
+
+  private rememberObservation(response: BrowserAutomationResponse, dispatch: BrowserAutomationHostDispatch): BrowserAutomationResponse {
+    if (!response.ok) return response;
+    const result = response.result as { observationRef?: string };
+    if (!result.observationRef) return response;
+    this.observations.set(result.observationRef, {
+      targetGeneration: dispatch.target.targetGeneration,
+      controlRevision: dispatch.request.expectedControlEpoch,
+      capabilityRevision: dispatch.connection?.capabilityRevision ?? this.options.getCapabilityRevision?.() ?? 1,
+      observationRevision: 0,
+    });
+    return response;
   }
 
   private revisionDrift(dispatch: BrowserAutomationHostDispatch): BrowserAutomationResponse | null {

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -6,6 +6,14 @@ import type {
 
 const MAX_IDEMPOTENCY_RECORDS = 256;
 const IDEMPOTENCY_TTL_MS = 30 * 60_000;
+const SECRET_TEXT = /\b(password|token|secret|authorization|cookie|credential|session|api[_-]?key)\b\s*[:=]\s*[^,;\s]+/gi;
+
+function sanitizePublicDetail(value: unknown): string {
+  return String(value ?? "")
+    .replace(/https?:\/\/[^\s"']+/gi, "[URL]")
+    .replace(SECRET_TEXT, "$1=[REDACTED]")
+    .slice(0, 256);
+}
 
 type OpenDispatch = BrowserAutomationHostDispatch & {
   request: Extract<BrowserAutomationHostDispatch["request"], { operation: "open" }>;
@@ -19,7 +27,8 @@ interface IdempotencyRecord {
 }
 
 interface ObservationRecord {
-  readonly targetGeneration: number;
+  readonly hostRevision: number;
+  readonly documentRevision: number;
   readonly controlRevision: number;
   readonly capabilityRevision: number;
   observationRevision: number;
@@ -53,6 +62,10 @@ export interface BrowserSessionDriverOptions {
   readonly electron: BrowserSessionRuntimeAdapter;
   readonly isElectron?: () => boolean;
   readonly getCapabilityRevision?: () => number;
+  readonly getHostRevision?: (dispatch: BrowserAutomationHostDispatch) => number;
+  readonly getDocumentRevision?: (dispatch: BrowserAutomationHostDispatch) => number;
+  readonly getControlRevision?: (dispatch: BrowserAutomationHostDispatch) => number;
+  readonly supportedActOperations?: readonly string[] | (() => readonly string[]);
 }
 
 /**
@@ -175,7 +188,7 @@ export class BrowserSessionDriver {
   }
 
   private withObservationRef(response: BrowserAutomationResponse): BrowserAutomationResponse {
-    if (!response.ok || response.result.operation !== "open" || response.result.observationRef) return response;
+    if (!response.ok || !response.result || (response.result.operation !== "open" && response.result.operation !== "inspect") || response.result.observationRef) return response;
     return { ...response, result: { ...response.result, observationRef: globalThis.crypto.randomUUID() } };
   }
 
@@ -186,7 +199,7 @@ export class BrowserSessionDriver {
     const drift = this.revisionDrift(dispatch);
     if (drift) return Promise.resolve(drift);
     return (this.isElectron() ? this.options.electron : this.options.web).execute(dispatch, signal)
-      .then((response) => this.rememberObservation(response, dispatch));
+      .then((response) => this.rememberObservation(this.withObservationRef(response), dispatch));
   }
 
   private executeAct(
@@ -196,21 +209,27 @@ export class BrowserSessionDriver {
     const request = dispatch.request as Extract<BrowserAutomationHostDispatch["request"], { operation: "act" }>;
     const observation = this.observations.get(request.args.observationRef);
     const capabilityRevision = this.options.getCapabilityRevision?.() ?? dispatch.connection?.capabilityRevision ?? 1;
+    const supported = typeof this.options.supportedActOperations === "function" ? this.options.supportedActOperations() : this.options.supportedActOperations;
+    if (supported && request.args.steps.some((step: BrowserAutomationActStep) => !supported.includes(step.operation))) {
+      return Promise.resolve(this.actFailure(dispatch, "UNSUPPORTED_OPERATION", "Browser runtime cannot execute every browser_act step"));
+    }
+    const currentBinding = this.currentObservationBinding(dispatch, capabilityRevision);
     const baseObservation = observation ?? {
-      targetGeneration: dispatch.target.targetGeneration,
-      controlRevision: request.expectedControlEpoch,
+      ...currentBinding,
       capabilityRevision,
       observationRevision: 0,
     };
-    if (!observation || observation.targetGeneration !== dispatch.target.targetGeneration || observation.controlRevision !== request.expectedControlEpoch || observation.capabilityRevision !== capabilityRevision) {
+    if (!observation || observation.hostRevision !== currentBinding.hostRevision || observation.documentRevision !== currentBinding.documentRevision || observation.controlRevision !== currentBinding.controlRevision || observation.capabilityRevision !== currentBinding.capabilityRevision) {
       return Promise.resolve(this.actFailure(dispatch, "STALE_TARGET_GENERATION", "Browser observation is stale; inspect before browser_act"));
     }
+    this.observations.delete(request.args.observationRef);
     const deadline = Math.min(dispatch.request.deadline, Date.now() + request.args.deadlineMs);
     const receipts: Array<{ index: number; operation: string; status: "applied" | "satisfied" | "failed" | "interrupted" | "skipped"; message?: string }> = [];
     const nextObservationRef = globalThis.crypto.randomUUID();
     let effect: "none" | "partial" | "complete" = "none";
     let outcome: "completed" | "failed" | "interrupted" = "completed";
     let stoppingPosition = request.args.steps.length;
+    let documentRevision = baseObservation.documentRevision;
     const run = async (): Promise<BrowserAutomationResponse> => {
       for (let index = 0; index < request.args.steps.length; index += 1) {
         const step = request.args.steps[index] as BrowserAutomationActStep;
@@ -222,7 +241,7 @@ export class BrowserSessionDriver {
           break;
         }
         const drift = this.revisionDrift(dispatch);
-        if (drift) {
+        if (drift || !this.observationStillCurrent(dispatch, baseObservation)) {
           outcome = "interrupted";
           stoppingPosition = index;
           receipts.push({ index, operation: step.operation, status: "interrupted", message: "Browser capability revision changed" });
@@ -234,13 +253,14 @@ export class BrowserSessionDriver {
         if (!response.ok) {
           outcome = response.error.code === "OPERATION_CANCELLED" || response.error.code === "HUMAN_INTERRUPTED" || response.error.code === "DEADLINE_EXCEEDED" ? "interrupted" : "failed";
           stoppingPosition = index;
-          receipts.push({ index, operation: step.operation, status: outcome === "interrupted" ? "interrupted" : "failed", message: response.error.message });
+          receipts.push({ index, operation: step.operation, status: outcome === "interrupted" ? "interrupted" : "failed", message: sanitizePublicDetail(response.error.message) });
           for (let skipped = index + 1; skipped < request.args.steps.length; skipped += 1) receipts.push({ index: skipped, operation: request.args.steps[skipped]!.operation, status: "skipped" });
           break;
         }
         receipts.push({ index, operation: step.operation, status: step.operation === "assert" || step.operation === "wait" ? "satisfied" : "applied" });
         effect = "complete";
         if (step.operation === "navigate" || step.operation === "back" || step.operation === "forward" || step.operation === "reload") {
+          documentRevision += 1;
           stoppingPosition = index + 1;
           for (let skipped = index + 1; skipped < request.args.steps.length; skipped += 1) receipts.push({ index: skipped, operation: request.args.steps[skipped]!.operation, status: "skipped" });
           break;
@@ -250,13 +270,13 @@ export class BrowserSessionDriver {
       if (outcome === "completed" && stoppingPosition < request.args.steps.length) outcome = "completed";
       const finalObservation = {
         observationRef: nextObservationRef,
-        hostRevision: dispatch.target.targetGeneration,
-        documentRevision: dispatch.target.targetGeneration,
-        controlRevision: request.expectedControlEpoch,
+        hostRevision: baseObservation.hostRevision,
+        documentRevision,
+        controlRevision: baseObservation.controlRevision,
         capabilityRevision,
         observationRevision: baseObservation.observationRevision + 1,
       };
-      this.observations.set(nextObservationRef, { targetGeneration: finalObservation.hostRevision, controlRevision: finalObservation.controlRevision, capabilityRevision, observationRevision: finalObservation.observationRevision });
+      this.observations.set(nextObservationRef, { hostRevision: finalObservation.hostRevision, documentRevision: finalObservation.documentRevision, controlRevision: finalObservation.controlRevision, capabilityRevision, observationRevision: finalObservation.observationRevision });
       return {
         contractVersion: request.contractVersion,
         requestId: request.requestId,
@@ -283,21 +303,36 @@ export class BrowserSessionDriver {
     } as unknown as BrowserAutomationHostDispatch;
   }
 
-  private actFailure(dispatch: BrowserAutomationHostDispatch, code: "STALE_TARGET_GENERATION" | "CAPABILITY_CHANGED", message: string): BrowserAutomationResponse {
+  private actFailure(dispatch: BrowserAutomationHostDispatch, code: "STALE_TARGET_GENERATION" | "CAPABILITY_CHANGED" | "UNSUPPORTED_OPERATION", message: string): BrowserAutomationResponse {
     return { contractVersion: dispatch.request.contractVersion, requestId: dispatch.request.requestId, sequence: dispatch.request.sequence, ok: false, error: { code, message, retryable: false, stage: "observation", effect: "none", recovery: "inspect" } };
   }
 
   private rememberObservation(response: BrowserAutomationResponse, dispatch: BrowserAutomationHostDispatch): BrowserAutomationResponse {
-    if (!response.ok) return response;
+    if (!response.ok || !response.result) return response;
     const result = response.result as { observationRef?: string };
     if (!result.observationRef) return response;
     this.observations.set(result.observationRef, {
-      targetGeneration: dispatch.target.targetGeneration,
+      hostRevision: dispatch.connection?.connectionGeneration ?? 0,
+      documentRevision: dispatch.target.targetGeneration,
       controlRevision: dispatch.request.expectedControlEpoch,
       capabilityRevision: dispatch.connection?.capabilityRevision ?? this.options.getCapabilityRevision?.() ?? 1,
       observationRevision: 0,
     });
     return response;
+  }
+
+  private currentObservationBinding(dispatch: BrowserAutomationHostDispatch, capabilityRevision: number): Pick<ObservationRecord, "hostRevision" | "documentRevision" | "controlRevision" | "capabilityRevision"> {
+    return {
+      hostRevision: this.options.getHostRevision?.(dispatch) ?? dispatch.connection?.connectionGeneration ?? 0,
+      documentRevision: this.options.getDocumentRevision?.(dispatch) ?? dispatch.target.targetGeneration,
+      controlRevision: this.options.getControlRevision?.(dispatch) ?? dispatch.request.expectedControlEpoch,
+      capabilityRevision,
+    };
+  }
+
+  private observationStillCurrent(dispatch: BrowserAutomationHostDispatch, observation: ObservationRecord): boolean {
+    const current = this.currentObservationBinding(dispatch, observation.capabilityRevision);
+    return current.hostRevision === observation.hostRevision && current.documentRevision === observation.documentRevision && current.controlRevision === observation.controlRevision && current.capabilityRevision === observation.capabilityRevision;
   }
 
   private revisionDrift(dispatch: BrowserAutomationHostDispatch): BrowserAutomationResponse | null {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -419,6 +419,7 @@ export {
   BROWSER_AUTOMATION_MAX_RECORDING_BYTES,
   BROWSER_AUTOMATION_MAX_PENDING_REQUESTS,
   BROWSER_AUTOMATION_MAX_TYPED_TEXT_CHARS,
+  BROWSER_AUTOMATION_ACT_MAX_STEPS,
   BROWSER_AUTOMATION_MAX_INSPECT_TABS,
   BROWSER_AUTOMATION_MAX_GUIDANCE_CHARS,
   BROWSER_AUTOMATION_OPERATIONS,
@@ -452,6 +453,9 @@ export {
   BrowserAutomationExecutorDescriptorSchema,
   BrowserAutomationInspectTargetSchema,
   BrowserAutomationInspectReadinessSchema,
+  BrowserAutomationActStepSchema,
+  BrowserAutomationObservationBindingSchema,
+  BrowserAutomationActResultSchema,
 } from "./models/browser-automation.js";
 export type {
   BrowserAutomationOperation,
@@ -474,6 +478,9 @@ export type {
   BrowserAutomationHostRuntime,
   BrowserAutomationTargetIdentity,
   BrowserAutomationExecutorDescriptor,
+  BrowserAutomationActStep,
+  BrowserAutomationObservationBinding,
+  BrowserAutomationActResult,
 } from "./models/browser-automation.js";
 
 // Events

--- a/packages/contracts/src/models/__tests__/browser-automation.test.ts
+++ b/packages/contracts/src/models/__tests__/browser-automation.test.ts
@@ -732,4 +732,23 @@ describe("browser automation boundaries", () => {
       }).success,
     ).toBe(true);
   });
+
+  it("bounds browser_act batches and rejects malformed later steps before effects", () => {
+    const valid = {
+      ...requestBase,
+      operation: "act",
+      args: {
+        idempotencyKey: "act-key",
+        observationRef: "observation-1",
+        deadlineMs: 1_000,
+        steps: [{ operation: "click", target }],
+      },
+    };
+    expect(BrowserAutomationRequestSchema().safeParse(valid).success).toBe(true);
+    expect(BrowserAutomationRequestSchema().safeParse({ ...valid, args: { ...valid.args, steps: [] } }).success).toBe(false);
+    expect(BrowserAutomationRequestSchema().safeParse({ ...valid, args: { ...valid.args, steps: Array.from({ length: 9 }, () => valid.args.steps[0]) } }).success).toBe(false);
+    expect(BrowserAutomationRequestSchema().safeParse({ ...valid, args: { ...valid.args, deadlineMs: 0 } }).success).toBe(false);
+    expect(BrowserAutomationRequestSchema().safeParse({ ...valid, args: { ...valid.args, deadlineMs: 60_001 } }).success).toBe(false);
+    expect(BrowserAutomationRequestSchema().safeParse({ ...valid, args: { ...valid.args, steps: [valid.args.steps[0], { operation: "click", target, clickCount: 4 }] } }).success).toBe(false);
+  });
 });

--- a/packages/contracts/src/models/browser-automation.ts
+++ b/packages/contracts/src/models/browser-automation.ts
@@ -29,6 +29,8 @@ export const BROWSER_AUTOMATION_MAX_RECORDING_BYTES = 512 * 1_024;
 export const BROWSER_AUTOMATION_MAX_PENDING_REQUESTS = 32;
 /** Maximum text characters accepted by a type operation. */
 export const BROWSER_AUTOMATION_MAX_TYPED_TEXT_CHARS = 16_384;
+/** Maximum ordered mutations accepted by browser_act. */
+export const BROWSER_AUTOMATION_ACT_MAX_STEPS = 8;
 
 /** Explicit opt-in environment flag for registration by the pure web runtime. */
 export const BROWSER_AUTOMATION_WEB_DEV_FLAG = "MCODE_WEB_AUTOMATION" as const;
@@ -97,8 +99,8 @@ export const BROWSER_AUTOMATION_OPERATIONS = [
 ] as const;
 
 /** One browser automation operation identifier. */
-export type BrowserAutomationOperation = (typeof BROWSER_AUTOMATION_OPERATIONS)[number] | "inspect";
-const browserOperationSchema = z.union([z.enum(BROWSER_AUTOMATION_OPERATIONS), z.literal("inspect")]);
+export type BrowserAutomationOperation = (typeof BROWSER_AUTOMATION_OPERATIONS)[number] | "inspect" | "act";
+const browserOperationSchema = z.union([z.enum(BROWSER_AUTOMATION_OPERATIONS), z.literal("inspect"), z.literal("act")]);
 
 /** Provider-facing MCP tool annotations for one operation. */
 export interface BrowserAutomationOperationAnnotations {
@@ -205,6 +207,14 @@ Object.defineProperty(BROWSER_AUTOMATION_OPERATION_METADATA, "inspect", {
     annotations: readOnly,
   } satisfies BrowserAutomationOperationMetadata,
 });
+Object.defineProperty(BROWSER_AUTOMATION_OPERATION_METADATA, "act", {
+  enumerable: false,
+  value: {
+    operation: "act",
+    mcpName: "browser_act",
+    annotations: input,
+  } satisfies BrowserAutomationOperationMetadata,
+});
 
 /** Maximum tabs returned by one browser_inspect response. */
 export const BROWSER_AUTOMATION_MAX_INSPECT_TABS = 32;
@@ -215,7 +225,7 @@ export const BROWSER_AUTOMATION_MAX_GUIDANCE_CHARS = 4_000;
 export const BrowserAutomationExecutorDescriptorSchema = lazySchema(() =>
   z.object({
     runtime: BrowserAutomationHostRuntimeSchema,
-    operations: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 1),
+    operations: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 2),
     constraints: z.object({
       maxTabs: z.number().int().positive().max(BROWSER_AUTOMATION_MAX_INSPECT_TABS),
       maxSnapshotChars: z.number().int().positive().max(BROWSER_AUTOMATION_MAX_VISIBLE_TEXT_CHARS),
@@ -685,7 +695,7 @@ export const BrowserAutomationHostRegistrationSchema = lazySchema(() =>
       capabilities: z
         .array(BrowserAutomationHostCapabilitySchema())
         .min(1)
-        .max(BROWSER_AUTOMATION_OPERATIONS.length + 1),
+        .max(BROWSER_AUTOMATION_OPERATIONS.length + 2),
       maxPendingRequests: z
         .number()
         .int()
@@ -820,7 +830,7 @@ export const BrowserAutomationCredentialClaimsSchema = lazySchema(() =>
       operations: z
         .array(browserOperationSchema)
         .min(1)
-        .max(BROWSER_AUTOMATION_OPERATIONS.length + 1),
+        .max(BROWSER_AUTOMATION_OPERATIONS.length + 2),
       issuedAt: z.number().int().nonnegative(),
       expiresAt: z.number().int().nonnegative(),
     })
@@ -864,6 +874,53 @@ const requestBase = {
   deadline: z.number().int().positive(),
   expectedControlEpoch: z.number().int().nonnegative(),
 };
+
+const actTarget = z.object({ target: BrowserAutomationTargetSchema() }).strict();
+const actTimeout = z.number().int().min(1).max(BROWSER_AUTOMATION_MAX_TIMEOUT_MS).optional();
+
+/** One bounded mutation admitted by browser_act. */
+export const BrowserAutomationActStepSchema = lazySchema(() => z.discriminatedUnion("operation", [
+  z.object({ operation: z.literal("navigate"), url: BrowserAutomationUrlSchema() }).strict(),
+  z.object({ operation: z.literal("back") }).strict(),
+  z.object({ operation: z.literal("forward") }).strict(),
+  z.object({ operation: z.literal("reload") }).strict(),
+  z.object({ operation: z.literal("resize"), width: z.number().int().min(320).max(7_680), height: z.number().int().min(240).max(4_320) }).strict(),
+  z.object({ operation: z.literal("hover"), ...actTarget.shape, timeoutMs: actTimeout }).strict(),
+  z.object({ operation: z.literal("click"), ...actTarget.shape, button: z.enum(["left", "middle", "right"]).default("left"), clickCount: z.literal(2).or(z.literal(1)).default(1), timeoutMs: actTimeout }).strict(),
+  z.object({ operation: z.literal("drag"), source: BrowserAutomationTargetSchema(), target: BrowserAutomationTargetSchema(), timeoutMs: actTimeout }).strict(),
+  z.object({ operation: z.literal("type"), target: BrowserAutomationTargetSchema().optional(), text: z.string().max(BROWSER_AUTOMATION_MAX_TYPED_TEXT_CHARS), clear: z.boolean().default(false), submit: z.boolean().default(false), timeoutMs: actTimeout }).strict(),
+  z.object({ operation: z.literal("press"), key: z.string().min(1).max(64), modifiers: z.array(z.enum(["Alt", "Control", "Meta", "Shift"])).max(4).default([]), timeoutMs: actTimeout }).strict(),
+  z.object({ operation: z.literal("scroll"), target: BrowserAutomationTargetSchema().optional(), deltaX: z.number().finite().min(-100_000).max(100_000).default(0), deltaY: z.number().finite().min(-100_000).max(100_000), timeoutMs: actTimeout }).strict(),
+  z.object({ operation: z.literal("wait"), durationMs: z.number().int().min(1).max(BROWSER_AUTOMATION_MAX_TIMEOUT_MS) }).strict(),
+  z.object({ operation: z.literal("assert"), target: BrowserAutomationTargetSchema().optional(), text: z.string().min(1).max(SHORT_TEXT_MAX).optional(), url: BrowserAutomationUrlSchema().optional() }).strict(),
+  z.object({ operation: z.literal("recordingStart") }).strict(),
+  z.object({ operation: z.literal("recordingStop") }).strict(),
+]).superRefine((value, context) => {
+  if (value.operation === "assert" && value.target === undefined && value.text === undefined && value.url === undefined) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "Assert requires target, text, or url", path: ["assert"] });
+  }
+}));
+/** Typed bounded browser_act step. */
+export type BrowserAutomationActStep = z.infer<ReturnType<typeof BrowserAutomationActStepSchema>>;
+
+/** Observation revisions bound to a visible Preview before mutation. */
+export const BrowserAutomationObservationBindingSchema = lazySchema(() => z.object({
+  observationRef: idSchema,
+  hostRevision: z.number().int().nonnegative(),
+  documentRevision: z.number().int().nonnegative(),
+  controlRevision: z.number().int().nonnegative(),
+  capabilityRevision: z.number().int().positive(),
+  observationRevision: z.number().int().nonnegative(),
+}).strict());
+/** Typed observation binding. */
+export type BrowserAutomationObservationBinding = z.infer<ReturnType<typeof BrowserAutomationObservationBindingSchema>>;
+
+const actArgs = z.object({
+  idempotencyKey: idempotencyKeySchema,
+  observationRef: idSchema,
+  deadlineMs: z.number().int().min(1).max(BROWSER_AUTOMATION_MAX_TIMEOUT_MS),
+  steps: z.array(BrowserAutomationActStepSchema()).min(1).max(BROWSER_AUTOMATION_ACT_MAX_STEPS),
+}).strict();
 
 const requestVariant = <T extends BrowserAutomationOperation>(
   operation: T,
@@ -950,6 +1007,7 @@ export const BrowserAutomationRequestSchema = lazySchema(() =>
       z.object({ maxDurationMs: z.number().int().min(1_000).max(RECORDING_MAX_DURATION_MS).default(RECORDING_MAX_DURATION_MS) }).strict(),
     ),
     requestVariant("recordingStop", emptyArgs),
+    requestVariant("act", actArgs),
   ]),
 );
 
@@ -964,6 +1022,35 @@ const actionResultFields = {
 const actionResult = <T extends BrowserAutomationOperation>(operation: T) =>
   z.object({ operation: z.literal(operation), ...actionResultFields }).strict();
 
+const actReceiptSchema = z.object({
+  index: z.number().int().nonnegative(),
+  operation: z.string().min(1).max(32),
+  status: z.enum(["applied", "satisfied", "failed", "interrupted", "skipped"]),
+  message: z.string().max(SHORT_TEXT_MAX).optional(),
+}).strict();
+const actObservationSchema = z.object({
+  observationRef: idSchema,
+  hostRevision: z.number().int().nonnegative(),
+  documentRevision: z.number().int().nonnegative(),
+  controlRevision: z.number().int().nonnegative(),
+  capabilityRevision: z.number().int().positive(),
+  observationRevision: z.number().int().nonnegative(),
+}).strict();
+
+/** Structured result for one bounded browser_act batch. */
+export const BrowserAutomationActResultSchema = lazySchema(() => z.object({
+  operation: z.literal("act"),
+  outcome: z.enum(["completed", "failed", "interrupted"]),
+  stoppingPosition: z.number().int().nonnegative(),
+  effect: z.enum(["none", "partial", "complete"]),
+  recovery: z.enum(["inspect", "reopen", "wait", "yield_to_user", "do_not_retry"]),
+  receipts: z.array(actReceiptSchema).max(BROWSER_AUTOMATION_ACT_MAX_STEPS),
+  finalObservation: actObservationSchema,
+  nextObservationRef: idSchema.optional(),
+}).strict());
+/** Typed browser_act result. */
+export type BrowserAutomationActResult = z.infer<ReturnType<typeof BrowserAutomationActResultSchema>>;
+
 /** Exhaustive operation-specific browser success result. */
 export const BrowserAutomationResultSchema = lazySchema(() =>
   z.discriminatedUnion("operation", [
@@ -977,7 +1064,7 @@ export const BrowserAutomationResultSchema = lazySchema(() =>
       diagnostics: z.array(z.string().max(SHORT_TEXT_MAX)).max(BROWSER_AUTOMATION_MAX_DIAGNOSTIC_ENTRIES).optional(),
       observationRef: idSchema.optional(),
       capabilityRevision: z.number().int().positive().optional(),
-      capabilities: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 1).optional(),
+      capabilities: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 2).optional(),
       guidance: z.string().max(BROWSER_AUTOMATION_MAX_GUIDANCE_CHARS).optional(),
     }).strict(),
     z.object({
@@ -990,7 +1077,7 @@ export const BrowserAutomationResultSchema = lazySchema(() =>
       focused: z.boolean(),
       viewport: z.object({ width: z.number().int().min(1).max(10_000), height: z.number().int().min(1).max(10_000) }).strict(),
       controller: BrowserAutomationControllerStateSchema().optional(),
-      capabilities: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 1).optional(),
+      capabilities: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 2).optional(),
       capabilityRevision: z.number().int().positive().optional(),
     }).strict(),
     z.object({
@@ -1016,6 +1103,7 @@ export const BrowserAutomationResultSchema = lazySchema(() =>
     z.object({ operation: z.literal("evaluate"), valueJson: z.string().refine((value) => utf8Length(value) <= BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES, "Evaluation result exceeds 64 KiB"), controlEpoch: z.number().int().nonnegative() }).strict(),
     z.object({ operation: z.literal("recordingStart"), recordingId: idSchema, startedAt: z.number().int().nonnegative(), controlEpoch: z.number().int().nonnegative() }).strict(),
     z.object({ operation: z.literal("recordingStop"), recordingId: idSchema, mediaType: z.literal("video/webm"), dataBase64: z.string().max(RECORDING_MAX_BASE64_CHARS).refine((value) => { const size = decodedBase64Size(value); return size !== null && size <= BROWSER_AUTOMATION_MAX_RECORDING_BYTES; }, "Recording must be valid base64 within 512 KiB decoded"), durationMs: z.number().int().nonnegative().max(RECORDING_MAX_DURATION_MS), truncation: BrowserAutomationTruncationSchema(), controlEpoch: z.number().int().nonnegative() }).strict(),
+    BrowserAutomationActResultSchema(),
   ]).superRefine((value, context) => {
     if (value.operation === "console" || value.operation === "network") {
       validateTruncation(value.truncation, value.entries.length, context, ["truncation"]);
@@ -1059,6 +1147,7 @@ export const BROWSER_AUTOMATION_ERROR_CODES = [
   "RESULT_TOO_LARGE",
   "RECORDING_NOT_ACTIVE",
   "INTERNAL_ERROR",
+  "BROWSER_BUSY",
 ] as const;
 
 /** One stable browser automation error code. */
@@ -1073,7 +1162,7 @@ export const BrowserAutomationErrorSchema = lazySchema(() =>
       retryable: z.boolean(),
       stage: z.enum(["validation", "authorization", "allocation", "observation", "effect", "recovery", "transport"]).optional(),
       effect: z.enum(["none", "created", "closed", "preserved", "unknown"]).optional(),
-      recovery: z.enum(["none", "retry", "refresh", "reopen", "manual", "inspect", "yield_to_user"]).optional(),
+      recovery: z.enum(["none", "retry", "refresh", "reopen", "manual", "inspect", "wait", "yield_to_user", "do_not_retry"]).optional(),
       correlationId: idSchema.optional(),
     })
     .strict(),


### PR DESCRIPTION
## What
Adds observation-bound browser_act batches with up to eight ordered steps and a bounded 60-second deadline.

## Why
Provider sessions need one coherent mutation boundary that rejects stale observations, concurrent mutations, and unsupported mechanics before an effect occurs.

## Key Changes
- Adds strict Browser action contracts, MCP schemas, receipts, revision checks, and document-boundary handling.
- Enforces provider-session idempotency, duplicate joins, and BROWSER_BUSY admission.
- Grants inspect before act and preserves host-issued observation references.
- Keeps inspected web target identities stable through a bounded document-scoped registry.
- Adds focused contract, broker, MCP, driver, web executor, and Electron coverage.

## Verification
- 236 focused Browser tests passed across contracts, server, web, and Electron.
- Live same-origin Preview produced an applied click receipt, complete effect, and fresh observation reference.
- Full typecheck and lint passed. The full unit phase remains environment-limited by local Bun 1.3.11 localStorage behavior; the repository pins Bun 1.2.14.

Closes #1046

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788299172&installation_model_id=20477&pr_number=1063&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1063&signature=dc1e591257c056d7f520723f139d211660444679b4fd72ea345022539a441e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser interaction capabilities for navigation, clicking, typing, keyboard input, scrolling, waiting, assertions, and recording.
  * Browser interactions now support structured multi-step actions with validation, results, and follow-up observations.
  * Improved web element targeting using accessible roles, names, and stable semantic references.
* **Bug Fixes**
  * Prevented conflicting concurrent actions and safely replays duplicate requests.
  * Added safeguards for stale observations, interrupted sessions, navigation changes, and unavailable controls.
  * Improved sensitive-detail handling in browser automation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->