### PR TITLE
feat(browser): secure privileged page evaluation

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
@@ -187,6 +187,14 @@ function request(
   args: Record<string, unknown> = {},
   overrides: { requestId?: string; threadId?: string; expectedControlEpoch?: number } = {},
 ): BrowserAutomationRequest {
+  const requestArgs = operation === "evaluate"
+    ? {
+        idempotencyKey: overrides.requestId ?? "evaluate-key",
+        observationRef: "observation-ref",
+        deadlineMs: 10_000,
+        ...args,
+      }
+    : args;
   return {
     contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
     workspaceId: "workspace",
@@ -198,7 +206,7 @@ function request(
     deadline: Date.now() + 10_000,
     expectedControlEpoch: overrides.expectedControlEpoch ?? 0,
     operation,
-    args,
+    args: requestArgs,
   } as BrowserAutomationRequest;
 }
 

--- a/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-narrative-persist.test.ts
@@ -324,6 +324,51 @@ describe("AgentService narrative persistence", () => {
     expect(toolCalls[0].exitCode).toBe(1);
   });
 
+  it("persists privileged Browser evaluation without source, result, or artifacts", async () => {
+    const { providerEmitter, toolBulk } = build();
+
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolUse,
+      threadId: THREAD_ID,
+      toolCallId: "evaluate-1",
+      toolName: "mcp__mcode-browser__browser_evaluate",
+      toolInput: { expression: "globalThis.SECRET_SOURCE" },
+    });
+    providerEmitter.emit("event", {
+      type: AgentEventType.ToolResult,
+      threadId: THREAD_ID,
+      toolCallId: "evaluate-1",
+      output: '{"valueJson":"SECRET_RESULT"}',
+      isError: false,
+      outputTruncated: true,
+      outputTotalBytes: 999,
+      outputArtifactPath: "C:\\secret-result.txt",
+      toolInput: { expression: "globalThis.SECRET_SOURCE" },
+    });
+    providerEmitter.emit("event", {
+      type: AgentEventType.TurnComplete,
+      threadId: THREAD_ID,
+      tokensIn: 0,
+      tokensOut: 0,
+      contextWindow: 0,
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(toolBulk).toHaveBeenCalledOnce();
+    const toolCalls: CreateToolCallRecordInput[] = toolBulk.mock.calls[0][0];
+    expect(toolCalls[0]).toMatchObject({
+      toolName: "mcp__mcode-browser__browser_evaluate",
+      inputSummary: "{}",
+      outputSummary: "",
+      outputTruncated: false,
+    });
+    expect(toolCalls[0].outputArtifactPath).toBeUndefined();
+    expect(JSON.stringify(toolCalls[0])).not.toContain("SECRET_SOURCE");
+    expect(JSON.stringify(toolCalls[0])).not.toContain("SECRET_RESULT");
+  });
+
   it("applies a TaskUpdate status transition to the persisted task by harness id", () => {
     const { providerEmitter, taskUpdate } = build();
 

--- a/apps/server/src/services/__tests__/browser-evaluation-event-sanitizer.test.ts
+++ b/apps/server/src/services/__tests__/browser-evaluation-event-sanitizer.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { AgentEventType, type AgentEvent } from "@mcode/contracts";
+import { BrowserEvaluationEventSanitizer } from "../browser-evaluation-event-sanitizer.js";
+
+describe("BrowserEvaluationEventSanitizer", () => {
+  it.each([
+    "browser_evaluate",
+    "mcp__mcode-browser__browser_evaluate",
+  ])("removes evaluation source and result from %s events", (toolName) => {
+    const sanitizer = new BrowserEvaluationEventSanitizer();
+    const use = sanitizer.sanitize({
+      type: AgentEventType.ToolUse,
+      threadId: "thread-1",
+      toolCallId: "call-1",
+      toolName,
+      toolInput: { expression: "globalThis.SECRET_SOURCE", observationRef: "observation-1" },
+    });
+    const result = sanitizer.sanitize({
+      type: AgentEventType.ToolResult,
+      threadId: "thread-1",
+      toolCallId: "call-1",
+      output: '{"valueJson":"SECRET_RESULT"}',
+      isError: false,
+      outputTruncated: true,
+      outputTotalBytes: 999,
+      outputArtifactPath: "C:\\secret-result.txt",
+      toolInput: { expression: "globalThis.SECRET_SOURCE" },
+    });
+
+    expect(use).toMatchObject({ toolInput: {} });
+    expect(JSON.stringify(use)).not.toContain("SECRET_SOURCE");
+    expect(result).toMatchObject({ output: "", toolInput: {}, isError: false });
+    expect(result).not.toHaveProperty("outputTruncated");
+    expect(result).not.toHaveProperty("outputTotalBytes");
+    expect(result).not.toHaveProperty("outputArtifactPath");
+    expect(JSON.stringify(result)).not.toContain("SECRET_RESULT");
+    expect(JSON.stringify(result)).not.toContain("SECRET_SOURCE");
+  });
+
+  it("preserves unrelated tool events", () => {
+    const sanitizer = new BrowserEvaluationEventSanitizer();
+    const event = {
+      type: AgentEventType.ToolUse,
+      threadId: "thread-1",
+      toolCallId: "call-1",
+      toolName: "browser_inspect",
+      toolInput: { includeDiagnostics: true },
+    } satisfies AgentEvent;
+
+    expect(sanitizer.sanitize(event)).toBe(event);
+  });
+});

--- a/apps/server/src/services/__tests__/browser-evaluation-event-sanitizer.test.ts
+++ b/apps/server/src/services/__tests__/browser-evaluation-event-sanitizer.test.ts
@@ -7,7 +7,9 @@ describe("BrowserEvaluationEventSanitizer", () => {
     "browser_evaluate",
     "mcp__mcode-browser__browser_evaluate",
   ])("removes evaluation source and result from %s events", (toolName) => {
-    const sanitizer = new BrowserEvaluationEventSanitizer();
+    const sanitizer = new BrowserEvaluationEventSanitizer(
+      (_threadId, toolCallId) => toolCallId === "call-1" ? toolName : undefined,
+    );
     const use = sanitizer.sanitize({
       type: AgentEventType.ToolUse,
       threadId: "thread-1",
@@ -48,5 +50,42 @@ describe("BrowserEvaluationEventSanitizer", () => {
     } satisfies AgentEvent;
 
     expect(sanitizer.sanitize(event)).toBe(event);
+  });
+
+  it("preserves unrelated results without retaining evaluation correlations", () => {
+    const evaluationToolNames = new Map<string, string>();
+    const sanitizer = new BrowserEvaluationEventSanitizer(
+      (_threadId, toolCallId) => evaluationToolNames.get(toolCallId),
+    );
+    for (let index = 0; index <= 1_024; index++) {
+      evaluationToolNames.set(`call-${index}`, "browser_evaluate");
+      sanitizer.sanitize({
+        type: AgentEventType.ToolUse,
+        threadId: "thread-overflow",
+        toolCallId: `call-${index}`,
+        toolName: "browser_evaluate",
+        toolInput: { expression: `globalThis.SECRET_${index}` },
+      });
+    }
+
+    const evaluationResult = sanitizer.sanitize({
+      type: AgentEventType.ToolResult,
+      threadId: "thread-overflow",
+      toolCallId: "call-0",
+      output: "SECRET_EVICTED_RESULT",
+      isError: false,
+      outputArtifactPath: "C:\\secret-result.txt",
+    });
+    const unrelatedResult = {
+      type: AgentEventType.ToolResult,
+      threadId: "thread-overflow",
+      toolCallId: "unrelated-call",
+      output: "ordinary output",
+      isError: false,
+    } satisfies AgentEvent;
+
+    expect(evaluationResult).toMatchObject({ output: "", toolInput: {} });
+    expect(evaluationResult).not.toHaveProperty("outputArtifactPath");
+    expect(sanitizer.sanitize(unrelatedResult)).toBe(unrelatedResult);
   });
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -253,7 +253,7 @@ function parseHarnessTaskId(output: string): string | null {
 export class AgentService {
   /** Canonical per-thread execution identity and lifecycle authority. */
   private readonly turnRuntime = new TurnRuntimeRegistry();
-  private readonly browserEvaluationEventSanitizer = new BrowserEvaluationEventSanitizer();
+  private readonly browserEvaluationEventSanitizer: BrowserEvaluationEventSanitizer;
   private readonly preparedProviderEvents = new WeakMap<object, AgentEvent | undefined>();
   private readonly activeSessionIds = new Set<string>();
   private readonly nativeGoalRefreshInFlight = new Set<string>();
@@ -431,6 +431,11 @@ export class AgentService {
     @inject(ThreadControlMutationReservationService)
     mutationReservations?: ThreadControlMutationReservationService,
   ) {
+    this.browserEvaluationEventSanitizer = new BrowserEvaluationEventSanitizer(
+      (threadId, toolCallId) => this.narrativeStore.getBufferedToolCalls(threadId)
+        .find((toolCall) => toolCall.toolCallId === toolCallId)
+        ?.toolName,
+    );
     this.mutationReservations = mutationReservations ?? new ThreadControlMutationReservationService();
     this.turnFileTracker = new TurnFileTracker(
       (cwd, ref, path) => this.snapshotService.getFileAtRef(cwd, ref, path),

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -84,6 +84,7 @@ import { InternalThreadControlMcpRuntime } from "./thread-control-mcp-runtime.js
 import { ThreadControlMutationReservationService } from "./thread-control-mutation-reservation-service.js";
 import { TurnRuntimeRegistry } from "./turn-runtime.js";
 import type { TurnOutcome } from "./turn-outcome.js";
+import { BrowserEvaluationEventSanitizer } from "./browser-evaluation-event-sanitizer.js";
 
 /**
  * Escape special XML characters in a string to prevent injection into
@@ -252,6 +253,7 @@ function parseHarnessTaskId(output: string): string | null {
 export class AgentService {
   /** Canonical per-thread execution identity and lifecycle authority. */
   private readonly turnRuntime = new TurnRuntimeRegistry();
+  private readonly browserEvaluationEventSanitizer = new BrowserEvaluationEventSanitizer();
   private readonly preparedProviderEvents = new WeakMap<object, AgentEvent | undefined>();
   private readonly activeSessionIds = new Set<string>();
   private readonly nativeGoalRefreshInFlight = new Set<string>();
@@ -2188,7 +2190,10 @@ export class AgentService {
     if (this.preparedProviderEvents.has(event as object)) {
       return this.preparedProviderEvents.get(event as object);
     }
-    const normalized = this.turnRuntime.normalizeEvent(event);
+    const normalizedEvent = this.turnRuntime.normalizeEvent(event);
+    const normalized = normalizedEvent
+      ? this.browserEvaluationEventSanitizer.sanitize(normalizedEvent)
+      : undefined;
     this.preparedProviderEvents.set(event as object, normalized);
     return normalized;
   }

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -195,6 +195,10 @@ describe("BrowserAutomationBroker", () => {
     };
 
     expect(broker.availableOperations(scope)).toEqual(["open", "evaluate"]);
+    expect(broker.availableOperations({
+      ...scope,
+      permissionCapability: "interact",
+    })).toEqual(["open"]);
   });
 
   it("never advertises evaluation through a web executor", () => {
@@ -1463,6 +1467,46 @@ describe("BrowserAutomationBroker", () => {
     const conflict = await makeEvaluate("evaluate-4", "same", "document.URL", 4);
     expect(conflict).toMatchObject({ ok: false, error: { code: "IDEMPOTENCY_CONFLICT" } });
     expect(conflict.ok && JSON.stringify(conflict)).toBe(false);
+  });
+
+  it("rejects a raw Electron evaluation result at the broker boundary", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({ now: () => 10, send: (_socket, channel, data) => {
+      deliveries.push({ channel, data });
+      return true;
+    } }));
+    const hostSocket = socket("raw-evaluate");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("raw-evaluate", "workspace-a"),
+      executorDescriptor: { ...registration("raw-evaluate", "workspace-a").executorDescriptor, operations: ["inspect", "evaluate"] },
+      capabilities: [{ operation: "evaluate", available: true }],
+    }, authorization("raw-evaluate")).generation;
+    broker.updateTargets(hostSocket, "raw-evaluate", generation, [statusTarget("raw-evaluate", generation)]);
+    const scope = { ...claims("thread-a", "workspace-a"), permissionCapability: "privileged" as const, allowedOperations: ["evaluate" as const] };
+    const pending = broker.execute(scope, {
+      ...request(scope),
+      operation: "evaluate",
+      args: {
+        idempotencyKey: "raw-evaluate-key",
+        observationRef: "observation-ref",
+        deadlineMs: 10_000,
+        expression: "globalThis.SECRET_SOURCE",
+        awaitPromise: true,
+        timeoutMs: 1_000,
+      },
+    });
+    const delivery = deliveries.find(({ channel }) => channel === "browserAutomation.request")!;
+    broker.respond(hostSocket, "raw-evaluate", generation, {
+      contractVersion: 1,
+      requestId: delivery.data.dispatch.request.requestId,
+      sequence: delivery.data.dispatch.request.sequence,
+      ok: true,
+      result: { operation: "evaluate", valueJson: "\"SECRET_RESULT\"", controlEpoch: 0 },
+    }, delivery.data.dispatch.target);
+
+    const result = await pending;
+    expect(result).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST", effect: "none" } });
+    expect(JSON.stringify(result)).not.toContain("SECRET_RESULT");
   });
 
   it("drops keyed open replay when its host reconnects", async () => {

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -174,6 +174,53 @@ describe("BrowserAutomationBroker", () => {
     }, authorization("mismatch"))).toThrow("runtime does not match");
   });
 
+  it("advertises bootstrap operations from a selected executor before a target exists", () => {
+    const broker = new BrowserAutomationBroker(options());
+    const hostSocket = socket("bootstrap-discovery");
+    broker.registerHost(hostSocket, {
+      ...registration("bootstrap-discovery", "workspace-a"),
+      executorDescriptor: {
+        ...registration("bootstrap-discovery", "workspace-a").executorDescriptor,
+        operations: ["open", "evaluate"],
+      },
+      capabilities: [
+        { operation: "open", available: true },
+        { operation: "evaluate", available: true },
+      ],
+    }, authorization("bootstrap-discovery"));
+    const scope = {
+      ...claims("thread-a", "workspace-a"),
+      permissionCapability: "privileged" as const,
+      allowedOperations: ["open", "evaluate"] as const,
+    };
+
+    expect(broker.availableOperations(scope)).toEqual(["open", "evaluate"]);
+  });
+
+  it("never advertises evaluation through a web executor", () => {
+    const broker = new BrowserAutomationBroker(options());
+    broker.registerHost(socket("web-discovery"), {
+      ...registration("web-discovery", "workspace-a"),
+      runtime: "web",
+      executorDescriptor: {
+        ...registration("web-discovery", "workspace-a").executorDescriptor,
+        runtime: "web",
+        operations: ["open", "evaluate"],
+      },
+      capabilities: [
+        { operation: "open", available: true },
+        { operation: "evaluate", available: true },
+      ],
+    }, { ...authorization("web-discovery"), allowWebRuntime: true });
+    const scope = {
+      ...claims("thread-a", "workspace-a"),
+      permissionCapability: "privileged" as const,
+      allowedOperations: ["open", "evaluate"] as const,
+    };
+
+    expect(broker.availableOperations(scope)).toEqual(["open"]);
+  });
+
   it("derives bounded inspect metadata from descriptor, credential, host, and target state", async () => {
     const deliveries: Array<{ channel: string; data: any }> = [];
     const broker = new BrowserAutomationBroker(options({ now: () => 10, send: (_socket, channel, data) => {
@@ -1360,6 +1407,62 @@ describe("BrowserAutomationBroker", () => {
     await expect(first).resolves.toMatchObject({ ok: true });
     await expect(joined).resolves.toMatchObject({ ok: true, requestId: "act-2" });
     expect(deliveries.filter(({ channel }) => channel === "browserAutomation.request")).toHaveLength(1);
+  });
+
+  it("serializes browser_evaluate, joins exact duplicates, and hashes expressions for conflicts", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({ now: () => 10, send: (_socket, channel, data) => { deliveries.push({ channel, data }); return true; } }));
+    const hostSocket = socket("evaluate-lock");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("evaluate-lock", "workspace-a"),
+      executorDescriptor: { ...registration("evaluate-lock", "workspace-a").executorDescriptor, operations: ["inspect", "evaluate"] },
+      capabilities: [{ operation: "evaluate", available: true }],
+    }, authorization("evaluate-lock")).generation;
+    broker.updateTargets(hostSocket, "evaluate-lock", generation, [statusTarget("evaluate-lock", generation)]);
+    const scope = { ...claims("thread-a", "workspace-a"), permissionCapability: "privileged" as const, allowedOperations: ["evaluate" as const] };
+    const makeEvaluate = (requestId: string, key: string, expression: string, sequence: number) => broker.execute(scope, {
+      ...request(scope, sequence), requestId, operation: "evaluate", args: {
+        idempotencyKey: key,
+        observationRef: "obs",
+        deadlineMs: 10_000,
+        expression,
+        awaitPromise: true,
+        timeoutMs: 1_000,
+      },
+    });
+    const first = makeEvaluate("evaluate-1", "same", "document.title", 1);
+    const joined = makeEvaluate("evaluate-2", "same", "document.title", 2);
+    const busy = makeEvaluate("evaluate-3", "different", "document.URL", 3);
+    await expect(busy).resolves.toMatchObject({ ok: false, error: { code: "BROWSER_BUSY", effect: "none", recovery: "wait" } });
+    const delivery = deliveries.find(({ channel }) => channel === "browserAutomation.request")!;
+    broker.respond(hostSocket, "evaluate-lock", generation, {
+      contractVersion: 1, requestId: delivery.data.dispatch.request.requestId, sequence: delivery.data.dispatch.request.sequence, ok: true,
+      result: {
+        operation: "evaluate",
+        outcome: "completed",
+        stoppingPosition: 1,
+        effect: "complete",
+        recovery: "inspect",
+        receipts: [{ index: 0, operation: "evaluate", status: "applied" }],
+        finalObservation: {
+          observationRef: "next",
+          hostRevision: generation,
+          documentRevision: 1,
+          controlRevision: 0,
+          capabilityRevision: 1,
+          observationRevision: 1,
+        },
+        nextObservationRef: "next",
+        valueJson: "\"Example\"",
+      },
+    }, delivery.data.dispatch.target);
+    await expect(first).resolves.toMatchObject({ ok: true });
+    await expect(joined).resolves.toMatchObject({ ok: true, requestId: "evaluate-2" });
+    expect(deliveries.filter(({ channel }) => channel === "browserAutomation.request")).toHaveLength(1);
+
+    const conflict = await makeEvaluate("evaluate-4", "same", "document.URL", 4);
+    expect(conflict).toMatchObject({ ok: false, error: { code: "IDEMPOTENCY_CONFLICT" } });
+    expect(conflict.ok && JSON.stringify(conflict)).toBe(false);
   });
 
   it("drops keyed open replay when its host reconnects", async () => {

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -1,5 +1,5 @@
 import type { WebSocket } from "ws";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   BROWSER_AUTOMATION_CONTRACT_VERSION,
   BROWSER_AUTOMATION_MAX_PENDING_REQUESTS,
@@ -51,6 +51,12 @@ interface OpenReplayRecord {
 }
 
 interface ActReplayRecord {
+  readonly fingerprint: string;
+  readonly promise: Promise<BrowserAutomationResponse>;
+  lastUsedAt: number;
+}
+
+interface EvaluateReplayRecord {
   readonly fingerprint: string;
   readonly promise: Promise<BrowserAutomationResponse>;
   lastUsedAt: number;
@@ -168,6 +174,14 @@ function openReplayKey(
 
 function actReplayKey(providerId: string, request: Extract<BrowserAutomationRequest, { operation: "act" }>): string {
   return JSON.stringify([providerId, request.providerSessionId, request.workspaceId, request.threadId, request.args.idempotencyKey]);
+}
+
+function evaluateReplayKey(providerId: string, request: Extract<BrowserAutomationRequest, { operation: "evaluate" }>): string {
+  return JSON.stringify([providerId, request.providerSessionId, request.workspaceId, request.threadId, request.args.idempotencyKey]);
+}
+
+function hashExpression(expression: string): string {
+  return createHash("sha256").update(expression, "utf8").digest("hex");
 }
 
 function targetsMatch(
@@ -318,7 +332,8 @@ export class BrowserAutomationBroker {
   private readonly maxTargets: number;
   private readonly openReplay = new Map<string, OpenReplayRecord>();
   private readonly actReplay = new Map<string, ActReplayRecord>();
-  private readonly actMutations = new Map<string, string>();
+  private readonly evaluateReplay = new Map<string, EvaluateReplayRecord>();
+  private readonly browserMutations = new Map<string, string>();
   private nextGeneration = 1;
   private readonly reliability: BrowserAutomationReliabilityCounters = {
     dispatched: 0,
@@ -658,6 +673,7 @@ export class BrowserAutomationBroker {
     const parsed = BrowserAutomationRequestSchema().safeParse(input);
     if (!parsed.success) return this.executeInternal(claims, input);
     if (parsed.data.operation === "act") return this.executeAct(claims, parsed.data);
+    if (parsed.data.operation === "evaluate") return this.executeEvaluate(claims, parsed.data);
     if (parsed.data.operation !== "open") return this.executeInternal(claims, input);
     const request = parsed.data;
     const key = request.args.idempotencyKey;
@@ -722,21 +738,65 @@ export class BrowserAutomationBroker {
       return existing.promise.then((response) => ({ ...response, requestId: request.requestId, sequence: request.sequence }));
     }
     const sessionKey = JSON.stringify([claims.providerId, claims.providerSessionId]);
-    if (this.actMutations.has(sessionKey)) {
+    if (this.browserMutations.has(sessionKey)) {
       return Promise.resolve(failure(request, "BROWSER_BUSY", "Another browser mutation is active for this provider session", true));
     }
     const token = randomUUID();
-    this.actMutations.set(sessionKey, token);
+    this.browserMutations.set(sessionKey, token);
     const promise = this.executeInternal(claims, request)
       .catch(() => failure(request, "INTERNAL_ERROR", "Browser mutation failed before a terminal result was produced", false))
       .finally(() => {
-        if (this.actMutations.get(sessionKey) === token) this.actMutations.delete(sessionKey);
+        if (this.browserMutations.get(sessionKey) === token) this.browserMutations.delete(sessionKey);
       });
     this.actReplay.set(replayKey, { fingerprint, promise, lastUsedAt: this.now() });
     while (this.actReplay.size > 256) {
       const oldest = this.actReplay.keys().next().value as string | undefined;
       if (!oldest) break;
       this.actReplay.delete(oldest);
+    }
+    return promise;
+  }
+
+  private executeEvaluate(
+    claims: BrowserAutomationCredentialClaims,
+    request: Extract<BrowserAutomationRequest, { operation: "evaluate" }>,
+  ): Promise<BrowserAutomationResponse> {
+    const cutoff = this.now() - 30 * 60_000;
+    for (const [key, record] of this.evaluateReplay) {
+      if (record.lastUsedAt < cutoff) this.evaluateReplay.delete(key);
+    }
+    const replayKey = evaluateReplayKey(claims.providerId, request);
+    const fingerprint = JSON.stringify({
+      observationRef: request.args.observationRef,
+      deadlineMs: request.args.deadlineMs,
+      awaitPromise: request.args.awaitPromise,
+      timeoutMs: request.args.timeoutMs,
+      expressionSha256: hashExpression(request.args.expression),
+    });
+    const existing = this.evaluateReplay.get(replayKey);
+    if (existing) {
+      existing.lastUsedAt = this.now();
+      if (existing.fingerprint !== fingerprint) {
+        return Promise.resolve(failure(request, "IDEMPOTENCY_CONFLICT", "The idempotency key was already used with different browser_evaluate arguments", false));
+      }
+      return existing.promise.then((response) => ({ ...response, requestId: request.requestId, sequence: request.sequence }));
+    }
+    const sessionKey = JSON.stringify([claims.providerId, claims.providerSessionId]);
+    if (this.browserMutations.has(sessionKey)) {
+      return Promise.resolve(failure(request, "BROWSER_BUSY", "Another browser mutation is active for this provider session", true));
+    }
+    const token = randomUUID();
+    this.browserMutations.set(sessionKey, token);
+    const promise = this.executeInternal(claims, request)
+      .catch(() => failure(request, "INTERNAL_ERROR", "Browser mutation failed before a terminal result was produced", false))
+      .finally(() => {
+        if (this.browserMutations.get(sessionKey) === token) this.browserMutations.delete(sessionKey);
+      });
+    this.evaluateReplay.set(replayKey, { fingerprint, promise, lastUsedAt: this.now() });
+    while (this.evaluateReplay.size > 256) {
+      const oldest = this.evaluateReplay.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.evaluateReplay.delete(oldest);
     }
     return promise;
   }
@@ -910,7 +970,8 @@ export class BrowserAutomationBroker {
     }
     this.pending.clear();
     this.actReplay.clear();
-    this.actMutations.clear();
+    this.evaluateReplay.clear();
+    this.browserMutations.clear();
   }
 
   /** Returns bounded broker counts for status and tests. */
@@ -922,6 +983,25 @@ export class BrowserAutomationBroker {
   /** Returns a snapshot of bounded reliability counters without page or credential data. */
   reliabilityStatus(): BrowserAutomationReliabilityCounters {
     return { ...this.reliability };
+  }
+
+  /** Returns the operations both the credential and its selected executor support. */
+  availableOperations(
+    claims: BrowserAutomationCredentialClaims,
+  ): readonly BrowserAutomationOperation[] {
+    const host = this.resolveSelectedHost(claims);
+    if (!host) return [];
+    const descriptorOperations = new Set(host.registration.executorDescriptor.operations);
+    const liveCapabilities = new Set(
+      host.registration.capabilities
+        .filter((capability) => capability.available)
+        .map((capability) => capability.operation),
+    );
+    return claims.allowedOperations.filter((operation) =>
+      descriptorOperations.has(operation) &&
+      liveCapabilities.has(operation) &&
+      (operation !== "evaluate" || host.registration.runtime === "electron"),
+    );
   }
 
   /** Releases sticky routing state when a provider session closes or rotates credentials. */
@@ -964,7 +1044,11 @@ export class BrowserAutomationBroker {
       const parts = JSON.parse(key) as string[];
       if (parts[0] === providerId && parts[1] === providerSessionId) this.actReplay.delete(key);
     }
-    this.actMutations.delete(JSON.stringify([providerId, providerSessionId]));
+    for (const key of this.evaluateReplay.keys()) {
+      const parts = JSON.parse(key) as string[];
+      if (parts[0] === providerId && parts[1] === providerSessionId) this.evaluateReplay.delete(key);
+    }
+    this.browserMutations.delete(JSON.stringify([providerId, providerSessionId]));
     return removed;
   }
 
@@ -1018,6 +1102,35 @@ export class BrowserAutomationBroker {
     return selected;
   }
 
+  private resolveSelectedHost(
+    claims: BrowserAutomationCredentialClaims,
+  ): RegisteredHost | undefined {
+    const key = assignmentKey(claims);
+    const assigned = this.assignments.get(key);
+    if (assigned) {
+      const assignedTarget = assigned.host.targets.get(assigned.targetKey);
+      if (assignedTarget && this.matchesScope(assigned.host, claims)) {
+        assigned.lastUsedAt = this.now();
+        return assigned.host;
+      }
+      this.assignments.delete(key);
+    }
+    return [...this.hostsBySocket.values()]
+      .filter((host) => this.matchesScope(host, claims))
+      .map((host) => ({
+        host,
+        target: [...host.targets.values()].find((target) => target.threadId === claims.threadId),
+      }))
+      .sort((left, right) =>
+        Number(Boolean(right.target)) - Number(Boolean(left.target)) ||
+        Number(right.target?.focused ?? false) - Number(left.target?.focused ?? false) ||
+        Number(right.target?.active ?? false) - Number(left.target?.active ?? false) ||
+        (right.target?.lastUsedAt ?? 0) - (left.target?.lastUsedAt ?? 0) ||
+        left.host.pending - right.host.pending ||
+        left.host.generation - right.host.generation,
+      )[0]?.host;
+  }
+
   private canAccept(
     host: RegisteredHost,
     claims: BrowserAutomationCredentialClaims,
@@ -1037,6 +1150,7 @@ export class BrowserAutomationBroker {
 
   private supportsOperation(host: RegisteredHost, request: BrowserAutomationRequest): boolean {
     const descriptor = host.registration.executorDescriptor;
+    if (request.operation === "evaluate" && host.registration.runtime !== "electron") return false;
     if (!descriptor.operations.includes(request.operation)) return false;
     return host.registration.capabilities.some(
       (capability) => capability.operation === request.operation && capability.available,

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -563,6 +563,19 @@ export class BrowserAutomationBroker {
       );
       return;
     }
+    if (
+      negotiatedResponse.ok &&
+      pending.request.operation === "evaluate" &&
+      negotiatedResponse.result.operation === "evaluate" &&
+      !("outcome" in negotiatedResponse.result)
+    ) {
+      this.settle(
+        key,
+        pending,
+        failure(pending.request, "INVALID_REQUEST", "Browser evaluation response is missing its mutation envelope", false),
+      );
+      return;
+    }
     if (negotiatedResponse.ok && !pending.target) {
       if (!responseTarget) {
         this.settle(
@@ -1000,7 +1013,10 @@ export class BrowserAutomationBroker {
     return claims.allowedOperations.filter((operation) =>
       descriptorOperations.has(operation) &&
       liveCapabilities.has(operation) &&
-      (operation !== "evaluate" || host.registration.runtime === "electron"),
+      (operation !== "evaluate" || (
+        claims.permissionCapability === "privileged" &&
+        host.registration.runtime === "electron"
+      )),
     );
   }
 

--- a/apps/server/src/services/browser-automation/mcp-handler.test.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.test.ts
@@ -48,7 +48,11 @@ describe("BrowserAutomationMcpHandler", () => {
     cancelFromProvider = vi.fn(() => false);
     handler = new BrowserAutomationMcpHandler({
       credentials,
-      broker: { execute, cancelFromProvider } as unknown as BrowserAutomationBroker,
+      broker: {
+        execute,
+        cancelFromProvider,
+        availableOperations: (claims: { allowedOperations: readonly string[] }) => claims.allowedOperations,
+      } as unknown as BrowserAutomationBroker,
       now: () => 1_000,
       maxSequenceEntries: 1,
     });
@@ -83,6 +87,12 @@ describe("BrowserAutomationMcpHandler", () => {
       destructiveHint: true,
       openWorldHint: true,
     });
+    expect(payload.result.tools.find((tool: any) => tool.name === "browser_evaluate").inputSchema.required).toEqual([
+      "idempotencyKey",
+      "observationRef",
+      "deadlineMs",
+      "expression",
+    ]);
   });
 
   it("discovers browser_act with bounded required arguments and rejects invalid batches before broker execution", async () => {

--- a/apps/server/src/services/browser-automation/mcp-handler.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.ts
@@ -176,12 +176,19 @@ function inputSchema(operation: BrowserAutomationOperation): Record<string, unkn
     network: { failedOnly: { type: "boolean" }, limit: { type: "integer", minimum: 1, maximum: 200 } },
     accessibility: { root: { type: "object" }, limit: { type: "integer", minimum: 1, maximum: 1000 } },
     performance: { includeMemory: { type: "boolean" } },
-    evaluate: { expression: { type: "string", minLength: 1, maxLength: 65536 }, awaitPromise: { type: "boolean" }, timeoutMs: { type: "integer", minimum: 1, maximum: 60000 } },
+    evaluate: {
+      idempotencyKey: { type: "string", minLength: 1, maxLength: 256 },
+      observationRef: { type: "string", minLength: 1, maxLength: 256 },
+      deadlineMs: { type: "integer", minimum: 1, maximum: 60000 },
+      expression: { type: "string", minLength: 1, maxLength: 65536 },
+      awaitPromise: { type: "boolean" },
+      timeoutMs: { type: "integer", minimum: 1, maximum: 60000 },
+    },
     recordingStart: { maxDurationMs: { type: "integer", minimum: 1000, maximum: 600000 } },
     recordingStop: {},
   };
   const requiredByOperation: Partial<Record<BrowserAutomationOperation, string[]>> = {
-    open: ["idempotencyKey"], act: ["idempotencyKey", "observationRef", "deadlineMs", "steps"], navigate: ["url"], resize: ["width", "height"], click: ["target"], type: ["text"], press: ["key"], scroll: ["deltaY"], evaluate: ["expression"],
+    open: ["idempotencyKey"], act: ["idempotencyKey", "observationRef", "deadlineMs", "steps"], navigate: ["url"], resize: ["width", "height"], click: ["target"], type: ["text"], press: ["key"], scroll: ["deltaY"], evaluate: ["idempotencyKey", "observationRef", "deadlineMs", "expression"],
   };
   return {
     type: "object",
@@ -343,7 +350,7 @@ export class BrowserAutomationMcpHandler {
       return { jsonrpc: "2.0", id, result: { protocolVersion, capabilities: { tools: { listChanged: false } }, serverInfo: { name: "mcode-browser", version: String(BROWSER_AUTOMATION_CONTRACT_VERSION) } } };
     }
     if (request.method === "tools/list") {
-      return { jsonrpc: "2.0", id, result: { tools: toolList(claims.allowedOperations) } };
+      return { jsonrpc: "2.0", id, result: { tools: toolList(this.broker.availableOperations(claims)) } };
     }
     if (request.method === "notifications/cancelled") {
       const cancelledId = request.params && typeof request.params === "object" && !Array.isArray(request.params)

--- a/apps/server/src/services/browser-evaluation-event-sanitizer.ts
+++ b/apps/server/src/services/browser-evaluation-event-sanitizer.ts
@@ -1,0 +1,46 @@
+import { AgentEventType, type AgentEvent } from "@mcode/contracts";
+
+const MAX_TRACKED_EVALUATIONS = 1_024;
+
+function evaluationCallKey(threadId: string, toolCallId: string): string {
+  return JSON.stringify([threadId, toolCallId]);
+}
+
+function isBrowserEvaluationTool(toolName: string): boolean {
+  const normalized = toolName.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  return normalized === "browser_evaluate" || normalized.endsWith("_browser_evaluate");
+}
+
+/** Removes privileged Browser evaluation content at the provider-event boundary. */
+export class BrowserEvaluationEventSanitizer {
+  private readonly evaluationCalls = new Set<string>();
+
+  /** Returns a content-free event while preserving tool identity and status. */
+  sanitize(event: AgentEvent): AgentEvent {
+    if (event.type === AgentEventType.ToolUse && isBrowserEvaluationTool(event.toolName)) {
+      const key = evaluationCallKey(event.threadId, event.toolCallId);
+      while (this.evaluationCalls.size >= MAX_TRACKED_EVALUATIONS) {
+        const oldest = this.evaluationCalls.values().next().value as string | undefined;
+        if (!oldest) break;
+        this.evaluationCalls.delete(oldest);
+      }
+      this.evaluationCalls.add(key);
+      return { ...event, toolInput: {} };
+    }
+
+    if (event.type !== AgentEventType.ToolResult) return event;
+    const key = evaluationCallKey(event.threadId, event.toolCallId);
+    if (!this.evaluationCalls.delete(key)) return event;
+    const {
+      outputTruncated: _outputTruncated,
+      outputTotalBytes: _outputTotalBytes,
+      outputArtifactPath: _outputArtifactPath,
+      ...contentFreeEvent
+    } = event;
+    return {
+      ...contentFreeEvent,
+      output: "",
+      toolInput: {},
+    };
+  }
+}

--- a/apps/server/src/services/browser-evaluation-event-sanitizer.ts
+++ b/apps/server/src/services/browser-evaluation-event-sanitizer.ts
@@ -1,11 +1,5 @@
 import { AgentEventType, type AgentEvent } from "@mcode/contracts";
 
-const MAX_TRACKED_EVALUATIONS = 1_024;
-
-function evaluationCallKey(threadId: string, toolCallId: string): string {
-  return JSON.stringify([threadId, toolCallId]);
-}
-
 function isBrowserEvaluationTool(toolName: string): boolean {
   const normalized = toolName.toLowerCase().replace(/[^a-z0-9]+/g, "_");
   return normalized === "browser_evaluate" || normalized.endsWith("_browser_evaluate");
@@ -13,24 +7,19 @@ function isBrowserEvaluationTool(toolName: string): boolean {
 
 /** Removes privileged Browser evaluation content at the provider-event boundary. */
 export class BrowserEvaluationEventSanitizer {
-  private readonly evaluationCalls = new Set<string>();
+  constructor(
+    private readonly resolveToolName: (threadId: string, toolCallId: string) => string | undefined = () => undefined,
+  ) {}
 
   /** Returns a content-free event while preserving tool identity and status. */
   sanitize(event: AgentEvent): AgentEvent {
     if (event.type === AgentEventType.ToolUse && isBrowserEvaluationTool(event.toolName)) {
-      const key = evaluationCallKey(event.threadId, event.toolCallId);
-      while (this.evaluationCalls.size >= MAX_TRACKED_EVALUATIONS) {
-        const oldest = this.evaluationCalls.values().next().value as string | undefined;
-        if (!oldest) break;
-        this.evaluationCalls.delete(oldest);
-      }
-      this.evaluationCalls.add(key);
       return { ...event, toolInput: {} };
     }
 
     if (event.type !== AgentEventType.ToolResult) return event;
-    const key = evaluationCallKey(event.threadId, event.toolCallId);
-    if (!this.evaluationCalls.delete(key)) return event;
+    const toolName = this.resolveToolName(event.threadId, event.toolCallId);
+    if (!toolName || !isBrowserEvaluationTool(toolName)) return event;
     const {
       outputTruncated: _outputTruncated,
       outputTotalBytes: _outputTotalBytes,

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   BROWSER_AUTOMATION_CONTRACT_VERSION,
   BROWSER_AUTOMATION_MAX_PENDING_REQUESTS,
-  BROWSER_AUTOMATION_OPERATIONS,
   BrowserAutomationHostDispatchSchema,
   BrowserAutomationRequestSchema,
   type BrowserAutomationHostDispatch,
@@ -38,13 +37,14 @@ import {
 } from "./browserAutomationRuntime";
 import { executeWebBrowserDispatch } from "./browserAutomationWebExecutor";
 import { captureVisibleWebLocation, sanitizeWebLocation } from "./web-browser-automation/capture";
-import { BrowserSessionDriver, ElectronBrowserSessionAdapter } from "@/services/browser-automation/browserSessionDriver";
+import {
+  BrowserSessionDriver,
+  ElectronBrowserSessionAdapter,
+  getBrowserAutomationRuntimeOperations,
+} from "@/services/browser-automation/browserSessionDriver";
 import { WebBrowserSessionAdapter } from "@/services/browser-automation/webBrowserSessionAdapter";
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
-const UNAVAILABLE_OPERATIONS = new Map<BrowserAutomationOperation, string>([
-]);
-
 const WEB_AUTOMATION_UNAVAILABLE_REASON = "Web automation executor is unavailable";
 
 export { isBrowserAutomationWebRuntimeEnabled } from "./browserAutomationRuntime";
@@ -115,7 +115,12 @@ async function executeBrowserDispatch(
   recorder: BrowserAutomationRecorder,
   dispatch: BrowserAutomationHostDispatch,
   signal: AbortSignal,
+  runtimeOperations?: readonly BrowserAutomationOperation[],
 ): Promise<BrowserAutomationResponse> {
+  const operations = runtimeOperations ?? getBrowserAutomationRuntimeOperations(
+    bridge ? "electron" : "web",
+    { recordingAvailable: bridge ? recordingAvailable() : false },
+  );
   if (!bridge) {
     const response = await executeWebBrowserDispatch(dispatch, signal);
     if (dispatch.request.operation !== "status" || !response.ok || response.result.operation !== "status") return response;
@@ -131,9 +136,9 @@ async function executeBrowserDispatch(
       }
       const location = captureVisibleWebLocation(iframe);
       if (!location.ok) return failureResponse(dispatch.request, location.code, "Visible preview is cross-origin");
-      return { ...response, result: { ...response.result, url: location.value } };
+      return { ...response, result: { ...response.result, url: location.value, capabilities: [...operations] } };
     }
-    return { ...response, result: { ...response.result, url: sanitizeWebLocation(response.result.url) } };
+    return { ...response, result: { ...response.result, url: sanitizeWebLocation(response.result.url), capabilities: [...operations] } };
   }
   const rendererOwned = dispatch.request.operation === "resize" ||
     dispatch.request.operation === "recordingStart" ||
@@ -190,9 +195,7 @@ async function executeBrowserDispatch(
     ...response,
     result: {
       ...response.result,
-      capabilities: BROWSER_AUTOMATION_OPERATIONS.filter((operation) =>
-        recordingAvailable() || (operation !== "recordingStart" && operation !== "recordingStop"),
-      ),
+      capabilities: [...operations],
     },
   };
 }
@@ -531,12 +534,17 @@ export function BrowserAutomationHost() {
   const registered = useBrowserAutomationStore((state) => state.registered);
   const leaseRef = useRef<HostLease | null>(null);
   const shutdownLeaseRef = useRef<HostLease | null>(null);
-  const executorDescriptor = useMemo(() => ({
-    runtime: window.desktopBridge?.preview?.automation ? "electron" as const : "web" as const,
-    operations: ["inspect", "act", ...BROWSER_AUTOMATION_OPERATIONS] as BrowserAutomationOperation[],
-    constraints: { maxTabs: 32, maxSnapshotChars: 20_000, maxDiagnostics: 200 },
-    capabilityRevision: 1,
-  }), []);
+  const executorDescriptor = useMemo(() => {
+    const runtime = window.desktopBridge?.preview?.automation ? "electron" as const : "web" as const;
+    return {
+      runtime,
+      operations: [...getBrowserAutomationRuntimeOperations(runtime, {
+        recordingAvailable: runtime === "electron" ? recordingAvailable() : false,
+      })],
+      constraints: { maxTabs: 32, maxSnapshotChars: 20_000, maxDiagnostics: 200 },
+      capabilityRevision: 1,
+    };
+  }, []);
   const recorderRef = useRef(new BrowserAutomationRecorder());
   const registrationEpochRef = useRef(0);
   const inFlightRef = useRef(new Map<string, BrowserAutomationHostDispatch>());
@@ -576,13 +584,22 @@ export function BrowserAutomationHost() {
       },
       onHumanInput: (dispatch) => webHumanCancelRef.current.get(browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence))?.(),
       onObserver: (dispatch, dispose) => webObserverRef.current.set(browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence), dispose),
-      executeNonInteraction: (dispatch, signal) => executeBrowserDispatch(undefined, recorderRef.current, dispatch, signal),
+      executeNonInteraction: (dispatch, signal) => executeBrowserDispatch(undefined, recorderRef.current, dispatch, signal, executorDescriptor.operations),
     });
     sessionDriverRef.current = new BrowserSessionDriver({
       web: webAdapter,
       getCapabilityRevision: () => executorDescriptor.capabilityRevision,
+      getHostRevision: () => leaseRef.current?.generation ?? 0,
+      getDocumentRevision: (dispatch) => executorDescriptor.runtime === "web"
+        ? useBrowserAutomationStore.getState().liveTargets.get(
+          browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+        )?.revision ?? dispatch.target.targetGeneration
+        : dispatch.target.targetGeneration,
+      getControlRevision: (dispatch) => useBrowserAutomationStore.getState().controllers.get(
+        browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+      )?.controlEpoch ?? dispatch.target.controller?.controlEpoch ?? dispatch.request.expectedControlEpoch,
       electron: new ElectronBrowserSessionAdapter(
-        (dispatch, signal) => executeBrowserDispatch(window.desktopBridge?.preview?.automation, recorderRef.current, dispatch, signal),
+        (dispatch, signal) => executeBrowserDispatch(window.desktopBridge?.preview?.automation, recorderRef.current, dispatch, signal, executorDescriptor.operations),
       ),
       supportedActOperations: window.desktopBridge?.preview?.automation
         ? ["navigate", "click", "type", "press", "scroll"]
@@ -685,24 +702,7 @@ export function BrowserAutomationHost() {
         targetIdentity: webTargetIdentity(worktreeIdentity, "pending-desktop", activeTarget),
       } : {}),
       executorDescriptor,
-      capabilities: [{ operation: "inspect", available: true }, { operation: "act", available: true }, ...BROWSER_AUTOMATION_OPERATIONS.map((operation) => {
-        if (!desktopAutomation) {
-          const available = operation === "click" || operation === "type" ||
-            operation === "status" || operation === "open" || operation === "navigate" ||
-            operation === "snapshot" || operation === "screenshot";
-          return available
-            ? { operation, available: true }
-            : { operation, available: false, unavailableReason: WEB_AUTOMATION_UNAVAILABLE_REASON };
-        }
-        const recordingUnavailable =
-          (operation === "recordingStart" || operation === "recordingStop") &&
-          !recordingAvailable();
-        const unavailableReason = UNAVAILABLE_OPERATIONS.get(operation) ??
-          (recordingUnavailable ? "Visible tab recording is unavailable in this renderer" : undefined);
-        return unavailableReason
-          ? { operation, available: false, unavailableReason }
-          : { operation, available: true };
-      })],
+      capabilities: executorDescriptor.operations.map((operation) => ({ operation, available: true })),
       maxPendingRequests: BROWSER_AUTOMATION_MAX_PENDING_REQUESTS,
       connectedAt: Date.now(),
     }).then((result) => {

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -287,6 +287,41 @@ describe("BrowserAutomationHost", () => {
     webExecutor.executeWebBrowserDispatch.mockReset();
   });
 
+  it("keeps evaluate out of the pure web descriptor, registration, and status capabilities", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    const statusDispatch = dispatch(1, 93);
+    webExecutor.executeWebBrowserDispatch.mockResolvedValue(successResponse(statusDispatch.request));
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const registration = harness.transport.registerBrowserAutomationHost.mock.calls[0]?.[0];
+    expect(registration.executorDescriptor.operations).not.toContain("evaluate");
+    expect(registration.capabilities.map((capability: { operation: string }) => capability.operation)).not.toContain("evaluate");
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: statusDispatch }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    const status = harness.transport.respondToBrowserAutomationRequest.mock.calls[0]?.[2];
+    expect(status).toMatchObject({ ok: true, result: { operation: "status" } });
+    if (status.ok && status.result.operation === "status") expect(status.result.capabilities).not.toContain("evaluate");
+    view.unmount();
+  });
+
+  it("advertises evaluate in Electron descriptor, registration, and status capabilities", async () => {
+    execute.mockResolvedValue(successResponse(dispatch(1, 94).request));
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const registration = harness.transport.registerBrowserAutomationHost.mock.calls[0]?.[0];
+    expect(registration.executorDescriptor.operations).toContain("evaluate");
+    expect(registration.capabilities).toContainEqual({ operation: "evaluate", available: true });
+    const request = dispatch(1, 94);
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: request }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    const status = harness.transport.respondToBrowserAutomationRequest.mock.calls[0]?.[2];
+    expect(status).toMatchObject({ ok: true, result: { operation: "status", capabilities: expect.arrayContaining(["evaluate"]) } });
+    view.unmount();
+  });
+
   it("carries an initial web open URL into the visible preview state", async () => {
     delete window.desktopBridge;
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { BrowserAutomationHostDispatch, BrowserAutomationResponse } from "@mcode/contracts";
+import type { BrowserAutomationHostDispatch, BrowserAutomationHostDispatchTarget, BrowserAutomationResponse } from "@mcode/contracts";
 import { BrowserSessionDriver, ElectronBrowserSessionAdapter, getBrowserAutomationRuntimeOperations } from "./browserSessionDriver";
 import { WebBrowserSessionAdapter } from "./webBrowserSessionAdapter";
 
@@ -228,6 +228,41 @@ describe("BrowserSessionDriver", () => {
       },
     });
     expect(electron).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a deferred Electron evaluation when capability revision changes before completion", async () => {
+    let revision = 1;
+    let resolveEvaluate!: (response: BrowserAutomationResponse) => void;
+    const deferredEvaluate = new Promise<BrowserAutomationResponse>((resolve) => {
+      resolveEvaluate = resolve;
+    });
+    const electron = vi.fn((value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "inspect") {
+        return Promise.resolve({ ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse);
+      }
+      return deferredEvaluate;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute: vi.fn() },
+      electron: { execute: electron },
+      isElectron: () => true,
+      getCapabilityRevision: () => revision,
+    });
+    const inspect = await driver.execute(inspectDispatch(), new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+    const pending = driver.execute(evaluateDispatch(observationRef), new AbortController().signal);
+    await Promise.resolve();
+    revision = 2;
+    resolveEvaluate({
+      ok: true,
+      result: { operation: "evaluate", valueJson: '"private"', controlEpoch: 0 },
+    } as unknown as BrowserAutomationResponse);
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      error: { code: "CAPABILITY_CHANGED", effect: "none", recovery: "inspect" },
+    });
+    expect(JSON.stringify(await pending)).not.toContain("private");
   });
 
   function actDispatch(observationRef: string, steps: unknown[], requestId = "act"): BrowserAutomationHostDispatch {
@@ -495,6 +530,85 @@ describe("BrowserSessionDriver", () => {
     await expect(first).resolves.toMatchObject({ ok: true });
     await expect(driver.execute(open("third-open", "tab-3", "key-3"), new AbortController().signal)).resolves.toMatchObject({ ok: true });
     expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops a tab close when cancellation arrives during lifecycle enumeration", async () => {
+    const target: BrowserAutomationHostDispatchTarget = {
+      desktopInstanceId: "desktop",
+      threadId: "thread",
+      tabId: "agent-tab",
+      windowId: 1,
+      connectionGeneration: 1,
+      targetGeneration: 1,
+      active: true,
+      focused: true,
+      lastUsedAt: 1,
+    };
+    let resolveList!: (targets: readonly BrowserAutomationHostDispatchTarget[]) => void;
+    const list = vi.fn(() => new Promise<readonly BrowserAutomationHostDispatchTarget[]>((resolve) => {
+      resolveList = resolve;
+    }));
+    const close = vi.fn();
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => ({
+      contractVersion: 1,
+      requestId: value.request.requestId,
+      sequence: value.request.sequence,
+      ok: true,
+      result: value.request.operation === "inspect"
+        ? { operation: "inspect", tabs: [target] }
+        : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+    }) as unknown as BrowserAutomationResponse);
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      webTabs: { list, close },
+    });
+    const opened = await driver.execute({
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target,
+      request: {
+        contractVersion: 1,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId: "open",
+        sequence: 1,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "open",
+        args: { idempotencyKey: "open-key" },
+      },
+    } as BrowserAutomationHostDispatch, new AbortController().signal);
+    const observationRef = (opened as { result: { observationRef: string } }).result.observationRef;
+    const controller = new AbortController();
+    const pending = driver.execute({
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target,
+      request: {
+        contractVersion: 1,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId: "close",
+        sequence: 2,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "tabs",
+        args: { action: "close", tabId: "agent-tab", idempotencyKey: "close-key", observationRef },
+      },
+    } as unknown as BrowserAutomationHostDispatch, controller.signal);
+    expect(list).toHaveBeenCalledOnce();
+    controller.abort();
+    resolveList([target]);
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      error: { code: "OPERATION_CANCELLED", effect: "none", recovery: "inspect" },
+    });
+    expect(close).not.toHaveBeenCalled();
   });
 
   it("claims and releases user tabs without physically closing them", async () => {

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -57,6 +57,90 @@ describe("BrowserSessionDriver", () => {
     } as unknown as BrowserAutomationHostDispatch;
   }
 
+  function browserTarget(tabId: string, lastUsedAt = 1): BrowserAutomationHostDispatchTarget {
+    return {
+      desktopInstanceId: "desktop",
+      threadId: "thread",
+      tabId,
+      windowId: 1,
+      connectionGeneration: 1,
+      targetGeneration: 1,
+      active: tabId === "tab-2",
+      focused: tabId === "tab-2",
+      lastUsedAt,
+    };
+  }
+
+  function openTabDispatch(target: BrowserAutomationHostDispatchTarget, requestId: string, sequence: number): BrowserAutomationHostDispatch {
+    return {
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target,
+      request: {
+        contractVersion: 1,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId,
+        sequence,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "open",
+        args: { idempotencyKey: `${requestId}-key` },
+      },
+    } as unknown as BrowserAutomationHostDispatch;
+  }
+
+  function inspectTabDispatch(target: BrowserAutomationHostDispatchTarget, requestId: string, sequence: number): BrowserAutomationHostDispatch {
+    return {
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target,
+      request: {
+        contractVersion: 1,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId,
+        sequence,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "inspect",
+        args: { includeScreenshot: false, includeDiagnostics: false },
+      },
+    } as unknown as BrowserAutomationHostDispatch;
+  }
+
+  function tabsDispatch(
+    target: BrowserAutomationHostDispatchTarget,
+    requestId: string,
+    sequence: number,
+    observationRef: string,
+    args: Record<string, unknown>,
+  ): BrowserAutomationHostDispatch {
+    return {
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target,
+      request: {
+        contractVersion: 1,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId,
+        sequence,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "tabs",
+        args: {
+          idempotencyKey: `${requestId}-key`,
+          observationRef,
+          ...args,
+        },
+      },
+    } as unknown as BrowserAutomationHostDispatch;
+  }
+
   it("derives truthful operation sets for each runtime", () => {
     const webOperations = getBrowserAutomationRuntimeOperations("web");
     const electronOperations = getBrowserAutomationRuntimeOperations("electron");
@@ -609,6 +693,181 @@ describe("BrowserSessionDriver", () => {
       error: { code: "OPERATION_CANCELLED", effect: "none", recovery: "inspect" },
     });
     expect(close).not.toHaveBeenCalled();
+  });
+
+  it("reconciles the current tab after close completes before cancellation", async () => {
+    const tab1 = browserTarget("tab-1");
+    const tab2 = browserTarget("tab-2", 2);
+    const liveTargets = new Map([[tab1.tabId, tab1], [tab2.tabId, tab2]]);
+    let resolveClose!: () => void;
+    const close = vi.fn((target: BrowserAutomationHostDispatchTarget) => new Promise<void>((resolve) => {
+      resolveClose = () => {
+        liveTargets.delete(target.tabId);
+        resolve();
+      };
+    }));
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "open") liveTargets.set(value.target.tabId, value.target);
+      return {
+        contractVersion: 1,
+        requestId: value.request.requestId,
+        sequence: value.request.sequence,
+        ok: true,
+        result: value.request.operation === "inspect"
+          ? { operation: "inspect", tabs: [...liveTargets.values()] }
+          : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+      } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      webTabs: { list: async () => [...liveTargets.values()], close },
+    });
+    await driver.execute(openTabDispatch(tab1, "open-1", 1), new AbortController().signal);
+    await driver.execute(openTabDispatch(tab2, "open-2", 2), new AbortController().signal);
+    const inspected = await driver.execute(inspectTabDispatch(tab1, "inspect", 3), new AbortController().signal);
+    const inspectedRef = (inspected as { result: { observationRef: string } }).result.observationRef;
+    const selected = await driver.execute(tabsDispatch(tab1, "select", 4, inspectedRef, { action: "select", tabId: "tab-1" }), new AbortController().signal);
+    const selectedRef = (selected as { result: { observationRef: string } }).result.observationRef;
+    const controller = new AbortController();
+    const closeDispatch = tabsDispatch(tab1, "close", 5, selectedRef, { action: "close", tabId: "tab-1" });
+    const pending = driver.execute(closeDispatch, controller.signal);
+    await Promise.resolve();
+    expect(close).toHaveBeenCalledOnce();
+    controller.abort();
+    resolveClose();
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      error: { code: "OPERATION_CANCELLED", effect: "unknown", recovery: "inspect" },
+    });
+    const refreshed = await driver.execute(inspectTabDispatch(tab2, "refresh", 6), new AbortController().signal);
+    const refreshedRef = (refreshed as { result: { observationRef: string } }).result.observationRef;
+    const released = await driver.execute(tabsDispatch(tab2, "release", 7, refreshedRef, { action: "release", tabId: "tab-2" }), new AbortController().signal);
+    expect(released).toMatchObject({
+      ok: true,
+      result: { tabs: [{ tabId: "tab-2", ownership: "released", disposition: "release" }] },
+    });
+    expect((released as { result: { currentTabId?: string } }).result.currentTabId).toBeUndefined();
+  });
+
+  it("preserves remaining ownership when finalization is cancelled after a close", async () => {
+    const tab1 = browserTarget("tab-1");
+    const tab2 = browserTarget("tab-2", 2);
+    const liveTargets = new Map([[tab1.tabId, tab1], [tab2.tabId, tab2]]);
+    let resolveFirstClose!: () => void;
+    const close = vi.fn((target: BrowserAutomationHostDispatchTarget) => {
+      if (target.tabId === "tab-1") {
+        return new Promise<void>((resolve) => {
+          resolveFirstClose = () => {
+            liveTargets.delete(target.tabId);
+            resolve();
+          };
+        });
+      }
+      liveTargets.delete(target.tabId);
+      return Promise.resolve();
+    });
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "open") liveTargets.set(value.target.tabId, value.target);
+      return {
+        contractVersion: 1,
+        requestId: value.request.requestId,
+        sequence: value.request.sequence,
+        ok: true,
+        result: value.request.operation === "inspect"
+          ? { operation: "inspect", tabs: [...liveTargets.values()] }
+          : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+      } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      webTabs: { list: async () => [...liveTargets.values()], close },
+    });
+    await driver.execute(openTabDispatch(tab1, "open-1", 1), new AbortController().signal);
+    await driver.execute(openTabDispatch(tab2, "open-2", 2), new AbortController().signal);
+    const inspected = await driver.execute(inspectTabDispatch(tab1, "inspect", 3), new AbortController().signal);
+    const inspectedRef = (inspected as { result: { observationRef: string } }).result.observationRef;
+    const selected = await driver.execute(tabsDispatch(tab1, "select", 4, inspectedRef, { action: "select", tabId: "tab-1" }), new AbortController().signal);
+    const selectedRef = (selected as { result: { observationRef: string } }).result.observationRef;
+    const controller = new AbortController();
+    const finalizeDispatch = tabsDispatch(tab1, "finalize", 5, selectedRef, {
+      action: "finalize",
+      dispositions: [
+        { tabId: "tab-1", disposition: "close" },
+        { tabId: "tab-2", disposition: "close" },
+      ],
+    });
+    const pending = driver.execute(finalizeDispatch, controller.signal);
+    await Promise.resolve();
+    expect(close).toHaveBeenCalledOnce();
+    controller.abort();
+    resolveFirstClose();
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      error: { code: "OPERATION_CANCELLED", effect: "unknown", recovery: "inspect" },
+    });
+    const refreshed = await driver.execute(inspectTabDispatch(tab2, "refresh", 6), new AbortController().signal);
+    const refreshedRef = (refreshed as { result: { observationRef: string } }).result.observationRef;
+    const released = await driver.execute(tabsDispatch(tab2, "release", 7, refreshedRef, { action: "release", tabId: "tab-2" }), new AbortController().signal);
+    expect(released).toMatchObject({
+      ok: true,
+      result: { tabs: [{ tabId: "tab-2", ownership: "released", disposition: "release" }] },
+    });
+    expect((released as { result: { currentTabId?: string } }).result.currentTabId).toBeUndefined();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("returns a truthful envelope when tab close rejects and preserves the controlled state", async () => {
+    const target = browserTarget("tab-1");
+    const liveTargets = new Map([[target.tabId, target]]);
+    const close = vi.fn()
+      .mockRejectedValueOnce(new Error("close failed token=topsecret"))
+      .mockImplementation(async (value: BrowserAutomationHostDispatchTarget) => {
+        liveTargets.delete(value.tabId);
+      });
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "open") liveTargets.set(value.target.tabId, value.target);
+      return {
+        contractVersion: 1,
+        requestId: value.request.requestId,
+        sequence: value.request.sequence,
+        ok: true,
+        result: value.request.operation === "inspect"
+          ? { operation: "inspect", tabs: [...liveTargets.values()] }
+          : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+      } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      webTabs: { list: async () => [...liveTargets.values()], close },
+    });
+    await driver.execute(openTabDispatch(target, "open", 1), new AbortController().signal);
+    const inspected = await driver.execute(inspectTabDispatch(target, "inspect", 2), new AbortController().signal);
+    const inspectedRef = (inspected as { result: { observationRef: string } }).result.observationRef;
+    const failed = await driver.execute(tabsDispatch(target, "close", 3, inspectedRef, { action: "close", tabId: "tab-1" }), new AbortController().signal);
+    expect(failed).toMatchObject({
+      ok: false,
+      error: {
+        code: "TAB_UNAVAILABLE",
+        retryable: true,
+        stage: "effect",
+        effect: "unknown",
+        recovery: "inspect",
+      },
+    });
+    expect(JSON.stringify(failed)).not.toContain("topsecret");
+    const refreshed = await driver.execute(inspectTabDispatch(target, "refresh", 4), new AbortController().signal);
+    const refreshedRef = (refreshed as { result: { observationRef: string } }).result.observationRef;
+    const retried = await driver.execute(tabsDispatch(target, "retry-close", 5, refreshedRef, { action: "close", tabId: "tab-1" }), new AbortController().signal);
+    expect(retried).toMatchObject({ ok: true, result: { tabs: [] } });
+    expect(close).toHaveBeenCalledTimes(2);
   });
 
   it("claims and releases user tabs without physically closing them", async () => {

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -1,12 +1,235 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BrowserAutomationHostDispatch, BrowserAutomationResponse } from "@mcode/contracts";
-import { BrowserSessionDriver, ElectronBrowserSessionAdapter } from "./browserSessionDriver";
+import { BrowserSessionDriver, ElectronBrowserSessionAdapter, getBrowserAutomationRuntimeOperations } from "./browserSessionDriver";
 import { WebBrowserSessionAdapter } from "./webBrowserSessionAdapter";
 
 const response = {} as BrowserAutomationResponse;
 const dispatch = {} as BrowserAutomationHostDispatch;
 
 describe("BrowserSessionDriver", () => {
+  function inspectDispatch(requestId = "inspect"): BrowserAutomationHostDispatch {
+    return {
+      connection: { connectionGeneration: 1, targetGeneration: 1, capabilityRevision: 1 },
+      target: { threadId: "thread", tabId: "tab", targetGeneration: 1, windowId: 1 },
+      request: {
+        contractVersion: 1,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId,
+        sequence: 1,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "inspect",
+        args: { includeScreenshot: false, includeDiagnostics: false },
+      },
+    } as unknown as BrowserAutomationHostDispatch;
+  }
+
+  function evaluateDispatch(
+    observationRef: string,
+    options: { requestId?: string; deadline?: number; deadlineMs?: number } = {},
+  ): BrowserAutomationHostDispatch {
+    return {
+      connection: { connectionGeneration: 1, targetGeneration: 1, capabilityRevision: 1 },
+      target: { threadId: "thread", tabId: "tab", targetGeneration: 1, windowId: 1 },
+      request: {
+        contractVersion: 1,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId: options.requestId ?? "evaluate",
+        sequence: 2,
+        deadline: options.deadline ?? Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "evaluate",
+        args: {
+          idempotencyKey: "evaluate-key",
+          observationRef,
+          deadlineMs: options.deadlineMs ?? 10_000,
+          expression: "document.title",
+          awaitPromise: true,
+          timeoutMs: 10_000,
+        },
+      },
+    } as unknown as BrowserAutomationHostDispatch;
+  }
+
+  it("derives truthful operation sets for each runtime", () => {
+    const webOperations = getBrowserAutomationRuntimeOperations("web");
+    const electronOperations = getBrowserAutomationRuntimeOperations("electron");
+    expect(webOperations).not.toContain("evaluate");
+    expect(electronOperations).toContain("evaluate");
+    expect(webOperations).toContain("act");
+    expect(electronOperations).toContain("inspect");
+  });
+
+  it("fails closed for web evaluate without invoking either runtime adapter", async () => {
+    const web = vi.fn();
+    const electron = vi.fn();
+    const driver = new BrowserSessionDriver({
+      web: { execute: web },
+      electron: { execute: electron },
+      isElectron: () => false,
+    });
+    const result = await driver.execute(evaluateDispatch("missing"), new AbortController().signal);
+    expect(result).toMatchObject({ ok: false, error: { code: "UNSUPPORTED_OPERATION", effect: "none" } });
+    expect(web).not.toHaveBeenCalled();
+    expect(electron).not.toHaveBeenCalled();
+  });
+
+  it("wraps an Electron raw evaluate success and consumes the observation", async () => {
+    const electron = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => {
+      if (dispatch.request.operation === "inspect") {
+        return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
+      }
+      return {
+        contractVersion: 1,
+        requestId: dispatch.request.requestId,
+        sequence: dispatch.request.sequence,
+        ok: true,
+        result: { operation: "evaluate", valueJson: '"title"', controlEpoch: 0 },
+      } as BrowserAutomationResponse;
+    });
+    const web = vi.fn();
+    const driver = new BrowserSessionDriver({
+      web: { execute: web },
+      electron: { execute: electron },
+      isElectron: () => true,
+    });
+    const inspect = await driver.execute(inspectDispatch(), new AbortController().signal);
+    const observationRef = (inspect as { result?: { observationRef?: string } }).result?.observationRef;
+    const result = await driver.execute(evaluateDispatch(observationRef!), new AbortController().signal);
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        operation: "evaluate",
+        outcome: "completed",
+        stoppingPosition: 1,
+        effect: "complete",
+        recovery: "inspect",
+        receipts: [{ index: 0, operation: "evaluate", status: "applied" }],
+        valueJson: '"title"',
+        finalObservation: { observationRevision: 1 },
+        nextObservationRef: expect.any(String),
+      },
+    });
+    expect(web).not.toHaveBeenCalled();
+    expect(electron).toHaveBeenCalledTimes(2);
+    const nextObservationRef = (result as { result?: { nextObservationRef?: string } }).result?.nextObservationRef;
+    await expect(driver.execute(evaluateDispatch(observationRef!, { requestId: "replay" }), new AbortController().signal))
+      .resolves.toMatchObject({ ok: false, error: { code: "STALE_TARGET_GENERATION" } });
+    expect(nextObservationRef).toEqual(expect.any(String));
+  });
+
+  it("returns an interrupted envelope when the Electron adapter cancels", async () => {
+    const electron = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => {
+      if (dispatch.request.operation === "inspect") {
+        return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
+      }
+      return {
+        contractVersion: 1,
+        requestId: dispatch.request.requestId,
+        sequence: dispatch.request.sequence,
+        ok: false,
+        error: { code: "OPERATION_CANCELLED", message: "cancelled", retryable: true },
+      } as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute: vi.fn() },
+      electron: { execute: electron },
+      isElectron: () => true,
+    });
+    const inspect = await driver.execute(inspectDispatch(), new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+    const result = await driver.execute(evaluateDispatch(observationRef), new AbortController().signal);
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        operation: "evaluate",
+        outcome: "interrupted",
+        effect: "partial",
+        receipts: [{ index: 0, operation: "evaluate", status: "interrupted" }],
+        finalObservation: { observationRevision: 1 },
+        nextObservationRef: expect.any(String),
+      },
+    });
+  });
+
+  it("bounds the Electron evaluation deadline by deadlineMs", async () => {
+    const electron = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => {
+      if (dispatch.request.operation === "inspect") {
+        return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
+      }
+      return { ok: true, result: { operation: "evaluate", valueJson: "null", controlEpoch: 0 } } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute: vi.fn() },
+      electron: { execute: electron },
+      isElectron: () => true,
+    });
+    const inspect = await driver.execute(inspectDispatch(), new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+    const startedAt = Date.now();
+    const originalDeadline = startedAt + 60_000;
+    await driver.execute(evaluateDispatch(observationRef, { deadline: originalDeadline, deadlineMs: 1_000 }), new AbortController().signal);
+    const evaluateRequest = electron.mock.calls[1]![0].request;
+    expect(evaluateRequest.deadline).toBeLessThan(originalDeadline);
+    expect(evaluateRequest.deadline).toBeGreaterThanOrEqual(startedAt + 900);
+    expect(evaluateRequest.deadline).toBeLessThanOrEqual(startedAt + 1_100);
+  });
+
+  it("stops before Electron evaluate when the live document revision changed", async () => {
+    let documentRevision = 1;
+    const electron = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => {
+      if (dispatch.request.operation === "inspect") {
+        return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
+      }
+      return { ok: true, result: { operation: "evaluate", valueJson: "null", controlEpoch: 0 } } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute: vi.fn() },
+      electron: { execute: electron },
+      isElectron: () => true,
+      getDocumentRevision: () => documentRevision,
+    });
+    const inspect = await driver.execute(inspectDispatch(), new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+    documentRevision = 2;
+    const result = await driver.execute(evaluateDispatch(observationRef), new AbortController().signal);
+    expect(result).toMatchObject({ ok: false, error: { code: "STALE_TARGET_GENERATION", effect: "none" } });
+    expect(electron).toHaveBeenCalledOnce();
+  });
+
+  it("stops before Electron evaluate when the request is already aborted", async () => {
+    const electron = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => {
+      if (dispatch.request.operation === "inspect") return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
+      return { ok: true, result: { operation: "evaluate", valueJson: "null", controlEpoch: 0 } } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute: vi.fn() },
+      electron: { execute: electron },
+      isElectron: () => true,
+    });
+    const inspect = await driver.execute(inspectDispatch(), new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+    const controller = new AbortController();
+    controller.abort(new Error("revoked"));
+    const result = await driver.execute(evaluateDispatch(observationRef), controller.signal);
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        operation: "evaluate",
+        outcome: "interrupted",
+        effect: "none",
+        receipts: [{ index: 0, operation: "evaluate", status: "interrupted" }],
+      },
+    });
+    expect(electron).toHaveBeenCalledOnce();
+  });
+
   function actDispatch(observationRef: string, steps: unknown[], requestId = "act"): BrowserAutomationHostDispatch {
     return {
       connection: { connectionGeneration: 1, capabilityRevision: 1 },

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -167,7 +167,7 @@ export class BrowserSessionDriver {
     if (initialDrift) return Promise.resolve(initialDrift);
     if (dispatch.request?.operation === "evaluate") return this.executeEvaluate(dispatch, signal);
     if (dispatch.request?.operation === "act") return this.executeAct(dispatch, signal);
-    if (dispatch.request?.operation === "tabs") return this.executeTabs(dispatch);
+    if (dispatch.request?.operation === "tabs") return this.executeTabs(dispatch, signal);
     if (dispatch.request?.operation !== "open") {
       return this.executeAdapter(dispatch, signal);
     }
@@ -469,7 +469,7 @@ export class BrowserSessionDriver {
       request: { ...dispatch.request, deadline },
     };
     return this.options.electron.execute(boundedDispatch, signal)
-      .then((response) => this.evaluateResponse(dispatch, observation, response))
+      .then((response) => this.evaluateResponse(dispatch, observation, response, signal))
       .catch((cause: unknown) => this.evaluateEnvelope(dispatch, observation, {
         outcome: this.isCancellation(cause) ? "interrupted" : "failed",
         effect: "partial",
@@ -482,7 +482,10 @@ export class BrowserSessionDriver {
     dispatch: BrowserAutomationHostDispatch,
     observation: ObservationRecord,
     response: BrowserAutomationResponse,
+    signal: AbortSignal,
   ): BrowserAutomationResponse {
+    const boundary = this.evaluateCompletionBoundary(dispatch, observation, signal);
+    if (boundary) return boundary;
     if (!response.ok) {
       const interrupted = this.isCancellation(response.error.code);
       return this.evaluateEnvelope(dispatch, observation, {
@@ -514,6 +517,27 @@ export class BrowserSessionDriver {
       status: "applied",
       valueJson: response.result.valueJson,
     });
+  }
+
+  private evaluateCompletionBoundary(
+    dispatch: BrowserAutomationHostDispatch,
+    observation: ObservationRecord,
+    signal: AbortSignal,
+  ): BrowserAutomationResponse | null {
+    if (signal.aborted) {
+      return this.evaluateEnvelope(dispatch, observation, {
+        outcome: "interrupted",
+        effect: "partial",
+        status: "interrupted",
+        message: "Browser evaluation was interrupted before completion",
+      });
+    }
+    const drift = this.revisionDrift(dispatch);
+    if (drift) return drift;
+    if (!this.observationStillCurrent(dispatch, observation)) {
+      return this.operationFailure(dispatch, "STALE_TARGET_GENERATION", "Browser observation changed before browser_evaluate completed");
+    }
+    return null;
   }
 
   private evaluateEnvelope(
@@ -609,9 +633,12 @@ export class BrowserSessionDriver {
     };
   }
 
-  private executeTabs(dispatch: BrowserAutomationHostDispatch): Promise<BrowserAutomationResponse> {
+  private executeTabs(dispatch: BrowserAutomationHostDispatch, signal: AbortSignal): Promise<BrowserAutomationResponse> {
     const request = dispatch.request as Extract<BrowserAutomationHostDispatch["request"], { operation: "tabs" }>;
     const sessionKey = this.sessionKey(dispatch);
+    if (signal.aborted) {
+      return Promise.resolve(this.tabCancellation(dispatch, "Browser tab mutation was interrupted before the effect"));
+    }
     const replayKey = JSON.stringify([request.providerSessionId, request.providerInstanceId, request.args.idempotencyKey]);
     const fingerprint = JSON.stringify(request.args);
     const replay = this.tabIdempotency.get(replayKey);
@@ -632,7 +659,7 @@ export class BrowserSessionDriver {
     }
     this.observations.delete(request.args.observationRef);
     this.activeTabMutations.add(sessionKey);
-    const promise = this.applyTabsMutation(dispatch, observation, capabilityRevision)
+    const promise = this.applyTabsMutation(dispatch, observation, capabilityRevision, signal)
       .finally(() => this.activeTabMutations.delete(sessionKey));
     this.tabIdempotency.set(replayKey, { fingerprint, lastUsedAt: Date.now(), promise });
     this.pruneIdempotency();
@@ -643,11 +670,18 @@ export class BrowserSessionDriver {
     dispatch: BrowserAutomationHostDispatch,
     observation: ObservationRecord,
     capabilityRevision: number,
+    signal: AbortSignal,
   ): Promise<BrowserAutomationResponse> {
     const request = dispatch.request as Extract<BrowserAutomationHostDispatch["request"], { operation: "tabs" }>;
     const session = this.tabSession(dispatch);
     const adapter = this.tabAdapter();
+    if (signal.aborted) {
+      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before enumeration");
+    }
     const liveTargets = new Map((adapter ? await adapter.list(dispatch) : [dispatch.target]).map((target) => [target.tabId, target]));
+    if (signal.aborted) {
+      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before the next effect");
+    }
     if (!this.observationStillCurrent(dispatch, observation)) {
       return this.failure(dispatch, "STALE_TARGET_GENERATION", "Browser generations changed before the next tab effect", "inspect");
     }
@@ -693,9 +727,18 @@ export class BrowserSessionDriver {
     } else if ((request.args.action === "release" || request.args.action === "close") && requestedTabId) {
       const controlled = session.tabs.get(requestedTabId);
       if (request.args.action === "close" && controlled?.provenance === "agent-created") {
+        if (signal.aborted) {
+          return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before closing the tab");
+        }
         await adapter?.close(controlled.target);
         session.tabs.delete(requestedTabId);
+        if (signal.aborted) {
+          return this.tabCancellation(dispatch, "Browser tab mutation was interrupted after closing the tab", "unknown");
+        }
       } else if (controlled) {
+        if (signal.aborted) {
+          return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before releasing the tab");
+        }
         session.tabs.set(requestedTabId, { ...controlled, ownership: "released", disposition: "release" });
       }
       if (session.current?.tabId === requestedTabId) session.current = null;
@@ -709,13 +752,26 @@ export class BrowserSessionDriver {
           ? requested === "handoff" || requested === "deliverable" ? requested : "release"
           : requested ?? "close";
         if (disposition === "close") {
+          if (signal.aborted) {
+            return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before closing the next tab");
+          }
           await adapter?.close(controlled.target);
           session.tabs.delete(tabId);
+          if (signal.aborted) {
+            return this.tabCancellation(dispatch, "Browser tab mutation was interrupted after closing a tab", "unknown");
+          }
         } else {
+          if (signal.aborted) {
+            return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before settling the next tab");
+          }
           session.tabs.set(tabId, { ...controlled, ownership: "released", disposition });
         }
       }
       session.current = null;
+    }
+
+    if (signal.aborted) {
+      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before completion");
     }
 
     const nextObservationRef = session.current ? globalThis.crypto.randomUUID() : undefined;
@@ -883,4 +939,24 @@ export class BrowserSessionDriver {
     };
   }
 
+  private tabCancellation(
+    dispatch: BrowserAutomationHostDispatch,
+    message: string,
+    effect: "none" | "unknown" = "none",
+  ): BrowserAutomationResponse {
+    return {
+      contractVersion: dispatch.request.contractVersion,
+      requestId: dispatch.request.requestId,
+      sequence: dispatch.request.sequence,
+      ok: false,
+      error: {
+        code: "OPERATION_CANCELLED",
+        message,
+        retryable: false,
+        stage: "effect",
+        effect,
+        recovery: "inspect",
+      },
+    };
+  }
 }

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -727,14 +727,8 @@ export class BrowserSessionDriver {
     } else if ((request.args.action === "release" || request.args.action === "close") && requestedTabId) {
       const controlled = session.tabs.get(requestedTabId);
       if (request.args.action === "close" && controlled?.provenance === "agent-created") {
-        if (signal.aborted) {
-          return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before closing the tab");
-        }
-        await adapter?.close(controlled.target);
-        session.tabs.delete(requestedTabId);
-        if (signal.aborted) {
-          return this.tabCancellation(dispatch, "Browser tab mutation was interrupted after closing the tab", "unknown");
-        }
+        const closeResult = await this.closeControlledTab(dispatch, session, adapter, requestedTabId, controlled, signal);
+        if (closeResult) return closeResult;
       } else if (controlled) {
         if (signal.aborted) {
           return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before releasing the tab");
@@ -752,19 +746,14 @@ export class BrowserSessionDriver {
           ? requested === "handoff" || requested === "deliverable" ? requested : "release"
           : requested ?? "close";
         if (disposition === "close") {
-          if (signal.aborted) {
-            return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before closing the next tab");
-          }
-          await adapter?.close(controlled.target);
-          session.tabs.delete(tabId);
-          if (signal.aborted) {
-            return this.tabCancellation(dispatch, "Browser tab mutation was interrupted after closing a tab", "unknown");
-          }
+          const closeResult = await this.closeControlledTab(dispatch, session, adapter, tabId, controlled, signal);
+          if (closeResult) return closeResult;
         } else {
           if (signal.aborted) {
             return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before settling the next tab");
           }
           session.tabs.set(tabId, { ...controlled, ownership: "released", disposition });
+          if (session.current?.tabId === tabId) session.current = null;
         }
       }
       session.current = null;
@@ -796,6 +785,55 @@ export class BrowserSessionDriver {
         ...(session.current ? { currentTabId: session.current.tabId } : {}),
         ...(nextObservationRef ? { observationRef: nextObservationRef } : {}),
         tabs: [...session.tabs.values()].map(({ target: _target, ...tab }) => tab),
+      },
+    };
+  }
+
+  private async closeControlledTab(
+    dispatch: BrowserAutomationHostDispatch,
+    session: ProviderTabSession,
+    adapter: BrowserSessionTabLifecycleAdapter | undefined,
+    tabId: string,
+    controlled: ControlledTab,
+    signal: AbortSignal,
+  ): Promise<BrowserAutomationResponse | null> {
+    if (signal.aborted) {
+      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before closing the tab");
+    }
+    try {
+      await adapter?.close(controlled.target);
+    } catch (cause) {
+      return this.tabCloseFailure(dispatch, cause, signal);
+    }
+    session.tabs.delete(tabId);
+    if (session.current?.tabId === tabId) session.current = null;
+    if (signal.aborted) {
+      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted after closing the tab", "unknown");
+    }
+    return null;
+  }
+
+  private tabCloseFailure(
+    dispatch: BrowserAutomationHostDispatch,
+    cause: unknown,
+    signal: AbortSignal,
+  ): BrowserAutomationResponse {
+    if (signal.aborted || this.isCancellation(cause)) {
+      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted while closing the tab", "unknown");
+    }
+    const detail = sanitizePublicDetail(cause instanceof Error ? cause.message : cause);
+    return {
+      contractVersion: dispatch.request.contractVersion,
+      requestId: dispatch.request.requestId,
+      sequence: dispatch.request.sequence,
+      ok: false,
+      error: {
+        code: "TAB_UNAVAILABLE",
+        message: detail ? `Browser tab close failed: ${detail}` : "Browser tab close failed",
+        retryable: true,
+        stage: "effect",
+        effect: "unknown",
+        recovery: "inspect",
       },
     };
   }

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -2,11 +2,53 @@ import type {
   BrowserAutomationHostDispatch,
   BrowserAutomationResponse,
   BrowserAutomationActStep,
+  BrowserAutomationEvaluateResult,
+  BrowserAutomationResult,
+  BrowserAutomationErrorCode,
+  BrowserAutomationOperation,
+  BrowserAutomationHostRuntime,
+} from "@mcode/contracts";
+import {
+  BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES,
+  BROWSER_AUTOMATION_OPERATIONS,
 } from "@mcode/contracts";
 
 const MAX_IDEMPOTENCY_RECORDS = 256;
 const IDEMPOTENCY_TTL_MS = 30 * 60_000;
 const SECRET_TEXT = /\b(password|token|secret|authorization|cookie|credential|session|api[_-]?key)\b\s*[:=]\s*[^,;\s]+/gi;
+
+const WEB_RUNTIME_OPERATIONS = [
+  "inspect",
+  "act",
+  "status",
+  "open",
+  "navigate",
+  "snapshot",
+  "screenshot",
+  "click",
+  "type",
+] as const satisfies readonly BrowserAutomationOperation[];
+
+/** Options that affect the operations a runtime can truthfully advertise. */
+export interface BrowserAutomationRuntimeOperationOptions {
+  readonly recordingAvailable?: boolean;
+}
+
+/** Returns the one operation set shared by runtime descriptors, status, and registration. */
+export function getBrowserAutomationRuntimeOperations(
+  runtime: BrowserAutomationHostRuntime,
+  options: BrowserAutomationRuntimeOperationOptions = {},
+): readonly BrowserAutomationOperation[] {
+  if (runtime === "web") return WEB_RUNTIME_OPERATIONS;
+  const recordingAvailable = options.recordingAvailable ?? true;
+  return [
+    "inspect",
+    "act",
+    ...BROWSER_AUTOMATION_OPERATIONS.filter((operation) =>
+      recordingAvailable || (operation !== "recordingStart" && operation !== "recordingStop"),
+    ),
+  ];
+}
 
 function sanitizePublicDetail(value: unknown): string {
   return String(value ?? "")
@@ -89,6 +131,7 @@ export class BrowserSessionDriver {
   ): Promise<BrowserAutomationResponse> {
     const initialDrift = this.revisionDrift(dispatch);
     if (initialDrift) return Promise.resolve(initialDrift);
+    if (dispatch.request?.operation === "evaluate") return this.executeEvaluate(dispatch, signal);
     if (dispatch.request?.operation === "act") return this.executeAct(dispatch, signal);
     if (dispatch.request?.operation !== "open") {
       return this.executeAdapter(dispatch, signal);
@@ -286,6 +329,187 @@ export class BrowserSessionDriver {
       } as BrowserAutomationResponse;
     };
     return run();
+  }
+
+  private executeEvaluate(
+    dispatch: BrowserAutomationHostDispatch,
+    signal: AbortSignal,
+  ): Promise<BrowserAutomationResponse> {
+    if (!this.isElectron()) {
+      return Promise.resolve(this.operationFailure(dispatch, "UNSUPPORTED_OPERATION", "Browser evaluation requires the Electron runtime"));
+    }
+    const request = dispatch.request as Extract<BrowserAutomationHostDispatch["request"], { operation: "evaluate" }>;
+    const observation = this.observations.get(request.args.observationRef);
+    const capabilityRevision = this.options.getCapabilityRevision?.() ?? dispatch.connection?.capabilityRevision ?? 1;
+    const currentBinding = this.currentObservationBinding(dispatch, capabilityRevision);
+    if (!observation) {
+      return Promise.resolve(this.operationFailure(dispatch, "STALE_TARGET_GENERATION", "Browser observation is stale; inspect before browser_evaluate"));
+    }
+    if (
+      observation.hostRevision !== currentBinding.hostRevision ||
+      observation.documentRevision !== currentBinding.documentRevision ||
+      observation.controlRevision !== currentBinding.controlRevision ||
+      observation.capabilityRevision !== currentBinding.capabilityRevision
+    ) {
+      return Promise.resolve(this.operationFailure(dispatch, "STALE_TARGET_GENERATION", "Browser observation is stale; inspect before browser_evaluate"));
+    }
+    const deadline = Math.min(dispatch.request.deadline, Date.now() + request.args.deadlineMs);
+    if (signal.aborted || Date.now() >= deadline) {
+      this.observations.delete(request.args.observationRef);
+      return Promise.resolve(this.evaluateEnvelope(dispatch, observation, {
+        outcome: "interrupted",
+        effect: "none",
+        status: "interrupted",
+        message: signal.aborted ? "Browser evaluation was interrupted before the effect" : "Browser evaluation deadline elapsed before the effect",
+      }));
+    }
+    const finalDrift = this.revisionDrift(dispatch);
+    if (finalDrift || !this.observationStillCurrent(dispatch, observation)) {
+      return Promise.resolve(this.operationFailure(dispatch, "STALE_TARGET_GENERATION", "Browser observation changed before browser_evaluate"));
+    }
+    this.observations.delete(request.args.observationRef);
+    const boundedDispatch: BrowserAutomationHostDispatch = {
+      ...dispatch,
+      request: { ...dispatch.request, deadline },
+    };
+    return this.options.electron.execute(boundedDispatch, signal)
+      .then((response) => this.evaluateResponse(dispatch, observation, response))
+      .catch((cause: unknown) => this.evaluateEnvelope(dispatch, observation, {
+        outcome: this.isCancellation(cause) ? "interrupted" : "failed",
+        effect: "partial",
+        status: this.isCancellation(cause) ? "interrupted" : "failed",
+        message: sanitizePublicDetail(cause instanceof Error ? cause.message : cause),
+      }));
+  }
+
+  private evaluateResponse(
+    dispatch: BrowserAutomationHostDispatch,
+    observation: ObservationRecord,
+    response: BrowserAutomationResponse,
+  ): BrowserAutomationResponse {
+    if (!response.ok) {
+      const interrupted = this.isCancellation(response.error.code);
+      return this.evaluateEnvelope(dispatch, observation, {
+        outcome: interrupted ? "interrupted" : "failed",
+        effect: response.error.effect === "none" ? "none" : "partial",
+        status: interrupted ? "interrupted" : "failed",
+        message: sanitizePublicDetail(response.error.message),
+      });
+    }
+    if (response.result.operation !== "evaluate" || !this.isRawEvaluateResult(response.result)) {
+      return this.evaluateEnvelope(dispatch, observation, {
+        outcome: "failed",
+        effect: "partial",
+        status: "failed",
+        message: "Electron browser evaluation returned an invalid result",
+      });
+    }
+    if (new TextEncoder().encode(response.result.valueJson).byteLength > BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES) {
+      return this.evaluateEnvelope(dispatch, observation, {
+        outcome: "failed",
+        effect: "complete",
+        status: "failed",
+        message: "Evaluation result exceeds 64 KiB",
+      });
+    }
+    return this.evaluateEnvelope(dispatch, observation, {
+      outcome: "completed",
+      effect: "complete",
+      status: "applied",
+      valueJson: response.result.valueJson,
+    });
+  }
+
+  private evaluateEnvelope(
+    dispatch: BrowserAutomationHostDispatch,
+    observation: ObservationRecord,
+    outcome: {
+      readonly outcome: "completed" | "failed" | "interrupted";
+      readonly effect: "none" | "partial" | "complete";
+      readonly status: "applied" | "failed" | "interrupted";
+      readonly message?: string;
+      readonly valueJson?: string;
+    },
+  ): BrowserAutomationResponse {
+    const capabilityRevision = this.options.getCapabilityRevision?.() ?? observation.capabilityRevision;
+    const current = this.currentObservationBinding(dispatch, capabilityRevision);
+    const nextObservationRef = globalThis.crypto.randomUUID();
+    const finalObservation = {
+      observationRef: nextObservationRef,
+      hostRevision: current.hostRevision,
+      documentRevision: current.documentRevision,
+      controlRevision: current.controlRevision,
+      capabilityRevision: current.capabilityRevision,
+      observationRevision: observation.observationRevision + 1,
+    };
+    this.observations.set(nextObservationRef, {
+      hostRevision: finalObservation.hostRevision,
+      documentRevision: finalObservation.documentRevision,
+      controlRevision: finalObservation.controlRevision,
+      capabilityRevision: finalObservation.capabilityRevision,
+      observationRevision: finalObservation.observationRevision,
+    });
+    const result: BrowserAutomationEvaluateResult = {
+      operation: "evaluate",
+      outcome: outcome.outcome,
+      stoppingPosition: outcome.outcome === "completed" ? 1 : 0,
+      effect: outcome.effect,
+      recovery: "inspect",
+      receipts: [{
+        index: 0,
+        operation: "evaluate",
+        status: outcome.status,
+        ...(outcome.message ? { message: outcome.message.slice(0, 1_024) } : {}),
+      }],
+      finalObservation,
+      nextObservationRef,
+      ...(outcome.valueJson !== undefined ? { valueJson: outcome.valueJson } : {}),
+    };
+    return {
+      contractVersion: dispatch.request.contractVersion,
+      requestId: dispatch.request.requestId,
+      sequence: dispatch.request.sequence,
+      ok: true,
+      result,
+    };
+  }
+
+  private isRawEvaluateResult(
+    result: Extract<BrowserAutomationResult, { operation: "evaluate" }>,
+  ): result is Extract<BrowserAutomationResult, { operation: "evaluate"; valueJson: string; controlEpoch: number }> {
+    return result.operation === "evaluate" && typeof result.valueJson === "string" && !("outcome" in result);
+  }
+
+  private isCancellation(value: unknown): boolean {
+    if (typeof value === "string") {
+      return value === "OPERATION_CANCELLED" || value === "HUMAN_INTERRUPTED" || value === "DEADLINE_EXCEEDED";
+    }
+    if (typeof value === "object" && value !== null && "code" in value) {
+      const code = (value as { code?: unknown }).code;
+      return code === "OPERATION_CANCELLED" || code === "HUMAN_INTERRUPTED" || code === "DEADLINE_EXCEEDED";
+    }
+    return value instanceof Error && /cancel|interrupt|deadline|abort/i.test(value.message);
+  }
+
+  private operationFailure(
+    dispatch: BrowserAutomationHostDispatch,
+    code: Extract<BrowserAutomationErrorCode, "UNSUPPORTED_OPERATION" | "STALE_TARGET_GENERATION" | "CAPABILITY_CHANGED">,
+    message: string,
+  ): BrowserAutomationResponse {
+    return {
+      contractVersion: dispatch.request.contractVersion,
+      requestId: dispatch.request.requestId,
+      sequence: dispatch.request.sequence,
+      ok: false,
+      error: {
+        code,
+        message,
+        retryable: false,
+        stage: "observation",
+        effect: "none",
+        recovery: "inspect",
+      },
+    };
   }
 
   private stepDispatch(dispatch: BrowserAutomationHostDispatch, step: BrowserAutomationActStep, deadline: number, index: number): BrowserAutomationHostDispatch {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -456,6 +456,7 @@ export {
   BrowserAutomationActStepSchema,
   BrowserAutomationObservationBindingSchema,
   BrowserAutomationActResultSchema,
+  BrowserAutomationEvaluateResultSchema,
 } from "./models/browser-automation.js";
 export type {
   BrowserAutomationOperation,
@@ -481,6 +482,7 @@ export type {
   BrowserAutomationActStep,
   BrowserAutomationObservationBinding,
   BrowserAutomationActResult,
+  BrowserAutomationEvaluateResult,
 } from "./models/browser-automation.js";
 
 // Events

--- a/packages/contracts/src/models/__tests__/browser-automation.test.ts
+++ b/packages/contracts/src/models/__tests__/browser-automation.test.ts
@@ -61,7 +61,12 @@ const argsByOperation = {
   network: {},
   accessibility: {},
   performance: {},
-  evaluate: { expression: "document.title" },
+  evaluate: {
+    expression: "document.title",
+    idempotencyKey: "evaluate-key",
+    observationRef: "observation-1",
+    deadlineMs: 10_000,
+  },
   recordingStart: {},
   recordingStop: {},
 } satisfies Record<(typeof BROWSER_AUTOMATION_OPERATIONS)[number], object>;
@@ -138,7 +143,24 @@ const resultByOperation = {
     },
     controlEpoch: 1,
   },
-  evaluate: { operation: "evaluate", valueJson: "null", controlEpoch: 1 },
+  evaluate: {
+    operation: "evaluate",
+    outcome: "completed",
+    stoppingPosition: 1,
+    effect: "complete",
+    recovery: "inspect",
+    receipts: [{ index: 0, operation: "evaluate", status: "applied" }],
+    finalObservation: {
+      observationRef: "observation-2",
+      hostRevision: 1,
+      documentRevision: 1,
+      controlRevision: 0,
+      capabilityRevision: 1,
+      observationRevision: 1,
+    },
+    nextObservationRef: "observation-2",
+    valueJson: "null",
+  },
   recordingStart: {
     operation: "recordingStart",
     recordingId: "recording-1",
@@ -436,12 +458,22 @@ describe("browser automation boundaries", () => {
     expect(parse("type", { text: "a".repeat(BROWSER_AUTOMATION_MAX_TYPED_TEXT_CHARS + 1) })).toBe(
       false,
     );
-    expect(parse("evaluate", { expression: "a".repeat(BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES) })).toBe(
-      true,
-    );
+    const evaluateEnvelope = {
+      idempotencyKey: "evaluate-key",
+      observationRef: "observation-1",
+      deadlineMs: 10_000,
+    };
+    expect(parse("evaluate", {
+      ...evaluateEnvelope,
+      expression: "a".repeat(BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES),
+    })).toBe(true);
     expect(
-      parse("evaluate", { expression: "a".repeat(BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES + 1) }),
+      parse("evaluate", {
+        ...evaluateEnvelope,
+        expression: "a".repeat(BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES + 1),
+      }),
     ).toBe(false);
+    expect(parse("evaluate", { expression: "document.title" })).toBe(false);
     expect(parse("screenshot", { maxWidth: BROWSER_AUTOMATION_MAX_SCREENSHOT_WIDTH })).toBe(true);
     expect(parse("screenshot", { maxWidth: BROWSER_AUTOMATION_MAX_SCREENSHOT_WIDTH + 1 })).toBe(
       false,

--- a/packages/contracts/src/models/browser-automation.ts
+++ b/packages/contracts/src/models/browser-automation.ts
@@ -915,10 +915,14 @@ export const BrowserAutomationObservationBindingSchema = lazySchema(() => z.obje
 /** Typed observation binding. */
 export type BrowserAutomationObservationBinding = z.infer<ReturnType<typeof BrowserAutomationObservationBindingSchema>>;
 
-const actArgs = z.object({
+const mutationArgs = {
   idempotencyKey: idempotencyKeySchema,
   observationRef: idSchema,
   deadlineMs: z.number().int().min(1).max(BROWSER_AUTOMATION_MAX_TIMEOUT_MS),
+} as const;
+
+const actArgs = z.object({
+  ...mutationArgs,
   steps: z.array(BrowserAutomationActStepSchema()).min(1).max(BROWSER_AUTOMATION_ACT_MAX_STEPS),
 }).strict();
 
@@ -1000,7 +1004,12 @@ export const BrowserAutomationRequestSchema = lazySchema(() =>
     ),
     requestVariant(
       "evaluate",
-      z.object({ expression: z.string().min(1).refine((value) => utf8Length(value) <= BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES, "Expression exceeds 64 KiB"), awaitPromise: z.boolean().default(true), timeoutMs: timeoutSchema }).strict(),
+      z.object({
+        ...mutationArgs,
+        expression: z.string().min(1).refine((value) => utf8Length(value) <= BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES, "Expression exceeds 64 KiB"),
+        awaitPromise: z.boolean().default(true),
+        timeoutMs: timeoutSchema,
+      }).strict(),
     ),
     requestVariant(
       "recordingStart",
@@ -1022,20 +1031,15 @@ const actionResultFields = {
 const actionResult = <T extends BrowserAutomationOperation>(operation: T) =>
   z.object({ operation: z.literal(operation), ...actionResultFields }).strict();
 
-const actReceiptSchema = z.object({
+/** One content-free receipt for a bounded Browser mutation step. */
+export const BrowserAutomationMutationReceiptSchema = lazySchema(() => z.object({
   index: z.number().int().nonnegative(),
   operation: z.string().min(1).max(32),
   status: z.enum(["applied", "satisfied", "failed", "interrupted", "skipped"]),
   message: z.string().max(SHORT_TEXT_MAX).optional(),
-}).strict();
-const actObservationSchema = z.object({
-  observationRef: idSchema,
-  hostRevision: z.number().int().nonnegative(),
-  documentRevision: z.number().int().nonnegative(),
-  controlRevision: z.number().int().nonnegative(),
-  capabilityRevision: z.number().int().positive(),
-  observationRevision: z.number().int().nonnegative(),
-}).strict();
+}).strict());
+/** Typed content-free receipt for a bounded Browser mutation step. */
+export type BrowserAutomationMutationReceipt = z.infer<ReturnType<typeof BrowserAutomationMutationReceiptSchema>>;
 
 /** Structured result for one bounded browser_act batch. */
 export const BrowserAutomationActResultSchema = lazySchema(() => z.object({
@@ -1044,16 +1048,39 @@ export const BrowserAutomationActResultSchema = lazySchema(() => z.object({
   stoppingPosition: z.number().int().nonnegative(),
   effect: z.enum(["none", "partial", "complete"]),
   recovery: z.enum(["inspect", "reopen", "wait", "yield_to_user", "do_not_retry"]),
-  receipts: z.array(actReceiptSchema).max(BROWSER_AUTOMATION_ACT_MAX_STEPS),
-  finalObservation: actObservationSchema,
+  receipts: z.array(BrowserAutomationMutationReceiptSchema()).max(BROWSER_AUTOMATION_ACT_MAX_STEPS),
+  finalObservation: BrowserAutomationObservationBindingSchema(),
   nextObservationRef: idSchema.optional(),
 }).strict());
 /** Typed browser_act result. */
 export type BrowserAutomationActResult = z.infer<ReturnType<typeof BrowserAutomationActResultSchema>>;
 
+/** Structured result for one privileged browser_evaluate mutation. */
+export const BrowserAutomationEvaluateResultSchema = lazySchema(() => z.object({
+  operation: z.literal("evaluate"),
+  outcome: z.enum(["completed", "failed", "interrupted"]),
+  stoppingPosition: z.number().int().min(0).max(1),
+  effect: z.enum(["none", "partial", "complete"]),
+  recovery: z.enum(["inspect", "reopen", "wait", "yield_to_user", "do_not_retry"]),
+  receipts: z.array(BrowserAutomationMutationReceiptSchema()).length(1),
+  finalObservation: BrowserAutomationObservationBindingSchema(),
+  nextObservationRef: idSchema.optional(),
+  valueJson: z.string().refine((value) => utf8Length(value) <= BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES, "Evaluation result exceeds 64 KiB").optional(),
+}).strict().superRefine((value, context) => {
+  if (value.outcome === "completed" && value.valueJson === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Completed evaluation requires a bounded result",
+      path: ["valueJson"],
+    });
+  }
+}));
+/** Typed browser_evaluate mutation result. */
+export type BrowserAutomationEvaluateResult = z.infer<ReturnType<typeof BrowserAutomationEvaluateResultSchema>>;
+
 /** Exhaustive operation-specific browser success result. */
 export const BrowserAutomationResultSchema = lazySchema(() =>
-  z.discriminatedUnion("operation", [
+  z.union([
     z.object({
       operation: z.literal("inspect"),
       readiness: BrowserAutomationInspectReadinessSchema().optional(),
@@ -1100,7 +1127,10 @@ export const BrowserAutomationResultSchema = lazySchema(() =>
     z.object({ operation: z.literal("network"), entries: z.array(BrowserAutomationNetworkEntrySchema()).max(BROWSER_AUTOMATION_MAX_DIAGNOSTIC_ENTRIES), truncation: BrowserAutomationTruncationSchema() }).strict(),
     z.object({ operation: z.literal("accessibility"), nodes: z.array(BrowserAutomationAccessibilityNodeSchema()).max(BROWSER_AUTOMATION_MAX_AX_NODES), truncation: BrowserAutomationTruncationSchema() }).strict(),
     z.object({ operation: z.literal("performance"), metrics: BrowserAutomationPerformanceMetricsSchema(), controlEpoch: z.number().int().nonnegative() }).strict(),
+    // The Electron kernel returns this internal result to BrowserSessionDriver,
+    // which wraps it in the public mutation envelope before broker delivery.
     z.object({ operation: z.literal("evaluate"), valueJson: z.string().refine((value) => utf8Length(value) <= BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES, "Evaluation result exceeds 64 KiB"), controlEpoch: z.number().int().nonnegative() }).strict(),
+    BrowserAutomationEvaluateResultSchema(),
     z.object({ operation: z.literal("recordingStart"), recordingId: idSchema, startedAt: z.number().int().nonnegative(), controlEpoch: z.number().int().nonnegative() }).strict(),
     z.object({ operation: z.literal("recordingStop"), recordingId: idSchema, mediaType: z.literal("video/webm"), dataBase64: z.string().max(RECORDING_MAX_BASE64_CHARS).refine((value) => { const size = decodedBase64Size(value); return size !== null && size <= BROWSER_AUTOMATION_MAX_RECORDING_BYTES; }, "Recording must be valid base64 within 512 KiB decoded"), durationMs: z.number().int().nonnegative().max(RECORDING_MAX_DURATION_MS), truncation: BrowserAutomationTruncationSchema(), controlEpoch: z.number().int().nonnegative() }).strict(),
     BrowserAutomationActResultSchema(),


### PR DESCRIPTION
## What
Add privileged, Electron-only `browser_evaluate` support to the Browser automation contract and runtime.

## Why
Issue #1048 requires page evaluation to use the same authority, observation, mutation, and privacy boundaries as `browser_act` while remaining unavailable in pure web hosts.

## Key Changes
- Intersect credential authority with the selected executor's advertised capabilities before exposing evaluation.
- Add observation binding, revision checks, deadlines, serialization, idempotency, receipts, and effect reporting.
- Reject raw Electron evaluation results at the broker boundary.
- Remove evaluation source, results, and artifact metadata from persisted and broadcast provider events.
- Advertise evaluation from Electron hosts and omit it from pure web hosts.

## Verification
- Focused contract, broker, MCP, host, driver, desktop kernel, and privacy tests passed.
- Affected package typechecks passed.
- Live renderer evidence confirmed web omission and Electron advertisement.
- Independent Standards and Spec reviews approved the final commits.
- `bun run verify` passed typecheck and lint. Its unit phase failed in unrelated Windows filesystem and process-scope integration tests. An elevated rerun cleared the filesystem and orphan-cleanup failures but retained two unrelated process termination failures.

Closes #1048

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788332931&installation_model_id=20477&pr_number=1064&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1064&signature=6a8ab291ad6192b23915bbb08cdbec782dd05bdaa5a8f837423434b2ba9e8bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser evaluation support for Electron-based automation.
  * Added runtime capability reporting so unsupported operations are hidden.
  * Added structured evaluation results with observations, receipts, deadlines, and cancellation handling.

* **Security & Reliability**
  * Sensitive evaluation inputs, outputs, and metadata are removed from persisted and downstream events.
  * Added idempotency, request serialization, freshness checks, and result-size limits.
  * Improved cancellation and error handling for browser tab operations.
  * Expanded validation and regression coverage for browser automation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->