### PR TITLE
feat(browser): manage tab ownership and disposition

### DIFF
--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -1120,7 +1120,9 @@ export class BrowserAutomationKernel {
       tabId: state.tabId,
       controller,
       controlEpoch: state.controlEpoch,
-      ...(request && request.operation !== "inspect" && request.operation !== "act" ? { providerSessionId: request.providerSessionId, operation: request.operation } : {}),
+      ...(request && request.operation !== "inspect" && request.operation !== "act" && request.operation !== "tabs"
+        ? { providerSessionId: request.providerSessionId, operation: request.operation }
+        : {}),
       ...(pointer ? { pointer } : {}),
     };
     state.controller = payload;

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -1334,6 +1334,44 @@ describe("BrowserAutomationBroker", () => {
     expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(3);
   });
 
+  it("serializes fresh opens with every other provider-session mutation", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        deliveries.push({ channel, data });
+        return true;
+      },
+    }));
+    const hostSocket = socket("open-lock");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("open-lock", "workspace-a"),
+      executorDescriptor: { ...registration("open-lock", "workspace-a").executorDescriptor, operations: ["open", "tabs"] },
+      capabilities: [{ operation: "open", available: true }, { operation: "tabs", available: true }],
+    }, authorization("open-lock")).generation;
+    broker.updateTargets(hostSocket, "open-lock", generation, [statusTarget("open-lock", generation)]);
+    const scope = { ...claims("thread-a", "workspace-a"), permissionCapability: "interact" as const, allowedOperations: ["open", "tabs"] as const };
+    const opened = broker.execute(scope, {
+      ...request(scope), requestId: "locked-open", operation: "open" as const,
+      args: { idempotencyKey: "locked-open-key", url: "https://example.test/" },
+    });
+    const busy = broker.execute(scope, {
+      ...request(scope, 2), requestId: "tabs-during-open", operation: "tabs" as const,
+      args: { action: "claim" as const, tabId: "tab-thread-a", idempotencyKey: "tabs-during-open-key", observationRef: "obs" },
+    });
+    await expect(busy).resolves.toMatchObject({ ok: false, error: { code: "BROWSER_BUSY" } });
+    const bootstrap = deliveries.find(({ channel }) => channel === "browserAutomation.bootstrap")!;
+    const target = { ...statusTarget("open-lock", generation), tabId: "agent-tab" };
+    broker.respond(hostSocket, "open-lock", generation, {
+      contractVersion: 1,
+      requestId: bootstrap.data.request.requestId,
+      sequence: bootstrap.data.request.sequence,
+      ok: true,
+      result: { operation: "open", url: "https://example.test/", title: "Example", controlEpoch: 0 },
+    }, target);
+    await expect(opened).resolves.toMatchObject({ ok: true });
+  });
+
   it("serializes browser_act per provider session and joins exact duplicates", async () => {
     const deliveries: Array<{ channel: string; data: any }> = [];
     const broker = new BrowserAutomationBroker(options({ now: () => 10, send: (_socket, channel, data) => { deliveries.push({ channel, data }); return true; } }));
@@ -1360,6 +1398,144 @@ describe("BrowserAutomationBroker", () => {
     await expect(first).resolves.toMatchObject({ ok: true });
     await expect(joined).resolves.toMatchObject({ ok: true, requestId: "act-2" });
     expect(deliveries.filter(({ channel }) => channel === "browserAutomation.request")).toHaveLength(1);
+  });
+
+  it("routes browser_tabs selection to the requested tab and keeps lifecycle state sticky", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        deliveries.push({ channel, data });
+        return true;
+      },
+    }));
+    const hostSocket = socket("tabs-routing");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("tabs-routing", "workspace-a"),
+      executorDescriptor: { ...registration("tabs-routing", "workspace-a").executorDescriptor, operations: ["inspect", "tabs"] },
+      capabilities: [{ operation: "tabs", available: true }],
+    }, authorization("tabs-routing")).generation;
+    broker.updateTargets(hostSocket, "tabs-routing", generation, [
+      { ...statusTarget("tabs-routing", generation), tabId: "tab-a", focused: true },
+      { ...statusTarget("tabs-routing", generation), tabId: "tab-b", focused: false, lastUsedAt: 2 },
+    ]);
+    const scope = { ...claims("thread-a", "workspace-a"), permissionCapability: "interact" as const, allowedOperations: ["tabs" as const] };
+    const tabsRequest = (requestId: string, sequence: number, args: any) => ({
+      ...request(scope, sequence),
+      requestId,
+      operation: "tabs" as const,
+      args,
+    });
+    const first = broker.execute(scope, tabsRequest("tabs-select", 1, {
+      action: "select", tabId: "tab-b", idempotencyKey: "tabs-select-key", observationRef: "obs-1",
+    }));
+    const firstDelivery = deliveries.find(({ channel }) => channel === "browserAutomation.request")!;
+    expect(firstDelivery.data.dispatch.target.tabId).toBe("tab-b");
+    broker.respond(hostSocket, "tabs-routing", generation, {
+      contractVersion: 1,
+      requestId: firstDelivery.data.dispatch.request.requestId,
+      sequence: firstDelivery.data.dispatch.request.sequence,
+      ok: true,
+      result: { operation: "tabs", action: "select", currentTabId: "tab-b", observationRef: "obs-2", tabs: [] },
+    }, { ...firstDelivery.data.dispatch.target, focused: true, lastUsedAt: 20 });
+    await expect(first).resolves.toMatchObject({ ok: true, result: { action: "select", currentTabId: "tab-b" } });
+
+    const release = broker.execute(scope, tabsRequest("tabs-release", 2, {
+      action: "release", idempotencyKey: "tabs-release-key", observationRef: "obs-2",
+    }));
+    const releaseDelivery = deliveries.filter(({ channel }) => channel === "browserAutomation.request").at(-1)!;
+    expect(releaseDelivery.data.dispatch.target.tabId).toBe("tab-b");
+    expect(releaseDelivery.data.dispatch.target.lastUsedAt).toBe(20);
+    broker.respond(hostSocket, "tabs-routing", generation, {
+      contractVersion: 1,
+      requestId: releaseDelivery.data.dispatch.request.requestId,
+      sequence: releaseDelivery.data.dispatch.request.sequence,
+      ok: true,
+      result: { operation: "tabs", action: "release", tabs: [] },
+    }, releaseDelivery.data.dispatch.target);
+    await expect(release).resolves.toMatchObject({ ok: true, result: { action: "release" } });
+    expect(broker.status().assignments).toBe(0);
+  });
+
+  it("replays browser_tabs idempotency keys and shares mutation exclusion with browser_act", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        deliveries.push({ channel, data });
+        return true;
+      },
+    }));
+    const hostSocket = socket("tabs-lock");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("tabs-lock", "workspace-a"),
+      executorDescriptor: { ...registration("tabs-lock", "workspace-a").executorDescriptor, operations: ["inspect", "tabs", "act"] },
+      capabilities: [{ operation: "tabs", available: true }, { operation: "act", available: true }],
+    }, authorization("tabs-lock")).generation;
+    broker.updateTargets(hostSocket, "tabs-lock", generation, [statusTarget("tabs-lock", generation)]);
+    const scope = { ...claims("thread-a", "workspace-a"), permissionCapability: "interact" as const, allowedOperations: ["tabs", "act"] as const };
+    const tabs = (requestId: string, sequence: number, idempotencyKey: string) => broker.execute(scope, {
+      ...request(scope, sequence),
+      requestId,
+      operation: "tabs" as const,
+      args: { action: "claim" as const, tabId: "tab-thread-a", idempotencyKey, observationRef: "obs-1" },
+    });
+    const first = tabs("tabs-lock-1", 1, "same-key");
+    const duplicate = tabs("tabs-lock-2", 2, "same-key");
+    const conflict = tabs("tabs-lock-3", 3, "other-key");
+    await expect(conflict).resolves.toMatchObject({ ok: false, error: { code: "BROWSER_BUSY" } });
+    expect(deliveries.filter(({ channel }) => channel === "browserAutomation.request")).toHaveLength(1);
+    const delivery = deliveries.find(({ channel }) => channel === "browserAutomation.request")!;
+    broker.respond(hostSocket, "tabs-lock", generation, {
+      contractVersion: 1,
+      requestId: delivery.data.dispatch.request.requestId,
+      sequence: delivery.data.dispatch.request.sequence,
+      ok: true,
+      result: { operation: "tabs", action: "claim", currentTabId: "tab-thread-a", tabs: [] },
+    }, delivery.data.dispatch.target);
+    await expect(first).resolves.toMatchObject({ ok: true });
+    await expect(duplicate).resolves.toMatchObject({ ok: true, requestId: "tabs-lock-2", sequence: 2 });
+  });
+
+  it("notifies the routed host after its provider-session assignment is cleared", async () => {
+    const deliveries: Array<{ channel: string; data: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        deliveries.push({ channel, data });
+        return true;
+      },
+    }));
+    const hostSocket = socket("tabs-release-notify");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("tabs-release-notify", "workspace-a"),
+      executorDescriptor: { ...registration("tabs-release-notify", "workspace-a").executorDescriptor, operations: ["inspect", "tabs"] },
+      capabilities: [{ operation: "tabs", available: true }],
+    }, authorization("tabs-release-notify")).generation;
+    broker.updateTargets(hostSocket, "tabs-release-notify", generation, [statusTarget("tabs-release-notify", generation)]);
+    const scope = { ...claims("thread-a", "workspace-a"), permissionCapability: "interact" as const, allowedOperations: ["tabs" as const] };
+    const pending = broker.execute(scope, {
+      ...request(scope),
+      operation: "tabs" as const,
+      args: { action: "claim" as const, tabId: "tab-thread-a", idempotencyKey: "notify-key", observationRef: "obs-1" },
+    });
+    const delivery = deliveries.find(({ channel }) => channel === "browserAutomation.request")!;
+    broker.respond(hostSocket, "tabs-release-notify", generation, {
+      contractVersion: 1,
+      requestId: delivery.data.dispatch.request.requestId,
+      sequence: delivery.data.dispatch.request.sequence,
+      ok: true,
+      result: { operation: "tabs", action: "claim", currentTabId: "tab-thread-a", tabs: [] },
+    }, delivery.data.dispatch.target);
+    await pending;
+    expect(broker.status().assignments).toBe(1);
+    broker.updateTargets(hostSocket, "tabs-release-notify", generation, []);
+    expect(broker.status().assignments).toBe(0);
+    expect(broker.releaseProviderSession("cursor", scope.providerSessionId, "provider-session-ended")).toBe(0);
+    expect(deliveries.find(({ channel }) => channel === "browserAutomation.sessionRelease")).toEqual({
+      channel: "browserAutomation.sessionRelease",
+      data: { hostId: "tabs-release-notify", generation, providerSessionId: scope.providerSessionId, reason: "provider-session-ended" },
+    });
   });
 
   it("drops keyed open replay when its host reconnects", async () => {

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -56,6 +56,12 @@ interface ActReplayRecord {
   lastUsedAt: number;
 }
 
+interface TabsReplayRecord {
+  readonly fingerprint: string;
+  readonly promise: Promise<BrowserAutomationResponse>;
+  lastUsedAt: number;
+}
+
 /** Content-free reliability counters for the browser automation broker. */
 export interface BrowserAutomationReliabilityCounters {
   dispatched: number;
@@ -73,9 +79,12 @@ export interface BrowserAutomationReliabilityCounters {
 /** Function used by the broker to deliver a directed, validated push event. */
 export type BrowserAutomationDirectedSender = (
   socket: WebSocket,
-  channel: "browserAutomation.bootstrap" | "browserAutomation.request" | "browserAutomation.cancel",
+  channel: "browserAutomation.bootstrap" | "browserAutomation.request" | "browserAutomation.cancel" | "browserAutomation.sessionRelease",
   data: unknown,
 ) => boolean;
+
+/** Reason sent to a renderer when a provider-session-owned Browser lifecycle ends. */
+export type BrowserAutomationSessionReleaseReason = "credential-revoked" | "provider-session-ended";
 
 /** Server-derived identity and workspace scope expected for one renderer connection. */
 export interface BrowserAutomationHostConnectionAuthorization {
@@ -168,6 +177,14 @@ function openReplayKey(
 
 function actReplayKey(providerId: string, request: Extract<BrowserAutomationRequest, { operation: "act" }>): string {
   return JSON.stringify([providerId, request.providerSessionId, request.workspaceId, request.threadId, request.args.idempotencyKey]);
+}
+
+function tabsReplayKey(providerId: string, request: Extract<BrowserAutomationRequest, { operation: "tabs" }>): string {
+  return JSON.stringify([providerId, request.providerSessionId, request.workspaceId, request.threadId, request.args.idempotencyKey]);
+}
+
+function sessionRoutingKey(providerId: string, providerSessionId: string): string {
+  return JSON.stringify([providerId, providerSessionId]);
 }
 
 function targetsMatch(
@@ -263,6 +280,9 @@ function shapeNegotiatedResponse(
         }
       : response.result.snapshot;
     const diagnostics = response.result.diagnostics?.slice(0, descriptor.constraints.maxDiagnostics);
+    const inspectedTabs = pending.target
+      ? [pending.target, ...response.result.tabs.filter((tab) => tab.tabId !== pending.target?.tabId)]
+      : response.result.tabs;
     return {
       ...response,
       result: {
@@ -275,7 +295,7 @@ function shapeNegotiatedResponse(
         target: pending.target
           ? { threadId: pending.target.threadId, tabId: pending.target.tabId, targetGeneration: pending.target.targetGeneration, sticky: true }
           : undefined,
-        tabs: (pending.target ? [pending.target] : response.result.tabs).slice(0, descriptor.constraints.maxTabs),
+        tabs: inspectedTabs.slice(0, descriptor.constraints.maxTabs),
         snapshot,
         ...(diagnostics ? { diagnostics } : {}),
         ...(hostObservationRef
@@ -318,7 +338,9 @@ export class BrowserAutomationBroker {
   private readonly maxTargets: number;
   private readonly openReplay = new Map<string, OpenReplayRecord>();
   private readonly actReplay = new Map<string, ActReplayRecord>();
+  private readonly tabsReplay = new Map<string, TabsReplayRecord>();
   private readonly actMutations = new Map<string, string>();
+  private readonly sessionHosts = new Map<string, RegisteredHost>();
   private nextGeneration = 1;
   private readonly reliability: BrowserAutomationReliabilityCounters = {
     dispatched: 0,
@@ -572,7 +594,7 @@ export class BrowserAutomationBroker {
           }
         }
       }
-    } else if (responseTarget && pending.target && !targetsMatch(responseTarget, pending.target)) {
+    } else if (responseTarget && pending.target && !targetsMatch(responseTarget, pending.target) && !this.isTabsResponseTarget(pending, responseTarget)) {
       this.settle(
         key,
         pending,
@@ -586,6 +608,9 @@ export class BrowserAutomationBroker {
         ),
       );
       return;
+    }
+    if (negotiatedResponse.ok && pending.request.operation === "tabs" && negotiatedResponse.result.operation === "tabs") {
+      this.updateTabsAssignment(pending, negotiatedResponse.result, responseTarget);
     }
     this.settle(key, pending, negotiatedResponse);
   }
@@ -655,9 +680,16 @@ export class BrowserAutomationBroker {
     for (const [replayKey, record] of this.openReplay) {
       if (record.lastUsedAt < cutoff) this.openReplay.delete(replayKey);
     }
+    for (const [replayKey, record] of this.actReplay) {
+      if (record.lastUsedAt < cutoff) this.actReplay.delete(replayKey);
+    }
+    for (const [replayKey, record] of this.tabsReplay) {
+      if (record.lastUsedAt < cutoff) this.tabsReplay.delete(replayKey);
+    }
     const parsed = BrowserAutomationRequestSchema().safeParse(input);
     if (!parsed.success) return this.executeInternal(claims, input);
     if (parsed.data.operation === "act") return this.executeAct(claims, parsed.data);
+    if (parsed.data.operation === "tabs") return this.executeTabs(claims, parsed.data);
     if (parsed.data.operation !== "open") return this.executeInternal(claims, input);
     const request = parsed.data;
     const key = request.args.idempotencyKey;
@@ -673,8 +705,17 @@ export class BrowserAutomationBroker {
       }
       return existing.promise.then((response) => ({ ...response, requestId: request.requestId, sequence: request.sequence }));
     }
+    const sessionKey = sessionRoutingKey(claims.providerId, claims.providerSessionId);
+    if (this.actMutations.has(sessionKey)) {
+      return Promise.resolve(failure(request, "BROWSER_BUSY", "Another browser mutation is active for this provider session", true));
+    }
+    const mutationToken = randomUUID();
+    this.actMutations.set(sessionKey, mutationToken);
+    const releaseMutation = (): void => {
+      if (this.actMutations.get(sessionKey) === mutationToken) this.actMutations.delete(sessionKey);
+    };
     const bootstrapHost = this.resolveBootstrapHost(claims, request);
-    if (!bootstrapHost) return this.executeInternal(claims, request);
+    if (!bootstrapHost) return this.executeInternal(claims, request).finally(releaseMutation);
     let resolveReplay!: (response: BrowserAutomationResponse) => void;
     const replayPromise = new Promise<BrowserAutomationResponse>((resolve) => {
       resolveReplay = resolve;
@@ -691,11 +732,45 @@ export class BrowserAutomationBroker {
       if (!oldest) break;
       this.openReplay.delete(oldest);
     }
-    const promise = this.executeInternal(claims, request);
+    const promise = this.executeInternal(claims, request).finally(releaseMutation);
     void promise.then((response) => {
       resolveReplay(response);
       if (!response.ok && this.openReplay.get(replayKey) === replayRecord) this.openReplay.delete(replayKey);
     });
+    return promise;
+  }
+
+  private executeTabs(
+    claims: BrowserAutomationCredentialClaims,
+    request: Extract<BrowserAutomationRequest, { operation: "tabs" }>,
+  ): Promise<BrowserAutomationResponse> {
+    const replayKey = tabsReplayKey(claims.providerId, request);
+    const fingerprint = JSON.stringify(request.args);
+    const existing = this.tabsReplay.get(replayKey);
+    if (existing) {
+      existing.lastUsedAt = this.now();
+      if (existing.fingerprint !== fingerprint) {
+        return Promise.resolve(failure(request, "IDEMPOTENCY_CONFLICT", "The idempotency key was already used with different browser_tabs arguments", false));
+      }
+      return existing.promise.then((response) => ({ ...response, requestId: request.requestId, sequence: request.sequence }));
+    }
+    const sessionKey = sessionRoutingKey(claims.providerId, claims.providerSessionId);
+    if (this.actMutations.has(sessionKey)) {
+      return Promise.resolve(failure(request, "BROWSER_BUSY", "Another browser mutation is active for this provider session", true));
+    }
+    const token = randomUUID();
+    this.actMutations.set(sessionKey, token);
+    const promise = this.executeInternal(claims, request)
+      .catch(() => failure(request, "INTERNAL_ERROR", "Browser mutation failed before a terminal result was produced", false))
+      .finally(() => {
+        if (this.actMutations.get(sessionKey) === token) this.actMutations.delete(sessionKey);
+      });
+    this.tabsReplay.set(replayKey, { fingerprint, promise, lastUsedAt: this.now() });
+    while (this.tabsReplay.size > 256) {
+      const oldest = this.tabsReplay.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.tabsReplay.delete(oldest);
+    }
     return promise;
   }
 
@@ -721,7 +796,7 @@ export class BrowserAutomationBroker {
       }
       return existing.promise.then((response) => ({ ...response, requestId: request.requestId, sequence: request.sequence }));
     }
-    const sessionKey = JSON.stringify([claims.providerId, claims.providerSessionId]);
+    const sessionKey = sessionRoutingKey(claims.providerId, claims.providerSessionId);
     if (this.actMutations.has(sessionKey)) {
       return Promise.resolve(failure(request, "BROWSER_BUSY", "Another browser mutation is active for this provider session", true));
     }
@@ -781,7 +856,9 @@ export class BrowserAutomationBroker {
     // original target.
     const assignment = request.operation === "open" && request.args.idempotencyKey !== undefined
       ? undefined
-      : this.resolveAssignment(claims, request);
+      : request.operation === "tabs"
+        ? this.resolveTabsAssignment(claims, request)
+        : this.resolveAssignment(claims, request);
     if (!assignment) {
       if (request.operation === "open") {
         const host = this.resolveBootstrapHost(claims, request);
@@ -790,6 +867,7 @@ export class BrowserAutomationBroker {
       return finishImmediately(failure(request, "TAB_UNAVAILABLE", "No authorized visible browser tab is available", true));
     }
     const { host, target } = assignment;
+    this.sessionHosts.set(sessionRoutingKey(claims.providerId, claims.providerSessionId), host);
     if (!this.supportsOperation(host, request)) {
       return finishImmediately(failure(
         request,
@@ -886,6 +964,9 @@ export class BrowserAutomationBroker {
     for (const [key, assigned] of this.assignments) {
       if (assigned.host === host) this.assignments.delete(key);
     }
+    for (const [key, sessionHost] of this.sessionHosts) {
+      if (sessionHost === host) this.sessionHosts.delete(key);
+    }
     for (const [key, pending] of this.pending) {
       if (pending.host === host) {
         this.settle(
@@ -910,7 +991,9 @@ export class BrowserAutomationBroker {
     }
     this.pending.clear();
     this.actReplay.clear();
+    this.tabsReplay.clear();
     this.actMutations.clear();
+    this.sessionHosts.clear();
   }
 
   /** Returns bounded broker counts for status and tests. */
@@ -925,8 +1008,23 @@ export class BrowserAutomationBroker {
   }
 
   /** Releases sticky routing state when a provider session closes or rotates credentials. */
-  releaseProviderSession(providerId: string, providerSessionId: string): number {
+  releaseProviderSession(
+    providerId: string,
+    providerSessionId: string,
+    reason: BrowserAutomationSessionReleaseReason = "credential-revoked",
+  ): number {
     let removed = 0;
+    const sessionKey = sessionRoutingKey(providerId, providerSessionId);
+    const sessionHost = this.sessionHosts.get(sessionKey);
+    if (sessionHost) {
+      this.trySend(sessionHost.socket, "browserAutomation.sessionRelease", {
+        hostId: sessionHost.registration.hostId,
+        generation: sessionHost.generation,
+        providerSessionId,
+        reason,
+      });
+      this.sessionHosts.delete(sessionKey);
+    }
     for (const key of this.assignments.keys()) {
       const [assignedProviderId, assignedProviderSessionId] = JSON.parse(key) as string[];
       if (
@@ -964,7 +1062,11 @@ export class BrowserAutomationBroker {
       const parts = JSON.parse(key) as string[];
       if (parts[0] === providerId && parts[1] === providerSessionId) this.actReplay.delete(key);
     }
-    this.actMutations.delete(JSON.stringify([providerId, providerSessionId]));
+    for (const key of this.tabsReplay.keys()) {
+      const parts = JSON.parse(key) as string[];
+      if (parts[0] === providerId && parts[1] === providerSessionId) this.tabsReplay.delete(key);
+    }
+    this.actMutations.delete(sessionKey);
     return removed;
   }
 
@@ -1016,6 +1118,47 @@ export class BrowserAutomationBroker {
       });
     }
     return selected;
+  }
+
+  private resolveTabsAssignment(
+    claims: BrowserAutomationCredentialClaims,
+    request: Extract<BrowserAutomationRequest, { operation: "tabs" }>,
+  ): { host: RegisteredHost; target: BrowserAutomationHostDispatchTarget } | undefined {
+    const action = request.args.action;
+    const assigned = this.assignments.get(assignmentKey(claims));
+    if (action !== "select" && action !== "claim" && assigned) {
+      const assignedTarget = assigned.host.targets.get(assigned.targetKey);
+      if (assignedTarget && this.matchesScope(assigned.host, claims)) {
+        assigned.lastUsedAt = this.now();
+        return { host: assigned.host, target: assignedTarget };
+      }
+      this.assignments.delete(assignmentKey(claims));
+    }
+    const requestedTabId = "tabId" in request.args ? request.args.tabId : undefined;
+    if (!requestedTabId) return undefined;
+    return this.resolveExplicitTarget(claims, request, requestedTabId);
+  }
+
+  private resolveExplicitTarget(
+    claims: BrowserAutomationCredentialClaims,
+    request: BrowserAutomationRequest,
+    tabId: string,
+  ): { host: RegisteredHost; target: BrowserAutomationHostDispatchTarget } | undefined {
+    const sessionHost = this.sessionHosts.get(sessionRoutingKey(claims.providerId, claims.providerSessionId));
+    const candidates = [...this.hostsBySocket.values()]
+      .filter((host) => !sessionHost || host === sessionHost)
+      .filter((host) => this.canAccept(host, claims, request))
+      .flatMap((host) => [...host.targets.values()]
+        .filter((target) => target.threadId === claims.threadId && target.tabId === tabId)
+        .map((target) => ({ host, target })))
+      .sort((a, b) =>
+        Number(b.target.focused) - Number(a.target.focused) ||
+        Number(b.target.active) - Number(a.target.active) ||
+        b.target.lastUsedAt - a.target.lastUsedAt ||
+        a.host.pending - b.host.pending ||
+        a.host.generation - b.host.generation ||
+        a.target.windowId - b.target.windowId);
+    return candidates[0];
   }
 
   private canAccept(
@@ -1080,6 +1223,10 @@ export class BrowserAutomationBroker {
     claims: BrowserAutomationCredentialClaims,
     request: BrowserAutomationRequest,
   ): RegisteredHost | undefined {
+    const sessionHost = this.sessionHosts.get(sessionRoutingKey(claims.providerId, claims.providerSessionId));
+    if (sessionHost && this.hostsBySocket.get(sessionHost.socket) === sessionHost && this.canAccept(sessionHost, claims, request)) {
+      return sessionHost;
+    }
     return [...this.hostsBySocket.values()]
       .filter((host) => this.canAccept(host, claims, request))
       .sort((left, right) => left.pending - right.pending || left.generation - right.generation)[0];
@@ -1090,6 +1237,7 @@ export class BrowserAutomationBroker {
     providerId: string,
     request: BrowserAutomationRequest,
   ): Promise<BrowserAutomationResponse> {
+    this.sessionHosts.set(sessionRoutingKey(providerId, request.providerSessionId), host);
     const key = pendingKey(host, request.requestId, request.sequence);
     if (this.pending.has(key)) {
       const response = failure(request, "INVALID_REQUEST", "Browser request correlation is already pending", false);
@@ -1137,6 +1285,66 @@ export class BrowserAutomationBroker {
     const latencyMs = Math.max(0, this.now() - pending.startedAt);
     this.recordOutcome(response, latencyMs);
     pending.resolve(response);
+  }
+
+  private updateTabsAssignment(
+    pending: PendingRequest,
+    result: Extract<BrowserAutomationResponse, { ok: true }>['result'] & { operation: "tabs" },
+    responseTarget: BrowserAutomationHostDispatchTarget | undefined,
+  ): void {
+    const key = assignmentKeyParts(
+      pending.providerId,
+      pending.request.providerSessionId,
+      pending.host.registration.worktreeIdentity,
+      pending.request.workspaceId,
+      pending.request.threadId,
+    );
+    const target = responseTarget ?? pending.target;
+    if (target) pending.host.targets.set(targetKey(target), target);
+    if (result.action === "select" || result.action === "claim") {
+      const selectedTarget = result.currentTabId
+        ? pending.host.targets.get(JSON.stringify([pending.request.threadId, result.currentTabId])) ??
+          (target?.tabId === result.currentTabId ? target : undefined)
+        : target;
+      if (selectedTarget) this.storeAssignment(key, pending.host, selectedTarget);
+      else this.assignments.delete(key);
+      return;
+    }
+    if (!result.currentTabId) {
+      this.assignments.delete(key);
+      return;
+    }
+    const currentTarget = pending.host.targets.get(JSON.stringify([pending.request.threadId, result.currentTabId]));
+    if (currentTarget) {
+      this.storeAssignment(key, pending.host, currentTarget);
+    } else if (target?.tabId === result.currentTabId) {
+      this.storeAssignment(key, pending.host, target);
+    } else {
+      this.assignments.delete(key);
+    }
+  }
+
+  private isTabsResponseTarget(
+    pending: PendingRequest,
+    responseTarget: BrowserAutomationHostDispatchTarget,
+  ): boolean {
+    if (pending.request.operation !== "tabs") return false;
+    if (
+      responseTarget.desktopInstanceId !== pending.host.registration.desktopInstanceId ||
+      responseTarget.connectionGeneration !== pending.host.generation ||
+      responseTarget.threadId !== pending.request.threadId
+    ) return false;
+    const advertised = pending.host.targets.get(targetKey(responseTarget));
+    return advertised !== undefined && targetsMatch(advertised, responseTarget);
+  }
+
+  private storeAssignment(
+    key: string,
+    host: RegisteredHost,
+    target: BrowserAutomationHostDispatchTarget,
+  ): void {
+    while (this.assignments.size >= this.maxAssignments && !this.assignments.has(key)) this.evictOldestAssignment();
+    this.assignments.set(key, { host, targetKey: targetKey(target), lastUsedAt: this.now() });
   }
 
   private recordOutcome(response: BrowserAutomationResponse, latencyMs: number): void {
@@ -1258,7 +1466,7 @@ export class BrowserAutomationBroker {
 
   private trySend(
     socket: WebSocket,
-    channel: "browserAutomation.bootstrap" | "browserAutomation.request" | "browserAutomation.cancel",
+    channel: "browserAutomation.bootstrap" | "browserAutomation.request" | "browserAutomation.cancel" | "browserAutomation.sessionRelease",
     data: unknown,
   ): boolean {
     try {

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.test.ts
@@ -73,8 +73,18 @@ describe("BrowserAutomationSessionLease", () => {
     expect(new Set(interact.allowedOperations).size).toBe(interact.allowedOperations.length);
     expect(privileged.allowedOperations.slice(0, 2)).toEqual(["inspect", "act"]);
     expect(privileged.allowedOperations).toContain("evaluate");
-    expect(privileged.allowedOperations).toEqual(["inspect", "act", ...BROWSER_AUTOMATION_OPERATIONS]);
+    expect(privileged.allowedOperations).toEqual(["inspect", "act", "tabs", ...BROWSER_AUTOMATION_OPERATIONS]);
     expect(new Set(privileged.allowedOperations).size).toBe(privileged.allowedOperations.length);
+  });
+
+  it("advertises browser_tabs for interact and privileged leases, but not observe", () => {
+    const lease = configuredLease();
+    const observe = lease.issue(lease.stage({ ...scope(), permissionCapability: "observe" }))!;
+    const interact = lease.issue(lease.stage({ ...scope(), permissionCapability: "interact", providerSessionId: "interact-session" }))!;
+    const privileged = lease.issue(lease.stage({ ...scope(), permissionCapability: "privileged", providerSessionId: "privileged-session" }))!;
+    expect(observe.allowedOperations).not.toContain("tabs");
+    expect(interact.allowedOperations).toContain("tabs");
+    expect(privileged.allowedOperations).toContain("tabs");
   });
 
   it("cleans a staged scope when registry issuance fails", () => {

--- a/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
+++ b/apps/server/src/services/browser-automation/browser-automation-session-lease.ts
@@ -101,9 +101,9 @@ function allowedOperations(
     return ["inspect", ...BROWSER_AUTOMATION_OPERATIONS.filter((operation) => OBSERVE_OPERATIONS.has(operation))];
   }
   if (capability === "interact") {
-    return ["inspect", "act", ...BROWSER_AUTOMATION_OPERATIONS.filter((operation) => operation !== "evaluate")];
+    return ["inspect", "act", "tabs", ...BROWSER_AUTOMATION_OPERATIONS.filter((operation) => operation !== "evaluate")];
   }
-  return ["inspect", "act", ...BROWSER_AUTOMATION_OPERATIONS];
+  return ["inspect", "act", "tabs", ...BROWSER_AUTOMATION_OPERATIONS];
 }
 
 function validateConfiguration(configuration: BrowserAutomationSessionLeaseConfiguration): void {

--- a/apps/server/src/services/browser-automation/credential-registry.test.ts
+++ b/apps/server/src/services/browser-automation/credential-registry.test.ts
@@ -106,6 +106,21 @@ describe("BrowserAutomationCredentialRegistry", () => {
     expect(() => registry.issue({ ...scope(), permissionCapability: "observe", allowedOperations: ["click"] })).toThrow();
   });
 
+  it("allows browser_tabs only for mutation-capable credentials", () => {
+    const registry = new BrowserAutomationCredentialRegistry();
+    const interact = registry.issue({
+      ...scope(),
+      permissionCapability: "interact",
+      allowedOperations: ["tabs"],
+    });
+    expect(registry.authenticate(interact.token)?.allowedOperations).toEqual(["tabs"]);
+    expect(() => registry.issue({
+      ...scope(),
+      permissionCapability: "observe",
+      allowedOperations: ["tabs"],
+    })).toThrow();
+  });
+
   it("stays bounded under concurrent issuance", async () => {
     const registry = new BrowserAutomationCredentialRegistry({ maxCredentials: 16 });
     await Promise.all(

--- a/apps/server/src/services/browser-automation/credential-registry.ts
+++ b/apps/server/src/services/browser-automation/credential-registry.ts
@@ -84,10 +84,10 @@ function validateScope(scope: BrowserAutomationCredentialScope): void {
   if (ids.some((value) => value.length < 1 || value.length > 256)) {
     throw new Error("Browser automation credential scope contains an invalid identifier");
   }
-  const supported = new Set<BrowserAutomationOperation>([...BROWSER_AUTOMATION_OPERATIONS, "inspect", "act"]);
+  const supported = new Set<BrowserAutomationOperation>([...BROWSER_AUTOMATION_OPERATIONS, "inspect", "act", "tabs"]);
   if (
     scope.allowedOperations.length < 1 ||
-    scope.allowedOperations.length > BROWSER_AUTOMATION_OPERATIONS.length + 2 ||
+    scope.allowedOperations.length > BROWSER_AUTOMATION_OPERATIONS.length + 3 ||
     new Set(scope.allowedOperations).size !== scope.allowedOperations.length ||
     scope.allowedOperations.some((operation) => !supported.has(operation))
   ) {

--- a/apps/server/src/services/browser-automation/mcp-handler.test.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.test.ts
@@ -127,6 +127,38 @@ describe("BrowserAutomationMcpHandler", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
+  it("advertises and routes browser_tabs actions for an interact credential", async () => {
+    const tabs = credentials.issue({
+      providerId: "cursor",
+      providerSessionId: "tabs-provider",
+      mcodeSessionId: "tabs-mcode",
+      threadId: "thread-tabs",
+      workspaceId: "workspace-a",
+      worktreeIdentity: "worktree-a",
+      permissionCapability: "interact",
+      allowedOperations: ["tabs"],
+    });
+    const listed = await post(JSON.stringify({ jsonrpc: "2.0", id: 11, method: "tools/list", params: {} }), `Bearer ${tabs.token}`);
+    const tool = (await listed.json() as any).result.tools[0];
+    expect(tool.name).toBe("browser_tabs");
+    expect(tool.annotations).toMatchObject({ readOnlyHint: false, destructiveHint: true, idempotentHint: true });
+    expect(tool.inputSchema.oneOf).toHaveLength(5);
+    const response = await post(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 12,
+      method: "tools/call",
+      params: {
+        name: "browser_tabs",
+        arguments: { action: "select", tabId: "tab-2", idempotencyKey: "tabs-key", observationRef: "obs-1" },
+      },
+    }), `Bearer ${tabs.token}`);
+    expect(response.status).toBe(200);
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ threadId: "thread-tabs" }), expect.objectContaining({
+      operation: "tabs",
+      args: { action: "select", tabId: "tab-2", idempotencyKey: "tabs-key", observationRef: "obs-1" },
+    }));
+  });
+
   it("advertises only the operations allowed by the authenticated credential", async () => {
     const observe = credentials.issue({
       providerId: "cursor",

--- a/apps/server/src/services/browser-automation/mcp-handler.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.ts
@@ -19,6 +19,7 @@ const MCP_PROTOCOL_VERSIONS = ["2025-03-26", "2024-11-05"] as const;
 const TOOL_NAME_TO_OPERATION = new Map<string, BrowserAutomationOperation>([
   ["browser_inspect", "inspect" as BrowserAutomationOperation],
   ["browser_act", "act" as BrowserAutomationOperation],
+  ["browser_tabs", "tabs" as BrowserAutomationOperation],
   ...BROWSER_AUTOMATION_OPERATIONS.map((operation) => [
     BROWSER_AUTOMATION_OPERATION_METADATA[operation].mcpName,
     operation,
@@ -149,6 +150,61 @@ const actStepVariants = [
   actStepSchema("recordingStop", {}),
 ];
 
+const tabsMutationProperties = {
+  idempotencyKey: { type: "string", minLength: 1, maxLength: 256 },
+  observationRef: { type: "string", minLength: 1, maxLength: 256 },
+  ...commonProperties,
+} as const;
+
+const tabsMutationVariants = [
+  {
+    type: "object",
+    properties: { ...tabsMutationProperties, action: { const: "select" }, tabId: { type: "string", minLength: 1, maxLength: 256 } },
+    required: ["action", "tabId", "idempotencyKey", "observationRef"],
+    additionalProperties: false,
+  },
+  {
+    type: "object",
+    properties: { ...tabsMutationProperties, action: { const: "claim" }, tabId: { type: "string", minLength: 1, maxLength: 256 } },
+    required: ["action", "tabId", "idempotencyKey", "observationRef"],
+    additionalProperties: false,
+  },
+  {
+    type: "object",
+    properties: { ...tabsMutationProperties, action: { const: "release" }, tabId: { type: "string", minLength: 1, maxLength: 256 } },
+    required: ["action", "idempotencyKey", "observationRef"],
+    additionalProperties: false,
+  },
+  {
+    type: "object",
+    properties: { ...tabsMutationProperties, action: { const: "close" }, tabId: { type: "string", minLength: 1, maxLength: 256 } },
+    required: ["action", "idempotencyKey", "observationRef"],
+    additionalProperties: false,
+  },
+  {
+    type: "object",
+    properties: {
+      ...tabsMutationProperties,
+      action: { const: "finalize" },
+      dispositions: {
+        type: "array",
+        maxItems: 32,
+        items: {
+          type: "object",
+          properties: {
+            tabId: { type: "string", minLength: 1, maxLength: 256 },
+            disposition: { enum: ["close", "release", "handoff", "deliverable"] },
+          },
+          required: ["tabId", "disposition"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["action", "dispositions", "idempotencyKey", "observationRef"],
+    additionalProperties: false,
+  },
+];
+
 function inputSchema(operation: BrowserAutomationOperation): Record<string, unknown> {
   const schemas: Record<BrowserAutomationOperation, Record<string, unknown>> = {
     inspect: { includeScreenshot: { type: "boolean", default: false }, includeDiagnostics: { type: "boolean", default: false } },
@@ -179,10 +235,12 @@ function inputSchema(operation: BrowserAutomationOperation): Record<string, unkn
     evaluate: { expression: { type: "string", minLength: 1, maxLength: 65536 }, awaitPromise: { type: "boolean" }, timeoutMs: { type: "integer", minimum: 1, maximum: 60000 } },
     recordingStart: { maxDurationMs: { type: "integer", minimum: 1000, maximum: 600000 } },
     recordingStop: {},
+    tabs: { oneOf: tabsMutationVariants },
   };
   const requiredByOperation: Partial<Record<BrowserAutomationOperation, string[]>> = {
     open: ["idempotencyKey"], act: ["idempotencyKey", "observationRef", "deadlineMs", "steps"], navigate: ["url"], resize: ["width", "height"], click: ["target"], type: ["text"], press: ["key"], scroll: ["deltaY"], evaluate: ["expression"],
   };
+  if (operation === "tabs") return { oneOf: tabsMutationVariants };
   return {
     type: "object",
     properties: { ...commonProperties, ...schemas[operation] },

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -533,7 +533,7 @@ export function BrowserAutomationHost() {
   const shutdownLeaseRef = useRef<HostLease | null>(null);
   const executorDescriptor = useMemo(() => ({
     runtime: window.desktopBridge?.preview?.automation ? "electron" as const : "web" as const,
-    operations: ["inspect", "act", ...BROWSER_AUTOMATION_OPERATIONS] as BrowserAutomationOperation[],
+    operations: ["inspect", "act", "tabs", ...BROWSER_AUTOMATION_OPERATIONS] as BrowserAutomationOperation[],
     constraints: { maxTabs: 32, maxSnapshotChars: 20_000, maxDiagnostics: 200 },
     capabilityRevision: 1,
   }), []);
@@ -554,6 +554,37 @@ export function BrowserAutomationHost() {
   const persistentWebTabsRef = useRef(new Map<string, PersistentAutomationWebTab>());
   const agentOpenTabsRef = useRef(new Map<string, string>());
   const [, setPersistentWebTabsRevision] = useState(0);
+  const listLifecycleTargets = async (
+    dispatch: BrowserAutomationHostDispatch,
+  ): Promise<readonly BrowserAutomationHostDispatchTarget[]> => {
+    const lease = leaseRef.current;
+    if (!lease) return [];
+    const candidates = [...useBrowserAutomationStore.getState().liveTargets.values()]
+      .filter((target) => target.threadId === dispatch.request.threadId);
+    const bridge = window.desktopBridge?.preview?.automation;
+    if (!bridge) {
+      return candidates.map((target) => ({
+        desktopInstanceId: lease.desktopInstanceId,
+        windowId: 1,
+        connectionGeneration: lease.generation,
+        threadId: target.threadId,
+        tabId: target.tabId,
+        targetGeneration: Math.max(1, target.revision),
+        active: false,
+        focused: false,
+        lastUsedAt: target.lastUsedAt,
+      }));
+    }
+    const described = await Promise.all(candidates.map((target) => bridge.describeTarget({
+      threadId: target.threadId,
+      tabId: target.tabId,
+    })));
+    return described.flatMap((result) => result.ok ? [{
+      ...result.target,
+      desktopInstanceId: lease.desktopInstanceId,
+      connectionGeneration: lease.generation,
+    }] : []);
+  };
   const sessionDriverRef = useRef<BrowserSessionDriver | null>(null);
   if (!sessionDriverRef.current) {
     const webAdapter = new WebBrowserSessionAdapter({
@@ -587,6 +618,14 @@ export function BrowserAutomationHost() {
       supportedActOperations: window.desktopBridge?.preview?.automation
         ? ["navigate", "click", "type", "press", "scroll"]
         : ["navigate", "click", "type"],
+      webTabs: {
+        list: listLifecycleTargets,
+        close: async (target) => removePersistentWebTab(target.tabId),
+      },
+      electronTabs: {
+        list: listLifecycleTargets,
+        close: async (target) => usePreviewTabsStore.getState().closePage(target.threadId, target.tabId),
+      },
     });
   }
   const addPersistentWebTab = (tab: PersistentAutomationWebTab): void => {
@@ -685,7 +724,7 @@ export function BrowserAutomationHost() {
         targetIdentity: webTargetIdentity(worktreeIdentity, "pending-desktop", activeTarget),
       } : {}),
       executorDescriptor,
-      capabilities: [{ operation: "inspect", available: true }, { operation: "act", available: true }, ...BROWSER_AUTOMATION_OPERATIONS.map((operation) => {
+      capabilities: [{ operation: "inspect", available: true }, { operation: "act", available: true }, { operation: "tabs", available: true }, ...BROWSER_AUTOMATION_OPERATIONS.map((operation) => {
         if (!desktopAutomation) {
           const available = operation === "click" || operation === "type" ||
             operation === "status" || operation === "open" || operation === "navigate" ||
@@ -1042,12 +1081,13 @@ export function BrowserAutomationHost() {
       });
       void guardedOperation.then((response) => {
         if (leaseRef.current !== lease || cancelledRef.current.has(key)) return;
-        return webDispatch || webNavigateRequest || (!bridge && webAutomationEnabled && dispatch.request.operation === "screenshot")
+        const responseTarget = sessionDriverRef.current!.responseTarget(dispatch, response);
+        return webDispatch || webNavigateRequest || dispatch.request.operation === "tabs" || (!bridge && webAutomationEnabled && dispatch.request.operation === "screenshot")
           ? getTransport().respondToBrowserAutomationRequest(
             lease.hostId,
             lease.generation,
             response,
-            dispatch.target,
+            responseTarget,
           )
           : getTransport().respondToBrowserAutomationRequest(
             lease.hostId,
@@ -1399,6 +1439,8 @@ export function BrowserAutomationHost() {
   useEffect(() => onBrowserAutomationScopeRelease((release) => {
     const matches = (threadId: string, workspaceId: string): boolean =>
       release.threadId !== undefined ? threadId === release.threadId : workspaceId === release.workspaceId;
+    if (release.threadId !== undefined) void sessionDriverRef.current?.releaseThread(release.threadId);
+    else void sessionDriverRef.current?.releaseWorkspace(release.workspaceId);
     const nextScopes = backgroundScopesRef.current.filter(
       (scope) => !matches(scope.threadId, scope.workspaceId),
     );
@@ -1432,6 +1474,16 @@ export function BrowserAutomationHost() {
       cancelHostedRequest(key, dispatch, "host-shutdown", lease);
     }
   }), [cancelHostedRequest]);
+
+  useEffect(() => pushEmitter.on("browserAutomation.sessionRelease", (input) => {
+    const payload = input as { hostId?: unknown; generation?: unknown; providerSessionId?: unknown };
+    const lease = leaseRef.current;
+    if (
+      !lease || payload.hostId !== lease.hostId || payload.generation !== lease.generation ||
+      typeof payload.providerSessionId !== "string"
+    ) return;
+    void sessionDriverRef.current?.releaseProviderSession(payload.providerSessionId);
+  }), []);
 
   useEffect(() => () => {
     // Registration cleanup runs before this effect during unmount, so retain

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -271,6 +271,22 @@ describe("BrowserAutomationHost", () => {
     execute.mockReset();
   });
 
+  it("settles driver-owned tabs when the broker releases a provider session", async () => {
+    const release = vi.spyOn(BrowserSessionDriver.prototype, "releaseProviderSession").mockResolvedValue();
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+    act(() => harness.emit("browserAutomation.sessionRelease", {
+      hostId,
+      generation: 1,
+      providerSessionId: "provider-session-1",
+      reason: "credential-revoked",
+    }));
+    await waitFor(() => expect(release).toHaveBeenCalledWith("provider-session-1"));
+    view.unmount();
+    release.mockRestore();
+  });
+
   it("enters BrowserSessionDriver before web adapter dispatch", async () => {
     delete window.desktopBridge;
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -233,4 +233,163 @@ describe("BrowserSessionDriver", () => {
     await driver.execute(makeDispatch("fresh", "https://example.test/", 2), new AbortController().signal);
     expect(execute).toHaveBeenCalledTimes(4);
   });
+
+  it("claims and releases user tabs without physically closing them", async () => {
+    const current = { threadId: "thread", tabId: "agent-tab", windowId: 1, connectionGeneration: 1, targetGeneration: 1 };
+    const user = { threadId: "thread", tabId: "user-tab", windowId: 1, connectionGeneration: 1, targetGeneration: 4 };
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => ({
+      contractVersion: 1,
+      requestId: value.request.requestId,
+      sequence: value.request.sequence,
+      ok: true,
+      result: value.request.operation === "inspect"
+        ? { operation: "inspect", tabs: [current, user] }
+        : { operation: value.request.operation, url: "about:blank", title: "", controlEpoch: 0 },
+    }) as BrowserAutomationResponse);
+    const close = vi.fn();
+    const driver = new BrowserSessionDriver({
+      web: { execute }, electron: { execute }, isElectron: () => false,
+      webTabs: { list: async () => [current, user] as never, close },
+    });
+    const base = {
+      scope: { workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance" },
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target: current,
+    };
+    const inspect = await driver.execute({ ...base, request: {
+      contractVersion: 1, workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance",
+      requestId: "inspect-tabs", sequence: 1, deadline: Date.now() + 10_000, expectedControlEpoch: 0, operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false },
+    } } as BrowserAutomationHostDispatch, new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+    const claimDispatch = { ...base, request: {
+      contractVersion: 1, workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance",
+      requestId: "claim", sequence: 2, deadline: Date.now() + 10_000, expectedControlEpoch: 0, operation: "tabs",
+      args: { action: "claim", tabId: "user-tab", idempotencyKey: "claim-key", observationRef },
+    } } as BrowserAutomationHostDispatch;
+    const claim = await driver.execute(claimDispatch, new AbortController().signal);
+    expect(claim).toMatchObject({ ok: true, result: { operation: "tabs", currentTabId: "user-tab", tabs: [{ tabId: "user-tab", provenance: "claimed-user", ownership: "claimed" }] } });
+    expect(driver.responseTarget(claimDispatch, claim)).toMatchObject({ tabId: "user-tab", targetGeneration: 4 });
+    const nextObservationRef = (claim as { result: { observationRef: string } }).result.observationRef;
+    const closed = await driver.execute({ ...base, target: user, request: {
+      contractVersion: 1, workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance",
+      requestId: "close-user", sequence: 3, deadline: Date.now() + 10_000, expectedControlEpoch: 0, operation: "tabs",
+      args: { action: "close", idempotencyKey: "close-user-key", observationRef: nextObservationRef },
+    } } as BrowserAutomationHostDispatch, new AbortController().signal);
+    expect(closed).toMatchObject({ ok: true, result: { tabs: [{ tabId: "user-tab", ownership: "released", disposition: "release" }] } });
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("closes omitted agent tabs at finalization and preserves deliverables across session cleanup", async () => {
+    const liveTargets = new Map<string, BrowserAutomationHostDispatch["target"]>();
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "open") liveTargets.set(value.target.tabId, value.target);
+      return {
+        contractVersion: 1, requestId: value.request.requestId, sequence: value.request.sequence, ok: true,
+        result: value.request.operation === "inspect"
+          ? { operation: "inspect", tabs: [...liveTargets.values()] }
+          : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+      } as BrowserAutomationResponse;
+    });
+    const close = vi.fn();
+    const driver = new BrowserSessionDriver({
+      web: { execute }, electron: { execute }, isElectron: () => false,
+      webTabs: { list: async () => [...liveTargets.values()], close },
+    });
+    const open = (tabId: string, key: string) => ({
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target: { threadId: "thread", tabId, windowId: 1, connectionGeneration: 1, targetGeneration: 1 },
+      request: { contractVersion: 1, workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance", requestId: key, sequence: 1, deadline: Date.now() + 10_000, expectedControlEpoch: 0, operation: "open", args: { idempotencyKey: key } },
+    }) as BrowserAutomationHostDispatch;
+    await driver.execute(open("tab-1", "open-1"), new AbortController().signal);
+    await driver.execute(open("tab-2", "open-2"), new AbortController().signal);
+    await driver.execute(open("tab-3", "open-3"), new AbortController().signal);
+    const fourth = await driver.execute(open("tab-4", "open-4"), new AbortController().signal);
+    expect(fourth).toMatchObject({ ok: false, error: { code: "BROWSER_BUSY" } });
+    const inspect = await driver.execute({ ...open("tab-1", "inspect"), request: {
+      ...open("tab-1", "inspect").request,
+      operation: "inspect",
+      args: { includeScreenshot: false, includeDiagnostics: false },
+    } } as BrowserAutomationHostDispatch, new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+    const claimed = await driver.execute({ ...open("tab-1", "claim-agent"), request: {
+      ...open("tab-1", "claim-agent").request,
+      operation: "tabs",
+      args: { action: "claim", tabId: "tab-1", idempotencyKey: "claim-agent-key", observationRef },
+    } } as BrowserAutomationHostDispatch, new AbortController().signal);
+    expect(claimed).toMatchObject({ ok: true, result: { operation: "tabs", action: "claim" } });
+    expect((claimed as { result: { tabs: unknown[] } }).result.tabs).toContainEqual(expect.objectContaining({
+      tabId: "tab-1",
+      provenance: "agent-created",
+      ownership: "owned",
+    }));
+    const claimObservationRef = (claimed as { result: { observationRef: string } }).result.observationRef;
+    liveTargets.set("tab-2", { ...liveTargets.get("tab-2")!, targetGeneration: 2 });
+    const stale = await driver.execute({ ...open("tab-1", "stale-finalize"), request: {
+      ...open("tab-1", "stale-finalize").request,
+      operation: "tabs",
+      args: { action: "finalize", idempotencyKey: "stale-finalize-key", observationRef: claimObservationRef, dispositions: [] },
+    } } as BrowserAutomationHostDispatch, new AbortController().signal);
+    expect(stale).toMatchObject({ ok: false, error: { code: "STALE_TARGET_GENERATION", effect: "none" } });
+    expect(close).not.toHaveBeenCalled();
+    const refreshed = await driver.execute({ ...open("tab-1", "refresh"), request: {
+      ...open("tab-1", "refresh").request,
+      operation: "inspect",
+      args: { includeScreenshot: false, includeDiagnostics: false },
+    } } as BrowserAutomationHostDispatch, new AbortController().signal);
+    const refreshedObservationRef = (refreshed as { result: { observationRef: string } }).result.observationRef;
+    const finalized = await driver.execute({ ...open("tab-1", "finalize"), request: {
+      ...open("tab-1", "finalize").request,
+      operation: "tabs",
+      args: { action: "finalize", idempotencyKey: "finalize-key", observationRef: refreshedObservationRef, dispositions: [{ tabId: "tab-1", disposition: "deliverable" }] },
+    } } as BrowserAutomationHostDispatch, new AbortController().signal);
+    expect(finalized).toMatchObject({ ok: true, result: { tabs: [{ tabId: "tab-1", disposition: "deliverable", ownership: "released" }] } });
+    expect(close.mock.calls.map(([target]) => target.tabId).sort()).toEqual(["tab-2", "tab-3"]);
+    await driver.releaseProviderSession("session");
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it("normalizes web and Electron ownership outcomes while using runtime-specific cleanup", async () => {
+    const run = async (electronRuntime: boolean) => {
+      const webClose = vi.fn();
+      const electronClose = vi.fn();
+      const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => ({
+        contractVersion: 1,
+        requestId: value.request.requestId,
+        sequence: value.request.sequence,
+        ok: true,
+        result: { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+      }) as BrowserAutomationResponse);
+      const driver = new BrowserSessionDriver({
+        web: { execute }, electron: { execute }, isElectron: () => electronRuntime,
+        webTabs: { list: async (value) => [value.target], close: webClose },
+        electronTabs: { list: async (value) => [value.target], close: electronClose },
+      });
+      const opened = {
+        connection: { connectionGeneration: 1, capabilityRevision: 1 },
+        target: { threadId: "thread", tabId: "agent-tab", windowId: 1, connectionGeneration: 1, targetGeneration: 1 },
+        request: {
+          contractVersion: 1, workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance",
+          requestId: "open", sequence: 1, deadline: Date.now() + 10_000, expectedControlEpoch: 0, operation: "open", args: { idempotencyKey: "open-key" },
+        },
+      } as BrowserAutomationHostDispatch;
+      const openResponse = await driver.execute(opened, new AbortController().signal);
+      const observationRef = (openResponse as { result: { observationRef: string } }).result.observationRef;
+      const result = await driver.execute({ ...opened, request: {
+        ...opened.request,
+        requestId: "finalize",
+        operation: "tabs",
+        args: { action: "finalize", idempotencyKey: "finalize-key", observationRef, dispositions: [] },
+      } } as BrowserAutomationHostDispatch, new AbortController().signal);
+      return { result, webClose, electronClose };
+    };
+
+    const web = await run(false);
+    const electron = await run(true);
+    expect(web.result).toEqual(electron.result);
+    expect(web.result).toMatchObject({ ok: true, result: { operation: "tabs", action: "finalize", tabs: [] } });
+    expect(web.webClose).toHaveBeenCalledOnce();
+    expect(web.electronClose).not.toHaveBeenCalled();
+    expect(electron.electronClose).toHaveBeenCalledOnce();
+    expect(electron.webClose).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -234,6 +234,46 @@ describe("BrowserSessionDriver", () => {
     expect(execute).toHaveBeenCalledTimes(4);
   });
 
+  it("serializes fresh opens with browser_tabs at the driver boundary", async () => {
+    let resolveFirst!: (response: BrowserAutomationResponse) => void;
+    const firstResponse = new Promise<BrowserAutomationResponse>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const success = {
+      contractVersion: 1,
+      requestId: "open",
+      sequence: 1,
+      ok: true,
+      result: { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+    } as BrowserAutomationResponse;
+    const execute = vi.fn()
+      .mockImplementationOnce(() => firstResponse)
+      .mockResolvedValue(success);
+    const driver = new BrowserSessionDriver({ web: { execute }, electron: { execute }, isElectron: () => false });
+    const open = (requestId: string, tabId: string, idempotencyKey: string) => ({
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target: { threadId: "thread", tabId, windowId: 1, connectionGeneration: 1, targetGeneration: 1 },
+      request: {
+        contractVersion: 1, workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance",
+        requestId, sequence: 1, deadline: Date.now() + 10_000, expectedControlEpoch: 0, operation: "open", args: { idempotencyKey },
+      },
+    }) as BrowserAutomationHostDispatch;
+    const first = driver.execute(open("first-open", "tab-1", "key-1"), new AbortController().signal);
+    const concurrentOpen = await driver.execute(open("second-open", "tab-2", "key-2"), new AbortController().signal);
+    const concurrentTabs = await driver.execute({ ...open("tabs", "tab-1", "tabs-key"), request: {
+      ...open("tabs", "tab-1", "tabs-key").request,
+      operation: "tabs",
+      args: { action: "close", idempotencyKey: "tabs-key", observationRef: "unobserved" },
+    } } as BrowserAutomationHostDispatch, new AbortController().signal);
+    expect(concurrentOpen).toMatchObject({ ok: false, error: { code: "BROWSER_BUSY" } });
+    expect(concurrentTabs).toMatchObject({ ok: false, error: { code: "BROWSER_BUSY" } });
+    expect(execute).toHaveBeenCalledOnce();
+    resolveFirst(success);
+    await expect(first).resolves.toMatchObject({ ok: true });
+    await expect(driver.execute(open("third-open", "tab-3", "key-3"), new AbortController().signal)).resolves.toMatchObject({ ok: true });
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
   it("claims and releases user tabs without physically closing them", async () => {
     const current = { threadId: "thread", tabId: "agent-tab", windowId: 1, connectionGeneration: 1, targetGeneration: 1 };
     const user = { threadId: "thread", tabId: "user-tab", windowId: 1, connectionGeneration: 1, targetGeneration: 4 };

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -187,8 +187,14 @@ export class BrowserSessionDriver {
         },
       },
     } as OpenDispatch;
+    const mutationKey = this.sessionKey(dispatch);
+    if (this.activeTabMutations.has(mutationKey)) {
+      return Promise.resolve(this.failure(dispatch, "BROWSER_BUSY", "Another browser mutation is active for this provider session", "wait"));
+    }
+    this.activeTabMutations.add(mutationKey);
     const session = this.tabSession(dispatch);
     if ([...session.tabs.values()].filter((tab) => tab.provenance === "agent-created" && tab.ownership !== "released").length >= 3) {
+      this.activeTabMutations.delete(mutationKey);
       return Promise.resolve(this.failure(dispatch, "BROWSER_BUSY", "This provider session already owns three agent-created tabs", "wait"));
     }
     const promise = this.executeAdapter(normalized, signal)
@@ -203,7 +209,8 @@ export class BrowserSessionDriver {
           });
         }
         return this.withObservationRef(response);
-      });
+      })
+      .finally(() => this.activeTabMutations.delete(mutationKey));
     this.idempotency.set(scopeKey, {
       fingerprint,
       target: {

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -1,5 +1,7 @@
 import type {
   BrowserAutomationHostDispatch,
+  BrowserAutomationHostDispatchTarget,
+  BrowserAutomationOwnedTab,
   BrowserAutomationResponse,
   BrowserAutomationActStep,
 } from "@mcode/contracts";
@@ -32,6 +34,25 @@ interface ObservationRecord {
   readonly controlRevision: number;
   readonly capabilityRevision: number;
   observationRevision: number;
+  readonly targets: ReadonlyMap<string, BrowserAutomationHostDispatchTarget>;
+}
+
+interface TabReplayRecord {
+  readonly fingerprint: string;
+  lastUsedAt: number;
+  readonly promise: Promise<BrowserAutomationResponse>;
+}
+
+interface ControlledTab extends BrowserAutomationOwnedTab {
+  target: BrowserAutomationHostDispatchTarget;
+}
+
+interface ProviderTabSession {
+  readonly workspaceId: string;
+  readonly providerSessionId: string;
+  readonly providerInstanceId: string;
+  current: BrowserAutomationHostDispatchTarget | null;
+  readonly tabs: Map<string, ControlledTab>;
 }
 
 /** Runtime implementation used by the client BrowserSessionDriver. */
@@ -40,6 +61,12 @@ export interface BrowserSessionRuntimeAdapter {
     dispatch: BrowserAutomationHostDispatch,
     signal: AbortSignal,
   ): Promise<BrowserAutomationResponse>;
+}
+
+/** Runtime mechanics used by the driver to enumerate and physically close Preview tabs. */
+export interface BrowserSessionTabLifecycleAdapter {
+  list(dispatch: BrowserAutomationHostDispatch): Promise<readonly BrowserAutomationHostDispatchTarget[]>;
+  close(target: BrowserAutomationHostDispatchTarget): Promise<void>;
 }
 
 /** Renderer-side adapter that forwards Browser v1 commands to Electron preload. */
@@ -66,6 +93,8 @@ export interface BrowserSessionDriverOptions {
   readonly getDocumentRevision?: (dispatch: BrowserAutomationHostDispatch) => number;
   readonly getControlRevision?: (dispatch: BrowserAutomationHostDispatch) => number;
   readonly supportedActOperations?: readonly string[] | (() => readonly string[]);
+  readonly webTabs?: BrowserSessionTabLifecycleAdapter;
+  readonly electronTabs?: BrowserSessionTabLifecycleAdapter;
 }
 
 /**
@@ -76,7 +105,10 @@ export interface BrowserSessionDriverOptions {
 export class BrowserSessionDriver {
   private readonly isElectron: () => boolean;
   private readonly idempotency = new Map<string, IdempotencyRecord>();
+  private readonly tabIdempotency = new Map<string, TabReplayRecord>();
   private readonly observations = new Map<string, ObservationRecord>();
+  private readonly tabSessions = new Map<string, ProviderTabSession>();
+  private readonly activeTabMutations = new Set<string>();
 
   constructor(private readonly options: BrowserSessionDriverOptions) {
     this.isElectron = options.isElectron ?? (() => typeof window !== "undefined" && typeof window.desktopBridge?.preview === "object");
@@ -90,6 +122,7 @@ export class BrowserSessionDriver {
     const initialDrift = this.revisionDrift(dispatch);
     if (initialDrift) return Promise.resolve(initialDrift);
     if (dispatch.request?.operation === "act") return this.executeAct(dispatch, signal);
+    if (dispatch.request?.operation === "tabs") return this.executeTabs(dispatch);
     if (dispatch.request?.operation !== "open") {
       return this.executeAdapter(dispatch, signal);
     }
@@ -154,8 +187,23 @@ export class BrowserSessionDriver {
         },
       },
     } as OpenDispatch;
+    const session = this.tabSession(dispatch);
+    if ([...session.tabs.values()].filter((tab) => tab.provenance === "agent-created" && tab.ownership !== "released").length >= 3) {
+      return Promise.resolve(this.failure(dispatch, "BROWSER_BUSY", "This provider session already owns three agent-created tabs", "wait"));
+    }
     const promise = this.executeAdapter(normalized, signal)
-      .then((response) => this.withObservationRef(response));
+      .then((response) => {
+        if (response.ok) {
+          session.current = dispatch.target;
+          session.tabs.set(dispatch.target.tabId, {
+            tabId: dispatch.target.tabId,
+            provenance: "agent-created",
+            ownership: "owned",
+            target: dispatch.target,
+          });
+        }
+        return this.withObservationRef(response);
+      });
     this.idempotency.set(scopeKey, {
       fingerprint,
       target: {
@@ -178,6 +226,7 @@ export class BrowserSessionDriver {
   /** Clears bounded replay state when a provider session or host is released. */
   clearIdempotency(): void {
     this.idempotency.clear();
+    this.tabIdempotency.clear();
   }
 
   /** Clears replay state bound to one browser target after that target closes or is replaced. */
@@ -185,6 +234,31 @@ export class BrowserSessionDriver {
     for (const [key, record] of this.idempotency) {
       if (record.target.threadId === threadId && record.target.tabId === tabId) this.idempotency.delete(key);
     }
+    for (const session of this.tabSessions.values()) {
+      if (session.current?.threadId === threadId && session.current.tabId === tabId) session.current = null;
+      session.tabs.delete(tabId);
+    }
+  }
+
+  /** Returns the exact target selected by a successful lifecycle response. */
+  responseTarget(dispatch: BrowserAutomationHostDispatch, response: BrowserAutomationResponse): BrowserAutomationHostDispatchTarget {
+    if (!response.ok || response.result.operation !== "tabs") return dispatch.target;
+    return this.tabSessions.get(this.sessionKey(dispatch))?.current ?? dispatch.target;
+  }
+
+  /** Settles every tab owned or claimed by one terminated provider session. */
+  async releaseProviderSession(providerSessionId: string): Promise<void> {
+    await this.releaseSessions((session) => session.providerSessionId === providerSessionId);
+  }
+
+  /** Settles every tab owned or claimed by one deleted thread. */
+  async releaseThread(threadId: string): Promise<void> {
+    await this.releaseSessions((session) => [...session.tabs.values()].some((tab) => tab.target.threadId === threadId));
+  }
+
+  /** Settles every tab owned or claimed by one deleted workspace. */
+  async releaseWorkspace(workspaceId: string): Promise<void> {
+    await this.releaseSessions((session) => session.workspaceId === workspaceId);
   }
 
   private withObservationRef(response: BrowserAutomationResponse): BrowserAutomationResponse {
@@ -199,7 +273,19 @@ export class BrowserSessionDriver {
     const drift = this.revisionDrift(dispatch);
     if (drift) return Promise.resolve(drift);
     return (this.isElectron() ? this.options.electron : this.options.web).execute(dispatch, signal)
-      .then((response) => this.rememberObservation(this.withObservationRef(response), dispatch));
+      .then(async (response) => {
+        let normalized = this.withObservationRef(response);
+        if (normalized.ok && normalized.result?.operation === "inspect") {
+          const targets = await this.tabAdapter()?.list(dispatch);
+          if (targets) {
+            normalized = {
+              ...normalized,
+              result: { ...normalized.result, tabs: [...targets] },
+            };
+          }
+        }
+        return this.rememberObservation(normalized, dispatch);
+      });
   }
 
   private executeAct(
@@ -218,6 +304,7 @@ export class BrowserSessionDriver {
       ...currentBinding,
       capabilityRevision,
       observationRevision: 0,
+      targets: new Map([[dispatch.target.tabId, dispatch.target]]),
     };
     if (!observation || observation.hostRevision !== currentBinding.hostRevision || observation.documentRevision !== currentBinding.documentRevision || observation.controlRevision !== currentBinding.controlRevision || observation.capabilityRevision !== currentBinding.capabilityRevision) {
       return Promise.resolve(this.actFailure(dispatch, "STALE_TARGET_GENERATION", "Browser observation is stale; inspect before browser_act"));
@@ -276,7 +363,7 @@ export class BrowserSessionDriver {
         capabilityRevision,
         observationRevision: baseObservation.observationRevision + 1,
       };
-      this.observations.set(nextObservationRef, { hostRevision: finalObservation.hostRevision, documentRevision: finalObservation.documentRevision, controlRevision: finalObservation.controlRevision, capabilityRevision, observationRevision: finalObservation.observationRevision });
+      this.observations.set(nextObservationRef, { hostRevision: finalObservation.hostRevision, documentRevision: finalObservation.documentRevision, controlRevision: finalObservation.controlRevision, capabilityRevision, observationRevision: finalObservation.observationRevision, targets: baseObservation.targets });
       return {
         contractVersion: request.contractVersion,
         requestId: request.requestId,
@@ -286,6 +373,141 @@ export class BrowserSessionDriver {
       } as BrowserAutomationResponse;
     };
     return run();
+  }
+
+  private executeTabs(dispatch: BrowserAutomationHostDispatch): Promise<BrowserAutomationResponse> {
+    const request = dispatch.request as Extract<BrowserAutomationHostDispatch["request"], { operation: "tabs" }>;
+    const sessionKey = this.sessionKey(dispatch);
+    const replayKey = JSON.stringify([request.providerSessionId, request.providerInstanceId, request.args.idempotencyKey]);
+    const fingerprint = JSON.stringify(request.args);
+    const replay = this.tabIdempotency.get(replayKey);
+    if (replay) {
+      replay.lastUsedAt = Date.now();
+      if (replay.fingerprint !== fingerprint) {
+        return Promise.resolve(this.failure(dispatch, "IDEMPOTENCY_CONFLICT", "The idempotency key was already used with different browser_tabs arguments", "manual"));
+      }
+      return replay.promise.then((response) => ({ ...response, requestId: request.requestId, sequence: request.sequence }));
+    }
+    if (this.activeTabMutations.has(sessionKey)) {
+      return Promise.resolve(this.failure(dispatch, "BROWSER_BUSY", "Another browser mutation is active for this provider session", "wait"));
+    }
+    const observation = this.observations.get(request.args.observationRef);
+    const capabilityRevision = this.options.getCapabilityRevision?.() ?? dispatch.connection?.capabilityRevision ?? 1;
+    if (!observation || !this.observationStillCurrent(dispatch, observation)) {
+      return Promise.resolve(this.failure(dispatch, "STALE_TARGET_GENERATION", "Browser observation is stale; inspect before browser_tabs", "inspect"));
+    }
+    this.observations.delete(request.args.observationRef);
+    this.activeTabMutations.add(sessionKey);
+    const promise = this.applyTabsMutation(dispatch, observation, capabilityRevision)
+      .finally(() => this.activeTabMutations.delete(sessionKey));
+    this.tabIdempotency.set(replayKey, { fingerprint, lastUsedAt: Date.now(), promise });
+    this.pruneIdempotency();
+    return promise;
+  }
+
+  private async applyTabsMutation(
+    dispatch: BrowserAutomationHostDispatch,
+    observation: ObservationRecord,
+    capabilityRevision: number,
+  ): Promise<BrowserAutomationResponse> {
+    const request = dispatch.request as Extract<BrowserAutomationHostDispatch["request"], { operation: "tabs" }>;
+    const session = this.tabSession(dispatch);
+    const adapter = this.tabAdapter();
+    const liveTargets = new Map((adapter ? await adapter.list(dispatch) : [dispatch.target]).map((target) => [target.tabId, target]));
+    if (!this.observationStillCurrent(dispatch, observation)) {
+      return this.failure(dispatch, "STALE_TARGET_GENERATION", "Browser generations changed before the next tab effect", "inspect");
+    }
+    const requestedTabId = request.args.action === "select" || request.args.action === "claim"
+      ? request.args.tabId
+      : request.args.action === "release" || request.args.action === "close"
+        ? request.args.tabId ?? session.current?.tabId
+        : undefined;
+    const observedTarget = requestedTabId ? observation.targets.get(requestedTabId) : undefined;
+    const liveTarget = requestedTabId ? liveTargets.get(requestedTabId) : undefined;
+    if (requestedTabId && (!observedTarget || !liveTarget || observedTarget.targetGeneration !== liveTarget.targetGeneration || observedTarget.connectionGeneration !== liveTarget.connectionGeneration)) {
+      return this.failure(dispatch, "STALE_TARGET_GENERATION", "The selected Browser tab changed after it was observed", "inspect");
+    }
+    if (request.args.action === "finalize") {
+      const staleControlledTab = [...session.tabs.values()].find((controlled) => {
+        const observed = observation.targets.get(controlled.tabId);
+        const live = liveTargets.get(controlled.tabId);
+        return !observed || !live || observed.targetGeneration !== live.targetGeneration || observed.connectionGeneration !== live.connectionGeneration;
+      });
+      if (staleControlledTab) {
+        return this.failure(dispatch, "STALE_TARGET_GENERATION", "A controlled Browser tab changed after it was observed", "inspect");
+      }
+    }
+
+    if (request.args.action === "select" && liveTarget) {
+      session.current = liveTarget;
+    } else if (request.args.action === "claim" && liveTarget) {
+      session.current = liveTarget;
+      const controlled = session.tabs.get(liveTarget.tabId);
+      session.tabs.set(liveTarget.tabId, controlled
+        ? {
+            ...controlled,
+            ownership: controlled.provenance === "agent-created" ? "owned" : "claimed",
+            disposition: undefined,
+            target: liveTarget,
+          }
+        : {
+            tabId: liveTarget.tabId,
+            provenance: "claimed-user",
+            ownership: "claimed",
+            target: liveTarget,
+          });
+    } else if ((request.args.action === "release" || request.args.action === "close") && requestedTabId) {
+      const controlled = session.tabs.get(requestedTabId);
+      if (request.args.action === "close" && controlled?.provenance === "agent-created") {
+        await adapter?.close(controlled.target);
+        session.tabs.delete(requestedTabId);
+      } else if (controlled) {
+        session.tabs.set(requestedTabId, { ...controlled, ownership: "released", disposition: "release" });
+      }
+      if (session.current?.tabId === requestedTabId) session.current = null;
+    } else if (request.args.action === "finalize") {
+      type Disposition = "close" | "release" | "handoff" | "deliverable";
+      const entries = request.args.dispositions as Array<{ tabId: string; disposition: Disposition }>;
+      const dispositions = new Map<string, Disposition>(entries.map((entry) => [entry.tabId, entry.disposition]));
+      for (const [tabId, controlled] of [...session.tabs]) {
+        const requested = dispositions.get(tabId);
+        const disposition = controlled.provenance === "claimed-user"
+          ? requested === "handoff" || requested === "deliverable" ? requested : "release"
+          : requested ?? "close";
+        if (disposition === "close") {
+          await adapter?.close(controlled.target);
+          session.tabs.delete(tabId);
+        } else {
+          session.tabs.set(tabId, { ...controlled, ownership: "released", disposition });
+        }
+      }
+      session.current = null;
+    }
+
+    const nextObservationRef = session.current ? globalThis.crypto.randomUUID() : undefined;
+    if (session.current && nextObservationRef) {
+      this.observations.set(nextObservationRef, {
+        hostRevision: session.current.connectionGeneration,
+        documentRevision: session.current.targetGeneration,
+        controlRevision: dispatch.request.expectedControlEpoch,
+        capabilityRevision,
+        observationRevision: observation.observationRevision + 1,
+        targets: new Map(liveTargets),
+      });
+    }
+    return {
+      contractVersion: request.contractVersion,
+      requestId: request.requestId,
+      sequence: request.sequence,
+      ok: true,
+      result: {
+        operation: "tabs",
+        action: request.args.action,
+        ...(session.current ? { currentTabId: session.current.tabId } : {}),
+        ...(nextObservationRef ? { observationRef: nextObservationRef } : {}),
+        tabs: [...session.tabs.values()].map(({ target: _target, ...tab }) => tab),
+      },
+    };
   }
 
   private stepDispatch(dispatch: BrowserAutomationHostDispatch, step: BrowserAutomationActStep, deadline: number, index: number): BrowserAutomationHostDispatch {
@@ -309,7 +531,7 @@ export class BrowserSessionDriver {
 
   private rememberObservation(response: BrowserAutomationResponse, dispatch: BrowserAutomationHostDispatch): BrowserAutomationResponse {
     if (!response.ok || !response.result) return response;
-    const result = response.result as { observationRef?: string };
+    const result = response.result as { observationRef?: string; tabs?: BrowserAutomationHostDispatchTarget[] };
     if (!result.observationRef) return response;
     this.observations.set(result.observationRef, {
       hostRevision: dispatch.connection?.connectionGeneration ?? 0,
@@ -317,6 +539,7 @@ export class BrowserSessionDriver {
       controlRevision: dispatch.request.expectedControlEpoch,
       capabilityRevision: dispatch.connection?.capabilityRevision ?? this.options.getCapabilityRevision?.() ?? 1,
       observationRevision: 0,
+      targets: new Map((result.tabs ?? [dispatch.target]).map((target) => [target.tabId, target])),
     });
     return response;
   }
@@ -362,6 +585,68 @@ export class BrowserSessionDriver {
     for (const [key, record] of this.idempotency) {
       if (record.lastUsedAt < cutoff) this.idempotency.delete(key);
     }
+    for (const [key, record] of this.tabIdempotency) {
+      if (record.lastUsedAt < cutoff) this.tabIdempotency.delete(key);
+    }
+  }
+
+  private sessionKey(dispatch: BrowserAutomationHostDispatch): string {
+    return JSON.stringify([dispatch.request.providerSessionId, dispatch.request.providerInstanceId]);
+  }
+
+  private tabSession(dispatch: BrowserAutomationHostDispatch): ProviderTabSession {
+    const key = this.sessionKey(dispatch);
+    let session = this.tabSessions.get(key);
+    if (!session) {
+      session = {
+        workspaceId: dispatch.request.workspaceId,
+        providerSessionId: dispatch.request.providerSessionId,
+        providerInstanceId: dispatch.request.providerInstanceId,
+        current: null,
+        tabs: new Map(),
+      };
+      this.tabSessions.set(key, session);
+    }
+    return session;
+  }
+
+  private tabAdapter(): BrowserSessionTabLifecycleAdapter | undefined {
+    return this.isElectron() ? this.options.electronTabs : this.options.webTabs;
+  }
+
+  private async releaseSessions(predicate: (session: ProviderTabSession) => boolean): Promise<void> {
+    const adapter = this.tabAdapter();
+    for (const [key, session] of [...this.tabSessions]) {
+      if (!predicate(session)) continue;
+      for (const tab of session.tabs.values()) {
+        if (tab.provenance === "agent-created" && tab.ownership !== "released") {
+          await adapter?.close(tab.target);
+        }
+      }
+      this.tabSessions.delete(key);
+    }
+  }
+
+  private failure(
+    dispatch: BrowserAutomationHostDispatch,
+    code: "BROWSER_BUSY" | "IDEMPOTENCY_CONFLICT" | "STALE_TARGET_GENERATION",
+    message: string,
+    recovery: "wait" | "manual" | "inspect",
+  ): BrowserAutomationResponse {
+    return {
+      contractVersion: dispatch.request.contractVersion,
+      requestId: dispatch.request.requestId,
+      sequence: dispatch.request.sequence,
+      ok: false,
+      error: {
+        code,
+        message,
+        retryable: recovery === "wait",
+        stage: code === "STALE_TARGET_GENERATION" ? "observation" : code === "BROWSER_BUSY" ? "allocation" : "validation",
+        effect: "none",
+        recovery,
+      },
+    };
   }
 
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -456,6 +456,9 @@ export {
   BrowserAutomationActStepSchema,
   BrowserAutomationObservationBindingSchema,
   BrowserAutomationActResultSchema,
+  BrowserAutomationTabsArgsSchema,
+  BrowserAutomationOwnedTabSchema,
+  BrowserAutomationTabsResultSchema,
 } from "./models/browser-automation.js";
 export type {
   BrowserAutomationOperation,
@@ -481,6 +484,9 @@ export type {
   BrowserAutomationActStep,
   BrowserAutomationObservationBinding,
   BrowserAutomationActResult,
+  BrowserAutomationTabsArgs,
+  BrowserAutomationOwnedTab,
+  BrowserAutomationTabsResult,
 } from "./models/browser-automation.js";
 
 // Events

--- a/packages/contracts/src/models/__tests__/browser-automation.test.ts
+++ b/packages/contracts/src/models/__tests__/browser-automation.test.ts
@@ -195,6 +195,87 @@ describe("browser automation operation contract", () => {
     }
   });
 
+  it("defines browser_tabs as the idempotent Browser v2 lifecycle surface", () => {
+    expect(BROWSER_AUTOMATION_OPERATION_METADATA.tabs).toEqual({
+      operation: "tabs",
+      mcpName: "browser_tabs",
+      annotations: {
+        readOnly: false,
+        destructive: true,
+        idempotent: true,
+        openWorld: false,
+        privileged: false,
+      },
+    });
+    expect(Object.keys(BROWSER_AUTOMATION_OPERATION_METADATA)).not.toContain("tabs");
+
+    for (const args of [
+      { action: "select", tabId: "tab-2" },
+      { action: "claim", tabId: "tab-2" },
+      { action: "release" },
+      { action: "close" },
+      {
+        action: "finalize",
+        dispositions: [
+          { tabId: "tab-1", disposition: "deliverable" },
+          { tabId: "tab-2", disposition: "handoff" },
+        ],
+      },
+    ]) {
+      expect(BrowserAutomationRequestSchema().safeParse({
+        ...requestBase,
+        operation: "tabs",
+        args: {
+          ...args,
+          idempotencyKey: `tabs-${args.action}`,
+          observationRef: "observation-1",
+        },
+      }).success).toBe(true);
+    }
+
+    expect(BrowserAutomationRequestSchema().safeParse({
+      ...requestBase,
+      operation: "tabs",
+      args: { action: "close", idempotencyKey: "tabs-close" },
+    }).success).toBe(false);
+    expect(BrowserAutomationRequestSchema().safeParse({
+      ...requestBase,
+      operation: "tabs",
+      args: {
+        action: "finalize",
+        idempotencyKey: "tabs-finalize",
+        observationRef: "observation-1",
+        dispositions: [
+          { tabId: "tab-1", disposition: "close" },
+          { tabId: "tab-1", disposition: "deliverable" },
+        ],
+      },
+    }).success).toBe(false);
+  });
+
+  it("validates normalized browser_tabs ownership outcomes", () => {
+    expect(BrowserAutomationResultSchema().safeParse({
+      operation: "tabs",
+      action: "finalize",
+      currentTabId: "tab-2",
+      observationRef: "observation-2",
+      tabs: [
+        {
+          tabId: "tab-1",
+          provenance: "agent-created",
+          ownership: "released",
+          disposition: "deliverable",
+        },
+        {
+          tabId: "tab-2",
+          provenance: "claimed-user",
+          ownership: "claimed",
+          disposition: "handoff",
+        },
+      ],
+    }).success).toBe(true);
+  });
+
   it.each(BROWSER_AUTOMATION_OPERATIONS)("parses a scoped %s request", (operation) => {
     const parsed = BrowserAutomationRequestSchema().parse({
       ...requestBase,

--- a/packages/contracts/src/models/browser-automation.ts
+++ b/packages/contracts/src/models/browser-automation.ts
@@ -99,8 +99,13 @@ export const BROWSER_AUTOMATION_OPERATIONS = [
 ] as const;
 
 /** One browser automation operation identifier. */
-export type BrowserAutomationOperation = (typeof BROWSER_AUTOMATION_OPERATIONS)[number] | "inspect" | "act";
-const browserOperationSchema = z.union([z.enum(BROWSER_AUTOMATION_OPERATIONS), z.literal("inspect"), z.literal("act")]);
+export type BrowserAutomationOperation = (typeof BROWSER_AUTOMATION_OPERATIONS)[number] | "inspect" | "act" | "tabs";
+const browserOperationSchema = z.union([
+  z.enum(BROWSER_AUTOMATION_OPERATIONS),
+  z.literal("inspect"),
+  z.literal("act"),
+  z.literal("tabs"),
+]);
 
 /** Provider-facing MCP tool annotations for one operation. */
 export interface BrowserAutomationOperationAnnotations {
@@ -215,6 +220,14 @@ Object.defineProperty(BROWSER_AUTOMATION_OPERATION_METADATA, "act", {
     annotations: input,
   } satisfies BrowserAutomationOperationMetadata,
 });
+Object.defineProperty(BROWSER_AUTOMATION_OPERATION_METADATA, "tabs", {
+  enumerable: false,
+  value: {
+    operation: "tabs",
+    mcpName: "browser_tabs",
+    annotations: { ...input, idempotent: true },
+  } satisfies BrowserAutomationOperationMetadata,
+});
 
 /** Maximum tabs returned by one browser_inspect response. */
 export const BROWSER_AUTOMATION_MAX_INSPECT_TABS = 32;
@@ -225,7 +238,7 @@ export const BROWSER_AUTOMATION_MAX_GUIDANCE_CHARS = 4_000;
 export const BrowserAutomationExecutorDescriptorSchema = lazySchema(() =>
   z.object({
     runtime: BrowserAutomationHostRuntimeSchema,
-    operations: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 2),
+    operations: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 3),
     constraints: z.object({
       maxTabs: z.number().int().positive().max(BROWSER_AUTOMATION_MAX_INSPECT_TABS),
       maxSnapshotChars: z.number().int().positive().max(BROWSER_AUTOMATION_MAX_VISIBLE_TEXT_CHARS),
@@ -695,7 +708,7 @@ export const BrowserAutomationHostRegistrationSchema = lazySchema(() =>
       capabilities: z
         .array(BrowserAutomationHostCapabilitySchema())
         .min(1)
-        .max(BROWSER_AUTOMATION_OPERATIONS.length + 2),
+        .max(BROWSER_AUTOMATION_OPERATIONS.length + 3),
       maxPendingRequests: z
         .number()
         .int()
@@ -830,7 +843,7 @@ export const BrowserAutomationCredentialClaimsSchema = lazySchema(() =>
       operations: z
         .array(browserOperationSchema)
         .min(1)
-        .max(BROWSER_AUTOMATION_OPERATIONS.length + 2),
+        .max(BROWSER_AUTOMATION_OPERATIONS.length + 3),
       issuedAt: z.number().int().nonnegative(),
       expiresAt: z.number().int().nonnegative(),
     })
@@ -922,6 +935,39 @@ const actArgs = z.object({
   steps: z.array(BrowserAutomationActStepSchema()).min(1).max(BROWSER_AUTOMATION_ACT_MAX_STEPS),
 }).strict();
 
+const tabsMutationBase = {
+  idempotencyKey: idempotencyKeySchema,
+  observationRef: idSchema,
+};
+
+const tabsArgs = z.union([
+  z.object({ ...tabsMutationBase, action: z.literal("select"), tabId: idSchema }).strict(),
+  z.object({ ...tabsMutationBase, action: z.literal("claim"), tabId: idSchema }).strict(),
+  z.object({ ...tabsMutationBase, action: z.literal("release"), tabId: idSchema.optional() }).strict(),
+  z.object({ ...tabsMutationBase, action: z.literal("close"), tabId: idSchema.optional() }).strict(),
+  z.object({
+    ...tabsMutationBase,
+    action: z.literal("finalize"),
+    dispositions: z.array(z.object({
+      tabId: idSchema,
+      disposition: z.enum(["close", "release", "handoff", "deliverable"]),
+    }).strict()).max(BROWSER_AUTOMATION_MAX_INSPECT_TABS),
+  }).strict().superRefine((value, context) => {
+    if (new Set(value.dispositions.map((entry) => entry.tabId)).size !== value.dispositions.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Browser tab dispositions must identify unique tabs",
+        path: ["dispositions"],
+      });
+    }
+  }),
+]);
+
+/** One explicit Browser tab lifecycle mutation. */
+export const BrowserAutomationTabsArgsSchema = lazySchema(() => tabsArgs);
+/** Typed Browser tab lifecycle mutation. */
+export type BrowserAutomationTabsArgs = z.infer<ReturnType<typeof BrowserAutomationTabsArgsSchema>>;
+
 const requestVariant = <T extends BrowserAutomationOperation>(
   operation: T,
   args: z.ZodTypeAny,
@@ -1008,6 +1054,7 @@ export const BrowserAutomationRequestSchema = lazySchema(() =>
     ),
     requestVariant("recordingStop", emptyArgs),
     requestVariant("act", actArgs),
+    requestVariant("tabs", tabsArgs),
   ]),
 );
 
@@ -1051,6 +1098,27 @@ export const BrowserAutomationActResultSchema = lazySchema(() => z.object({
 /** Typed browser_act result. */
 export type BrowserAutomationActResult = z.infer<ReturnType<typeof BrowserAutomationActResultSchema>>;
 
+/** Normalized ownership state for one tab controlled by a provider session. */
+export const BrowserAutomationOwnedTabSchema = lazySchema(() => z.object({
+  tabId: idSchema,
+  provenance: z.enum(["agent-created", "claimed-user"]),
+  ownership: z.enum(["owned", "claimed", "released"]),
+  disposition: z.enum(["close", "release", "handoff", "deliverable"]).optional(),
+}).strict());
+/** Typed normalized Browser tab ownership state. */
+export type BrowserAutomationOwnedTab = z.infer<ReturnType<typeof BrowserAutomationOwnedTabSchema>>;
+
+/** Structured result for one browser_tabs lifecycle mutation. */
+export const BrowserAutomationTabsResultSchema = lazySchema(() => z.object({
+  operation: z.literal("tabs"),
+  action: z.enum(["select", "claim", "release", "close", "finalize"]),
+  currentTabId: idSchema.optional(),
+  observationRef: idSchema.optional(),
+  tabs: z.array(BrowserAutomationOwnedTabSchema()).max(BROWSER_AUTOMATION_MAX_INSPECT_TABS),
+}).strict());
+/** Typed browser_tabs result. */
+export type BrowserAutomationTabsResult = z.infer<ReturnType<typeof BrowserAutomationTabsResultSchema>>;
+
 /** Exhaustive operation-specific browser success result. */
 export const BrowserAutomationResultSchema = lazySchema(() =>
   z.discriminatedUnion("operation", [
@@ -1064,7 +1132,7 @@ export const BrowserAutomationResultSchema = lazySchema(() =>
       diagnostics: z.array(z.string().max(SHORT_TEXT_MAX)).max(BROWSER_AUTOMATION_MAX_DIAGNOSTIC_ENTRIES).optional(),
       observationRef: idSchema.optional(),
       capabilityRevision: z.number().int().positive().optional(),
-      capabilities: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 2).optional(),
+      capabilities: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 3).optional(),
       guidance: z.string().max(BROWSER_AUTOMATION_MAX_GUIDANCE_CHARS).optional(),
     }).strict(),
     z.object({
@@ -1077,7 +1145,7 @@ export const BrowserAutomationResultSchema = lazySchema(() =>
       focused: z.boolean(),
       viewport: z.object({ width: z.number().int().min(1).max(10_000), height: z.number().int().min(1).max(10_000) }).strict(),
       controller: BrowserAutomationControllerStateSchema().optional(),
-      capabilities: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 2).optional(),
+      capabilities: z.array(browserOperationSchema).max(BROWSER_AUTOMATION_OPERATIONS.length + 3).optional(),
       capabilityRevision: z.number().int().positive().optional(),
     }).strict(),
     z.object({
@@ -1104,6 +1172,7 @@ export const BrowserAutomationResultSchema = lazySchema(() =>
     z.object({ operation: z.literal("recordingStart"), recordingId: idSchema, startedAt: z.number().int().nonnegative(), controlEpoch: z.number().int().nonnegative() }).strict(),
     z.object({ operation: z.literal("recordingStop"), recordingId: idSchema, mediaType: z.literal("video/webm"), dataBase64: z.string().max(RECORDING_MAX_BASE64_CHARS).refine((value) => { const size = decodedBase64Size(value); return size !== null && size <= BROWSER_AUTOMATION_MAX_RECORDING_BYTES; }, "Recording must be valid base64 within 512 KiB decoded"), durationMs: z.number().int().nonnegative().max(RECORDING_MAX_DURATION_MS), truncation: BrowserAutomationTruncationSchema(), controlEpoch: z.number().int().nonnegative() }).strict(),
     BrowserAutomationActResultSchema(),
+    BrowserAutomationTabsResultSchema(),
   ]).superRefine((value, context) => {
     if (value.operation === "console" || value.operation === "network") {
       validateTruncation(value.truncation, value.entries.length, context, ["truncation"]);

--- a/packages/contracts/src/ws/__tests__/browser-automation-ws.test.ts
+++ b/packages/contracts/src/ws/__tests__/browser-automation-ws.test.ts
@@ -82,4 +82,19 @@ describe("browser automation WebSocket contracts", () => {
       reason: "deadline-exceeded",
     }).success).toBe(true);
   });
+
+  it("directs provider-session cleanup to the owning Browser host", () => {
+    expect(WS_CHANNELS["browserAutomation.sessionRelease"].safeParse({
+      hostId: "host-a",
+      generation: 1,
+      providerSessionId: "provider-a",
+      reason: "credential-revoked",
+    }).success).toBe(true);
+    expect(WS_CHANNELS["browserAutomation.sessionRelease"].safeParse({
+      hostId: "host-a",
+      generation: 1,
+      providerSessionId: "provider-a",
+      reason: "unknown",
+    }).success).toBe(false);
+  });
 });

--- a/packages/contracts/src/ws/channels.ts
+++ b/packages/contracts/src/ws/channels.ts
@@ -49,6 +49,15 @@ export const WS_CHANNELS = {
       reason: z.enum(["deadline-exceeded", "client-disconnected", "provider-cancelled", "user-stopped"]),
     })
     .strict(),
+  /** Settles every tab owned or claimed by one terminated provider session. */
+  "browserAutomation.sessionRelease": z
+    .object({
+      hostId: z.string().min(1).max(256),
+      generation: z.number().int().positive(),
+      providerSessionId: z.string().min(1).max(256),
+      reason: z.enum(["credential-revoked", "provider-session-ended"]),
+    })
+    .strict(),
   "agent.event": AgentEventSchema(),
   /**
    * @deprecated Legacy JSON format retained for backward compatibility.


### PR DESCRIPTION
## What
Add provider-session Browser tab ownership and disposition management through `browser_tabs`.

## Why
Issue #1047 requires bounded, generation-safe tab lifecycle control across web and Electron Browser hosts.

## Key Changes
- Add select, claim, release, close, and finalize lifecycle operations with idempotent replay.
- Enforce one sticky host and current tab, a three-agent-tab limit, and one session mutation at a time.
- Release claimed user tabs without auto-closing them; close agent-created tabs unless finalized for handoff or delivery.
- Settle owned tabs on credential revocation, provider termination, explicit close, and thread or workspace deletion.
- Normalize web and Electron outcomes while keeping runtime-specific physical cleanup.

## Verification
- Contracts: 88 tests passed.
- Server lifecycle: 76 tests passed.
- Web driver and host: 62 tests passed.
- Desktop kernel and bundle staging: 55 tests passed.
- Independent standards and specification reviews approved the final commits.
- `bun run verify`: typecheck and lint passed. Aggregate desktop units timed out in three unrelated slow files; those exact files passed in isolation, 19 tests passed.
- Live web app loaded and `/health` returned 200. Deeper Browser control disconnected after restart, and Electron dev startup did not pass its TypeScript watch settle barrier.

Closes #1047

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788332970&installation_model_id=20477&pr_number=1065&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1065&signature=2a0c5c4c81baeaaebdae2f1ae37c6e4cfb58c9bb98282b2c6cd49970abb905a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->