### PR TITLE
feat(browser): show active agent control

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
@@ -504,7 +504,7 @@ describe("BrowserAutomationKernel", () => {
     currentWebContents!.emit("did-start-navigation", {}, "https://example.test/next", false, true);
     await expect(kernel.execute(event(), payload(request("status", {}, { requestId: "status-after-click-navigation" })))).resolves.toMatchObject({
       ok: true,
-      result: { controller: { controller: "none", controlEpoch: 0 } },
+      result: { controller: { controller: "agent", controlEpoch: 0 } },
     });
     await vi.advanceTimersByTimeAsync(251);
     expect(kernel.interrupt(event(), { threadId: "thread", tabId: "tab" })).toBe(true);
@@ -557,6 +557,77 @@ describe("BrowserAutomationKernel", () => {
       expect.objectContaining({ kind: "pointer", count: 1 }),
     );
     unsubscribe();
+  });
+
+  it("retains agent control between Browser calls until the renderer releases the turn", async () => {
+    await expect(kernel.execute(event(), payload(request("press", {
+      key: "A",
+      modifiers: [],
+    }, { requestId: "retained-agent-control" })))).resolves.toMatchObject({ ok: true });
+
+    await expect(kernel.execute(event(), payload(request("status", {}, {
+      requestId: "status-during-agent-turn",
+    })))).resolves.toMatchObject({
+      ok: true,
+      result: { controller: { controller: "agent", controlEpoch: 0 } },
+    });
+
+    expect(kernel.releaseAgentControl(event(), {
+      threadId: "thread",
+      tabId: "tab",
+      controlEpoch: 0,
+      providerSessionId: "provider-session",
+    })).toBe(true);
+    await expect(kernel.execute(event(), payload(request("status", {}, {
+      requestId: "status-after-agent-turn",
+    })))).resolves.toMatchObject({
+      ok: true,
+      result: { controller: { controller: "none", controlEpoch: 0 } },
+    });
+  });
+
+  it("rejects sessionless and stale same-epoch releases after a newer inspect turn", async () => {
+    const oldInspect = {
+      ...request("inspect", {}, { requestId: "inspect-old-turn" }),
+      providerSessionId: "provider-session-old",
+    } as BrowserAutomationRequest;
+    const newInspect = {
+      ...request("inspect", {}, { requestId: "inspect-new-turn" }),
+      providerSessionId: "provider-session-new",
+    } as BrowserAutomationRequest;
+
+    await expect(kernel.execute(event(), payload(oldInspect))).resolves.toMatchObject({ ok: true });
+    await expect(kernel.execute(event(), payload(newInspect))).resolves.toMatchObject({ ok: true });
+
+    expect(kernel.releaseAgentControl(event(), {
+      threadId: "thread",
+      tabId: "tab",
+      controlEpoch: 0,
+    })).toBe(false);
+    expect(kernel.releaseAgentControl(event(), {
+      threadId: "thread",
+      tabId: "tab",
+      controlEpoch: 0,
+      providerSessionId: "provider-session-old",
+    })).toBe(false);
+    await expect(kernel.execute(event(), payload(request("status", {}, {
+      requestId: "status-after-stale-release",
+    })))).resolves.toMatchObject({
+      ok: true,
+      result: {
+        controller: {
+          controller: "agent",
+          controlEpoch: 0,
+          providerSessionId: "provider-session-new",
+        },
+      },
+    });
+    expect(kernel.releaseAgentControl(event(), {
+      threadId: "thread",
+      tabId: "tab",
+      controlEpoch: 0,
+      providerSessionId: "provider-session-new",
+    })).toBe(true);
   });
 
   it("distinguishes attached, visible, hidden, and detached wait states", async () => {

--- a/apps/desktop/src/main/browser-automation/index.ts
+++ b/apps/desktop/src/main/browser-automation/index.ts
@@ -11,6 +11,7 @@ export function registerBrowserAutomationHandlers(): void {
   ipcMain.handle("preview:automation.finish-renderer-operation", (event, payload: unknown) => kernel.finishRendererOperation(event, payload));
   ipcMain.handle("preview:automation.cancel", (_event, requestId: unknown) => kernel.cancel(requestId));
   ipcMain.handle("preview:automation.interrupt", (event, target: unknown) => kernel.interrupt(event, target));
+  ipcMain.handle("preview:automation.release-agent-control", (event, target: unknown) => kernel.releaseAgentControl(event, target));
   ipcMain.handle("preview:automation.describe-target", (event, target: unknown) => kernel.describeTarget(event, target));
   ipcMain.handle("preview:automation.media-source", (event, target: unknown) => kernel.getMediaSourceId(event, target));
   ipcMain.handle("preview:open-guest-devtools", (event, target: unknown) => kernel.openDevTools(event, target));

--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -701,11 +701,6 @@ export class BrowserAutomationKernel {
           });
         } finally {
           this.rendererOperationLeases.delete(leaseId);
-          if (
-            state.controller.controller === "agent" &&
-            state.controller.providerSessionId === request!.providerSessionId &&
-            state.controller.operation === request!.operation
-          ) this.emitController(state, "none");
         }
       });
       const cancellation = { cancel: scheduled.cancel };
@@ -776,6 +771,33 @@ export class BrowserAutomationKernel {
       state.controller.controller === "human"
     ) return false;
     this.humanInterrupt(state);
+    return true;
+  }
+
+  /** Releases retained agent presentation after its owning turn completes. */
+  releaseAgentControl(event: IpcMainInvokeEvent, target: unknown): boolean {
+    const input = asRecord(target);
+    let threadId: string;
+    let tabId: string;
+    let providerSessionId: string;
+    try {
+      threadId = assertShortId(input.threadId, "threadId");
+      tabId = assertShortId(input.tabId, "tabId");
+      providerSessionId = assertShortId(input.providerSessionId, "providerSessionId");
+    } catch {
+      return false;
+    }
+    if (!Number.isInteger(input.controlEpoch) || (input.controlEpoch as number) < 0) return false;
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return false;
+    const state = this.targets.get(targetKey(win.id, threadId, tabId));
+    if (
+      !state ||
+      state.controller.controller !== "agent" ||
+      state.controlEpoch !== input.controlEpoch ||
+      state.controller.providerSessionId !== providerSessionId
+    ) return false;
+    this.emitController(state, "none");
     return true;
   }
 
@@ -1120,8 +1142,13 @@ export class BrowserAutomationKernel {
       tabId: state.tabId,
       controller,
       controlEpoch: state.controlEpoch,
-      ...(request && request.operation !== "inspect" && request.operation !== "act" && request.operation !== "tabs"
-        ? { providerSessionId: request.providerSessionId, operation: request.operation }
+      ...(request
+        ? {
+            providerSessionId: request.providerSessionId,
+            ...(request.operation !== "inspect" && request.operation !== "act" && request.operation !== "tabs"
+              ? { operation: request.operation }
+              : {}),
+          }
         : {}),
       ...(pointer ? { pointer } : {}),
     };
@@ -1168,12 +1195,6 @@ export class BrowserAutomationKernel {
         ]);
       }
       state.syntheticInputDepth = 0;
-      if (
-        request.operation !== "status" &&
-        state.controller.controller === "agent" &&
-        state.controller.providerSessionId === request.providerSessionId &&
-        state.controller.operation === request.operation
-      ) this.emitController(state, "none");
     }
   }
 

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -355,6 +355,14 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       interrupt(target: { threadId: string; tabId: string }): Promise<boolean> {
         return ipcRenderer.invoke("preview:automation.interrupt", target);
       },
+      releaseAgentControl(target: {
+        threadId: string;
+        tabId: string;
+        controlEpoch: number;
+        providerSessionId: string;
+      }): Promise<boolean> {
+        return ipcRenderer.invoke("preview:automation.release-agent-control", target);
+      },
       describeTarget(target: { threadId: string; tabId: string }): Promise<unknown> {
         return ipcRenderer.invoke("preview:automation.describe-target", target);
       },

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -2,6 +2,10 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserTabSet } from "@mcode/contracts";
 import { rightPanelSingletonId, type RightPanelTab } from "@/stores/diffStore";
+import {
+  browserAutomationTargetKey,
+  useBrowserAutomationStore,
+} from "@/stores/browserAutomationStore";
 import { usePreviewSuppressionStore } from "@/stores/previewSuppressionStore";
 import { ActivityRail } from "./ActivityRail";
 
@@ -61,6 +65,7 @@ describe("ActivityRail expansion", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    useBrowserAutomationStore.setState({ controllers: new Map() });
     usePreviewSuppressionStore.setState({ count: 0 });
   });
 
@@ -79,15 +84,12 @@ describe("ActivityRail expansion", () => {
 
     act(() => vi.advanceTimersByTime(1));
     expect(rail).toHaveAttribute("data-expanded", "true");
-    expect(usePreviewSuppressionStore.getState().count).toBe(1);
-
     fireEvent.pointerLeave(rail, { pointerType: "mouse" });
     act(() => vi.advanceTimersByTime(EXPECTED_COLLAPSE_DELAY_MS - 1));
     expect(rail).toHaveAttribute("data-expanded", "true");
 
     act(() => vi.advanceTimersByTime(1));
     expect(rail).toHaveAttribute("data-expanded", "false");
-    expect(usePreviewSuppressionStore.getState().count).toBe(0);
   });
 
   it("keeps a fixed collapsed footprint above right-panel content", () => {
@@ -216,17 +218,40 @@ describe("ActivityRail expansion", () => {
     expect(rail).toHaveAttribute("data-expanded", "false");
   });
 
-  it("releases preview suppression when an expanded rail unmounts", () => {
+  it("floats the expanded rail above preview content without suppressing it", () => {
     const { unmount } = renderRail();
     const rail = screen.getByTestId("activity-rail");
 
     fireEvent.pointerEnter(rail, { pointerType: "mouse" });
     act(() => vi.advanceTimersByTime(EXPECTED_EXPAND_DELAY_MS));
-    expect(usePreviewSuppressionStore.getState().count).toBe(1);
+    expect(rail).toHaveAttribute("data-expanded", "true");
+    expect(rail).toHaveClass("z-30");
+    expect(usePreviewSuppressionStore.getState().count).toBe(0);
 
     unmount();
+  });
 
-    expect(usePreviewSuppressionStore.getState().count).toBe(0);
+  it("uses the amber pointer favicon and accessible name for an agent-controlled page", () => {
+    const page = browserTabSet.tabs[0]!;
+    useBrowserAutomationStore.setState({
+      controllers: new Map([
+        [
+          browserAutomationTargetKey(page.threadId, page.id),
+          { tabId: page.id, controller: "agent", controlEpoch: 1 },
+        ],
+      ]),
+    });
+
+    render(
+      <ActivityRail
+        {...railElement(["preview"]).props}
+        browserTabSet={browserTabSet}
+      />,
+    );
+
+    expect(screen.getByTestId("browser-agent-control-indicator")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Browser page: Example, agent controls Browser" })).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
   it("reorders only from a focused rail tab keyboard shortcut", () => {

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -5,7 +5,15 @@ import type {
   ReactNode,
 } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Globe, Maximize2, Minimize2, PanelRight, Plus, X } from "lucide-react";
+import {
+  Globe,
+  Maximize2,
+  Minimize2,
+  MousePointer2,
+  PanelRight,
+  Plus,
+  X,
+} from "lucide-react";
 import type { BrowserTabInfo, BrowserTabSet } from "@mcode/contracts";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -26,7 +34,10 @@ import {
   type PanelTabType,
 } from "@/lib/panel-tabs";
 import type { RightPanelTab, RightPanelTabInstance } from "@/stores/diffStore";
-import { usePreviewSuppressionStore } from "@/stores/previewSuppressionStore";
+import {
+  browserAutomationTargetKey,
+  useBrowserAutomationStore,
+} from "@/stores/browserAutomationStore";
 import { cn } from "@/lib/utils";
 
 /** Legacy task completion payload kept for tab API compatibility. */
@@ -350,6 +361,11 @@ function BrowserPageRailTab({
   onClose: (pageId: string) => void;
 }) {
   const label = pageLabel(page);
+  const agentControlled = useBrowserAutomationStore(
+    (state) =>
+      state.controllers.get(browserAutomationTargetKey(page.threadId, page.id))
+        ?.controller === "agent",
+  );
   return (
     <div className="group relative w-full">
       <Button
@@ -362,7 +378,7 @@ function BrowserPageRailTab({
         // The live page (active, and Browser owns the panel) is the current
         // page in the switcher; expose that beyond the visual lamp.
         aria-current={active && browserActive ? "page" : undefined}
-        aria-label={`Browser page: ${label}`}
+        aria-label={`Browser page: ${label}${agentControlled ? ", agent controls Browser" : ""}`}
         title={expanded ? undefined : label}
         onClick={() => onSelect(page.id)}
         className={cn(
@@ -374,7 +390,14 @@ function BrowserPageRailTab({
               : "text-foreground/70 hover:bg-card/60 hover:text-foreground",
         )}
       >
-        {page.faviconUrl ? (
+        {agentControlled ? (
+          <MousePointer2
+            data-testid="browser-agent-control-indicator"
+            size={17}
+            className="text-amber-500"
+            aria-hidden
+          />
+        ) : page.faviconUrl ? (
           <img src={page.faviconUrl} alt="" width={17} height={17} className="rounded-[3px]" />
         ) : (
           <Globe size={17} />
@@ -661,14 +684,6 @@ export function ActivityRail({
       if (!pointerWithinRef.current && !focusWithin) setExpanded(false);
     }, RAIL_COLLAPSE_DELAY_MS);
   }, [clearCollapseTimer, clearExpandTimer]);
-
-  const incrementPreviewSuppression = usePreviewSuppressionStore((s) => s.increment);
-  const decrementPreviewSuppression = usePreviewSuppressionStore((s) => s.decrement);
-  useEffect(() => {
-    if (!expanded) return;
-    incrementPreviewSuppression();
-    return () => decrementPreviewSuppression();
-  }, [decrementPreviewSuppression, expanded, incrementPreviewSuppression]);
 
   useEffect(
     () => () => {

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -15,6 +15,7 @@ import {
 } from "@mcode/contracts";
 import { getTransport, pushEmitter } from "@/transport";
 import { useConnectionStore } from "@/stores/connectionStore";
+import { useThreadStore } from "@/stores/threadStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import {
   browserAutomationRequestKey,
@@ -99,6 +100,31 @@ function failureResponse(
       correlationId: globalThis.crypto.randomUUID(),
     },
   };
+}
+
+function projectAgentControl(dispatch: BrowserAutomationHostDispatch): void {
+  if (
+    window.desktopBridge?.preview?.automation ||
+    dispatch.request.operation === "status" ||
+    !useThreadStore.getState().runningThreadIds.has(dispatch.target.threadId)
+  ) return;
+  useBrowserAutomationStore.getState().setControllerForTarget(
+    dispatch.target.threadId,
+    dispatch.target.tabId,
+    {
+      tabId: dispatch.target.tabId,
+      controller: "agent",
+      controlEpoch: dispatch.request.expectedControlEpoch,
+      providerSessionId: dispatch.request.providerSessionId,
+      ...(dispatch.request.operation !== "inspect" &&
+      dispatch.request.operation !== "act" &&
+      dispatch.request.operation !== "tabs"
+        ? {
+            operation: dispatch.request.operation,
+          }
+        : {}),
+    },
+  );
 }
 
 async function afterBrowserLayout(): Promise<void> {
@@ -570,6 +596,7 @@ function PersistentAutomationPreviewSurface({
  */
 export function BrowserAutomationHost() {
   const connectionStatus = useConnectionStore((state) => state.status);
+  const runningThreadIds = useThreadStore((state) => state.runningThreadIds);
   const workspaces = useWorkspaceStore((state) => state.workspaces);
   const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
   const liveTargets = useBrowserAutomationStore((state) => state.liveTargets);
@@ -974,6 +1001,7 @@ export function BrowserAutomationHost() {
       inFlightRef.current.set(key, dispatch);
       const store = useBrowserAutomationStore.getState();
       store.setActiveRequest({ dispatch, startedAt: Date.now() });
+      projectAgentControl(dispatch);
       const controller = new AbortController();
       requestAbortRef.current.set(key, controller);
       const webDispatch = !bridge && webAutomationEnabled &&
@@ -1399,6 +1427,7 @@ export function BrowserAutomationHost() {
               },
             }
           : dispatch;
+        projectAgentControl(executionDispatch);
         const response = await sessionDriverRef.current!.execute(executionDispatch, controller.signal);
         await restoreBackgroundContext();
         if (leaseRef.current === lease && !cancelledRef.current.has(key)) {
@@ -1451,12 +1480,13 @@ export function BrowserAutomationHost() {
     const bridge = window.desktopBridge?.preview?.automation;
     if (!bridge) return;
     return bridge.onControllerChanged((controller) => {
-      useBrowserAutomationStore.getState().setController(controller);
-      if (controller.controller !== "human") return;
+      const store = useBrowserAutomationStore.getState();
       const target = resolveBrowserAutomationControllerTarget(
-        useBrowserAutomationStore.getState().liveTargets.values(),
+        store.liveTargets.values(),
         controller,
       );
+      store.setController(controller);
+      if (controller.controller !== "human") return;
       if (!target) return;
       recorderRef.current.disposeTarget(target.threadId, target.tabId);
       for (const dispatch of inFlightRef.current.values()) {
@@ -1468,6 +1498,31 @@ export function BrowserAutomationHost() {
       }
     });
   }, [cancelHostedRequest]);
+
+  useEffect(() => {
+    const store = useBrowserAutomationStore.getState();
+    for (const [targetKey, controller] of store.controllers) {
+      if (controller.controller !== "agent") continue;
+      const target = store.liveTargets.get(targetKey);
+      if (!target || runningThreadIds.has(target.threadId)) continue;
+      if (!controller.providerSessionId) continue;
+      const bridge = window.desktopBridge?.preview?.automation;
+      if (bridge) {
+        void bridge.releaseAgentControl({
+          threadId: target.threadId,
+          tabId: target.tabId,
+          controlEpoch: controller.controlEpoch,
+          providerSessionId: controller.providerSessionId,
+        });
+      } else {
+        store.setControllerForTarget(target.threadId, target.tabId, {
+          tabId: target.tabId,
+          controller: "none",
+          controlEpoch: controller.controlEpoch,
+        });
+      }
+    }
+  }, [runningThreadIds]);
 
   useEffect(() => onBrowserAutomationInterruption((threadId, tabId, reason) => {
     recorderRef.current.disposeTarget(threadId, tabId);

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -19,6 +19,8 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import {
   browserAutomationRequestKey,
   browserAutomationTargetKey,
+  invalidateBrowserAutomationTargetObservation,
+  onBrowserAutomationObservationInvalidation,
   onBrowserAutomationInterruption,
   onBrowserAutomationScopeRelease,
   resolveBrowserAutomationControllerTarget,
@@ -591,7 +593,6 @@ export function BrowserAutomationHost() {
   const requestAbortRef = useRef(new Map<string, AbortController>());
   const webAbortRef = useRef(new Map<string, AbortController>());
   const webObserverRef = useRef(new Map<string, () => void>());
-  const webHumanCancelRef = useRef(new Map<string, () => void>());
   const webNavigationRef = useRef(new Map<string, WebNavigationExpectation>());
   const bootstrapPendingRef = useRef(new Set<string>());
   const bootstrapAbortRef = useRef(new Map<string, AbortController>());
@@ -653,7 +654,7 @@ export function BrowserAutomationHost() {
         const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
         return useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision ?? 0;
       },
-      onHumanInput: (dispatch) => webHumanCancelRef.current.get(browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence))?.(),
+      onHumanInput: (dispatch) => invalidateBrowserAutomationTargetObservation(dispatch.target.threadId, dispatch.target.tabId),
       onObserver: (dispatch, dispose) => webObserverRef.current.set(browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence), dispose),
       executeNonInteraction: (dispatch, signal) => executeBrowserDispatch(undefined, recorderRef.current, dispatch, signal, executorDescriptor.operations),
     });
@@ -1014,25 +1015,6 @@ export function BrowserAutomationHost() {
           }
         }
       }
-      const cancelForHuman = () => {
-        if (!operationAbort || cancelledRef.current.has(key)) return;
-        cancelledRef.current.add(key);
-        operationAbort.abort(new Error("Browser operation was interrupted by human input"));
-        const nextEpoch = (useBrowserAutomationStore.getState().controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch) + 1;
-        useBrowserAutomationStore.getState().setControllerForTarget(
-          dispatch.target.threadId,
-          dispatch.target.tabId,
-          { tabId: dispatch.target.tabId, controller: "human", controlEpoch: nextEpoch },
-        );
-        void getTransport().cancelBrowserAutomationRequest(
-          lease.hostId,
-          lease.generation,
-          dispatch.request.requestId,
-          dispatch.request.sequence,
-          "human-interrupted",
-        ).catch(() => undefined);
-      };
-      if (webDispatch) webHumanCancelRef.current.set(key, cancelForHuman);
       const executeWeb = async (): Promise<BrowserAutomationResponse> => {
         if (staleAtStart) {
           return failureResponse(dispatch.request, !liveTarget || liveTarget.revision !== dispatch.target.targetGeneration ? "STALE_TARGET_GENERATION" : "STALE_CONTROL_EPOCH", "Browser operation is stale");
@@ -1151,7 +1133,6 @@ export function BrowserAutomationHost() {
       }).catch(() => undefined).finally(() => {
         webObserverRef.current.get(key)?.();
         webObserverRef.current.delete(key);
-        webHumanCancelRef.current.delete(key);
         webAbortRef.current.delete(key);
         webNavigationRef.current.delete(key);
         if (inFlightRef.current.get(key) === dispatch) inFlightRef.current.delete(key);
@@ -1462,6 +1443,10 @@ export function BrowserAutomationHost() {
     });
   }, []);
 
+  useEffect(() => onBrowserAutomationObservationInvalidation((threadId, tabId) => {
+    sessionDriverRef.current?.invalidateTargetObservations(threadId, tabId);
+  }), []);
+
   useEffect(() => {
     const bridge = window.desktopBridge?.preview?.automation;
     if (!bridge) return;
@@ -1574,7 +1559,6 @@ export function BrowserAutomationHost() {
     for (const dispose of webObserverRef.current.values()) dispose();
     webAbortRef.current.clear();
     webObserverRef.current.clear();
-    webHumanCancelRef.current.clear();
     for (const tab of persistentWebTabsRef.current.values()) {
       usePreviewTabsStore.getState().removePersistentTab(tab.threadId, tab.tabId);
     }

--- a/apps/web/src/components/panels/BrowserHeader.tsx
+++ b/apps/web/src/components/panels/BrowserHeader.tsx
@@ -4,13 +4,9 @@ import {
   ArrowRight,
   ArrowUpRight,
   Camera,
-  Bot,
-  Hand,
   PenTool,
   RotateCw,
-  Square,
 } from "lucide-react";
-import type { BrowserAutomationControllerState } from "@mcode/contracts";
 import { cn } from "@/lib/utils";
 import { ICON_HIT_SLOP } from "@/lib/ui-hit-target";
 import { Button } from "@/components/ui/button";
@@ -77,14 +73,6 @@ export interface BrowserHeaderProps {
   readonly onOpenDevTools?: () => void;
   /** Whether overflow overlays must hide the native preview layer. */
   readonly suppressPreviewForOverlays?: boolean;
-  /** Current controller for the active visible Browser tab. */
-  readonly automationController?: BrowserAutomationControllerState | null;
-  /** True while the active tab owns an in-flight browser operation. */
-  readonly automationBusy?: boolean;
-  /** Stop only the active tab's browser operation. */
-  readonly onStopAutomation?: () => void;
-  /** Transfer browser control when the human focuses the omnibox. */
-  readonly onHumanFocus?: () => void;
 }
 
 /**
@@ -130,10 +118,6 @@ export function BrowserHeader({
   onSetZoom,
   onOpenDevTools = () => undefined,
   suppressPreviewForOverlays = true,
-  automationController = null,
-  automationBusy = false,
-  onStopAutomation,
-  onHumanFocus,
 }: BrowserHeaderProps) {
   const {
     displayValue,
@@ -270,7 +254,6 @@ export function BrowserHeader({
             onChange={(e) => onChange(e.target.value)}
             onFocus={() => {
               setFocused(true);
-              onHumanFocus?.();
               onFocus();
             }}
             onBlur={() => {
@@ -324,37 +307,6 @@ export function BrowserHeader({
       </div>
 
       {/* Right cluster: page actions (loaded) + the overflow kebab. */}
-      {automationController && automationController.controller !== "none" ? (
-        <div
-          className={cn(
-            "flex h-7 shrink-0 items-center gap-1 rounded-sm border px-1.5 text-[11px] font-medium",
-            automationController.controller === "agent"
-              ? "border-amber-500/35 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-              : "border-border/60 bg-muted/50 text-muted-foreground",
-          )}
-          role="status"
-          aria-live="polite"
-          data-testid="browser-controller-badge"
-        >
-          {automationController.controller === "agent" ? (
-            <Bot size={13} aria-hidden />
-          ) : (
-            <Hand size={13} aria-hidden />
-          )}
-          <span>{automationController.controller === "agent" ? "Agent" : "You"}</span>
-          {automationController.controller === "agent" && automationBusy && onStopAutomation ? (
-            <button
-              type="button"
-              className="ml-0.5 inline-flex size-5 items-center justify-center rounded-sm text-current hover:bg-amber-500/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              onClick={onStopAutomation}
-              aria-label="Stop browser automation"
-              title="Stop browser automation"
-            >
-              <Square size={10} fill="currentColor" aria-hidden />
-            </button>
-          ) : null}
-        </div>
-      ) : null}
       {hasLoadedPage ? (
         <>
           <Tooltip>

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -2752,12 +2752,18 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
         {agentControlsBrowser ? (
           <div
             data-testid="browser-automation-overlay"
-            className="pointer-events-none absolute inset-0 z-20"
+            className="pointer-events-none absolute inset-0 z-20 rounded-tl-md border-2 border-primary"
             style={{
+              backgroundImage: [
+                "linear-gradient(to right, color-mix(in oklab, var(--primary) 26%, transparent), transparent 32px)",
+                "linear-gradient(to left, color-mix(in oklab, var(--primary) 26%, transparent), transparent 32px)",
+                "linear-gradient(to bottom, color-mix(in oklab, var(--primary) 26%, transparent), transparent 32px)",
+                "linear-gradient(to top, color-mix(in oklab, var(--primary) 26%, transparent), transparent 32px)",
+              ].join(", "),
               boxShadow: [
-                "inset 0 0 0 1px color-mix(in oklab, var(--primary) 28%, transparent)",
-                "inset 0 0 28px color-mix(in oklab, var(--primary) 12%, transparent)",
-                "0 0 20px color-mix(in oklab, var(--primary) 10%, transparent)",
+                "inset 0 0 0 1px color-mix(in oklab, var(--primary) 88%, white 12%)",
+                "inset 0 0 40px color-mix(in oklab, var(--primary) 30%, transparent)",
+                "0 0 24px color-mix(in oklab, var(--primary) 28%, transparent)",
               ].join(", "),
             }}
           >

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -18,6 +18,7 @@ import {
   Globe,
   GripVertical,
   Link2,
+  MousePointer2,
   Pipette,
   SlidersHorizontal,
   Trash2,
@@ -75,7 +76,7 @@ import type { MentionSuggestion } from "@/components/chat/useFileAutocomplete";
 import { useWorkspaceThread } from "@/stores/workspace-selectors";
 import {
   browserAutomationTargetKey,
-  interruptBrowserAutomationTarget,
+  invalidateBrowserAutomationTargetObservation,
   selectWarmBrowserTabIds,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
@@ -1899,19 +1900,8 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
   const activeAutomationController = automationControllers.get(
     browserAutomationTargetKey(threadId, activeWebviewTabId),
   );
-  const activeAutomationRequest = [...automationActiveRequests.values()].find(
-    ({ dispatch }) =>
-      dispatch.target.threadId === threadId && dispatch.target.tabId === activeWebviewTabId,
-  );
-  const automationPointer = (() => {
-    if (activeAutomationController?.pointer) return activeAutomationController.pointer;
-    const request = activeAutomationRequest?.dispatch.request;
-    if (!request || !("target" in request.args)) return null;
-    const target = request.args.target;
-    return target && "x" in target && "y" in target
-      ? { x: target.x, y: target.y }
-      : null;
-  })();
+  const agentControlsBrowser = activeAutomationController?.controller === "agent";
+  const automationPointer = activeAutomationController?.pointer ?? null;
   const activeWebviewRef = useCallback(
     (): PreviewWebviewHandle | null =>
       webviewRefs.current[activeWebviewTabId] ?? null,
@@ -2608,30 +2598,30 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
             regionBusy={capture.regionBusy}
             focusRequest={omniboxFocusTick}
             onNavigate={(url) => {
-              interruptBrowserAutomationTarget(threadId, activeWebviewTabId, "human-interrupted");
+              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
               effectiveNavigate(url);
             }}
             onGoBack={() => {
-              interruptBrowserAutomationTarget(threadId, activeWebviewTabId, "human-interrupted");
+              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
               effectiveGoBack();
             }}
             onGoForward={() => {
-              interruptBrowserAutomationTarget(threadId, activeWebviewTabId, "human-interrupted");
+              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
               effectiveGoForward();
             }}
             onReload={() => {
-              interruptBrowserAutomationTarget(threadId, activeWebviewTabId, "human-interrupted");
+              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
               effectiveReload();
             }}
             onOpenExternal={effectiveOpenExternal}
             onToggleDesign={onToggleDesignMode}
             onScreenshot={capture.onAddPictureReference}
             onNewPage={() => {
-              interruptBrowserAutomationTarget(threadId, activeWebviewTabId, "human-interrupted");
+              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
               tabs.newTab();
             }}
             onForceReload={() => {
-              interruptBrowserAutomationTarget(threadId, activeWebviewTabId, "human-interrupted");
+              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
               effectiveForceReload();
             }}
             onRegionCapture={capture.onAddRegionPictureReference}
@@ -2647,19 +2637,6 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
               });
             }}
             suppressPreviewForOverlays={!showWebviewPreview}
-            automationController={activeAutomationController ?? null}
-            automationBusy={activeAutomationRequest !== undefined}
-            onHumanFocus={() => {
-              if (activeAutomationController?.controller !== "agent") return;
-              interruptBrowserAutomationTarget(threadId, activeWebviewTabId, "human-interrupted");
-            }}
-            onStopAutomation={() =>
-              interruptBrowserAutomationTarget(
-                threadId,
-                activeWebviewTabId,
-                "user-stopped",
-              )
-            }
           />
         )}
       </div>
@@ -2772,13 +2749,34 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
             ))}
           </div>
         ) : null}
-        {activeAutomationController?.controller === "agent" && automationPointer ? (
+        {agentControlsBrowser ? (
           <div
-            data-testid="browser-automation-pointer"
-            className="pointer-events-none absolute z-20 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-amber-200 bg-amber-500 shadow-sm motion-reduce:transition-none"
-            style={{ left: automationPointer.x, top: automationPointer.y }}
-            aria-hidden
-          />
+            data-testid="browser-automation-overlay"
+            className="pointer-events-none absolute inset-0 z-20"
+            style={{
+              boxShadow: [
+                "inset 0 0 0 1px color-mix(in oklab, var(--primary) 28%, transparent)",
+                "inset 0 0 28px color-mix(in oklab, var(--primary) 12%, transparent)",
+                "0 0 20px color-mix(in oklab, var(--primary) 10%, transparent)",
+              ].join(", "),
+            }}
+          >
+            <span className="sr-only" role="status" aria-live="polite">
+              Agent controls Browser
+            </span>
+            {automationPointer ? (
+              <MousePointer2
+                data-testid="browser-automation-pointer"
+                className="absolute size-5 fill-primary text-primary motion-reduce:transition-none"
+                style={{
+                  left: automationPointer.x,
+                  top: automationPointer.y,
+                  filter: "drop-shadow(0 0 5px color-mix(in oklab, var(--primary) 72%, transparent)) drop-shadow(0 2px 5px rgb(0 0 0 / 0.35))",
+                }}
+                aria-hidden
+              />
+            ) : null}
+          </div>
         ) : null}
         {visiblePageAnnotations.map((annotation) => {
           const targetLabel =

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import type { PreviewPageStatus } from "@mcode/contracts";
 import {
-  interruptBrowserAutomationTarget,
+  invalidateBrowserAutomationTargetObservation,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
 
@@ -372,7 +372,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       if (!message || typeof message !== "object" || Array.isArray(message)) return;
       const kind = (message as { kind?: unknown }).kind;
       if (typeof kind !== "string" || !HUMAN_INPUT_KINDS.has(kind)) return;
-      interruptBrowserAutomationTarget(threadId, tabId, "human-interrupted");
+      invalidateBrowserAutomationTargetObservation(threadId, tabId);
     };
     el.addEventListener("did-start-loading", onStart);
     el.addEventListener("dom-ready", onDomReady);

--- a/apps/web/src/components/panels/RightPanel.test.tsx
+++ b/apps/web/src/components/panels/RightPanel.test.tsx
@@ -1,7 +1,7 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { activatePreviewPage, previewTabSet } = vi.hoisted(() => ({
+const { activatePreviewPage, previewTabSet, previewTabsBridge } = vi.hoisted(() => ({
   activatePreviewPage: vi.fn(),
   previewTabSet: { current: null as {
     threadId: string;
@@ -16,6 +16,11 @@ const { activatePreviewPage, previewTabSet } = vi.hoisted(() => ({
       active: boolean;
     }>;
   } | null },
+  previewTabsBridge: {
+    list: vi.fn(),
+    onUpdated: vi.fn(),
+    updatedListener: { current: null as ((payload: unknown) => void) | null },
+  },
 }));
 
 vi.mock("./ActivityRail", () => ({
@@ -45,7 +50,15 @@ vi.mock("@/components/terminal/TerminalPoolSlotContext", () => ({
 }));
 vi.mock("@/stores/previewTabsStore", () => ({
   usePreviewDisplayTabSet: () => previewTabSet.current,
-  usePreviewTabsStore: { getState: () => ({ activatePage: activatePreviewPage, closePage: vi.fn() }) },
+  usePreviewTabsStore: {
+    getState: () => ({
+      activatePage: activatePreviewPage,
+      closePage: vi.fn(),
+      setTabSet: (_scopeId: string, tabSet: typeof previewTabSet.current) => {
+        previewTabSet.current = tabSet;
+      },
+    }),
+  },
 }));
 vi.mock("@/lib/ensure-terminal", () => ({ createTerminalForScope: vi.fn() }));
 vi.mock("@/lib/right-panel-layout", () => ({ toggleRightPanelAdaptive: vi.fn() }));
@@ -61,6 +74,25 @@ describe("RightPanel", () => {
   beforeEach(() => {
     previewTabSet.current = null;
     activatePreviewPage.mockReset();
+    previewTabsBridge.list.mockReset();
+    previewTabsBridge.list.mockResolvedValue({ ok: true, data: null });
+    previewTabsBridge.updatedListener.current = null;
+    previewTabsBridge.onUpdated.mockReset();
+    previewTabsBridge.onUpdated.mockImplementation((listener: (payload: unknown) => void) => {
+      previewTabsBridge.updatedListener.current = listener;
+      return vi.fn();
+    });
+    Object.defineProperty(window, "desktopBridge", {
+      configurable: true,
+      value: {
+        preview: {
+          tabs: {
+            list: previewTabsBridge.list,
+            onUpdated: previewTabsBridge.onUpdated,
+          },
+        },
+      },
+    });
     useWorkspaceStore.setState({ activeWorkspaceId: "workspace-1", activeThreadId: null });
     useTerminalStore.setState({ terminals: {}, terminalPanelByThread: {}, ptyToThread: {} });
     useDiffStore.setState({
@@ -164,6 +196,69 @@ describe("RightPanel", () => {
       activeTab: "preview",
     });
     expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "browser-tab-1");
+  });
+
+  it("subscribes while empty so an Electron-created Browser page replaces the default screen", async () => {
+    const { rerender } = render(<RightPanel />);
+
+    act(() => useDiffStore.getState().showRightPanel("workspace-1"));
+    expect(screen.getByTestId("panel-empty-state")).toBeInTheDocument();
+
+    await waitFor(() => expect(previewTabsBridge.updatedListener.current).toBeTypeOf("function"));
+    act(() => {
+      previewTabsBridge.updatedListener.current?.({
+        threadId: "workspace-1",
+        activeTabId: "browser-tab-1",
+        tabs: [{
+          id: "browser-tab-1",
+          threadId: "workspace-1",
+          title: "Agent page",
+          url: "https://example.test",
+          faviconUrl: null,
+          warm: true,
+          active: true,
+        }],
+      });
+    });
+    rerender(<RightPanel />);
+
+    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
+    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+  });
+
+  it("replaces an already-visible default screen when Electron publishes a Browser page", async () => {
+    useDiffStore.setState({
+      rightPanelFallbackByWorkspace: {
+        "workspace-1": createRightPanelState({
+          visible: true,
+          width: 400,
+          openTabs: [],
+        }),
+      },
+    });
+    const { rerender } = render(<RightPanel />);
+    expect(screen.getByTestId("panel-empty-state")).toBeInTheDocument();
+
+    await waitFor(() => expect(previewTabsBridge.updatedListener.current).toBeTypeOf("function"));
+    act(() => {
+      previewTabsBridge.updatedListener.current?.({
+        threadId: "workspace-1",
+        activeTabId: "browser-tab-1",
+        tabs: [{
+          id: "browser-tab-1",
+          threadId: "workspace-1",
+          title: "Agent page",
+          url: "https://example.test",
+          faviconUrl: null,
+          warm: true,
+          active: true,
+        }],
+      });
+    });
+    rerender(<RightPanel />);
+
+    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
+    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
   });
 
   it("does not let a background Browser page alter an existing active panel tab", () => {

--- a/apps/web/src/components/panels/RightPanel.test.tsx
+++ b/apps/web/src/components/panels/RightPanel.test.tsx
@@ -1,11 +1,30 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const { activatePreviewPage, previewTabSet } = vi.hoisted(() => ({
+  activatePreviewPage: vi.fn(),
+  previewTabSet: { current: null as {
+    threadId: string;
+    activeTabId: string | null;
+    tabs: Array<{
+      id: string;
+      threadId: string;
+      title: string | null;
+      url: string | null;
+      faviconUrl: string | null;
+      warm: boolean;
+      active: boolean;
+    }>;
+  } | null },
+}));
+
 vi.mock("./ActivityRail", () => ({
-  ActivityRail: () => <div data-testid="activity-rail" />,
+  ActivityRail: ({ tabInstances, activeTabId }: { tabInstances: Array<{ type: string }>; activeTabId: string | null }) => (
+    <div data-testid="activity-rail" data-open-tabs={tabInstances.map((instance) => instance.type).join(",")} data-active-tab-id={activeTabId} />
+  ),
 }));
 vi.mock("./PanelEmptyState", () => ({
-  PanelEmptyState: () => <div />,
+  PanelEmptyState: () => <div data-testid="panel-empty-state" />,
 }));
 vi.mock("./ResizableRightPanel", () => ({
   ResizableRightPanel: ({ children, testId }: { children: React.ReactNode; testId?: string }) => (
@@ -20,13 +39,13 @@ vi.mock("./CoordinationPanel", () => ({
 }));
 vi.mock("./plan", () => ({ PlanPanel: () => <div /> }));
 vi.mock("@/components/diff", () => ({ DiffPanel: () => <div /> }));
-vi.mock("@/components/panels/PreviewPanel", () => ({ PreviewPanel: () => <div /> }));
+vi.mock("@/components/panels/PreviewPanel", () => ({ PreviewPanel: () => <div data-testid="preview-panel" /> }));
 vi.mock("@/components/terminal/TerminalPoolSlotContext", () => ({
   TerminalPoolSlot: () => <div data-testid="terminal-pool-slot" />,
 }));
 vi.mock("@/stores/previewTabsStore", () => ({
-  usePreviewDisplayTabSet: () => null,
-  usePreviewTabsStore: { getState: () => ({ activatePage: vi.fn(), closePage: vi.fn() }) },
+  usePreviewDisplayTabSet: () => previewTabSet.current,
+  usePreviewTabsStore: { getState: () => ({ activatePage: activatePreviewPage, closePage: vi.fn() }) },
 }));
 vi.mock("@/lib/ensure-terminal", () => ({ createTerminalForScope: vi.fn() }));
 vi.mock("@/lib/right-panel-layout", () => ({ toggleRightPanelAdaptive: vi.fn() }));
@@ -40,6 +59,8 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 describe("RightPanel", () => {
   beforeEach(() => {
+    previewTabSet.current = null;
+    activatePreviewPage.mockReset();
     useWorkspaceStore.setState({ activeWorkspaceId: "workspace-1", activeThreadId: null });
     useTerminalStore.setState({ terminals: {}, terminalPanelByThread: {}, ptyToThread: {} });
     useDiffStore.setState({
@@ -80,5 +101,101 @@ describe("RightPanel", () => {
     render(<RightPanel />);
 
     expect(screen.getByTestId("coordination-panel-integration")).toHaveTextContent("workspace-1:thread-1");
+  });
+
+  it("reveals an existing Browser page when the user opens an empty hidden panel", () => {
+    previewTabSet.current = {
+      threadId: "workspace-1",
+      activeTabId: "browser-tab-1",
+      tabs: [{
+        id: "browser-tab-1",
+        threadId: "workspace-1",
+        title: "Background page",
+        url: "https://example.test",
+        faviconUrl: null,
+        warm: true,
+        active: true,
+      }],
+    };
+
+    render(<RightPanel />);
+    expect(useDiffStore.getState().getRightPanelVisible("workspace-1")).toBe(false);
+    expect(useDiffStore.getState().getRightPanel("workspace-1").openTabs).toEqual([]);
+
+    act(() => useDiffStore.getState().showRightPanel("workspace-1"));
+
+    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
+    expect(screen.getByTestId("activity-rail")).toHaveAttribute("data-open-tabs", "preview");
+    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+    expect(useDiffStore.getState().getRightPanel("workspace-1")).toMatchObject({
+      visible: true,
+      openTabs: ["preview"],
+      activeTab: "preview",
+    });
+    expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "browser-tab-1");
+  });
+
+  it("reveals a Browser page that is published after the empty panel opens", () => {
+    const { rerender } = render(<RightPanel />);
+
+    act(() => useDiffStore.getState().showRightPanel("workspace-1"));
+    expect(screen.getByTestId("panel-empty-state")).toBeInTheDocument();
+
+    previewTabSet.current = {
+      threadId: "workspace-1",
+      activeTabId: "browser-tab-1",
+      tabs: [{
+        id: "browser-tab-1",
+        threadId: "workspace-1",
+        title: "Background page",
+        url: "https://example.test",
+        faviconUrl: null,
+        warm: true,
+        active: true,
+      }],
+    };
+    rerender(<RightPanel />);
+
+    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
+    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+    expect(useDiffStore.getState().getRightPanel("workspace-1")).toMatchObject({
+      visible: true,
+      openTabs: ["preview"],
+      activeTab: "preview",
+    });
+    expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "browser-tab-1");
+  });
+
+  it("does not let a background Browser page alter an existing active panel tab", () => {
+    previewTabSet.current = {
+      threadId: "workspace-1",
+      activeTabId: "browser-tab-1",
+      tabs: [{
+        id: "browser-tab-1",
+        threadId: "workspace-1",
+        title: "Background page",
+        url: "https://example.test",
+        faviconUrl: null,
+        warm: true,
+        active: true,
+      }],
+    };
+    useDiffStore.setState({
+      rightPanelFallbackByWorkspace: {
+        "workspace-1": createRightPanelState({
+          visible: true,
+          width: 400,
+          openTabs: ["changes"],
+          activeTab: "changes",
+        }),
+      },
+    });
+
+    render(<RightPanel />);
+
+    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
+    expect(screen.getByTestId("activity-rail")).toHaveAttribute("data-open-tabs", "changes");
+    expect(useDiffStore.getState().getRightPanel("workspace-1").activeTab).toBe("changes");
+    expect(activatePreviewPage).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -18,10 +18,7 @@ import { ActivityRail, type ScopeProgress } from "./ActivityRail";
 import type { PanelScope } from "@/lib/panel-tabs";
 import { DiffPanel } from "@/components/diff";
 import { PreviewPanel } from "@/components/panels/PreviewPanel";
-import {
-  usePreviewDisplayTabSet,
-  usePreviewTabsStore,
-} from "@/stores/previewTabsStore";
+import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { TerminalPoolSlot } from "@/components/terminal/TerminalPoolSlotContext";
 import { createTerminalForScope } from "@/lib/ensure-terminal";
 import {
@@ -37,6 +34,7 @@ import {
   BROWSER_AUTOMATION_WARM_TARGET_LIMIT,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
+import { usePreviewTabSet } from "./hooks/usePreviewTabs";
 
 /** One thread/workspace Browser panel retained by the warm LRU pool. */
 export interface WarmPreviewScope {
@@ -152,9 +150,6 @@ export function RightPanel() {
       ? s.getRightPanelVisible(activeWorkspaceId, activeThreadId)
       : false,
   );
-  const previousPanelVisible = useRef(panelVisible);
-  const panelWasJustOpened = panelVisible && !previousPanelVisible.current;
-  const [awaitingBrowserReveal, setAwaitingBrowserReveal] = useState(false);
 
   // The Terminal and Preview tabs bind to the active thread, or to the
   // workspace itself in the threadless new-thread view (where they run against
@@ -194,15 +189,13 @@ export function RightPanel() {
   // page entries (and the active-page favicon glyph) even while another tab is
   // active. Null in web builds with no bridge, where the rail keeps the single
   // Browser glyph.
-  const browserTabSet = usePreviewDisplayTabSet(panelScopeId);
+  const browserTabSet = usePreviewTabSet(panelScopeId);
 
-  // A Browser tab can be created while this panel is hidden. Keep that agent
-  // activity background-only, then project the existing Browser tab on the
-  // first render after a human opens an otherwise empty panel. The layout
-  // effect persists the projection after the derived render has prevented the
-  // empty-state flash.
+  // Keep hidden agent activity background-only. Once the human can see an
+  // otherwise empty panel, project any recorded Browser page immediately,
+  // including a page published after the default screen was already visible.
   const revealExistingPreview =
-    (panelWasJustOpened || awaitingBrowserReveal) &&
+    panelVisible &&
     openTabs.length === 0 &&
     (browserTabSet?.tabs.length ?? 0) > 0;
   const renderedTabInstances = revealExistingPreview
@@ -211,15 +204,6 @@ export function RightPanel() {
   const renderedOpenTabs = renderedTabInstances.map((instance) => instance.type);
   const renderedActiveTabId = revealExistingPreview ? "singleton:preview" : activeTabId;
   const renderedActiveTab = revealExistingPreview ? "preview" : activeTab;
-
-  useLayoutEffect(() => {
-    previousPanelVisible.current = panelVisible;
-    if (!panelVisible || openTabs.length > 0 || revealExistingPreview) {
-      setAwaitingBrowserReveal(false);
-    } else if (panelWasJustOpened) {
-      setAwaitingBrowserReveal(true);
-    }
-  }, [openTabs.length, panelVisible, panelWasJustOpened, revealExistingPreview]);
 
   useLayoutEffect(() => {
     if (!revealExistingPreview || !activeWorkspaceId) return;

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useUiStore } from "@/stores/uiStore";
 import {
@@ -152,6 +152,9 @@ export function RightPanel() {
       ? s.getRightPanelVisible(activeWorkspaceId, activeThreadId)
       : false,
   );
+  const previousPanelVisible = useRef(panelVisible);
+  const panelWasJustOpened = panelVisible && !previousPanelVisible.current;
+  const [awaitingBrowserReveal, setAwaitingBrowserReveal] = useState(false);
 
   // The Terminal and Preview tabs bind to the active thread, or to the
   // workspace itself in the threadless new-thread view (where they run against
@@ -193,6 +196,48 @@ export function RightPanel() {
   // Browser glyph.
   const browserTabSet = usePreviewDisplayTabSet(panelScopeId);
 
+  // A Browser tab can be created while this panel is hidden. Keep that agent
+  // activity background-only, then project the existing Browser tab on the
+  // first render after a human opens an otherwise empty panel. The layout
+  // effect persists the projection after the derived render has prevented the
+  // empty-state flash.
+  const revealExistingPreview =
+    (panelWasJustOpened || awaitingBrowserReveal) &&
+    openTabs.length === 0 &&
+    (browserTabSet?.tabs.length ?? 0) > 0;
+  const renderedTabInstances = revealExistingPreview
+    ? [{ id: "singleton:preview", type: "preview" as const }]
+    : tabInstances;
+  const renderedOpenTabs = renderedTabInstances.map((instance) => instance.type);
+  const renderedActiveTabId = revealExistingPreview ? "singleton:preview" : activeTabId;
+  const renderedActiveTab = revealExistingPreview ? "preview" : activeTab;
+
+  useLayoutEffect(() => {
+    previousPanelVisible.current = panelVisible;
+    if (!panelVisible || openTabs.length > 0 || revealExistingPreview) {
+      setAwaitingBrowserReveal(false);
+    } else if (panelWasJustOpened) {
+      setAwaitingBrowserReveal(true);
+    }
+  }, [openTabs.length, panelVisible, panelWasJustOpened, revealExistingPreview]);
+
+  useLayoutEffect(() => {
+    if (!revealExistingPreview || !activeWorkspaceId) return;
+    const current = useDiffStore.getState().getRightPanel(activeWorkspaceId, activeThreadId);
+    if (!current.visible || current.openTabs.length > 0) return;
+    useDiffStore.getState().setRightPanelTab(activeWorkspaceId, activeThreadId, "preview");
+    const existingPageId = browserTabSet?.activeTabId ?? browserTabSet?.tabs[0]?.id;
+    if (panelScopeId && existingPageId) {
+      void usePreviewTabsStore.getState().activatePage(panelScopeId, existingPageId);
+    }
+  }, [
+    activeThreadId,
+    activeWorkspaceId,
+    browserTabSet,
+    panelScopeId,
+    revealExistingPreview,
+  ]);
+
   // Zustand action refs are stable (same identity for the store's lifetime),
   // so destructuring from getState() at render time is safe and avoids
   // adding actions to useCallback/useEffect dependency arrays.
@@ -226,12 +271,12 @@ export function RightPanel() {
   // A tab's content renders only when it is both the active tab and actually
   // open. Guards against a persisted/default activeTab leaking content behind
   // the card-grid empty state when its type is not in the open set.
-  const changesActive = activeTab === "changes" && openTabs.includes("changes");
-  const previewActive = activeTab === "preview" && openTabs.includes("preview");
+  const changesActive = renderedActiveTab === "changes" && renderedTabInstances.some((instance) => instance.type === "changes");
+  const previewActive = renderedActiveTab === "preview" && renderedTabInstances.some((instance) => instance.type === "preview");
   const terminalActive =
-    activeTab === "terminal" && openTabs.includes("terminal");
+    renderedActiveTab === "terminal" && renderedTabInstances.some((instance) => instance.type === "terminal");
   const subagentsActive =
-    activeTab === "subagents" && openTabs.includes("subagents");
+    renderedActiveTab === "subagents" && renderedTabInstances.some((instance) => instance.type === "subagents");
 
   useEffect(() => {
     const next = previewActive && panelScopeId && activeWorkspaceId
@@ -328,8 +373,8 @@ export function RightPanel() {
           keeps those panel actions beside the empty-state create list. */}
       <div className="flex min-h-0 flex-1 flex-row overflow-hidden">
         <ActivityRail
-          tabInstances={tabInstances}
-          activeTabId={activeTabId}
+          tabInstances={renderedTabInstances}
+          activeTabId={renderedActiveTabId}
           scope={panelScope}
           scopeProgress={scope}
           changesCount={changesCount}
@@ -342,7 +387,7 @@ export function RightPanel() {
           onToggleMaximized={toggleMaximized}
           onSelect={(instanceId) => {
             setRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId);
-            const terminal = tabInstances.find((instance) => instance.id === instanceId);
+            const terminal = renderedTabInstances.find((instance) => instance.id === instanceId);
             if (terminal?.type === "terminal" && panelScopeId) {
               useTerminalStore
                 .getState()
@@ -351,7 +396,7 @@ export function RightPanel() {
           }}
           onClose={(instanceId) =>
             {
-              const terminal = tabInstances.find((instance) => instance.id === instanceId);
+              const terminal = renderedTabInstances.find((instance) => instance.id === instanceId);
               if (terminal?.type === "terminal") {
                 const ptyId = instanceId.slice("terminal:".length);
                 void getTransport().terminalKill(ptyId).then(() => {
@@ -411,10 +456,10 @@ export function RightPanel() {
             and workspace thread switches. With no tab open the panel shows the
             card-grid empty state, which is itself the create surface. */}
         <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-          {openTabs.length === 0 && (
+          {renderedOpenTabs.length === 0 && (
             <PanelEmptyState
               scope={panelScope}
-              openTabs={openTabs}
+              openTabs={renderedOpenTabs}
               onOpen={(id) =>
                 id === "terminal" && panelScopeId
                   ? createTerminalForScope(panelScopeId)
@@ -422,14 +467,14 @@ export function RightPanel() {
               }
             />
           )}
-          {activeTab === "tasks" &&
-            openTabs.includes("tasks") &&
+          {renderedActiveTab === "tasks" &&
+            renderedOpenTabs.includes("tasks") &&
             activeThreadId && <PlanPanel threadId={activeThreadId} />}
           {subagentsActive && activeThreadId && (
             <SubagentsPanel key={activeThreadId} threadId={activeThreadId} />
           )}
-          {activeTab === "coordination" &&
-            openTabs.includes("coordination") &&
+          {renderedActiveTab === "coordination" &&
+            renderedOpenTabs.includes("coordination") &&
             activeThreadId &&
             activeWorkspaceId && (
               <CoordinationPanel

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@mcode/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useConnectionStore } from "@/stores/connectionStore";
+import { useThreadStore } from "@/stores/threadStore";
 import {
   interruptBrowserAutomationTarget,
   releaseBrowserAutomationThreadScope,
@@ -185,16 +186,19 @@ describe("BrowserAutomationHost", () => {
   const finishRendererOperation = vi.fn();
   const cancel = vi.fn();
   const interrupt = vi.fn();
+  const releaseAgentControl = vi.fn();
   const describeTarget = vi.fn();
   const createTab = vi.fn();
   const closeTab = vi.fn();
   const listTabs = vi.fn();
+  let controllerChanged: ((state: BrowserAutomationControllerState) => void) | null;
   let nextGeneration: number;
 
   beforeEach(() => {
     vi.clearAllMocks();
     harness.listeners.clear();
     sessionStorage.clear();
+    controllerChanged = null;
     nextGeneration = 1;
     harness.transport.registerBrowserAutomationHost.mockImplementation(async () => {
       const generation = nextGeneration++;
@@ -210,6 +214,14 @@ describe("BrowserAutomationHost", () => {
     });
     cancel.mockResolvedValue(true);
     interrupt.mockResolvedValue(true);
+    releaseAgentControl.mockImplementation(async (target: { tabId: string; controlEpoch: number }) => {
+      controllerChanged?.({
+        tabId: target.tabId,
+        controller: "none",
+        controlEpoch: target.controlEpoch,
+      });
+      return true;
+    });
     beginRendererOperation.mockResolvedValue({ ok: true, leaseId: "renderer-lease" });
     finishRendererOperation.mockResolvedValue(true);
     closeTab.mockResolvedValue({ ok: true, data: { threadId: "thread-1", activeTabId: "tab-1", tabs: [] } });
@@ -222,10 +234,14 @@ describe("BrowserAutomationHost", () => {
           finishRendererOperation,
           cancel,
           interrupt,
+          releaseAgentControl,
           describeTarget,
           getMediaSourceId: vi.fn(),
-          onControllerChanged(_callback: (state: BrowserAutomationControllerState) => void) {
-            return () => undefined;
+          onControllerChanged(callback: (state: BrowserAutomationControllerState) => void) {
+            controllerChanged = callback;
+            return () => {
+              if (controllerChanged === callback) controllerChanged = null;
+            };
           },
         },
         tabs: {
@@ -241,6 +257,7 @@ describe("BrowserAutomationHost", () => {
       workspaces: [{ id: "workspace-1" }] as never,
     });
     useConnectionStore.setState({ status: "connected" });
+    useThreadStore.setState({ runningThreadIds: new Set() });
     useBrowserAutomationStore.setState({
       liveTargets: new Map(),
       controllers: new Map(),
@@ -338,6 +355,60 @@ describe("BrowserAutomationHost", () => {
     view.unmount();
     driverExecute.mockRestore();
     execute.mockReset();
+  });
+
+  it("keeps Electron agent control visible between Browser calls while the turn is running", async () => {
+    useThreadStore.setState({ runningThreadIds: new Set(["thread-1"]) });
+    const request = dispatch(1, 96);
+    request.request = {
+      ...request.request,
+      operation: "navigate",
+      args: { url: "https://example.test/next" },
+    } as never;
+    execute.mockImplementation(async () => {
+      controllerChanged?.({
+        tabId: "tab-1",
+        controller: "agent",
+        controlEpoch: 0,
+        providerSessionId: "provider-session",
+        operation: "navigate",
+      });
+      return {
+        contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+        requestId: request.request.requestId,
+        sequence: request.request.sequence,
+        ok: true,
+        result: {
+          operation: "navigate",
+          url: "https://example.test/next",
+          title: "Example",
+          controlEpoch: 0,
+        },
+      } as BrowserAutomationResponse;
+    });
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
+    await waitFor(() => expect(controllerChanged).not.toBeNull());
+    const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
+
+    act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: request }));
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+
+    expect(useBrowserAutomationStore.getState().controllers.get(
+      JSON.stringify(["thread-1", "tab-1"]),
+    )).toMatchObject({ controller: "agent", controlEpoch: 0 });
+
+    act(() => useThreadStore.setState({ runningThreadIds: new Set() }));
+    await waitFor(() => expect(useBrowserAutomationStore.getState().controllers.get(
+      JSON.stringify(["thread-1", "tab-1"]),
+    )).toMatchObject({ controller: "none", controlEpoch: 0 }));
+    expect(releaseAgentControl).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      tabId: "tab-1",
+      controlEpoch: 0,
+      providerSessionId: "provider-session",
+    });
+    view.unmount();
   });
 
   it("settles driver-owned tabs when the broker releases a provider session", async () => {
@@ -1273,6 +1344,7 @@ describe("BrowserAutomationHost", () => {
   });
 
   it("bootstraps open from zero targets, reveals Browser, creates a tab, and navigates it", async () => {
+    useThreadStore.setState({ runningThreadIds: new Set(["thread-1"]) });
     useBrowserAutomationStore.setState({ liveTargets: new Map() });
     createTab.mockImplementation(async (threadId: string) => {
       useBrowserAutomationStore.getState().registerTarget("workspace-1", threadId, "created-tab");
@@ -1293,6 +1365,13 @@ describe("BrowserAutomationHost", () => {
       expect(
         usePreviewTabsStore.getState().tabSetByScope["thread-1"]?.tabs[0]?.url,
       ).toBe("about:blank");
+      controllerChanged?.({
+        tabId: "created-tab",
+        controller: "agent",
+        controlEpoch: 0,
+        providerSessionId: value.request.providerSessionId,
+        operation: "open",
+      });
       return {
         contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
         requestId: value.request.requestId,
@@ -1335,6 +1414,9 @@ describe("BrowserAutomationHost", () => {
       expect.objectContaining({ ok: true }),
       expect.objectContaining({ tabId: "created-tab", targetGeneration: 1 }),
     );
+    expect(useBrowserAutomationStore.getState().controllers.get(
+      JSON.stringify(["thread-1", "created-tab"]),
+    )).toMatchObject({ controller: "agent", operation: "open" });
     view.unmount();
   });
 

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -2127,7 +2127,7 @@ describe("BrowserAutomationHost", () => {
     frame.remove();
   });
 
-  it("cancels the exact web request on direct pointer takeover before click mutation", async () => {
+  it("invalidates the exact web target on direct pointer input without cancelling the request", async () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     delete window.desktopBridge;
     const frame = document.createElement("iframe");
@@ -2148,10 +2148,10 @@ describe("BrowserAutomationHost", () => {
     clickDispatch.request = { ...clickDispatch.request, operation: "click", args: { target: { cssSelector: "#save" }, button: "left", clickCount: 1, timeoutMs: 1000 } } as never;
     frameDocument.addEventListener("mousedown", () => frameDocument.dispatchEvent(new frameDocument.defaultView!.Event("pointerdown", { bubbles: true })), true);
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: clickDispatch }));
-    await waitFor(() => expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(hostId, 1, clickDispatch.request.requestId, clickDispatch.request.sequence, "human-interrupted"));
-    await waitFor(() => expect(useBrowserAutomationStore.getState().activeRequests.size).toBe(0));
-    expect(clicked).not.toHaveBeenCalled();
-    expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
+    await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
+    expect(harness.transport.cancelBrowserAutomationRequest).not.toHaveBeenCalled();
+    expect(clicked).toHaveBeenCalledOnce();
+    expect(useBrowserAutomationStore.getState().controllers).toHaveLength(0);
     view.unmount();
     frame.remove();
   });

--- a/apps/web/src/components/panels/__tests__/BrowserHeader.automation.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserHeader.automation.test.tsx
@@ -38,24 +38,11 @@ function renderHeader(overrides: Partial<BrowserHeaderProps> = {}) {
   return props;
 }
 
-describe("BrowserHeader automation controls", () => {
-  it("shows agent control and stops only through the browser-local action", async () => {
-    const user = userEvent.setup();
-    const onStopAutomation = vi.fn();
-    renderHeader({
-      automationController: {
-        tabId: "tab-1",
-        controller: "agent",
-        controlEpoch: 1,
-        providerSessionId: "provider-session",
-        operation: "click",
-      },
-      automationBusy: true,
-      onStopAutomation,
-    });
-    expect(screen.getByTestId("browser-controller-badge")).toHaveTextContent("Agent");
-    await user.click(screen.getByRole("button", { name: "Stop browser automation" }));
-    expect(onStopAutomation).toHaveBeenCalledOnce();
+describe("BrowserHeader", () => {
+  it("does not render a browser-local automation controller capsule", () => {
+    renderHeader();
+    expect(screen.queryByTestId("browser-controller-badge")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Stop browser automation" })).not.toBeInTheDocument();
   });
 
   it("opens adopted guest DevTools from the enabled menu item", async () => {
@@ -67,11 +54,4 @@ describe("BrowserHeader automation controls", () => {
     expect(onOpenDevTools).toHaveBeenCalledOnce();
   });
 
-  it("transfers control when the human focuses the browser omnibox", async () => {
-    const user = userEvent.setup();
-    const onHumanFocus = vi.fn();
-    renderHeader({ onHumanFocus });
-    await user.click(screen.getByRole("textbox", { name: "Preview URL" }));
-    expect(onHumanFocus).toHaveBeenCalledOnce();
-  });
 });

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -99,7 +99,10 @@ import { usePreviewDesignModeStore } from "@/stores/previewDesignModeStore";
 import { useProviderCatalogStore } from "@/stores/providerCatalogStore";
 import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { useDiffStore } from "@/stores/diffStore";
-import { useBrowserAutomationStore } from "@/stores/browserAutomationStore";
+import {
+  browserAutomationTargetKey,
+  useBrowserAutomationStore,
+} from "@/stores/browserAutomationStore";
 
 function mockBridgeState(overrides: Record<string, unknown> = {}) {
   const state = {
@@ -482,6 +485,7 @@ describe("PreviewPanel: full panel state", () => {
     usePreviewDesignModeStore.setState({ modes: {} });
     usePreviewTabsStore.setState({ tabSetByScope: {}, liveChromeByScope: {}, persistentTabIdsByScope: {} });
     useDiffStore.setState({ previewUrlByThread: {} });
+    useBrowserAutomationStore.setState({ controllers: new Map() });
     useProviderCatalogStore.getState().reset();
     mockUsePreviewBridge.mockReturnValue(mockBridgeState());
     mockUsePreviewTabs.mockReturnValue({
@@ -501,6 +505,7 @@ describe("PreviewPanel: full panel state", () => {
     usePreviewAnnotationStore.setState({ byThread: {}, drafts: {} });
     usePreviewDesignModeStore.setState({ modes: {} });
     usePreviewTabsStore.setState({ tabSetByScope: {}, liveChromeByScope: {}, persistentTabIdsByScope: {} });
+    useBrowserAutomationStore.setState({ controllers: new Map() });
     useProviderCatalogStore.getState().reset();
     mockUsePreviewBridge.mockClear();
     mockUsePreviewTabs.mockClear();
@@ -511,6 +516,31 @@ describe("PreviewPanel: full panel state", () => {
   it("renders the full panel when desktopBridge is present", () => {
     render(<PreviewPanel threadId="thread-1" />);
     expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+  });
+
+  it("uses a prominent frame and edge wash while the agent controls Browser", () => {
+    useBrowserAutomationStore.setState({
+      controllers: new Map([
+        [
+          browserAutomationTargetKey(
+            "thread-1",
+            PREVIEW_WEBVIEW_FALLBACK_TAB_ID,
+          ),
+          {
+            tabId: PREVIEW_WEBVIEW_FALLBACK_TAB_ID,
+            controller: "agent",
+            controlEpoch: 1,
+          },
+        ],
+      ]),
+    });
+
+    render(<PreviewPanel threadId="thread-1" />);
+
+    const overlay = screen.getByTestId("browser-automation-overlay");
+    expect(overlay).toHaveClass("border-2", "border-primary");
+    expect(overlay.style.backgroundImage).toContain("transparent 32px");
+    expect(overlay.style.boxShadow).toContain("inset 0 0 40px");
   });
 
   it("does not render the unavailable state when desktopBridge is present", () => {

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -4,6 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 
 import { PreviewWebview, type PreviewWebviewHandle } from "../PreviewWebview";
+import {
+  onBrowserAutomationObservationInvalidation,
+} from "@/stores/browserAutomationStore";
 
 describe("PreviewWebview", () => {
   let canGoBack: Mock<() => boolean>;
@@ -44,10 +47,11 @@ describe("PreviewWebview", () => {
     delete window.desktopBridge;
   });
 
-  it("transfers exact tab control only for the trusted guest input channel", () => {
-    const interrupt = vi.fn().mockResolvedValue(true);
+  it("notifies only for the trusted guest input channel", () => {
+    const humanInput = vi.fn();
+    const unsubscribe = onBrowserAutomationObservationInvalidation(humanInput);
     window.desktopBridge = {
-      preview: { automation: { interrupt } },
+      preview: {},
     } as unknown as NonNullable<typeof window.desktopBridge>;
     render(
       <PreviewWebview
@@ -74,8 +78,9 @@ describe("PreviewWebview", () => {
       channel: "untrusted-channel",
       args: [{ kind: "pointer" }],
     }));
-    expect(interrupt).toHaveBeenCalledOnce();
-    expect(interrupt).toHaveBeenCalledWith({ threadId: "thread-1", tabId: "tab-1" });
+    expect(humanInput).toHaveBeenCalledOnce();
+    expect(humanInput).toHaveBeenCalledWith("thread-1", "tab-1");
+    unsubscribe();
   });
 
   it("does not call Electron navigation methods before dom-ready", async () => {

--- a/apps/web/src/components/panels/hooks/usePreviewTabs.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewTabs.ts
@@ -19,27 +19,7 @@ import {
  * A no-op in non-desktop builds (the bridge is absent, so `tabSet` stays null).
  */
 export function usePreviewTabs(scopeId: string) {
-  const tabSet = usePreviewDisplayTabSet(scopeId);
-  const bridge = window.desktopBridge?.preview?.tabs;
-
-  useEffect(() => {
-    if (!bridge) return;
-    let cancelled = false;
-    const { setTabSet } = usePreviewTabsStore.getState();
-    void bridge.list(scopeId).then((r) => {
-      if (cancelled) return;
-      if (r.ok) setTabSet(scopeId, r.data);
-    });
-    const off = bridge.onUpdated((payload: BrowserTabSet) => {
-      if (cancelled) return;
-      if (payload.threadId === scopeId) setTabSet(scopeId, payload);
-    });
-    return () => {
-      cancelled = true;
-      off();
-    };
-  }, [bridge, scopeId]);
-
+  const tabSet = usePreviewTabSet(scopeId);
   const newTab = useCallback(
     () => usePreviewTabsStore.getState().createPage(scopeId),
     [scopeId],
@@ -55,4 +35,29 @@ export function usePreviewTabs(scopeId: string) {
   );
 
   return { tabSet, newTab, activateTab, closeTab };
+}
+
+/** Keeps Electron Browser tab membership synchronized for an optional panel scope. */
+export function usePreviewTabSet(scopeId: string | null): BrowserTabSet | null {
+  const tabSet = usePreviewDisplayTabSet(scopeId);
+  const bridge = window.desktopBridge?.preview?.tabs;
+
+  useEffect(() => {
+    if (!bridge || !scopeId) return;
+    let cancelled = false;
+    const { setTabSet } = usePreviewTabsStore.getState();
+    void bridge.list(scopeId).then((r) => {
+      if (cancelled) return;
+      if (r.ok) setTabSet(scopeId, r.data);
+    });
+    const off = bridge.onUpdated((payload: BrowserTabSet) => {
+      if (cancelled) return;
+      if (payload.threadId === scopeId) setTabSet(scopeId, payload);
+    });
+    return () => {
+      cancelled = true;
+      off();
+    };
+  }, [bridge, scopeId]);
+  return tabSet;
 }

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -454,6 +454,65 @@ describe("BrowserSessionDriver", () => {
     expect(result).toMatchObject({ ok: true, result: { outcome: "interrupted", effect: "partial", receipts: [{ index: 0, status: "applied" }, { index: 1, status: "interrupted" }] } });
     expect(execute).toHaveBeenCalledTimes(2);
   });
+
+  it("cooperatively stops an act batch after trusted human input invalidates its target", async () => {
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "inspect") {
+        return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
+      }
+      driver.invalidateTargetObservations("thread", "tab");
+      return { ok: true, result: { operation: value.request.operation } } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      supportedActOperations: ["click", "type"],
+    });
+    const inspect = await driver.execute(inspectDispatch(), new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+    const result = await driver.execute(actDispatch(observationRef, [
+      { operation: "click", target: { cssSelector: "#save" } },
+      { operation: "type", text: "human-safe" },
+    ]), new AbortController().signal);
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        outcome: "interrupted",
+        effect: "partial",
+        receipts: [
+          { index: 0, operation: "click", status: "applied" },
+          { index: 1, operation: "type", status: "interrupted" },
+        ],
+      },
+    });
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears invalidation state for a read-only target when its provider session ends", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { operation: "inspect" },
+    } as unknown as BrowserAutomationResponse);
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+    });
+
+    await driver.execute(inspectDispatch(), new AbortController().signal);
+    driver.invalidateTargetObservations("thread", "tab");
+    const interactionRevisions = (
+      driver as unknown as { humanInteractionRevisions: Map<string, number> }
+    ).humanInteractionRevisions;
+    expect(interactionRevisions.size).toBe(1);
+
+    await driver.releaseProviderSession("session");
+
+    expect(interactionRevisions.size).toBe(0);
+  });
+
   it("fails before adapter execution when descriptor revision drifts", async () => {
     const web = vi.fn().mockResolvedValue(response);
     const driver = new BrowserSessionDriver({
@@ -1007,10 +1066,18 @@ describe("BrowserSessionDriver", () => {
       expect.objectContaining({ tabId: "user-tab", provenance: "claimed-user", ownership: "claimed" }),
     ]));
 
+    driver.invalidateTargetObservations("thread", "agent-tab");
+    driver.invalidateTargetObservations("thread", "user-tab");
+    const interactionRevisions = (
+      driver as unknown as { humanInteractionRevisions: Map<string, number> }
+    ).humanInteractionRevisions;
+    expect(interactionRevisions.size).toBe(2);
+
     await driver.releaseProviderSession("session");
     expect(close).toHaveBeenCalledWith(agent);
     expect(close).not.toHaveBeenCalledWith(user);
     expect(projections.at(-1)).toEqual([]);
+    expect(interactionRevisions.size).toBe(0);
   });
 
   it("does not claim a target when a control operation fails or an observation is read-only", async () => {

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -47,6 +47,10 @@ const WEB_RUNTIME_OPERATIONS = [
   "type",
 ] as const satisfies readonly BrowserAutomationOperation[];
 
+function observationTargetKey(threadId: string, tabId: string): string {
+  return JSON.stringify([threadId, tabId]);
+}
+
 /** Options that affect the operations a runtime can truthfully advertise. */
 export interface BrowserAutomationRuntimeOperationOptions {
   readonly recordingAvailable?: boolean;
@@ -92,6 +96,12 @@ interface ObservationRecord {
   readonly documentRevision: number;
   readonly controlRevision: number;
   readonly capabilityRevision: number;
+  readonly humanInteractionRevision: number;
+  readonly targetKey: string;
+  readonly workspaceId: string;
+  readonly threadId: string;
+  readonly providerSessionId: string;
+  readonly providerInstanceId: string;
   observationRevision: number;
   readonly targets: ReadonlyMap<string, BrowserAutomationHostDispatchTarget>;
 }
@@ -112,6 +122,12 @@ interface ProviderTabSession {
   readonly providerInstanceId: string;
   current: BrowserAutomationHostDispatchTarget | null;
   readonly tabs: Map<string, ControlledTab>;
+}
+
+interface HumanInteractionScope {
+  readonly workspaceId: string;
+  readonly threadId: string;
+  readonly providerSessionId: string;
 }
 
 /** One lifecycle-backed Browser tab projected for renderer consumers. */
@@ -160,6 +176,7 @@ export interface BrowserSessionDriverOptions {
   readonly getHostRevision?: (dispatch: BrowserAutomationHostDispatch) => number;
   readonly getDocumentRevision?: (dispatch: BrowserAutomationHostDispatch) => number;
   readonly getControlRevision?: (dispatch: BrowserAutomationHostDispatch) => number;
+  readonly getHumanInteractionRevision?: (dispatch: BrowserAutomationHostDispatch) => number;
   readonly supportedActOperations?: readonly string[] | (() => readonly string[]);
   readonly webTabs?: BrowserSessionTabLifecycleAdapter;
   readonly electronTabs?: BrowserSessionTabLifecycleAdapter;
@@ -177,6 +194,8 @@ export class BrowserSessionDriver {
   private readonly idempotency = new Map<string, IdempotencyRecord>();
   private readonly tabIdempotency = new Map<string, TabReplayRecord>();
   private readonly observations = new Map<string, ObservationRecord>();
+  private readonly humanInteractionRevisions = new Map<string, number>();
+  private readonly humanInteractionScopes = new Map<string, HumanInteractionScope>();
   private readonly tabSessions = new Map<string, ProviderTabSession>();
   private readonly activeTabMutations = new Set<string>();
 
@@ -306,6 +325,25 @@ export class BrowserSessionDriver {
   clearIdempotency(): void {
     this.idempotency.clear();
     this.tabIdempotency.clear();
+    this.observations.clear();
+    this.humanInteractionRevisions.clear();
+    this.humanInteractionScopes.clear();
+  }
+
+  /** Invalidates observations for one target after trusted human input. */
+  invalidateTargetObservations(threadId: string, tabId: string): void {
+    const targetKey = observationTargetKey(threadId, tabId);
+    this.humanInteractionRevisions.set(
+      targetKey,
+      (this.humanInteractionRevisions.get(targetKey) ?? 0) + 1,
+    );
+    for (const [observationRef, observation] of this.observations) {
+      if (observation.targetKey === targetKey || [...observation.targets.values()].some(
+        (target) => observationTargetKey(target.threadId, target.tabId) === targetKey,
+      )) {
+        this.observations.delete(observationRef);
+      }
+    }
   }
 
   /** Publishes retained browser ownership after a host reconnects. */
@@ -315,6 +353,8 @@ export class BrowserSessionDriver {
 
   /** Clears replay state bound to one browser target after that target closes or is replaced. */
   clearIdempotencyForTarget(threadId: string, tabId: string): void {
+    this.invalidateTargetObservations(threadId, tabId);
+    this.clearHumanInteractionTarget(observationTargetKey(threadId, tabId));
     for (const [key, record] of this.idempotency) {
       if (record.target.threadId === threadId && record.target.tabId === tabId) this.idempotency.delete(key);
     }
@@ -333,16 +373,22 @@ export class BrowserSessionDriver {
 
   /** Settles every tab owned or claimed by one terminated provider session. */
   async releaseProviderSession(providerSessionId: string): Promise<void> {
+    this.clearObservations((observation) => observation.providerSessionId === providerSessionId);
+    this.clearHumanInteractionScopes((scope) => scope.providerSessionId === providerSessionId);
     await this.releaseSessions((session) => session.providerSessionId === providerSessionId);
   }
 
   /** Settles every tab owned or claimed by one deleted thread. */
   async releaseThread(threadId: string): Promise<void> {
+    this.clearObservations((observation) => observation.threadId === threadId);
+    this.clearHumanInteractionScopes((scope) => scope.threadId === threadId);
     await this.releaseSessions((session) => [...session.tabs.values()].some((tab) => tab.target.threadId === threadId));
   }
 
   /** Settles every tab owned or claimed by one deleted workspace. */
   async releaseWorkspace(workspaceId: string): Promise<void> {
+    this.clearObservations((observation) => observation.workspaceId === workspaceId);
+    this.clearHumanInteractionScopes((scope) => scope.workspaceId === workspaceId);
     await this.releaseSessions((session) => session.workspaceId === workspaceId);
   }
 
@@ -392,10 +438,16 @@ export class BrowserSessionDriver {
     const baseObservation = observation ?? {
       ...currentBinding,
       capabilityRevision,
+      humanInteractionRevision: this.currentHumanInteractionRevision(dispatch),
+      targetKey: observationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+      workspaceId: dispatch.request.workspaceId,
+      threadId: dispatch.request.threadId,
+      providerSessionId: dispatch.request.providerSessionId,
+      providerInstanceId: dispatch.request.providerInstanceId,
       observationRevision: 0,
       targets: new Map([[dispatch.target.tabId, dispatch.target]]),
     };
-    if (!observation || observation.hostRevision !== currentBinding.hostRevision || observation.documentRevision !== currentBinding.documentRevision || observation.controlRevision !== currentBinding.controlRevision || observation.capabilityRevision !== currentBinding.capabilityRevision) {
+    if (!observation || observation.hostRevision !== currentBinding.hostRevision || observation.documentRevision !== currentBinding.documentRevision || observation.controlRevision !== currentBinding.controlRevision || observation.capabilityRevision !== currentBinding.capabilityRevision || observation.humanInteractionRevision !== this.currentHumanInteractionRevision(dispatch)) {
       return Promise.resolve(this.actFailure(dispatch, "STALE_TARGET_GENERATION", "Browser observation is stale; inspect before browser_act"));
     }
     this.observations.delete(request.args.observationRef);
@@ -420,7 +472,7 @@ export class BrowserSessionDriver {
         if (drift || !this.observationStillCurrent(dispatch, baseObservation)) {
           outcome = "interrupted";
           stoppingPosition = index;
-          receipts.push({ index, operation: step.operation, status: "interrupted", message: "Browser capability revision changed" });
+          receipts.push({ index, operation: step.operation, status: "interrupted", message: "Browser observation was invalidated" });
           for (let skipped = index + 1; skipped < request.args.steps.length; skipped += 1) receipts.push({ index: skipped, operation: request.args.steps[skipped]!.operation, status: "skipped" });
           break;
         }
@@ -452,7 +504,20 @@ export class BrowserSessionDriver {
         capabilityRevision,
         observationRevision: baseObservation.observationRevision + 1,
       };
-      this.observations.set(nextObservationRef, { hostRevision: finalObservation.hostRevision, documentRevision: finalObservation.documentRevision, controlRevision: finalObservation.controlRevision, capabilityRevision, observationRevision: finalObservation.observationRevision, targets: baseObservation.targets });
+      this.observations.set(nextObservationRef, {
+        hostRevision: finalObservation.hostRevision,
+        documentRevision: finalObservation.documentRevision,
+        controlRevision: finalObservation.controlRevision,
+        capabilityRevision,
+        humanInteractionRevision: baseObservation.humanInteractionRevision,
+        targetKey: baseObservation.targetKey,
+        workspaceId: baseObservation.workspaceId,
+        threadId: baseObservation.threadId,
+        providerSessionId: baseObservation.providerSessionId,
+        providerInstanceId: baseObservation.providerInstanceId,
+        observationRevision: finalObservation.observationRevision,
+        targets: baseObservation.targets,
+      });
       return {
         contractVersion: request.contractVersion,
         requestId: request.requestId,
@@ -610,6 +675,12 @@ export class BrowserSessionDriver {
       documentRevision: finalObservation.documentRevision,
       controlRevision: finalObservation.controlRevision,
       capabilityRevision: finalObservation.capabilityRevision,
+      humanInteractionRevision: observation.humanInteractionRevision,
+      targetKey: observation.targetKey,
+      workspaceId: observation.workspaceId,
+      threadId: observation.threadId,
+      providerSessionId: observation.providerSessionId,
+      providerInstanceId: observation.providerInstanceId,
       observationRevision: finalObservation.observationRevision,
       targets: observation.targets,
     });
@@ -802,6 +873,12 @@ export class BrowserSessionDriver {
         documentRevision: session.current.targetGeneration,
         controlRevision: dispatch.request.expectedControlEpoch,
         capabilityRevision,
+        humanInteractionRevision: this.currentHumanInteractionRevisionForTarget(session.current.threadId, session.current.tabId),
+        targetKey: observationTargetKey(session.current.threadId, session.current.tabId),
+        workspaceId: dispatch.request.workspaceId,
+        threadId: session.current.threadId,
+        providerSessionId: dispatch.request.providerSessionId,
+        providerInstanceId: dispatch.request.providerInstanceId,
         observationRevision: observation.observationRevision + 1,
         targets: new Map(liveTargets),
       });
@@ -925,6 +1002,12 @@ export class BrowserSessionDriver {
       documentRevision: dispatch.target.targetGeneration,
       controlRevision: dispatch.request.expectedControlEpoch,
       capabilityRevision: dispatch.connection?.capabilityRevision ?? this.options.getCapabilityRevision?.() ?? 1,
+      humanInteractionRevision: this.currentHumanInteractionRevision(dispatch),
+      targetKey: observationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+      workspaceId: dispatch.request.workspaceId,
+      threadId: dispatch.request.threadId,
+      providerSessionId: dispatch.request.providerSessionId,
+      providerInstanceId: dispatch.request.providerInstanceId,
       observationRevision: 0,
       targets: new Map((result.tabs ?? [dispatch.target]).map((target) => [target.tabId, target])),
     });
@@ -940,9 +1023,50 @@ export class BrowserSessionDriver {
     };
   }
 
+  private currentHumanInteractionRevision(dispatch: BrowserAutomationHostDispatch): number {
+    this.humanInteractionScopes.set(
+      observationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+      {
+        workspaceId: dispatch.request.workspaceId,
+        threadId: dispatch.target.threadId,
+        providerSessionId: dispatch.request.providerSessionId,
+      },
+    );
+    return this.currentHumanInteractionRevisionForTarget(dispatch.target.threadId, dispatch.target.tabId, dispatch);
+  }
+
+  private currentHumanInteractionRevisionForTarget(
+    threadId: string,
+    tabId: string,
+    dispatch?: BrowserAutomationHostDispatch,
+  ): number {
+    const targetRevision = this.humanInteractionRevisions.get(observationTargetKey(threadId, tabId)) ?? 0;
+    const externalRevision = dispatch ? this.options.getHumanInteractionRevision?.(dispatch) : undefined;
+    return Math.max(targetRevision, externalRevision ?? 0);
+  }
+
   private observationStillCurrent(dispatch: BrowserAutomationHostDispatch, observation: ObservationRecord): boolean {
     const current = this.currentObservationBinding(dispatch, observation.capabilityRevision);
-    return current.hostRevision === observation.hostRevision && current.documentRevision === observation.documentRevision && current.controlRevision === observation.controlRevision && current.capabilityRevision === observation.capabilityRevision;
+    return current.hostRevision === observation.hostRevision && current.documentRevision === observation.documentRevision && current.controlRevision === observation.controlRevision && current.capabilityRevision === observation.capabilityRevision && this.currentHumanInteractionRevision(dispatch) === observation.humanInteractionRevision;
+  }
+
+  private clearObservations(predicate: (observation: ObservationRecord) => boolean): void {
+    for (const [observationRef, observation] of this.observations) {
+      if (predicate(observation)) this.observations.delete(observationRef);
+    }
+  }
+
+  private clearHumanInteractionTarget(targetKey: string): void {
+    this.humanInteractionRevisions.delete(targetKey);
+    this.humanInteractionScopes.delete(targetKey);
+  }
+
+  private clearHumanInteractionScopes(
+    predicate: (scope: HumanInteractionScope) => boolean,
+  ): void {
+    for (const [targetKey, scope] of this.humanInteractionScopes) {
+      if (predicate(scope)) this.clearHumanInteractionTarget(targetKey);
+    }
   }
 
   private revisionDrift(dispatch: BrowserAutomationHostDispatch): BrowserAutomationResponse | null {
@@ -1005,7 +1129,15 @@ export class BrowserSessionDriver {
     const adapter = this.tabAdapter();
     for (const [key, session] of [...this.tabSessions]) {
       if (!predicate(session)) continue;
+      if (session.current) {
+        this.clearHumanInteractionTarget(
+          observationTargetKey(session.current.threadId, session.current.tabId),
+        );
+      }
       for (const tab of session.tabs.values()) {
+        this.clearHumanInteractionTarget(
+          observationTargetKey(tab.target.threadId, tab.target.tabId),
+        );
         if (tab.provenance === "agent-created" && tab.ownership !== "released") {
           await adapter?.close(tab.target);
         }

--- a/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
+++ b/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
@@ -234,4 +234,29 @@ describe("browser automation renderer scope", () => {
     )).toEqual({ tabId: "tab-a", controller: "agent", controlEpoch: 3 });
     unsubscribe();
   });
+
+  it("shows agent control on only the latest Browser page in one thread", () => {
+    const store = useBrowserAutomationStore.getState();
+    store.registerTarget("workspace-agent", "thread-agent", "tab-first");
+    store.registerTarget("workspace-agent", "thread-agent", "tab-second");
+    store.setControllerForTarget("thread-agent", "tab-first", {
+      tabId: "tab-first",
+      controller: "agent",
+      controlEpoch: 1,
+    });
+    store.setControllerForTarget("thread-agent", "tab-second", {
+      tabId: "tab-second",
+      controller: "agent",
+      controlEpoch: 2,
+    });
+
+    expect(useBrowserAutomationStore.getState().controllers.get(
+      browserAutomationTargetKey("thread-agent", "tab-first"),
+    )).toEqual({ tabId: "tab-first", controller: "none", controlEpoch: 1 });
+    expect(useBrowserAutomationStore.getState().controllers.get(
+      browserAutomationTargetKey("thread-agent", "tab-second"),
+    )).toEqual({ tabId: "tab-second", controller: "agent", controlEpoch: 2 });
+
+    store.releaseThreadTargets("thread-agent");
+  });
 });

--- a/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
+++ b/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
@@ -4,6 +4,8 @@ import {
   browserAutomationRequestKey,
   browserAutomationTargetKey,
   onBrowserAutomationScopeRelease,
+  invalidateBrowserAutomationTargetObservation,
+  onBrowserAutomationObservationInvalidation,
   releaseBrowserAutomationThreadScope,
   releaseBrowserAutomationWorkspaceScopes,
   resolveBrowserAutomationControllerTarget,
@@ -211,5 +213,25 @@ describe("browser automation renderer scope", () => {
     unsubscribe();
     releaseBrowserAutomationThreadScope("thread-b");
     expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("notifies exact human-input listeners without changing controller state", () => {
+    useBrowserAutomationStore.getState().registerTarget("workspace-a", "thread-a", "tab-a");
+    useBrowserAutomationStore.getState().setControllerForTarget("thread-a", "tab-a", {
+      tabId: "tab-a",
+      controller: "agent",
+      controlEpoch: 3,
+    });
+    const listener = vi.fn();
+    const unsubscribe = onBrowserAutomationObservationInvalidation(listener);
+
+    invalidateBrowserAutomationTargetObservation("thread-a", "tab-a");
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith("thread-a", "tab-a");
+    expect(useBrowserAutomationStore.getState().controllers.get(
+      browserAutomationTargetKey("thread-a", "tab-a"),
+    )).toEqual({ tabId: "tab-a", controller: "agent", controlEpoch: 3 });
+    unsubscribe();
   });
 });

--- a/apps/web/src/stores/browserAutomationStore.ts
+++ b/apps/web/src/stores/browserAutomationStore.ts
@@ -270,6 +270,25 @@ type InterruptionListener = (
 const interruptionListeners = new Set<InterruptionListener>();
 const pendingInterruptions = new Map<string, Promise<boolean>>();
 
+type ObservationInvalidationListener = (threadId: string, tabId: string) => void;
+const observationInvalidationListeners = new Set<ObservationInvalidationListener>();
+
+/** Subscribe to trusted human input without changing Browser controller state. */
+export function onBrowserAutomationObservationInvalidation(
+  listener: ObservationInvalidationListener,
+): () => void {
+  observationInvalidationListeners.add(listener);
+  return () => observationInvalidationListeners.delete(listener);
+}
+
+/** Notify Browser automation listeners that one target received trusted human input. */
+export function invalidateBrowserAutomationTargetObservation(
+  threadId: string,
+  tabId: string,
+): void {
+  for (const listener of observationInvalidationListeners) listener(threadId, tabId);
+}
+
 /** Identifies persistent automation surfaces that must be released. */
 export type BrowserAutomationScopeRelease =
   | { readonly threadId: string; readonly workspaceId?: never }

--- a/apps/web/src/stores/browserAutomationStore.ts
+++ b/apps/web/src/stores/browserAutomationStore.ts
@@ -87,7 +87,7 @@ export function resolveBrowserAutomationControllerTarget(
 }
 
 /** Shared renderer state for browser host discovery, control, and warm leases. */
-export const useBrowserAutomationStore = create<BrowserAutomationState>((set) => ({
+export const useBrowserAutomationStore = create<BrowserAutomationState>((set, get) => ({
   liveTargets: new Map(),
   lifecycleTabs: new Map(),
   controllers: new Map(),
@@ -212,19 +212,29 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set) =>
       return { liveTargets, controllers, viewportByTarget, lifecycleTabs };
     });
   },
-  setController: (controller) =>
-    set((state) => {
-      const target = resolveBrowserAutomationControllerTarget(state.liveTargets.values(), controller);
-      if (!target) return state;
-      const controllers = new Map(state.controllers);
-      controllers.set(browserAutomationTargetKey(target.threadId, target.tabId), controller);
-      return { controllers };
-    }),
+  setController: (controller) => {
+    const target = resolveBrowserAutomationControllerTarget(get().liveTargets.values(), controller);
+    if (!target) return;
+    get().setControllerForTarget(target.threadId, target.tabId, controller);
+  },
   setControllerForTarget: (threadId, tabId, controller) =>
     set((state) => {
       const key = browserAutomationTargetKey(threadId, tabId);
       if (!state.liveTargets.has(key)) return state;
       const controllers = new Map(state.controllers);
+      if (controller.controller === "agent") {
+        for (const target of state.liveTargets.values()) {
+          if (target.threadId !== threadId || target.tabId === tabId) continue;
+          const otherKey = browserAutomationTargetKey(target.threadId, target.tabId);
+          const other = controllers.get(otherKey);
+          if (other?.controller !== "agent") continue;
+          controllers.set(otherKey, {
+            tabId: target.tabId,
+            controller: "none",
+            controlEpoch: other.controlEpoch,
+          });
+        }
+      }
       controllers.set(key, controller);
       return { controllers };
     }),

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -236,6 +236,13 @@ export interface PreviewAutomationBridge {
   >;
   /** Transfer one exact tab from agent control to the human. */
   interrupt(target: { threadId: string; tabId: string }): Promise<boolean>;
+  /** Clear retained agent presentation after its owning turn completes. */
+  releaseAgentControl(target: {
+    threadId: string;
+    tabId: string;
+    controlEpoch: number;
+    providerSessionId: string;
+  }): Promise<boolean>;
   /** Resolve desktop-main target identity without exposing WebContents. */
   describeTarget(target: {
     threadId: string;


### PR DESCRIPTION
## What
Show a clear agent-control treatment while an agent controls a Browser page in the web and Electron runtimes.

## Why
The Browser surface could look idle between agent operations, so users could not reliably tell when an agent still controlled a page. Browser pages opened before the right panel also remained disconnected from the panel's initial state.

## Key Changes
- Retain per-page agent control across Browser operations and release it only when the owning turn or session ends.
- Render the accepted amber perimeter, projected cursor, and Browser rail cursor icon only during agent control.
- Strengthen the active perimeter with a solid frame and denser edge wash for glance-level visibility.
- Invalidate stale observations after trusted human input without silently ending the Browser run.
- Reveal existing agent-opened Browser pages when the right panel opens instead of showing the default screen.
- Reject stale control releases and cover the controller, tab projection, and overlay behavior with focused tests.

## Verification
- Live Electron: a 10-step, 27.9-second Codex Browser run kept the frame and cursor icon visible throughout, then cleared them when the turn completed.
- Desktop Browser automation kernel: 45 tests passed.
- Focused web Browser suites: 162 tests passed.
- PreviewPanel overlay suite after the visual adjustment: 74 tests passed.
- Typecheck passed for all six packages.
- Lint passed.
- Full `bun run verify` reached the unit phase but exceeded the 120-second command cap before producing a unit-test verdict.

Closes #1050
Related to #1033

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788387475&installation_model_id=20477&pr_number=1068&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1068&signature=0ddcb872055ef0f20876628de4fdd59e620cacade09f635d916807d6ec071b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear visual indicators when an agent controls a browser page.
  * Added a full-page control overlay with improved accessibility status.
  * Browser previews now open and activate automatically when available.
  * Added safer agent-control release handling for active browser sessions.

* **Bug Fixes**
  * Human interaction now invalidates stale automation observations without prematurely cancelling actions.
  * Agent control is released appropriately when tasks stop or sessions change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->