### PR TITLE
fix(agent): require explicit thread-control requests

### DIFF
--- a/packages/thread-orchestration/src/__tests__/mcode-instructions.test.ts
+++ b/packages/thread-orchestration/src/__tests__/mcode-instructions.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  MCODE_INSTRUCTIONS_MAX_CHARS,
-  buildMcodeInstructionPlan,
-  renderMcodeInstructions,
-} from "../index.js";
+import { buildMcodeInstructionPlan } from "../index.js";
 
 describe("Mcode runtime instruction plan", () => {
   it("always includes identity and excludes ungranted capabilities", () => {
@@ -31,44 +27,5 @@ describe("Mcode runtime instruction plan", () => {
     expect(plan.text).toContain("thread-source");
     expect(plan.text).not.toContain("http://");
     expect(plan.text).not.toContain("Bearer");
-  });
-
-  it("keeps Mcode threads distinct from provider subagents", () => {
-    const plan = buildMcodeInstructionPlan({
-      sourceThreadId: "thread-source",
-      threadControlGranted: true,
-      browserAutomationGranted: false,
-    });
-
-    expect(plan.text).toContain(
-      "An Mcode task/thread/delegated thread is a persistent user-visible conversation controlled by thread_* tools.",
-    );
-    expect(plan.text).toContain(
-      "A subagent is provider/model-side delegation in the same turn.",
-    );
-    expect(plan.text).toContain("'use threads/tasks' maps to thread_* tools");
-    expect(plan.text).toContain(
-      "'use subagents' maps to the provider subagent mechanism",
-    );
-    expect(plan.text).toContain("Never translate one term into the other.");
-    expect(plan.text).not.toContain("'use threads/tasks' maps to subagents");
-    expect(plan.text).not.toContain("'use subagents' maps to thread_* tools");
-  });
-
-  it("keeps output within the documented cap", () => {
-    const plan = buildMcodeInstructionPlan({
-      sourceThreadId: "x".repeat(256),
-      threadControlGranted: true,
-      browserAutomationGranted: false,
-    });
-    expect(plan.text.length).toBeLessThanOrEqual(MCODE_INSTRUCTIONS_MAX_CHARS);
-  });
-
-  it("renders canonical text unchanged", () => {
-    const plan = buildMcodeInstructionPlan({
-      threadControlGranted: false,
-      browserAutomationGranted: true,
-    });
-    expect(renderMcodeInstructions(plan)).toBe(plan.text);
   });
 });

--- a/packages/thread-orchestration/src/mcode-instructions.ts
+++ b/packages/thread-orchestration/src/mcode-instructions.ts
@@ -29,10 +29,9 @@ const IDENTITY_BLOCK = [
 ].join(" ");
 
 const THREAD_CONTROL_BLOCK = [
-  "Use the mcode_internal_thread_control MCP server for cross-thread orchestration.",
-  "An Mcode task/thread/delegated thread is a persistent user-visible conversation controlled by thread_* tools. A subagent is provider/model-side delegation in the same turn.",
-  "User wording 'use threads/tasks' maps to thread_* tools. User wording 'use subagents' maps to the provider subagent mechanism. Never translate one term into the other.",
-  "Use workspace_search, worktree_list, thread_target_list, thread_create_batch, thread_search, thread_get, thread_send, thread_stop, and thread_wait as needed.",
+  "Use the mcode_internal_thread_control MCP server for cross-thread orchestration when explicitly asked by the user",
+  "An Mcode task/thread/delegated thread is a persistent user-visible conversation controlled by thread_* tools.",
+  "For an explicit thread/task request, use workspace_search, worktree_list, thread_target_list, thread_create_batch, thread_search, thread_get, thread_send, thread_stop, and thread_wait as needed.",
   "When a delegated thread needs a named provider or model, call thread_target_list first, then pass the exact returned providerId and modelId to thread_create_batch. Do not assume or enumerate providers or models.",
   "Route delegated Mcode threads through Mcode thread tools. Never target the source thread.",
 ].join(" ");


### PR DESCRIPTION
## What
Require an explicit user request before Mcode agents use thread-control tools.

## Why
Broad cross-thread orchestration guidance allowed ordinary subagent delegation to be interpreted as a request for persistent Mcode threads.

## Key Changes
- Gate internal thread-control guidance behind explicit thread or task requests.
- Retain only meaningful capability and credential-boundary tests for runtime instruction generation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788427166&installation_model_id=20477&pr_number=1070&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1070&signature=be55fb1039a8aefabd91a5c9b16c6753f81e573d6324269354c6f01f3e162f07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->