### PR TITLE
fix(web): use amber primary for markdown links

### DIFF
--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -62,7 +62,8 @@ describe("MarkdownContent link handling", () => {
     const link = container.querySelector("a");
     const favicon = screen.getByTestId("markdown-link-favicon");
 
-    expect(link).toHaveClass("text-link");
+    expect(link).toHaveClass("text-primary");
+    expect(link).not.toHaveClass("text-link");
     expect(screen.getByTestId("markdown-link-favicon-frame")).toBeInTheDocument();
     expect(favicon).toHaveAttribute("src", "https://example.com/favicon.ico");
     expect(favicon).toHaveClass("favicon-image-shadow");
@@ -398,12 +399,13 @@ describe("MarkdownContent variant styling", () => {
       expect(command?.querySelector("[data-entity-icon='command']")).toHaveClass("text-current");
     });
 
-    it("renders links with cool text-link", () => {
+    it("renders links with primary text", () => {
       const { container } = render(
         <MarkdownContent content="[link](https://example.com)" />,
       );
       const link = container.querySelector("a");
-      expect(link?.className).toContain("text-link");
+      expect(link).toHaveClass("text-primary");
+      expect(link).not.toHaveClass("text-link");
     });
 
     it("passes disableHighlighting=false to CodeBlock", () => {
@@ -424,12 +426,13 @@ describe("MarkdownContent variant styling", () => {
       expect(code?.className).toContain("bg-foreground/10");
     });
 
-    it("renders links with cool text-link", () => {
+    it("renders links with primary text", () => {
       const { container } = render(
         <MarkdownContent content="[link](https://example.com)" variant="user" />,
       );
       const link = container.querySelector("a");
-      expect(link?.className).toContain("text-link");
+      expect(link).toHaveClass("text-primary");
+      expect(link).not.toHaveClass("text-link");
     });
 
     it("renders user links with the same favicon treatment", () => {

--- a/apps/web/src/components/chat/MarkdownContent.tsx
+++ b/apps/web/src/components/chat/MarkdownContent.tsx
@@ -253,7 +253,7 @@ function MarkdownLink({
   const anchor = (
     <a
       href={safeHref}
-      className="inline-flex max-w-full items-center gap-1 align-baseline text-link no-underline transition-colors hover:underline"
+      className="inline-flex max-w-full items-center gap-1 align-baseline text-primary no-underline transition-colors hover:underline"
       target="_blank"
       rel="noopener noreferrer"
       data-testid="markdown-link"


### PR DESCRIPTION
## What
Updates chat Markdown links to use Mcode's amber primary color instead of the blue link token.

## Why
Links in conversation messages should use the requested amber treatment while preserving their existing behavior and icon hierarchy.

## Key Changes
- Apply `text-primary` to Markdown links rendered by `MarkdownContent`.
- Preserve the favicon, muted external-link icon, hover underline, and link behavior.
- Update assistant and user variant coverage to reject the old `text-link` class.

## Verification
- `bun run test -- src/__tests__/MarkdownContent.test.tsx` (36 tests passed)
- `bun run verify:changed` (passed)
- `bun run verify` (passed)
- Live dark-theme render confirmed the computed link color matches `--primary`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788430373&installation_model_id=20477&pr_number=1071&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1071&signature=ac3d2f703f0c431be125c33f51a8e643f99d76e8aeba953fdd817c0dbb25154f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated links in rendered Markdown content to use the primary text color for a more consistent visual appearance.
  - Link behavior and rendering remain unchanged.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->