### PR TITLE
fix(web): stabilize empty thread selectors

### DIFF
--- a/apps/web/src/components/panels/__tests__/SubagentsPanel.real-store.test.tsx
+++ b/apps/web/src/components/panels/__tests__/SubagentsPanel.real-store.test.tsx
@@ -14,6 +14,11 @@ describe("SubagentsPanel real thread store path", () => {
     });
   });
 
+  it("renders while the thread record is not hydrated", () => {
+    expect(() => render(<SubagentsPanel threadId="thread-1" />)).not.toThrow();
+    expect(screen.getByTestId("subagents-empty")).toBeInTheDocument();
+  });
+
   it("survives a transient record missing hydrated narrative data", () => {
     const record = createEmptyThreadRecord();
     const partialRecord = { ...record, narrativeByMessage: undefined } as unknown as typeof record;

--- a/apps/web/src/stores/thread-selectors.test.tsx
+++ b/apps/web/src/stores/thread-selectors.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useActiveThreadRecord } from "./thread-selectors";
+import { useThreadStore } from "./threadStore";
+
+describe("thread selectors", () => {
+  beforeEach(() => {
+    useThreadStore.setState({
+      currentThreadId: "thread-1",
+      records: new Map(),
+    });
+  });
+
+  it("keeps an active selector stable while its record is not hydrated", () => {
+    const { result, rerender } = renderHook(() => useActiveThreadRecord((record) => ({
+      messages: record.messages,
+      narrativeByMessage: record.narrativeByMessage,
+    })));
+    const initialSelection = result.current;
+
+    expect(initialSelection).toEqual({ messages: [], narrativeByMessage: {} });
+    rerender();
+    expect(result.current).toBe(initialSelection);
+  });
+});

--- a/apps/web/src/stores/thread-selectors.ts
+++ b/apps/web/src/stores/thread-selectors.ts
@@ -6,6 +6,16 @@ import {
   type ThreadRecord,
 } from "./thread-record";
 
+const EMPTY_HOOK_THREAD_RECORD = createEmptyThreadRecord();
+
+function getHookThreadRecord(
+  records: Map<string, ThreadRecord>,
+  threadId: string,
+): ThreadRecord {
+  if (!records.has(threadId)) return EMPTY_HOOK_THREAD_RECORD;
+  return getThreadRecord(records, threadId);
+}
+
 /**
  * Subscribe to one thread's record with shallow equality on the selected slice.
  */
@@ -15,8 +25,8 @@ export function useThreadRecord<T>(
 ): T {
   return useThreadStore(
     useShallow((state) => {
-      if (!threadId) return selector(createEmptyThreadRecord());
-      return selector(getThreadRecord(state.records, threadId));
+      if (!threadId) return selector(EMPTY_HOOK_THREAD_RECORD);
+      return selector(getHookThreadRecord(state.records, threadId));
     }),
   );
 }
@@ -30,7 +40,9 @@ export function useActiveThreadRecord<T>(
   return useThreadStore(
     useShallow((state) => {
       const id = state.currentThreadId;
-      const record = id ? getThreadRecord(state.records, id) : createEmptyThreadRecord();
+      const record = id
+        ? getHookThreadRecord(state.records, id)
+        : EMPTY_HOOK_THREAD_RECORD;
       return selector(record);
     }),
   );


### PR DESCRIPTION
## What
Stabilize empty thread snapshots used by React store selectors while a thread record is still hydrating.

## Why
The Subagents panel could receive a newly allocated empty record on every external-store snapshot. React treated each allocation as a state change and eventually threw Maximum update depth exceeded, which triggered the application error boundary.

## Key Changes
- Reuse one hook-only empty thread record until hydrated state arrives.
- Preserve fresh records for imperative callers and existing partial-record normalization.
- Add regressions for the Subagents panel and active-thread selector paths.

## Verification
- Reproduced the original React snapshot loop before the fix.
- Confirmed the focused selector and Subagents tests pass.
- Confirmed the live provisional-thread path shows no crash screen or React loop error.
- Ran bun run verify: typecheck, lint, and 2,927 tests passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788434777&installation_model_id=20477&pr_number=1085&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1085&signature=e6aaf6b3081fd48fc46ff16c9b92b617e5cad3c48e26fd3b605567d3dc763c2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread panel behavior when thread data has not yet loaded.
  * Prevented unnecessary updates when displaying empty thread states.

* **Tests**
  * Added coverage for empty thread records, selector stability, and rendering before hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->