### PR TITLE
fix(agent): allow sends to recoverable threads

### DIFF
--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -66,7 +66,7 @@ function buildService({
 }: {
   assertUsable?: ReturnType<typeof vi.fn>;
   resolveProvider?: ReturnType<typeof vi.fn>;
-  threadStatus?: Thread["status"] | "idle" | "stopped";
+  threadStatus?: Thread["status"] | "failed" | "idle" | "stopped";
 } = {}) {
   const thread = threadStatus === "idle" ? makeThread() : makeThread({ status: threadStatus as Thread["status"] });
 
@@ -245,7 +245,7 @@ describe("AgentService.sendMessage — provider availability gate", () => {
     });
   });
 
-  it.each(["errored", "interrupted", "stopped", "archived", "deleted"] as const)("rejects composer sends to %s threads before persistence", async (threadStatus) => {
+  it.each(["errored", "failed", "stopped", "archived", "deleted"] as const)("rejects composer sends to %s threads before persistence", async (threadStatus) => {
     const assertUsable = vi.fn();
     const { svc } = buildService({ threadStatus, assertUsable });
 
@@ -261,8 +261,8 @@ describe("AgentService.sendMessage — provider availability gate", () => {
     expect(assertUsable).not.toHaveBeenCalled();
   });
 
-  it("allows a direct follow-up to a completed thread through persistence and provider dispatch", async () => {
-    const { svc, threadRepo, messageRepo, providerStub } = buildService({ threadStatus: "completed" });
+  it.each(["completed", "interrupted"] as const)("allows a direct follow-up to a %s thread through persistence and provider dispatch", async (threadStatus) => {
+    const { svc, threadRepo, messageRepo, providerStub } = buildService({ threadStatus });
 
     await svc.sendMessage({
       threadId: THREAD_ID,
@@ -278,13 +278,12 @@ describe("AgentService.sendMessage — provider availability gate", () => {
     expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects a completed cross-thread target before persistence or provider side effects", async () => {
-    const assertUsable = vi.fn();
-    const { svc, threadRepo, messageRepo, providerStub } = buildService({ threadStatus: "completed", assertUsable });
+  it.each(["completed", "interrupted"] as const)("allows a fully-provenanced cross-thread send to a %s thread", async (threadStatus) => {
+    const { svc, threadRepo, messageRepo, providerStub } = buildService({ threadStatus });
 
-    await expect(svc.sendMessage({
+    await svc.sendMessage({
       threadId: THREAD_ID,
-      content: "Delegated follow-up must not resume a completed task",
+      content: "Delegated follow-up resumes the target task",
       permissionMode: "default",
       model: "claude-sonnet-4-6",
       attachments: [],
@@ -292,12 +291,29 @@ describe("AgentService.sendMessage — provider availability gate", () => {
       sourceThreadId: "source-thread",
       originSourceTurnId: "source-turn",
       sourceProviderId: "claude",
-    })).rejects.toThrow("terminal thread");
+    });
 
-    expect(assertUsable).not.toHaveBeenCalled();
-    expect(messageRepo.create).not.toHaveBeenCalled();
-    expect(threadRepo.updateStatus).not.toHaveBeenCalled();
-    expect(providerStub.sendTurn).not.toHaveBeenCalled();
+    expect(messageRepo.create).toHaveBeenCalledWith(
+      THREAD_ID,
+      "user",
+      "Delegated follow-up resumes the target task",
+      1,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        type: "thread",
+        sourceThreadId: "source-thread",
+        sourceTurnId: "source-turn",
+        sourceProviderId: "claude",
+      },
+    );
+    expect(threadRepo.updateStatus).toHaveBeenCalledWith(THREAD_ID, "active");
+    expect(providerStub.sendTurn).toHaveBeenCalledTimes(1);
   });
 
   it("rejects incomplete cross-thread provenance before provider side effects", async () => {

--- a/apps/server/src/services/__tests__/agent-service-gate.test.ts
+++ b/apps/server/src/services/__tests__/agent-service-gate.test.ts
@@ -26,8 +26,10 @@ vi.mock("../../transport/push.js", () => ({ broadcast: vi.fn() }));
 import { broadcast } from "../../transport/push.js";
 
 const THREAD_ID = "thread-abc";
+type PersistedThreadStatus = Thread["status"] | "failed" | "idle" | "stopped";
+type PersistedThread = Omit<Thread, "status"> & { status: PersistedThreadStatus };
 
-function makeThread(overrides: Partial<Thread> = {}): Thread {
+function makeThread(overrides: Partial<PersistedThread> = {}): PersistedThread {
   return {
     id: THREAD_ID,
     workspace_id: "ws-1",
@@ -66,9 +68,9 @@ function buildService({
 }: {
   assertUsable?: ReturnType<typeof vi.fn>;
   resolveProvider?: ReturnType<typeof vi.fn>;
-  threadStatus?: Thread["status"] | "failed" | "idle" | "stopped";
+  threadStatus?: PersistedThreadStatus;
 } = {}) {
-  const thread = threadStatus === "idle" ? makeThread() : makeThread({ status: threadStatus as Thread["status"] });
+  const thread = makeThread({ status: threadStatus });
 
   const threadRepo = {
     findById: vi.fn(() => thread),

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -574,11 +574,7 @@ export class AgentService {
 
     const thread = this.threadRepo.findById(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
-    const isCrossThreadSend = hasCompleteProvenance;
-    if (
-      ["errored", "failed", "interrupted", "stopped", "archived", "deleted"].includes(thread.status)
-      || (thread.status === "completed" && isCrossThreadSend)
-    ) {
+    if (["errored", "failed", "stopped", "archived", "deleted"].includes(thread.status)) {
       throw new Error(`Cannot send message to terminal thread: ${threadId}`);
     }
     // Use the thread's stored provider as authoritative fallback; only override


### PR DESCRIPTION
## What

Completed and interrupted threads now accept direct composer follow-ups and fully-provenanced cross-thread follow-ups.

## Why

Recoverable thread states were incorrectly rejected as terminal, so valid follow-ups could not resume them.

## Key Changes

- Restrict send rejection to errored, failed, stopped, archived, and deleted statuses.
- Add regression coverage for direct and cross-thread sends to completed and interrupted threads, including message persistence, active status, provenance, and provider dispatch.

## Testing

- Live Mcode Browser: opened the worktree UI, submitted follow-ups to persisted completed and interrupted probe threads, observed provider dispatch logs, and confirmed exact persisted assistant replies: `completed browser gate passed` and `interrupted browser gate passed`.
- Focused gate test: `bun run test -- src/services/__tests__/agent-service-gate.test.ts` (16/16 passed).
- `bun run typecheck` (6/6 packages passed).
- `bun run verify` (typecheck, lint, unit tests passed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788515556&installation_model_id=20477&pr_number=1090&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1090&signature=1215147e12258557506bca6724da2cd45d7ab1c35200167159ef841bd7fd02c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sending messages to interrupted threads is now supported.
  * Cross-thread messages can be sent to completed threads when the required conversation context is available.
  * Messages continue to be rejected for errored, failed, stopped, archived, and deleted threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->