### PR TITLE
test(browser): prove deterministic Browser v2 conformance

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,6 +32,7 @@
     "which": "^5.0.0"
   },
   "devDependencies": {
+    "@mcode/browser-conformance": "workspace:*",
     "@electron/fuses": "^2.1.1",
     "@resvg/resvg-js": "^2.6.2",
     "@types/uuid": "^10.0.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,8 +32,8 @@
     "which": "^5.0.0"
   },
   "devDependencies": {
-    "@mcode/browser-conformance": "workspace:*",
     "@electron/fuses": "^2.1.1",
+    "@mcode/browser-conformance": "workspace:*",
     "@resvg/resvg-js": "^2.6.2",
     "@types/uuid": "^10.0.0",
     "@types/which": "^3.0.4",
@@ -42,6 +42,7 @@
     "electron-builder": "^25.1.0",
     "electron-mksnapshot": "35.7.5",
     "esbuild": "^0.27.0",
+    "jsdom": "^29.0.1",
     "png-to-ico": "^3.0.1",
     "png2icons": "^2.0.1",
     "resedit": "^3.0.2",

--- a/apps/desktop/scripts/__tests__/sanitize-package-manifest.test.mjs
+++ b/apps/desktop/scripts/__tests__/sanitize-package-manifest.test.mjs
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { sanitizePackageManifest } from "../sanitize-package-manifest.mjs";
+
+describe("sanitizePackageManifest", () => {
+  it("removes workspace protocol entries from every npm dependency field", () => {
+    const manifest = {
+      name: "fixture",
+      version: "1.0.0",
+      dependencies: {
+        "@mcode/server": "workspace:*",
+        "better-sqlite3": "^11.8.0",
+      },
+      devDependencies: {
+        "@mcode/browser-conformance": "workspace:*",
+        vitest: "^3.2.4",
+      },
+      optionalDependencies: {
+        "@mcode/optional": "workspace:^",
+        koffi: "2.14.1",
+      },
+      peerDependencies: {
+        "@mcode/peer": "workspace:~",
+        electron: ">=35",
+      },
+      scripts: { test: "vitest" },
+      custom: { keep: true },
+    };
+    const original = structuredClone(manifest);
+
+    expect(sanitizePackageManifest(manifest)).toEqual({
+      name: "fixture",
+      version: "1.0.0",
+      dependencies: { "better-sqlite3": "^11.8.0" },
+      devDependencies: { vitest: "^3.2.4" },
+      optionalDependencies: { koffi: "2.14.1" },
+      peerDependencies: { electron: ">=35" },
+      scripts: { test: "vitest" },
+      custom: { keep: true },
+    });
+    expect(manifest).toEqual(original);
+  });
+});

--- a/apps/desktop/scripts/ci-package.mjs
+++ b/apps/desktop/scripts/ci-package.mjs
@@ -23,6 +23,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { execFileSync } from "child_process";
+import { sanitizePackageManifest } from "./sanitize-package-manifest.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
@@ -34,16 +35,11 @@ const pkgPath = resolve(desktopRoot, "package.json");
 //    rebuilds their native bindings. All other server JS is bundled in server.cjs.
 // ---------------------------------------------------------------------------
 
-const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
-const filteredDeps = {};
-for (const [name, version] of Object.entries(pkg.dependencies ?? {})) {
-  if (!String(version).startsWith("workspace:")) {
-    filteredDeps[name] = version;
-  }
-}
-pkg.dependencies = filteredDeps;
+const pkg = sanitizePackageManifest(JSON.parse(readFileSync(pkgPath, "utf8")));
 writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
-console.log("[ci-package] Stripped workspace:* dependencies from package.json");
+console.log(
+  "[ci-package] Stripped workspace:* entries from package.json dependency fields",
+);
 
 // ---------------------------------------------------------------------------
 // 2. Create a minimal package-lock.json to anchor npm in this directory and

--- a/apps/desktop/scripts/sanitize-package-manifest.mjs
+++ b/apps/desktop/scripts/sanitize-package-manifest.mjs
@@ -1,0 +1,38 @@
+const npmDependencyFields = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+
+/**
+ * Remove npm-incompatible workspace protocol entries from dependency fields.
+ *
+ * @param {Record<string, unknown>} manifest
+ * @returns {Record<string, unknown>}
+ */
+export function sanitizePackageManifest(manifest) {
+  const sanitizedManifest = { ...manifest };
+
+  for (const field of npmDependencyFields) {
+    const dependencies = manifest[field];
+    if (
+      dependencies === null ||
+      typeof dependencies !== "object" ||
+      Array.isArray(dependencies)
+    ) {
+      continue;
+    }
+
+    const filteredDependencies = {};
+    for (const [name, version] of Object.entries(dependencies)) {
+      if (typeof version === "string" && version.startsWith("workspace:")) {
+        continue;
+      }
+      filteredDependencies[name] = version;
+    }
+    sanitizedManifest[field] = filteredDependencies;
+  }
+
+  return sanitizedManifest;
+}

--- a/apps/desktop/src/main/__tests__/browser-automation-kernel-races.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel-races.test.ts
@@ -1,0 +1,594 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_AUTOMATION_CONTRACT_VERSION,
+  BROWSER_AUTOMATION_MAX_DIAGNOSTIC_ENTRIES,
+  BrowserAutomationResponseSchema,
+  type BrowserAutomationRequest,
+  type BrowserAutomationResponse,
+} from "@mcode/contracts";
+
+const rendererSender = new EventEmitter() as EventEmitter & {
+  isDestroyed: () => boolean;
+  send: ReturnType<typeof vi.fn>;
+};
+rendererSender.isDestroyed = () => false;
+rendererSender.send = vi.fn();
+
+const fakeWindow = {
+  id: 404,
+  isDestroyed: () => false,
+  webContents: rendererSender,
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>["resolve"];
+  let reject!: Deferred<T>["reject"];
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+type Command = { method: string; params: unknown };
+type CommandGate = {
+  matches: (command: Command) => boolean;
+  reached: Deferred<void>;
+  release: Deferred<void>;
+};
+
+let currentWebContents: FakeWebContents;
+const tabsByThread = new Map<string, { threadId: string; activeTabId: string; tabs: Array<{ id: string; threadId: string; view: null }> }>();
+
+class FakeDebugger extends EventEmitter {
+  attached = false;
+  readonly commands: Command[] = [];
+  private gate: CommandGate | null = null;
+
+  constructor(private readonly owner: FakeWebContents) {
+    super();
+  }
+
+  isAttached(): boolean {
+    return this.attached;
+  }
+
+  attach(): void {
+    this.attached = true;
+  }
+
+  detach(): void {
+    this.attached = false;
+    this.emit("detach");
+  }
+
+  blockNext(matches: CommandGate["matches"]): Pick<CommandGate, "reached" | "release" | "reject"> {
+    if (this.gate) throw new Error("A command gate is already installed");
+    const gate: CommandGate = { matches, reached: deferred<void>(), release: deferred<void>() };
+    this.gate = gate;
+    return gate;
+  }
+
+  async sendCommand(method: string, params?: unknown): Promise<unknown> {
+    const command = { method, params };
+    this.commands.push(command);
+    const gate = this.gate;
+    if (gate?.matches(command)) {
+      this.gate = null;
+      gate.reached.resolve(undefined);
+      await gate.release.promise;
+    }
+    if (method === "Input.dispatchKeyEvent") this.owner.emit("before-input-event", {});
+    if (method === "Page.getFrameTree") return { frameTree: { frame: { id: "main-frame" } } };
+    if (method === "Page.createIsolatedWorld") return { executionContextId: 7 };
+    if (method === "Runtime.callFunctionOn") {
+      const input = params as { functionDeclaration?: string; arguments?: Array<{ value?: unknown }> } | undefined;
+      const source = input?.functionDeclaration ?? "";
+      if (source.includes("inspectPageTarget")) {
+        return { result: { value: { attached: true, visible: true, x: 10, y: 20 } } };
+      }
+      if (source.includes("evaluateIsolatedExpression")) {
+        const argument = input?.arguments?.[0]?.value as { expression?: unknown } | undefined;
+        const expression = String(argument?.expression ?? "null");
+        if (expression === "never") return new Promise(() => undefined);
+        if (expression === "huge") return { result: { value: { ok: false, tooLarge: true } } };
+        return { result: { value: { ok: true, valueJson: "null" } } };
+      }
+      return { result: { value: false } };
+    }
+    return {};
+  }
+}
+
+class FakeWebContents extends EventEmitter {
+  readonly debugger = new FakeDebugger(this);
+  readonly send = vi.fn();
+  readonly stop = vi.fn();
+  readonly loadURL = vi.fn(async (_url: string) => undefined);
+  destroyed = false;
+  hostWebContents = rendererSender;
+  url = "https://example.test/";
+  title = "Example";
+
+  constructor(readonly id: number) {
+    super();
+  }
+
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  getURL(): string {
+    return this.url;
+  }
+
+  getTitle(): string {
+    return this.title;
+  }
+
+  isLoading(): boolean {
+    return false;
+  }
+
+  isFocused(): boolean {
+    return true;
+  }
+
+  async executeJavaScript(source: string): Promise<unknown> {
+    if (source.includes("window.innerWidth")) return { width: 1_280, height: 720 };
+    return {};
+  }
+}
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    fromWebContents: vi.fn(() => fakeWindow),
+    getAllWindows: vi.fn(() => [fakeWindow]),
+  },
+}));
+
+vi.mock("../preview/preview-webview-adopt.js", () => ({
+  findAdoptedWebContentsForWindow: vi.fn(() => currentWebContents),
+}));
+
+vi.mock("../preview/preview-session.js", () => ({
+  getSession: vi.fn(() => ({ lastPreviewThreadId: "thread", tabsByThread })),
+}));
+
+import { BrowserAutomationKernel } from "../browser-automation/kernel.js";
+
+function seedTab(tabId = "tab", threadId = "thread"): void {
+  tabsByThread.set(threadId, {
+    threadId,
+    activeTabId: tabId,
+    tabs: [{ id: tabId, threadId, view: null }],
+  });
+}
+
+let nextRequestId = 0;
+
+function request<T extends BrowserAutomationRequest["operation"]>(
+  operation: T,
+  args: Extract<BrowserAutomationRequest, { operation: T }>["args"],
+  overrides: { requestId?: string; deadline?: number; threadId?: string; expectedControlEpoch?: number } = {},
+): Extract<BrowserAutomationRequest, { operation: T }> {
+  const requestId = overrides.requestId ?? `race-${++nextRequestId}`;
+  return {
+    contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+    workspaceId: "workspace",
+    threadId: overrides.threadId ?? "thread",
+    providerSessionId: "provider-session",
+    providerInstanceId: "provider-instance",
+    requestId,
+    sequence: nextRequestId,
+    deadline: overrides.deadline ?? Date.now() + 5_000,
+    expectedControlEpoch: overrides.expectedControlEpoch ?? 0,
+    operation,
+    args,
+  } as Extract<BrowserAutomationRequest, { operation: T }>;
+}
+
+function dispatch(browserRequest: BrowserAutomationRequest, targetGeneration = 0, tabId = "tab") {
+  return {
+    scope: {
+      workspaceId: browserRequest.workspaceId,
+      threadId: browserRequest.threadId,
+      providerSessionId: browserRequest.providerSessionId,
+      providerInstanceId: browserRequest.providerInstanceId,
+    },
+    connection: {
+      desktopInstanceId: "desktop",
+      windowId: fakeWindow.id,
+      connectionGeneration: 1,
+      targetGeneration,
+    },
+    request: browserRequest,
+    target: {
+      desktopInstanceId: "desktop",
+      windowId: fakeWindow.id,
+      connectionGeneration: 1,
+      threadId: browserRequest.threadId,
+      tabId,
+      targetGeneration,
+      active: true,
+      focused: true,
+      lastUsedAt: 0,
+    },
+  };
+}
+
+function parseResponse(value: unknown): BrowserAutomationResponse {
+  const parsed = BrowserAutomationResponseSchema().safeParse(value);
+  expect(parsed.success, parsed.success ? undefined : parsed.error.message).toBe(true);
+  if (!parsed.success) throw new Error(parsed.error.message);
+  return parsed.data;
+}
+
+function event() {
+  return { sender: rendererSender } as never;
+}
+
+async function settleLateWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("BrowserAutomationKernel race conformance", () => {
+  let kernel: BrowserAutomationKernel;
+
+  beforeEach(() => {
+    currentWebContents = new FakeWebContents(1);
+    tabsByThread.clear();
+    seedTab();
+    nextRequestId = 0;
+    kernel = new BrowserAutomationKernel();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    kernel.disposeWindow(fakeWindow.id);
+    tabsByThread.clear();
+  });
+
+  it("trusted takeover stops a deferred mutation and cancellation releases held input", async () => {
+    const gate = currentWebContents.debugger.blockNext((command) =>
+      command.method === "Input.dispatchKeyEvent" &&
+      (command.params as { type?: string; key?: string }).type === "keyDown" &&
+      (command.params as { type?: string; key?: string }).key === "Enter",
+    );
+    const heldRequest = request("type", {
+      text: "typed-before-cancel",
+      clear: false,
+      submit: true,
+      timeoutMs: 5_000,
+    }, { requestId: "takeover", expectedControlEpoch: 0 });
+    const held = kernel.execute(event(), dispatch(heldRequest));
+    await gate.reached.promise;
+    expect(currentWebContents.debugger.commands).toContainEqual(expect.objectContaining({
+      method: "Input.insertText",
+      params: { text: "typed-before-cancel" },
+    }));
+    expect(kernel.interrupt(event(), { threadId: "thread", tabId: "tab" })).toBe(true);
+    gate.release.resolve(undefined);
+    const heldResponse = parseResponse(await held);
+    expect(heldResponse).toMatchObject({
+      ok: false,
+      requestId: "takeover",
+      error: { code: "HUMAN_INTERRUPTED", effect: "preserved", recovery: "retry" },
+    });
+    await settleLateWork();
+    const enterKeyDown = currentWebContents.debugger.commands.findIndex((command) =>
+      command.method === "Input.dispatchKeyEvent" &&
+      (command.params as { type?: string; key?: string }).type === "keyDown" &&
+      (command.params as { type?: string; key?: string }).key === "Enter",
+    );
+    expect(enterKeyDown).toBeGreaterThanOrEqual(0);
+    expect(currentWebContents.debugger.commands.slice(enterKeyDown + 1)).toContainEqual(expect.objectContaining({
+      method: "Input.dispatchKeyEvent",
+      params: expect.objectContaining({ type: "keyUp", key: "Enter" }),
+    }));
+    const status = parseResponse(await kernel.execute(event(), dispatch(request("status", {}, { requestId: "takeover-status" }))));
+    expect(status).toMatchObject({ ok: true, result: { controller: { controller: "human", controlEpoch: 1 } } });
+  });
+
+  it("does not continue a cleared type mutation after takeover before text insertion", async () => {
+    const gate = currentWebContents.debugger.blockNext((command) =>
+      command.method === "Input.dispatchKeyEvent" &&
+      (command.params as { type?: string; key?: string }).type === "keyUp" &&
+      (command.params as { type?: string; key?: string }).key === "Backspace",
+    );
+    const pending = kernel.execute(event(), dispatch(request("type", {
+      text: "must-not-be-inserted",
+      clear: true,
+      submit: false,
+      timeoutMs: 5_000,
+    }, { requestId: "clear-takeover" })));
+
+    await gate.reached.promise;
+    expect(currentWebContents.debugger.commands).toContainEqual(expect.objectContaining({
+      method: "Input.dispatchKeyEvent",
+      params: expect.objectContaining({ type: "keyDown", key: "a" }),
+    }));
+    expect(currentWebContents.debugger.commands).toContainEqual(expect.objectContaining({
+      method: "Input.dispatchKeyEvent",
+      params: expect.objectContaining({ type: "keyDown", key: "Backspace" }),
+    }));
+    gate.release.resolve(undefined);
+    expect(kernel.interrupt(event(), { threadId: "thread", tabId: "tab" })).toBe(true);
+
+    const response = parseResponse(await pending);
+    expect(response).toMatchObject({
+      ok: false,
+      requestId: "clear-takeover",
+      error: { code: "HUMAN_INTERRUPTED", effect: "preserved", recovery: "retry" },
+    });
+    await settleLateWork();
+    expect(currentWebContents.debugger.commands.filter((command) => command.method === "Input.insertText")).toHaveLength(0);
+    expect(parseResponse(await kernel.execute(event(), dispatch(request("status", {}, { requestId: "clear-takeover-status" }))))).toMatchObject({
+      ok: true,
+      result: { controller: { controller: "human", controlEpoch: 1 } },
+    });
+    expect(kernel.getCounters()).toMatchObject({ cancellations: 0, active: 0, queued: 0 });
+  });
+
+  it("does not release a clicked point after takeover before mouse release", async () => {
+    const gate = currentWebContents.debugger.blockNext((command) =>
+      command.method === "Input.dispatchMouseEvent" &&
+      (command.params as { type?: string }).type === "mousePressed",
+    );
+    const pending = kernel.execute(event(), dispatch(request("click", {
+      target: { x: 10, y: 20 },
+      button: "left",
+      clickCount: 1,
+      timeoutMs: 5_000,
+    }, { requestId: "click-takeover" })));
+
+    await gate.reached.promise;
+    gate.release.resolve(undefined);
+    expect(kernel.interrupt(event(), { threadId: "thread", tabId: "tab" })).toBe(true);
+    expect(parseResponse(await pending)).toMatchObject({
+      ok: false,
+      requestId: "click-takeover",
+      error: { code: "HUMAN_INTERRUPTED", effect: "preserved", recovery: "retry" },
+    });
+    await settleLateWork();
+    const pointReleases = currentWebContents.debugger.commands.filter((command) =>
+      command.method === "Input.dispatchMouseEvent" &&
+      (command.params as { type?: string; x?: number; y?: number }).type === "mouseReleased" &&
+      (command.params as { x?: number; y?: number }).x === 10 &&
+      (command.params as { x?: number; y?: number }).y === 20,
+    );
+    expect(pointReleases).toHaveLength(0);
+    expect(kernel.getCounters()).toMatchObject({ cancellations: 0, active: 0, queued: 0 });
+  });
+
+  it("does not type after a target click is interrupted", async () => {
+    const gate = currentWebContents.debugger.blockNext((command) =>
+      command.method === "Input.dispatchMouseEvent" &&
+      (command.params as { type?: string }).type === "mousePressed",
+    );
+    const pending = kernel.execute(event(), dispatch(request("type", {
+      target: { x: 10, y: 20 },
+      text: "must-not-follow-click",
+      clear: false,
+      submit: false,
+      timeoutMs: 5_000,
+    }, { requestId: "target-click-takeover" })));
+
+    await gate.reached.promise;
+    gate.release.resolve(undefined);
+    expect(kernel.interrupt(event(), { threadId: "thread", tabId: "tab" })).toBe(true);
+    expect(parseResponse(await pending)).toMatchObject({
+      ok: false,
+      requestId: "target-click-takeover",
+      error: { code: "HUMAN_INTERRUPTED", effect: "preserved", recovery: "retry" },
+    });
+    await settleLateWork();
+    expect(currentWebContents.debugger.commands.filter((command) => command.method === "Input.insertText")).toHaveLength(0);
+  });
+
+  it("reports evaluation oversize and timeout after dispatch as bounded failures", async () => {
+    const oversize = parseResponse(await kernel.execute(event(), dispatch(request("evaluate", {
+      idempotencyKey: "oversize",
+      observationRef: "observation",
+      deadlineMs: 1_000,
+      expression: "huge",
+      awaitPromise: true,
+      timeoutMs: 1_000,
+    }, { requestId: "evaluate-oversize" }))));
+    expect(oversize).toMatchObject({
+      ok: false,
+      requestId: "evaluate-oversize",
+      error: { code: "RESULT_TOO_LARGE", effect: "preserved", recovery: "manual" },
+    });
+
+    vi.useFakeTimers();
+    const timeout = kernel.execute(event(), dispatch(request("evaluate", {
+      idempotencyKey: "timeout",
+      observationRef: "observation",
+      deadlineMs: 1_000,
+      expression: "never",
+      awaitPromise: true,
+      timeoutMs: 10,
+    }, { requestId: "evaluate-timeout", deadline: Date.now() + 1_000 })));
+    await vi.advanceTimersByTimeAsync(10);
+    expect(parseResponse(await timeout)).toMatchObject({
+      ok: false,
+      requestId: "evaluate-timeout",
+      error: { code: "TIMEOUT", effect: "preserved", recovery: "retry" },
+    });
+    vi.useRealTimers();
+  });
+
+  it("cancellation and deadline between effects return bounded recovery without false success", async () => {
+    vi.useFakeTimers();
+    const gate = currentWebContents.debugger.blockNext((command) => command.method === "Input.insertText");
+    const cancelledRequest = request("type", {
+      text: "cancel-before-submit",
+      clear: false,
+      submit: true,
+      timeoutMs: 5_000,
+    }, { requestId: "cancel-between-effects" });
+    const cancelled = kernel.execute(event(), dispatch(cancelledRequest));
+    await gate.reached.promise;
+    expect(kernel.cancel(cancelledRequest.requestId)).toBe(true);
+    gate.release.reject(new Error("cancelled before text commit"));
+    const cancelledResponse = parseResponse(await cancelled);
+    expect(cancelledResponse).toMatchObject({
+      ok: false,
+      requestId: "cancel-between-effects",
+      error: { code: "OPERATION_CANCELLED", effect: "preserved", recovery: "retry" },
+    });
+    expect(cancelledResponse.ok).toBe(false);
+    expect(cancelledResponse.result).toBeUndefined();
+    expect(currentWebContents.debugger.commands).not.toContainEqual(expect.objectContaining({
+      method: "Input.dispatchKeyEvent",
+      params: expect.objectContaining({ type: "keyDown", key: "Enter" }),
+    }));
+
+    const load = deferred<void>();
+    currentWebContents.loadURL.mockImplementationOnce(() => load.promise);
+    const deadlineRequest = request("navigate", { url: "https://deadline.example/" }, {
+      requestId: "deadline-between-effects",
+      deadline: Date.now() + 30,
+    });
+    const deadline = kernel.execute(event(), dispatch(deadlineRequest));
+    await vi.advanceTimersByTimeAsync(31);
+    const deadlineResponse = parseResponse(await deadline);
+    expect(deadlineResponse).toMatchObject({
+      ok: false,
+      requestId: "deadline-between-effects",
+      error: { code: "TIMEOUT", effect: "preserved", recovery: "retry" },
+    });
+    load.resolve(undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deadlineResponse.ok).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("rejects stale late completion after target replacement without touching the new generation", async () => {
+    const oldTarget = currentWebContents;
+    const gate = oldTarget.debugger.blockNext((command) =>
+      command.method === "Input.dispatchKeyEvent" &&
+      (command.params as { type?: string; key?: string }).type === "keyDown" &&
+      (command.params as { type?: string; key?: string }).key === "Enter",
+    );
+    const oldRequest = request("type", { text: "old-target", clear: false, submit: true, timeoutMs: 5_000 }, { requestId: "old-target" });
+    const oldPending = kernel.execute(event(), dispatch(oldRequest));
+    await gate.reached.promise;
+
+    oldTarget.destroyed = true;
+    oldTarget.emit("destroyed");
+    currentWebContents = new FakeWebContents(2);
+    seedTab();
+    const replacement = currentWebContents;
+    const replacementResponse = parseResponse(await kernel.execute(event(), dispatch(
+      request("status", {}, { requestId: "new-target" }),
+      1,
+    )));
+    expect(replacementResponse).toMatchObject({ ok: true, result: { controller: { controller: "none" } } });
+
+    gate.release.resolve(undefined);
+    const oldResponse = parseResponse(await oldPending);
+    expect(oldResponse).toMatchObject({ ok: false, requestId: "old-target" });
+    await settleLateWork();
+    expect(replacement.debugger.commands.filter((command) => command.method.startsWith("Input."))).toHaveLength(0);
+    expect(parseResponse(await kernel.execute(event(), dispatch(
+      request("status", {}, { requestId: "new-target-after-late" }),
+      1,
+    )))).toMatchObject({ ok: true, result: { controller: { controller: "none", controlEpoch: 0 } } });
+  });
+
+  it("disposes active work and ignores late debugger, event, and timer activity", async () => {
+    vi.useFakeTimers();
+    const target = currentWebContents;
+    const pending = kernel.execute(event(), dispatch(request("waitFor", {
+      text: "never-observed",
+      timeoutMs: 5_000,
+    }, { requestId: "dispose-race" })));
+    for (let attempt = 0; attempt < 20 && target.debugger.listenerCount("message") === 0; attempt += 1) {
+      await Promise.resolve();
+    }
+    target.emit("console-message", {}, 3, "before-dispose", 1, "https://example.test/");
+    target.debugger.emit("message", {}, "Network.requestWillBeSent", {
+      requestId: "before-dispose",
+      request: { url: "https://example.test/resource", method: "GET" },
+    });
+    kernel.disposeWindow(fakeWindow.id);
+    setTimeout(() => {
+      target.emit("console-message", {}, 3, "late-console", 1, "https://late.example/");
+      target.debugger.emit("message", {}, "Network.responseReceived", {
+        requestId: "before-dispose",
+        response: { url: "https://late.example/", status: 200 },
+      });
+    }, 5);
+    parseResponse(await pending);
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(target.listenerCount("destroyed")).toBe(0);
+    expect(target.listenerCount("did-start-navigation")).toBe(0);
+    expect(target.listenerCount("console-message")).toBe(0);
+    expect(target.debugger.listenerCount("message")).toBe(0);
+    expect(target.debugger.listenerCount("detach")).toBe(0);
+    expect(target.debugger.isAttached()).toBe(false);
+    expect(kernel.getCounters()).toEqual({ targets: 0, targetGenerations: 0, cancellations: 0, active: 0, queued: 0 });
+
+    currentWebContents = new FakeWebContents(2);
+    seedTab();
+    const consoleResponse = parseResponse(await kernel.execute(event(), dispatch(request("console", { limit: 200 }, { requestId: "post-dispose-console" }))));
+    expect(consoleResponse).toMatchObject({ ok: true, result: { entries: [], truncation: { originalCount: 0 } } });
+    const networkResponse = parseResponse(await kernel.execute(event(), dispatch(request("network", { failedOnly: false, limit: 200 }, { requestId: "post-dispose-network" }))));
+    expect(networkResponse).toMatchObject({ ok: true, result: { entries: [], truncation: { originalCount: 0 } } });
+    vi.useRealTimers();
+  });
+
+  it("bounds diagnostic buffers and target-generation tombstones during churn", async () => {
+    await kernel.execute(event(), dispatch(request("network", { failedOnly: false, limit: 200 }, { requestId: "buffer-init" })));
+    for (let index = 0; index < BROWSER_AUTOMATION_MAX_DIAGNOSTIC_ENTRIES + 40; index += 1) {
+      currentWebContents.emit("console-message", {}, 2, `console-${index}`, index, "https://example.test/");
+      currentWebContents.debugger.emit("message", {}, "Network.requestWillBeSent", {
+        requestId: `request-${index}`,
+        request: { url: `https://example.test/resource-${index}`, method: "GET" },
+      });
+      currentWebContents.debugger.emit("message", {}, "Network.responseReceived", {
+        requestId: `request-${index}`,
+        response: { url: `https://example.test/resource-${index}`, status: 200 },
+      });
+    }
+    const consoleResponse = parseResponse(await kernel.execute(event(), dispatch(request("console", { limit: 200 }, { requestId: "buffer-console" }))));
+    const networkResponse = parseResponse(await kernel.execute(event(), dispatch(request("network", { failedOnly: false, limit: 200 }, { requestId: "buffer-network" }))));
+    expect(consoleResponse).toMatchObject({ ok: true, result: { entries: expect.any(Array) } });
+    expect(networkResponse).toMatchObject({ ok: true, result: { entries: expect.any(Array) } });
+    if (!consoleResponse.ok || !networkResponse.ok) throw new Error("Expected bounded diagnostic responses");
+    expect(consoleResponse.result.operation).toBe("console");
+    expect(networkResponse.result.operation).toBe("network");
+    expect(consoleResponse.result.entries).toHaveLength(BROWSER_AUTOMATION_MAX_DIAGNOSTIC_ENTRIES);
+    expect(networkResponse.result.entries).toHaveLength(BROWSER_AUTOMATION_MAX_DIAGNOSTIC_ENTRIES);
+
+    currentWebContents.destroyed = true;
+    currentWebContents.emit("destroyed");
+
+    for (let index = 0; index < 300; index += 1) {
+      const tabId = `churn-tab-${index}`;
+      seedTab(tabId);
+      currentWebContents = new FakeWebContents(index + 10);
+      parseResponse(await kernel.execute(event(), dispatch(
+        request("status", {}, { requestId: `churn-${index}` }),
+        0,
+        tabId,
+      )));
+      currentWebContents.destroyed = true;
+      currentWebContents.emit("destroyed");
+    }
+    expect(kernel.getCounters()).toMatchObject({ targets: 0, targetGenerations: 128, cancellations: 0, active: 0, queued: 0 });
+  });
+});

--- a/apps/desktop/src/main/__tests__/browser-automation-kernel-races.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel-races.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BROWSER_AUTOMATION_CONTRACT_VERSION,
@@ -6,7 +9,23 @@ import {
   BrowserAutomationResponseSchema,
   type BrowserAutomationRequest,
   type BrowserAutomationResponse,
+  type BrowserAutomationHostDispatch,
 } from "@mcode/contracts";
+import {
+  BROWSER_CONFORMANCE_RACE_CATALOGUE,
+  createBrowserConformanceResourceSnapshot,
+  createBrowserConformanceRevisionRaceSchedules,
+  createBrowserConformanceScenario,
+  createBrowserConformanceSchedule,
+  normalizeBrowserConformanceRun,
+  runBrowserConformanceScenarioWithReplay,
+  type BrowserConformanceCommand,
+  type BrowserConformanceNormalizedRun,
+  type BrowserConformanceReceipt,
+  type BrowserConformanceResourceSnapshot,
+  type BrowserConformanceScheduledEvent,
+  type BrowserConformanceSubject,
+} from "@mcode/browser-conformance";
 
 const rendererSender = new EventEmitter() as EventEmitter & {
   isDestroyed: () => boolean;
@@ -45,6 +64,7 @@ type CommandGate = {
 };
 
 let currentWebContents: FakeWebContents;
+const replayRoots: string[] = [];
 const tabsByThread = new Map<string, { threadId: string; activeTabId: string; tabs: Array<{ id: string; threadId: string; view: null }> }>();
 
 class FakeDebugger extends EventEmitter {
@@ -163,6 +183,7 @@ vi.mock("../preview/preview-session.js", () => ({
 }));
 
 import { BrowserAutomationKernel } from "../browser-automation/kernel.js";
+import { BrowserSessionDriver, ElectronBrowserSessionAdapter } from "../../../../web/src/services/browser-automation/browserSessionDriver";
 
 function seedTab(tabId = "tab", threadId = "thread"): void {
   tabsByThread.set(threadId, {
@@ -231,6 +252,186 @@ function parseResponse(value: unknown): BrowserAutomationResponse {
   return parsed.data;
 }
 
+type ConformanceRevisions = { host: number; document: number; control: number; capability: number; observation: number };
+type BrowserMutationCounters = { debuggerInput: number; navigation: number; loadURL: number };
+
+class KernelConformanceSubject implements BrowserConformanceSubject {
+  private readonly receipts: BrowserConformanceReceipt[] = [];
+  private readonly requestLeases = new Set<string>();
+  private readonly scheduled = new Set<string>();
+  private readonly timerLeases = new Set<number>();
+  private readonly heldInputLeases = new Set<string>();
+  private readonly controllerLeases = new Set<string>();
+  private readonly replayEntries = new Map<string, string>();
+  private readonly registryEntries = new Map<string, string>();
+  private readonly bufferEntries = new Set<string>();
+  private readonly mutationCounters?: () => BrowserMutationCounters;
+  private preActMutationCounters: BrowserMutationCounters | undefined;
+  private readonly revisions: ConformanceRevisions;
+  private readonly admissionRevisions: ConformanceRevisions;
+  private readonly liveTargets: Map<string, ReturnType<typeof kernelTarget>>;
+  private tick = 0;
+  private disposed = false;
+  private observationRef: string | undefined;
+
+  constructor(
+    private readonly driver: BrowserSessionDriver,
+    private readonly kernel: BrowserAutomationKernel,
+    revisions: ConformanceRevisions,
+    admissionRevisions: ConformanceRevisions,
+    liveTargets = new Map([["tab", kernelTarget()]]),
+    mutationCounters?: () => BrowserMutationCounters,
+  ) { this.revisions = revisions; this.admissionRevisions = admissionRevisions; this.liveTargets = liveTargets; this.mutationCounters = mutationCounters; }
+
+  mutationSnapshotBeforeAct(): BrowserMutationCounters | undefined {
+    return this.preActMutationCounters;
+  }
+
+  async dispatch(command: BrowserConformanceCommand): Promise<BrowserConformanceReceipt> {
+    if (command.operation === "act" && this.mutationCounters) this.preActMutationCounters = this.mutationCounters();
+    const requestKey = `${command.id}:${this.receipts.length}`;
+    this.requestLeases.add(requestKey);
+    this.bufferEntries.add(requestKey);
+    this.registryEntries.set("provider-session", "active");
+    if (command.operation === "act") {
+      this.heldInputLeases.add(requestKey);
+      this.controllerLeases.add(requestKey);
+    }
+    const args = { ...(command.args ?? (command.operation === "inspect" ? { includeScreenshot: false, includeDiagnostics: false } : {})) } as Record<string, unknown>;
+    if (command.operation === "act") args.observationRef = this.observationRef ?? "missing-observation";
+    const request = requestForConformance({ ...command, args }, this.receipts.length);
+    const envelope = dispatch(request) as unknown as BrowserAutomationHostDispatch;
+    envelope.connection = { ...envelope.connection, capabilityRevision: 1 };
+    const response = parseResponse(await this.driver.execute(envelope, new AbortController().signal));
+    if (response.ok) {
+      const result = response.result as { observationRef?: string; nextObservationRef?: string; finalObservation?: { observationRef?: string } };
+      this.observationRef = result.nextObservationRef ?? result.finalObservation?.observationRef ?? result.observationRef ?? this.observationRef;
+      if (this.observationRef) this.replayEntries.set(this.observationRef, requestKey);
+    }
+    const raw = {
+      receipts: [{
+        order: { tick: this.tick, ordinal: this.receipts.length },
+        commandId: command.id,
+        operation: command.operation,
+        status: response.ok ? "applied" : "failed",
+        effect: response.ok ? "none" : response.error.effect,
+        recovery: response.ok ? "none" : response.error.recovery,
+        errorCode: response.ok ? null : response.error.code,
+        errorStage: response.ok ? "observation" : response.error.stage,
+        revisions: this.revisions,
+      }],
+      outcome: response.ok ? { status: "completed", effect: "none", recovery: "none", revisions: this.revisions } : { status: "failed", effect: response.error.effect, recovery: response.error.recovery, errorCode: response.error.code, errorStage: response.error.stage, revisions: this.revisions },
+      finalState: { readiness: "ready", controlOwner: "none", tabCount: 1, currentUrl: null, revisions: this.revisions, resources: this.snapshotResources() },
+    };
+    const receipt = normalizeBrowserConformanceRun(raw).receipts[0]!;
+    this.receipts.push(receipt);
+    return receipt;
+  }
+
+  schedule(eventValue: BrowserConformanceScheduledEvent): void {
+    if (!this.disposed) this.scheduled.add(`${eventValue.order.tick}:${eventValue.order.ordinal}`);
+  }
+  async advanceClock(tick: number): Promise<void> {
+    this.tick = tick;
+    this.timerLeases.add(tick);
+  }
+  async injectExternalEvent(eventValue: BrowserConformanceScheduledEvent): Promise<void> {
+    if (this.disposed) return;
+    if (eventValue.kind === "target-close") {
+      this.driver.clearIdempotencyForTarget("thread", "tab");
+      this.liveTargets.delete("tab");
+    } else if (eventValue.kind === "target-register") {
+      this.liveTargets.set("tab", kernelTarget());
+    }
+    const revision = eventValue.revision ?? revisionForEvent(eventValue.kind);
+    if (revision) {
+      this.revisions[revision] += 1;
+      this.admissionRevisions[revision] += 1;
+      if (revision === "observation") this.driver.invalidateTargetObservations("thread", "tab");
+    }
+  }
+  snapshotOutcome(): BrowserConformanceNormalizedRun {
+    const last = this.receipts.at(-1);
+    return normalizeBrowserConformanceRun({
+      receipts: this.receipts,
+      outcome: { status: last?.status === "failed" ? "failed" : "completed", effect: last?.effect ?? "none", recovery: last?.recovery ?? "none", revisions: this.revisions },
+      finalState: { readiness: "ready", controlOwner: "none", tabCount: 1, currentUrl: null, revisions: this.revisions, resources: this.snapshotResources() },
+    });
+  }
+  snapshotResources(): BrowserConformanceResourceSnapshot {
+    const counters = this.kernel.getCounters();
+    const listenerCount = currentWebContents.eventNames().reduce((total, name) => total + currentWebContents.listenerCount(name), 0)
+      + currentWebContents.debugger.eventNames().reduce((total, name) => total + currentWebContents.debugger.listenerCount(name), 0);
+    return createBrowserConformanceResourceSnapshot({
+      counts: {
+        requests: this.requestLeases.size,
+        queues: Math.max(counters.queued, this.scheduled.size),
+        timers: this.timerLeases.size,
+        listeners: listenerCount,
+        heldInput: this.heldInputLeases.size,
+        controllerLeases: this.controllerLeases.size,
+        targets: counters.targets,
+        replayEntries: this.replayEntries.size,
+        registries: this.registryEntries.size,
+        buffers: this.bufferEntries.size,
+      },
+      identities: { targets: counters.targets > 0 ? [{ id: "browser-target", generation: kernelTarget().targetGeneration }] : [] },
+    });
+  }
+  async drainToQuiescence(): Promise<void> { await settleLateWork(); }
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    await this.driver.releaseProviderSession("provider-session");
+    this.kernel.disposeWindow(fakeWindow.id);
+    this.liveTargets.clear();
+    this.requestLeases.clear();
+    this.scheduled.clear();
+    this.timerLeases.clear();
+    this.heldInputLeases.clear();
+    this.controllerLeases.clear();
+    this.replayEntries.clear();
+    this.registryEntries.clear();
+    this.bufferEntries.clear();
+  }
+}
+
+function requestForConformance(command: BrowserConformanceCommand, sequence: number): BrowserAutomationRequest {
+  const args = command.args ?? (command.operation === "inspect" ? { includeScreenshot: false, includeDiagnostics: false } : {});
+  return request(command.operation as BrowserAutomationRequest["operation"], args as never, { requestId: `conformance-${command.id}-${sequence}`, expectedControlEpoch: 0 });
+}
+
+function revisionForEvent(kind: BrowserConformanceScheduledEvent["kind"]): keyof ConformanceRevisions | undefined {
+  switch (kind) {
+    case "host-disconnect":
+    case "host-reconnect": return "host";
+    case "navigation":
+    case "reload":
+    case "document-revision": return "document";
+    case "user-takeover":
+    case "competing-mutation":
+    case "cancel":
+    case "timeout":
+    case "resize":
+    case "control-revision": return "control";
+    case "capability-revision": return "capability";
+    case "observation-revision": return "observation";
+    default: return undefined;
+  }
+}
+
+function kernelTarget() {
+  return { desktopInstanceId: "desktop", windowId: fakeWindow.id, connectionGeneration: 1, threadId: "thread", tabId: "tab", targetGeneration: 0, active: true, focused: true, lastUsedAt: 0 } as const;
+}
+
+function mutationCounters(webContents: FakeWebContents): BrowserMutationCounters {
+  return {
+    debuggerInput: webContents.debugger.commands.filter((command) => command.method.startsWith("Input.")).length,
+    navigation: webContents.debugger.commands.filter((command) => command.method === "Page.navigate").length,
+    loadURL: webContents.loadURL.mock.calls.length,
+  };
+}
+
 function event() {
   return { sender: rendererSender } as never;
 }
@@ -252,10 +453,11 @@ describe("BrowserAutomationKernel race conformance", () => {
     kernel = new BrowserAutomationKernel();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
     kernel.disposeWindow(fakeWindow.id);
     tabsByThread.clear();
+    await Promise.all(replayRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
   });
 
   it("trusted takeover stops a deferred mutation and cancellation releases held input", async () => {
@@ -426,6 +628,143 @@ describe("BrowserAutomationKernel race conformance", () => {
       error: { code: "TIMEOUT", effect: "preserved", recovery: "retry" },
     });
     vi.useRealTimers();
+  });
+
+  it("executes every seeded revision schedule through the real Electron kernel with replay hooks", async () => {
+    const replayRoot = await mkdtemp(join(tmpdir(), "mcode-kernel-conformance-"));
+    replayRoots.push(replayRoot);
+    const generated = createBrowserConformanceRevisionRaceSchedules({
+      seed: "electron-kernel-revision-races",
+      maxCommands: 2,
+      maxEvents: 8,
+      maxCheckpoints: 4,
+      maxTick: 0,
+    });
+    const schedules = [...Object.values(generated.individual), ...generated.pairs, ...generated.highRisk];
+    for (const generatedSchedule of schedules) {
+      currentWebContents = new FakeWebContents(1);
+      tabsByThread.clear();
+      seedTab();
+      const seededKernel = new BrowserAutomationKernel();
+      const revisions = { host: 1, document: 0, control: 0, capability: 1, observation: 0 };
+      const liveTargets = new Map([["tab", kernelTarget()]]);
+      const electronAdapter = new ElectronBrowserSessionAdapter((dispatchValue) => seededKernel.execute(event(), dispatchValue));
+      const driver = new BrowserSessionDriver({
+        web: electronAdapter,
+        electron: electronAdapter,
+        isElectron: () => true,
+        getHostRevision: () => revisions.host,
+        getDocumentRevision: () => revisions.document,
+        getControlRevision: () => revisions.control,
+        getCapabilityRevision: () => revisions.capability,
+        supportedActOperations: ["click", "navigate"],
+        electronTabs: { list: async () => [...liveTargets.values()], close: async (closedTarget) => { liveTargets.delete(closedTarget.tabId); } },
+      });
+      const subject = new KernelConformanceSubject(driver, seededKernel, { host: 0, document: 0, control: 0, capability: 0, observation: 0 }, revisions, liveTargets, () => mutationCounters(currentWebContents));
+      const scenario = createBrowserConformanceScenario({
+        id: `electron-kernel-${generatedSchedule.id}`,
+        seed: generatedSchedule.schedule.seed,
+        commands: [
+          { id: "inspect-before-revision", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } },
+          {
+            id: "act-after-revision",
+            operation: "act",
+            args: {
+              observationRef: "$lastObservationRef",
+              deadlineMs: 10_000,
+              steps: [{ operation: "click", target: { cssSelector: "#save" } }],
+            },
+          },
+        ],
+        schedule: generatedSchedule.schedule,
+        cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+      });
+      const run = await runBrowserConformanceScenarioWithReplay(scenario, subject, {
+        workspaceRoot: replayRoot,
+        fileName: `electron-kernel-${generatedSchedule.id}.json`,
+        failingInvariant: "electron kernel seeded revision schedule remains bounded",
+      });
+      expect(run.outcome.status, generatedSchedule.id).not.toBe("unknown");
+      expect(run.finalState.resources.targets, generatedSchedule.id).toBe(1);
+      expect(run.finalState.resources.requests, generatedSchedule.id).toBeGreaterThan(0);
+      expect(run.receipts.length, generatedSchedule.id).toBe(2);
+      expect(run.receipts.every((receipt) => receipt.status !== "unknown" && receipt.effect !== "unknown" && receipt.recovery !== "unknown"), generatedSchedule.id).toBe(true);
+      const terminalReceipt = run.receipts.at(-1);
+      expect(terminalReceipt?.status, generatedSchedule.id).toBe("failed");
+      expect(terminalReceipt?.errorCode, generatedSchedule.id).toBe(
+        generatedSchedule.revisions.includes("capability") ? "CAPABILITY_CHANGED" : "STALE_TARGET_GENERATION",
+      );
+      expect(terminalReceipt?.effect, generatedSchedule.id).toBe("none");
+      expect(subject.mutationSnapshotBeforeAct(), generatedSchedule.id).toEqual(mutationCounters(currentWebContents));
+      expect(subject.snapshotResources()).toEqual(createBrowserConformanceResourceSnapshot());
+    }
+  });
+
+  it("executes every named catalogue race through the real Electron adapter with replay hooks", async () => {
+    const replayRoot = await mkdtemp(join(tmpdir(), "mcode-kernel-catalogue-"));
+    replayRoots.push(replayRoot);
+    const exercisedRaceIds = new Set<string>();
+    for (const race of BROWSER_CONFORMANCE_RACE_CATALOGUE) {
+      currentWebContents = new FakeWebContents(1);
+      tabsByThread.clear();
+      seedTab();
+      const seededKernel = new BrowserAutomationKernel();
+      const revisions = { host: 1, document: 0, control: 0, capability: 1, observation: 0 };
+      const liveTargets = new Map([["tab", kernelTarget()]]);
+      const electronAdapter = new ElectronBrowserSessionAdapter((dispatchValue) => seededKernel.execute(event(), dispatchValue));
+      const driver = new BrowserSessionDriver({
+        web: electronAdapter,
+        electron: electronAdapter,
+        isElectron: () => true,
+        getHostRevision: () => revisions.host,
+        getDocumentRevision: () => revisions.document,
+        getControlRevision: () => revisions.control,
+        getCapabilityRevision: () => revisions.capability,
+        supportedActOperations: ["click", "navigate"],
+        electronTabs: { list: async () => [...liveTargets.values()], close: async (closedTarget) => { liveTargets.delete(closedTarget.tabId); } },
+      });
+      const subject = new KernelConformanceSubject(driver, seededKernel, { host: 0, document: 0, control: 0, capability: 0, observation: 0 }, revisions, liveTargets, () => mutationCounters(currentWebContents));
+      const schedule = createBrowserConformanceSchedule({
+        seed: race.id,
+        maxCommands: 2,
+        maxEvents: race.events.length,
+        maxCheckpoints: 0,
+        maxTick: 0,
+        eventCount: 0,
+      });
+      const scenario = createBrowserConformanceScenario({
+        id: `electron-catalogue-${race.id}`,
+        seed: race.id,
+        commands: [
+          { id: `${race.id}-inspect`, operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } },
+          {
+            id: `${race.id}-act`,
+            operation: "act",
+            args: {
+              observationRef: "$lastObservationRef",
+              deadlineMs: 10_000,
+              steps: [{ operation: "click", target: { cssSelector: "#save" } }],
+            },
+          },
+        ],
+        schedule: {
+          ...schedule,
+          events: race.events.map((kind, ordinal) => ({ order: { tick: 0, ordinal }, kind })),
+        },
+        cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+      });
+      const run = await runBrowserConformanceScenarioWithReplay(scenario, subject, {
+        workspaceRoot: replayRoot,
+        fileName: `electron-catalogue-${race.id}.json`,
+        failingInvariant: race.invariant,
+      });
+      expect(run.outcome.status, race.id).not.toBe("unknown");
+      expect(run.finalState.resources.requests, race.id).toBeGreaterThan(0);
+      expect(run.receipts.every((receipt) => receipt.status !== "unknown" && receipt.effect !== "unknown" && receipt.recovery !== "unknown"), race.id).toBe(true);
+      expect(subject.snapshotResources(), race.id).toEqual(createBrowserConformanceResourceSnapshot());
+      exercisedRaceIds.add(race.id);
+    }
+    expect(exercisedRaceIds).toEqual(new Set(BROWSER_CONFORMANCE_RACE_CATALOGUE.map((race) => race.id)));
   });
 
   it("cancellation and deadline between effects return bounded recovery without false success", async () => {

--- a/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
@@ -476,16 +476,20 @@ describe("BrowserAutomationKernel", () => {
   });
 
   it("does not treat synthetic keyboard input as human takeover and releases held input", async () => {
-    let rendererInterruptResult: boolean | null = null;
+    let syntheticInputObserved = false;
     currentWebContents!.on("before-input-event", () => {
-      rendererInterruptResult = kernel.interrupt(event(), { threadId: "thread", tabId: "tab" });
+      syntheticInputObserved = true;
     });
     const pressed = await kernel.execute(event(), payload(request("press", { key: "A", modifiers: ["Shift"] })));
     expect(pressed).toMatchObject({ ok: true });
-    expect(rendererInterruptResult).toBe(false);
+    expect(syntheticInputObserved).toBe(true);
     const commands = currentWebContents!.debugger.commands.map((command) => command.method);
     expect(commands.filter((method) => method === "Input.dispatchKeyEvent").length).toBeGreaterThanOrEqual(4);
-    await expect(kernel.execute(event(), payload(request("status")))).resolves.toMatchObject({ ok: true });
+    await expect(kernel.execute(event(), payload(request("status")))).resolves.toMatchObject({
+      ok: true,
+      result: { controller: { controller: "agent", controlEpoch: 0 } },
+    });
+    expect(kernel.interrupt(event(), { threadId: "thread", tabId: "tab" })).toBe(true);
   });
 
   it("revokes failed CDP input before an immediate trusted human takeover", async () => {
@@ -516,7 +520,7 @@ describe("BrowserAutomationKernel", () => {
     expect(kernel.interrupt(event(), { threadId: "thread", tabId: "tab" })).toBe(true);
   });
 
-  it("does not treat a click-triggered link navigation as delayed human takeover", async () => {
+  it("does not treat click-triggered link navigation as human takeover", async () => {
     vi.useFakeTimers();
     currentWebContents!.semanticElements.set("link", { attached: true, visible: true, x: 10, y: 20 });
     await kernel.execute(event(), payload(request("click", {
@@ -525,17 +529,10 @@ describe("BrowserAutomationKernel", () => {
       clickCount: 1,
       timeoutMs: 1_000,
     }, { requestId: "click-link" })));
-    expect(kernel.interrupt(event(), { threadId: "thread", tabId: "tab" })).toBe(false);
     currentWebContents!.emit("did-start-navigation", {}, "https://example.test/next", false, true);
     await expect(kernel.execute(event(), payload(request("status", {}, { requestId: "status-after-click-navigation" })))).resolves.toMatchObject({
       ok: true,
       result: { controller: { controller: "agent", controlEpoch: 0 } },
-    });
-    await vi.advanceTimersByTimeAsync(251);
-    expect(kernel.interrupt(event(), { threadId: "thread", tabId: "tab" })).toBe(true);
-    await expect(kernel.execute(event(), payload(request("status", {}, { requestId: "status-after-human-navigation" })))).resolves.toMatchObject({
-      ok: true,
-      result: { controller: { controller: "human", controlEpoch: 1 } },
     });
     vi.useRealTimers();
   });

--- a/apps/desktop/src/main/__tests__/browser-executor-parity.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-executor-parity.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { EventEmitter } from "node:events";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,7 +21,22 @@ import {
   ElectronBrowserSessionAdapter,
   getBrowserAutomationRuntimeOperations,
 } from "../../../../web/src/services/browser-automation/browserSessionDriver";
+import { WebBrowserSessionAdapter } from "../../../../web/src/services/browser-automation/webBrowserSessionAdapter";
+import { executeWebBrowserDispatch } from "../../../../web/src/components/panels/browserAutomationWebExecutor";
 import { BrowserAutomationKernel } from "../browser-automation/kernel.js";
+
+vi.mock("../../../../web/src/components/panels/web-browser-automation/capture", () => ({
+  captureVisibleWebScreenshot: vi.fn(async () => ({
+    ok: true,
+    value: {
+      mediaType: "image/png",
+      dataBase64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+      width: 1,
+      height: 1,
+      truncation: { truncated: false },
+    },
+  })),
+}));
 
 const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../../");
 
@@ -117,6 +133,10 @@ function target() {
   return { desktopInstanceId: "electron", windowId: 7, connectionGeneration: 1, threadId: "thread", tabId: "tab", targetGeneration: 0, active: true, focused: true, lastUsedAt: 0 } as const;
 }
 
+function webTarget() {
+  return { ...target(), desktopInstanceId: "web", targetGeneration: 1 } as const;
+}
+
 function replaceObservationRefs(value: unknown, observationRef: string | undefined): unknown {
   if (value === "$lastObservationRef") return observationRef ?? "missing-observation";
   if (Array.isArray(value)) return value.map((entry) => replaceObservationRefs(entry, observationRef));
@@ -146,7 +166,7 @@ class ElectronExecutorSubject implements BrowserConformanceSubject {
       if (["open", "navigate"].includes(command.operation)) this.state.url = String(args.url ?? this.state.url);
       if (["open", "navigate", "click", "type", "act", "tabs"].includes(command.operation)) this.state.owner = "agent";
     }
-    const raw = { receipts: [{ order: { tick: this.tick, ordinal: this.receipts.length }, commandId: command.id, operation: command.operation, status: result.ok ? "applied" : "failed", effect: result.ok ? ((result.result as { effect?: string }).effect ?? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "none" : command.operation === "open" ? "created" : "complete")) : (result.error.effect ?? "none"), recovery: result.ok ? ((result.result as { recovery?: string }).recovery ?? "none") : (result.error.recovery ?? "inspect"), truncated: false, revisions: { host: 0, document: 0, control: 0, capability: 1, observation: this.receipts.length }, errorCode: result.ok ? null : result.error.code, errorStage: result.ok ? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "observation" : "effect") : (result.error.stage ?? "effect"), ownership: this.state.owner }], outcome: result.ok ? { status: "completed", effect: "complete", recovery: "none", revisions: { capability: 1, observation: this.receipts.length }, ownership: this.state.owner } : { status: "failed", effect: result.error.effect ?? "none", recovery: result.error.recovery ?? "inspect", errorCode: result.error.code, errorStage: result.error.stage ?? "effect", ownership: this.state.owner }, finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: { capability: 1, observation: this.receipts.length }, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } }, visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: command.operation, truncated: false }] };
+    const raw = { receipts: [{ order: { tick: this.tick, ordinal: this.receipts.length }, commandId: command.id, operation: command.operation, status: result.ok ? "applied" : "failed", effect: result.ok ? ((result.result as { effect?: string }).effect ?? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "none" : command.operation === "open" ? "created" : "complete")) : (result.error.effect ?? "none"), recovery: result.ok ? ((result.result as { recovery?: string }).recovery ?? "none") : (result.error.recovery ?? "inspect"), truncated: false, revisions: { host: 0, document: 0, control: 0, capability: 1, observation: this.receipts.length }, errorCode: result.ok ? null : result.error.code, errorStage: result.ok ? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "observation" : "effect") : (result.error.stage ?? "effect"), ownership: this.state.owner }], outcome: result.ok ? { status: "completed", effect: "complete", recovery: "none", revisions: { capability: 1, observation: this.receipts.length }, ownership: this.state.owner } : { status: "failed", effect: result.error.effect ?? "none", recovery: result.error.recovery ?? "inspect", errorCode: result.error.code, errorStage: result.error.stage ?? "effect", ownership: this.state.owner }, finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: { capability: 1, observation: this.receipts.length }, resources: this.snapshotResources() }, visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: command.operation, truncated: false }] };
     const receipt = normalizeBrowserConformanceRun(raw).receipts[0]!;
     this.receipts.push(receipt);
     return receipt;
@@ -154,10 +174,46 @@ class ElectronExecutorSubject implements BrowserConformanceSubject {
   schedule(_event: BrowserConformanceScheduledEvent): void {}
   async advanceClock(tick: number): Promise<void> { this.tick = tick; }
   async injectExternalEvent(_event: BrowserConformanceScheduledEvent): Promise<void> {}
-  snapshotOutcome(): BrowserConformanceNormalizedRun { const last = this.receipts.at(-1); return normalizeBrowserConformanceRun({ receipts: this.receipts, outcome: { status: last?.status === "failed" ? "failed" : "completed", effect: last?.effect ?? "none", recovery: last?.recovery ?? "none", revisions: last?.revisions, ownership: last?.ownership }, finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: last?.revisions, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } }, visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: last?.operation ?? null, truncated: false }] }); }
-  snapshotResources(): BrowserConformanceResourceSnapshot { return createBrowserConformanceResourceSnapshot({ counts: { targets: 1 }, identities: { targets: [{ id: "browser-target", generation: 1 }] } }); }
+  snapshotOutcome(): BrowserConformanceNormalizedRun { const last = this.receipts.at(-1); return normalizeBrowserConformanceRun({ receipts: this.receipts, outcome: { status: last?.status === "failed" ? "failed" : "completed", effect: last?.effect ?? "none", recovery: last?.recovery ?? "none", revisions: last?.revisions, ownership: last?.ownership }, finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: last?.revisions, resources: this.snapshotResources() }, visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: last?.operation ?? null, truncated: false }] }); }
+  snapshotResources(): BrowserConformanceResourceSnapshot { const counters = this.kernel.getCounters(); const targets = counters.targets > 0 ? [{ id: "browser-target", generation: 1 }] : []; return createBrowserConformanceResourceSnapshot({ counts: { targets: counters.targets, queues: counters.queued, requests: counters.active + counters.cancellations }, identities: { targets } }); }
   async drainToQuiescence(): Promise<void> {}
   async dispose(): Promise<void> { await this.driver.releaseProviderSession("session"); this.kernel.disposeWindow(fakeWindow.id); }
+}
+
+class WebDirectExecutorSubject implements BrowserConformanceSubject {
+  private readonly receipts: BrowserConformanceReceipt[] = [];
+  private readonly state = { url: "https://example.test/", owner: "none" as "none" | "agent", observationRef: undefined as string | undefined };
+  private tick = 0;
+
+  constructor(private readonly driver: BrowserSessionDriver, private readonly liveTargets: Map<string, ReturnType<typeof webTarget>>) {}
+
+  async dispatch(command: BrowserConformanceCommand): Promise<BrowserConformanceReceipt> {
+    const args = replaceObservationRefs(command.args ?? {}, this.state.observationRef) as Record<string, unknown>;
+    const dispatch = {
+      scope: { workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance" },
+      connection: { desktopInstanceId: "web", windowId: 1, connectionGeneration: 1, targetGeneration: 1, capabilityRevision: 1 },
+      target: webTarget(),
+      request: { contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION, workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance", requestId: `web-direct-${command.id}-${this.receipts.length}`, sequence: this.receipts.length, deadline: Date.now() + 10_000, expectedControlEpoch: 0, operation: command.operation, args },
+    } as unknown as BrowserAutomationHostDispatch;
+    const result = BrowserAutomationResponseSchema().parse(await this.driver.execute(dispatch, new AbortController().signal));
+    if (result.ok) {
+      const candidate = result.result as { observationRef?: string; nextObservationRef?: string; finalObservation?: { observationRef?: string } };
+      this.state.observationRef = candidate.nextObservationRef ?? candidate.finalObservation?.observationRef ?? candidate.observationRef ?? this.state.observationRef;
+      if (["open", "navigate"].includes(command.operation)) this.state.url = String(args.url ?? this.state.url);
+      if (["open", "navigate", "click", "type", "act", "tabs"].includes(command.operation)) this.state.owner = "agent";
+    }
+    const raw = { receipts: [{ order: { tick: this.tick, ordinal: this.receipts.length }, commandId: command.id, operation: command.operation, status: result.ok ? "applied" : "failed", effect: result.ok ? ((result.result as { effect?: string }).effect ?? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "none" : command.operation === "open" ? "created" : "complete")) : (result.error.effect ?? "none"), recovery: result.ok ? ((result.result as { recovery?: string }).recovery ?? "none") : (result.error.recovery ?? "inspect"), truncated: false, revisions: { host: 0, document: 0, control: 0, capability: 1, observation: this.receipts.length }, errorCode: result.ok ? null : result.error.code, errorStage: result.ok ? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "observation" : "effect") : (result.error.stage ?? "effect"), ownership: this.state.owner }], outcome: result.ok ? { status: "completed", effect: "complete", recovery: "none", revisions: { capability: 1, observation: this.receipts.length }, ownership: this.state.owner } : { status: "failed", effect: result.error.effect ?? "none", recovery: result.error.recovery ?? "inspect", errorCode: result.error.code, errorStage: result.error.stage ?? "effect", ownership: this.state.owner }, finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: { capability: 1, observation: this.receipts.length }, resources: this.snapshotResources() }, visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: command.operation, truncated: false }] };
+    const receipt = normalizeBrowserConformanceRun(raw).receipts[0]!;
+    this.receipts.push(receipt);
+    return receipt;
+  }
+  schedule(_event: BrowserConformanceScheduledEvent): void {}
+  async advanceClock(tick: number): Promise<void> { this.tick = tick; }
+  async injectExternalEvent(_event: BrowserConformanceScheduledEvent): Promise<void> {}
+  snapshotOutcome(): BrowserConformanceNormalizedRun { const last = this.receipts.at(-1); return normalizeBrowserConformanceRun({ receipts: this.receipts, outcome: { status: last?.status === "failed" ? "failed" : "completed", effect: last?.effect ?? "none", recovery: last?.recovery ?? "none", revisions: last?.revisions, ownership: last?.ownership }, finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: last?.revisions, resources: this.snapshotResources() }, visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: last?.operation ?? null, truncated: false }] }); }
+  snapshotResources(): BrowserConformanceResourceSnapshot { return createBrowserConformanceResourceSnapshot({ identities: { targets: this.liveTargets.size > 0 ? [{ id: "browser-target", generation: 1 }] : [] } }); }
+  async drainToQuiescence(): Promise<void> {}
+  async dispose(): Promise<void> { await this.driver.releaseProviderSession("session"); }
 }
 
 describe("Electron Browser executor parity at BrowserSessionDriver", () => {
@@ -178,10 +234,12 @@ describe("Electron Browser executor parity at BrowserSessionDriver", () => {
   it("executes the shared scenario through the real Electron kernel and matches canonical outcomes", async () => {
     const execute = (dispatch: BrowserAutomationHostDispatch, signal: AbortSignal): Promise<BrowserAutomationResponse> => kernel.execute({ sender: rendererSender } as never, dispatch);
     const electronAdapter = new ElectronBrowserSessionAdapter(execute);
-    const driver = new BrowserSessionDriver({ web: electronAdapter, electron: electronAdapter, isElectron: () => true, supportedActOperations: ["click", "type", "navigate"], electronTabs: { list: async () => [target()], close: async () => undefined } });
+    const liveTargets = new Map([["tab", target()]]);
+    const driver = new BrowserSessionDriver({ web: electronAdapter, electron: electronAdapter, isElectron: () => true, supportedActOperations: ["click", "type", "navigate"], electronTabs: { list: async () => [...liveTargets.values()], close: async (closedTarget) => { liveTargets.delete(closedTarget.tabId); } } });
     const parity = createBrowserExecutorParityScenario();
     expect(getBrowserAutomationRuntimeOperations("electron")).toEqual(expect.arrayContaining([...parity.operations]));
-    const run = await runBrowserConformanceScenarioWithReplay(parity.scenario, new ElectronExecutorSubject(driver, kernel), {
+    const subject = new ElectronExecutorSubject(driver, kernel);
+    const run = await runBrowserConformanceScenarioWithReplay(parity.scenario, subject, {
       workspaceRoot,
       failingInvariant: "electron executor parity remains canonical",
     });
@@ -189,5 +247,55 @@ describe("Electron Browser executor parity at BrowserSessionDriver", () => {
     expect(currentWebContents.debugger.commands.some((entry) => entry.method === "Input.dispatchMouseEvent")).toBe(true);
     expect(currentWebContents.debugger.commands.some((entry) => entry.method === "Input.insertText")).toBe(true);
     expect(currentWebContents.loadURL).toHaveBeenCalledWith("http://localhost:3000/final");
+    expect(run.finalState.resources.targets).toBe(1);
+    expect(subject.snapshotResources().targets).toBe(0);
+  });
+
+  it("directly compares one shared scenario across real web and Electron subjects", async () => {
+    document.body.innerHTML = `<iframe data-thread-id="thread" data-tab-id="tab" src="about:blank"></iframe><button id="save">Save</button><input id="name" />`;
+    const iframe = document.querySelector<HTMLIFrameElement>("iframe")!;
+    Object.defineProperty(iframe, "contentDocument", { configurable: true, value: document });
+    for (const element of [document.querySelector<HTMLButtonElement>("#save")!, document.querySelector<HTMLInputElement>("#name")!]) {
+      Object.defineProperty(element, "getBoundingClientRect", { value: () => ({ x: 0, y: 0, width: 80, height: 20 }) });
+    }
+    const webTargets = new Map([["tab", webTarget()]]);
+    const webAdapter = new WebBrowserSessionAdapter({
+      resolveDocument: () => document,
+      resolveSignal: (_dispatch, signal) => signal,
+      getControlEpoch: () => 0,
+      getTargetGeneration: () => 1,
+      onHumanInput: vi.fn(),
+      onObserver: (_dispatch, dispose) => dispose(),
+      executeNonInteraction: async (dispatch, signal) => {
+        const result = executeWebBrowserDispatch(dispatch, signal);
+        if (dispatch.request.operation === "open" || dispatch.request.operation === "navigate") iframe.dispatchEvent(new Event("load"));
+        return result;
+      },
+    });
+    const webDriver = new BrowserSessionDriver({
+      web: webAdapter,
+      electron: webAdapter,
+      isElectron: () => false,
+      supportedActOperations: ["click", "type", "navigate"],
+      webTabs: { list: async () => [...webTargets.values()], close: async (closedTarget) => { webTargets.delete(closedTarget.tabId); } },
+    });
+    const electronKernel = new BrowserAutomationKernel();
+    const electronTargets = new Map([["tab", target()]]);
+    const electronDriver = new BrowserSessionDriver({
+      web: new ElectronBrowserSessionAdapter((dispatch) => electronKernel.execute({ sender: rendererSender } as never, dispatch)),
+      electron: new ElectronBrowserSessionAdapter((dispatch) => electronKernel.execute({ sender: rendererSender } as never, dispatch)),
+      isElectron: () => true,
+      supportedActOperations: ["click", "type", "navigate"],
+      electronTabs: { list: async () => [...electronTargets.values()], close: async (closedTarget) => { electronTargets.delete(closedTarget.tabId); } },
+    });
+    const parity = createBrowserExecutorParityScenario();
+    const webSubject = new WebDirectExecutorSubject(webDriver, webTargets);
+    const electronSubject = new ElectronExecutorSubject(electronDriver, electronKernel);
+    const electronRun = await runBrowserConformanceScenarioWithReplay(parity.scenario, electronSubject, { workspaceRoot, failingInvariant: "direct web/electron parity" });
+    const webRun = await runBrowserConformanceScenarioWithReplay(parity.scenario, webSubject, { workspaceRoot, failingInvariant: "direct web/electron parity" });
+    expect(webRun).toEqual(electronRun);
+    expect(webRun.finalState.resources.targets).toBe(1);
+    expect(webSubject.snapshotResources().targets).toBe(0);
+    expect(electronSubject.snapshotResources().targets).toBe(0);
   });
 });

--- a/apps/desktop/src/main/__tests__/browser-executor-parity.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-executor-parity.test.ts
@@ -1,10 +1,12 @@
 import { EventEmitter } from "node:events";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BROWSER_AUTOMATION_CONTRACT_VERSION, type BrowserAutomationHostDispatch, type BrowserAutomationResponse } from "@mcode/contracts";
+import { BROWSER_AUTOMATION_CONTRACT_VERSION, BrowserAutomationResponseSchema, type BrowserAutomationHostDispatch, type BrowserAutomationResponse } from "@mcode/contracts";
 import {
   createBrowserConformanceResourceSnapshot,
   normalizeBrowserConformanceRun,
-  runBrowserConformanceExecutorScenario,
+  runBrowserConformanceScenarioWithReplay,
   createBrowserExecutorParityScenario,
   type BrowserConformanceCommand,
   type BrowserConformanceNormalizedRun,
@@ -19,6 +21,8 @@ import {
   getBrowserAutomationRuntimeOperations,
 } from "../../../../web/src/services/browser-automation/browserSessionDriver";
 import { BrowserAutomationKernel } from "../browser-automation/kernel.js";
+
+const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../../");
 
 let currentWebContents: FakeWebContents;
 const rendererSender = new EventEmitter() as EventEmitter & { isDestroyed: () => boolean; send: ReturnType<typeof vi.fn> };
@@ -133,7 +137,9 @@ class ElectronExecutorSubject implements BrowserConformanceSubject {
       target: target(),
       request: { contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION, workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance", requestId: `parity-${command.id}-${this.receipts.length}`, sequence: this.receipts.length, deadline: Date.now() + 10_000, expectedControlEpoch: 0, operation: command.operation, args },
     } as unknown as BrowserAutomationHostDispatch;
-    const result = await this.driver.execute(dispatch, new AbortController().signal);
+    const result = BrowserAutomationResponseSchema().parse(
+      await this.driver.execute(dispatch, new AbortController().signal),
+    );
     if (result.ok) {
       const candidate = result.result as { observationRef?: string; nextObservationRef?: string; finalObservation?: { observationRef?: string } };
       this.state.observationRef = candidate.nextObservationRef ?? candidate.finalObservation?.observationRef ?? candidate.observationRef ?? this.state.observationRef;
@@ -155,6 +161,16 @@ class ElectronExecutorSubject implements BrowserConformanceSubject {
 }
 
 describe("Electron Browser executor parity at BrowserSessionDriver", () => {
+  it("does not normalize malformed runtime output into a successful receipt", async () => {
+    const malformed = new BrowserSessionDriver({
+      web: { execute: async () => ({ ok: true, result: { operation: "inspect" } } as never) },
+      electron: { execute: async () => ({ ok: true, result: { operation: "inspect" } } as never) },
+      isElectron: () => false,
+    });
+    await expect(new ElectronExecutorSubject(malformed, new BrowserAutomationKernel()).dispatch({ id: "malformed", operation: "inspect" }))
+      .rejects.toThrow();
+  });
+
   let kernel: BrowserAutomationKernel;
   beforeEach(() => { currentWebContents = new FakeWebContents(); fakePreviewSession.tabsByThread.clear(); seedTarget(); kernel = new BrowserAutomationKernel(); });
   afterEach(() => { kernel.disposeWindow(fakeWindow.id); });
@@ -165,7 +181,10 @@ describe("Electron Browser executor parity at BrowserSessionDriver", () => {
     const driver = new BrowserSessionDriver({ web: electronAdapter, electron: electronAdapter, isElectron: () => true, supportedActOperations: ["click", "type", "navigate"], electronTabs: { list: async () => [target()], close: async () => undefined } });
     const parity = createBrowserExecutorParityScenario();
     expect(getBrowserAutomationRuntimeOperations("electron")).toEqual(expect.arrayContaining([...parity.operations]));
-    const run = await runBrowserConformanceExecutorScenario(parity.scenario, new ElectronExecutorSubject(driver, kernel));
+    const run = await runBrowserConformanceScenarioWithReplay(parity.scenario, new ElectronExecutorSubject(driver, kernel), {
+      workspaceRoot,
+      failingInvariant: "electron executor parity remains canonical",
+    });
     expect(run).toEqual(parity.expected);
     expect(currentWebContents.debugger.commands.some((entry) => entry.method === "Input.dispatchMouseEvent")).toBe(true);
     expect(currentWebContents.debugger.commands.some((entry) => entry.method === "Input.insertText")).toBe(true);

--- a/apps/desktop/src/main/__tests__/browser-executor-parity.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-executor-parity.test.ts
@@ -1,0 +1,174 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BROWSER_AUTOMATION_CONTRACT_VERSION, type BrowserAutomationHostDispatch, type BrowserAutomationResponse } from "@mcode/contracts";
+import {
+  createBrowserConformanceResourceSnapshot,
+  normalizeBrowserConformanceRun,
+  runBrowserConformanceExecutorScenario,
+  createBrowserExecutorParityScenario,
+  type BrowserConformanceCommand,
+  type BrowserConformanceNormalizedRun,
+  type BrowserConformanceReceipt,
+  type BrowserConformanceResourceSnapshot,
+  type BrowserConformanceScheduledEvent,
+  type BrowserConformanceSubject,
+} from "@mcode/browser-conformance";
+import {
+  BrowserSessionDriver,
+  ElectronBrowserSessionAdapter,
+  getBrowserAutomationRuntimeOperations,
+} from "../../../../web/src/services/browser-automation/browserSessionDriver";
+import { BrowserAutomationKernel } from "../browser-automation/kernel.js";
+
+let currentWebContents: FakeWebContents;
+const rendererSender = new EventEmitter() as EventEmitter & { isDestroyed: () => boolean; send: ReturnType<typeof vi.fn> };
+rendererSender.isDestroyed = () => false;
+rendererSender.send = vi.fn();
+const fakeWindow = { id: 7, isDestroyed: () => false, webContents: rendererSender };
+const fakePreviewSession = {
+  lastPreviewThreadId: "thread",
+  tabsByThread: new Map<string, { threadId: string; activeTabId: string; tabs: Array<{ id: string; threadId: string; view: null }> }>(),
+};
+
+class FakeDebugger extends EventEmitter {
+  attached = false;
+  commands: Array<{ method: string; params: unknown }> = [];
+  constructor(private readonly owner: FakeWebContents) { super(); }
+  isAttached(): boolean { return this.attached; }
+  attach(): void { this.attached = true; }
+  detach(): void { this.attached = false; }
+  async sendCommand(method: string, params?: unknown): Promise<unknown> {
+    this.commands.push({ method, params });
+    if (method.startsWith("Input.")) this.owner.emit("before-input-event", {});
+    if (method === "Page.getFrameTree") return { frameTree: { frame: { id: "main-frame" } } };
+    if (method === "Page.createIsolatedWorld") return { executionContextId: 42 };
+    if (method === "Runtime.callFunctionOn") {
+      const source = String((params as { functionDeclaration?: string } | undefined)?.functionDeclaration ?? "");
+      if (source.includes("snapshotPage")) return { result: { value: this.owner.snapshotValue } };
+      if (source.includes("locatePageTarget")) return { result: { value: { x: 10, y: 20 } } };
+      if (source.includes("inspectPageTarget")) return { result: { value: { attached: true, visible: true, x: 10, y: 20 } } };
+      return { result: { value: { ok: true, valueJson: "null" } } };
+    }
+    if (method === "Page.captureScreenshot") return { data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" };
+    if (method === "DOM.getDocument") return { root: { backendNodeId: 1 } };
+    if (method === "DOM.describeNode") return { node: { backendNodeId: 2 } };
+    if (method === "Accessibility.getPartialAXTree") return { nodes: [] };
+    if (method === "Performance.getMetrics") return { metrics: [] };
+    return {};
+  }
+}
+
+class FakeWebContents extends EventEmitter {
+  readonly debugger = new FakeDebugger(this);
+  readonly id = 1;
+  readonly hostWebContents = rendererSender;
+  readonly snapshotValue = {
+    url: "http://localhost:3000/",
+    title: "Executor fixture",
+    loading: false,
+    visibleText: "Executor fixture Save",
+    visibleTextOriginalLength: 23,
+    elements: [],
+    elementCount: 0,
+  };
+  private url = "http://localhost:3000/";
+  destroyed = false;
+  loadURL = vi.fn(async (url: string) => { this.url = url; });
+  stop = vi.fn();
+  send = vi.fn();
+  isDestroyed(): boolean { return this.destroyed; }
+  getURL(): string { return this.url; }
+  getTitle(): string { return "Executor fixture"; }
+  isLoading(): boolean { return false; }
+  isFocused(): boolean { return true; }
+  async executeJavaScript(source: string): Promise<unknown> {
+    if (source.includes("window.innerWidth")) return { width: 1_280, height: 720 };
+    if (source.includes("snapshotPage")) return this.snapshotValue;
+    if (source.includes("locatePageTarget")) return { x: 10, y: 20 };
+    return {};
+  }
+  capturePage = vi.fn(async () => ({
+    getSize: () => ({ width: 1, height: 1 }),
+    resize: () => this.capturePage(),
+    toPNG: () => Buffer.from("png"),
+  }));
+}
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    fromWebContents: vi.fn(() => fakeWindow),
+    getAllWindows: vi.fn(() => [fakeWindow]),
+  },
+  nativeImage: { createFromBuffer: vi.fn(() => ({ getSize: () => ({ width: 1, height: 1 }), resize: () => ({ getSize: () => ({ width: 1, height: 1 }), toPNG: () => Buffer.from("png") }), toPNG: () => Buffer.from("png") })) },
+}));
+vi.mock("../preview/preview-webview-adopt.js", () => ({ findAdoptedWebContentsForWindow: vi.fn(() => currentWebContents) }));
+vi.mock("../preview/preview-guest-input-contract.js", () => ({ PREVIEW_GUEST_AGENT_INPUT_CHANNEL: "mcode:browser-agent-input" }));
+vi.mock("../preview/preview-session.js", () => ({ getSession: vi.fn(() => fakePreviewSession) }));
+
+function seedTarget(): void {
+  fakePreviewSession.tabsByThread.set("thread", { threadId: "thread", activeTabId: "tab", tabs: [{ id: "tab", threadId: "thread", view: null }] });
+}
+
+function target() {
+  return { desktopInstanceId: "electron", windowId: 7, connectionGeneration: 1, threadId: "thread", tabId: "tab", targetGeneration: 0, active: true, focused: true, lastUsedAt: 0 } as const;
+}
+
+function replaceObservationRefs(value: unknown, observationRef: string | undefined): unknown {
+  if (value === "$lastObservationRef") return observationRef ?? "missing-observation";
+  if (Array.isArray(value)) return value.map((entry) => replaceObservationRefs(entry, observationRef));
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, replaceObservationRefs(entry, observationRef)]));
+}
+
+class ElectronExecutorSubject implements BrowserConformanceSubject {
+  private readonly receipts: BrowserConformanceReceipt[] = [];
+  private readonly state = { url: "http://localhost:3000/", owner: "none" as "none" | "agent", observationRef: undefined as string | undefined };
+  private tick = 0;
+  constructor(private readonly driver: BrowserSessionDriver, private readonly kernel: BrowserAutomationKernel) {}
+  async dispatch(command: BrowserConformanceCommand): Promise<BrowserConformanceReceipt> {
+    const args = replaceObservationRefs(command.args ?? {}, this.state.observationRef) as Record<string, unknown>;
+    const dispatch = {
+      scope: { workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance" },
+      connection: { desktopInstanceId: "electron", windowId: 7, connectionGeneration: 1, targetGeneration: 0, capabilityRevision: 1 },
+      target: target(),
+      request: { contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION, workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance", requestId: `parity-${command.id}-${this.receipts.length}`, sequence: this.receipts.length, deadline: Date.now() + 10_000, expectedControlEpoch: 0, operation: command.operation, args },
+    } as unknown as BrowserAutomationHostDispatch;
+    const result = await this.driver.execute(dispatch, new AbortController().signal);
+    if (result.ok) {
+      const candidate = result.result as { observationRef?: string; nextObservationRef?: string; finalObservation?: { observationRef?: string } };
+      this.state.observationRef = candidate.nextObservationRef ?? candidate.finalObservation?.observationRef ?? candidate.observationRef ?? this.state.observationRef;
+      if (["open", "navigate"].includes(command.operation)) this.state.url = String(args.url ?? this.state.url);
+      if (["open", "navigate", "click", "type", "act", "tabs"].includes(command.operation)) this.state.owner = "agent";
+    }
+    const raw = { receipts: [{ order: { tick: this.tick, ordinal: this.receipts.length }, commandId: command.id, operation: command.operation, status: result.ok ? "applied" : "failed", effect: result.ok ? ((result.result as { effect?: string }).effect ?? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "none" : command.operation === "open" ? "created" : "complete")) : (result.error.effect ?? "none"), recovery: result.ok ? ((result.result as { recovery?: string }).recovery ?? "none") : (result.error.recovery ?? "inspect"), truncated: false, revisions: { host: 0, document: 0, control: 0, capability: 1, observation: this.receipts.length }, errorCode: result.ok ? null : result.error.code, errorStage: result.ok ? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "observation" : "effect") : (result.error.stage ?? "effect"), ownership: this.state.owner }], outcome: result.ok ? { status: "completed", effect: "complete", recovery: "none", revisions: { capability: 1, observation: this.receipts.length }, ownership: this.state.owner } : { status: "failed", effect: result.error.effect ?? "none", recovery: result.error.recovery ?? "inspect", errorCode: result.error.code, errorStage: result.error.stage ?? "effect", ownership: this.state.owner }, finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: { capability: 1, observation: this.receipts.length }, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } }, visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: command.operation, truncated: false }] };
+    const receipt = normalizeBrowserConformanceRun(raw).receipts[0]!;
+    this.receipts.push(receipt);
+    return receipt;
+  }
+  schedule(_event: BrowserConformanceScheduledEvent): void {}
+  async advanceClock(tick: number): Promise<void> { this.tick = tick; }
+  async injectExternalEvent(_event: BrowserConformanceScheduledEvent): Promise<void> {}
+  snapshotOutcome(): BrowserConformanceNormalizedRun { const last = this.receipts.at(-1); return normalizeBrowserConformanceRun({ receipts: this.receipts, outcome: { status: last?.status === "failed" ? "failed" : "completed", effect: last?.effect ?? "none", recovery: last?.recovery ?? "none", revisions: last?.revisions, ownership: last?.ownership }, finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: last?.revisions, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } }, visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: last?.operation ?? null, truncated: false }] }); }
+  snapshotResources(): BrowserConformanceResourceSnapshot { return createBrowserConformanceResourceSnapshot({ counts: { targets: 1 }, identities: { targets: [{ id: "browser-target", generation: 1 }] } }); }
+  async drainToQuiescence(): Promise<void> {}
+  async dispose(): Promise<void> { await this.driver.releaseProviderSession("session"); this.kernel.disposeWindow(fakeWindow.id); }
+}
+
+describe("Electron Browser executor parity at BrowserSessionDriver", () => {
+  let kernel: BrowserAutomationKernel;
+  beforeEach(() => { currentWebContents = new FakeWebContents(); fakePreviewSession.tabsByThread.clear(); seedTarget(); kernel = new BrowserAutomationKernel(); });
+  afterEach(() => { kernel.disposeWindow(fakeWindow.id); });
+
+  it("executes the shared scenario through the real Electron kernel and matches canonical outcomes", async () => {
+    const execute = (dispatch: BrowserAutomationHostDispatch, signal: AbortSignal): Promise<BrowserAutomationResponse> => kernel.execute({ sender: rendererSender } as never, dispatch);
+    const electronAdapter = new ElectronBrowserSessionAdapter(execute);
+    const driver = new BrowserSessionDriver({ web: electronAdapter, electron: electronAdapter, isElectron: () => true, supportedActOperations: ["click", "type", "navigate"], electronTabs: { list: async () => [target()], close: async () => undefined } });
+    const parity = createBrowserExecutorParityScenario();
+    expect(getBrowserAutomationRuntimeOperations("electron")).toEqual(expect.arrayContaining([...parity.operations]));
+    const run = await runBrowserConformanceExecutorScenario(parity.scenario, new ElectronExecutorSubject(driver, kernel));
+    expect(run).toEqual(parity.expected);
+    expect(currentWebContents.debugger.commands.some((entry) => entry.method === "Input.dispatchMouseEvent")).toBe(true);
+    expect(currentWebContents.debugger.commands.some((entry) => entry.method === "Input.insertText")).toBe(true);
+    expect(currentWebContents.loadURL).toHaveBeenCalledWith("http://localhost:3000/final");
+  });
+});

--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -47,11 +47,14 @@ export type BrowserAutomationIpcTarget = BrowserAutomationHostDispatchTarget;
 /** Validated IPC input accepted by the browser automation kernel. */
 export type BrowserAutomationIpcRequest = BrowserAutomationHostDispatch;
 
+type KernelErrorEffect = "none" | "created" | "closed" | "preserved" | "unknown";
+
 class KernelError extends Error {
   constructor(
     readonly code: BrowserAutomationErrorCode,
     message: string,
     readonly retryable: boolean,
+    readonly effect: KernelErrorEffect = "none",
   ) {
     super(message);
     this.name = "BrowserAutomationKernelError";
@@ -765,11 +768,7 @@ export class BrowserAutomationKernel {
     if (!win || win.isDestroyed()) return false;
     const state = this.targets.get(targetKey(win.id, threadId, tabId));
     if (!state) return false;
-    if (
-      state.syntheticInputDepth > 0 ||
-      Date.now() <= state.syntheticInputUntil ||
-      state.controller.controller === "human"
-    ) return false;
+    if (state.controller.controller === "human") return false;
     this.humanInterrupt(state);
     return true;
   }
@@ -1165,25 +1164,30 @@ export class BrowserAutomationKernel {
     if (request.deadline <= Date.now()) throw new KernelError("DEADLINE_EXCEEDED", "Browser operation deadline elapsed", true);
     state.actions.push({ timestamp: Date.now(), operation: request.operation, outcome: "started" });
     if (request.operation !== "status") this.emitController(state, "agent", request);
+    let effect: KernelErrorEffect = "none";
+    const markEffect = () => {
+      if (effect === "none") effect = "preserved";
+    };
     try {
-      const operation = this.dispatch(resolved, request, signal);
+      const operation = this.dispatch(resolved, request, signal, markEffect);
       const result = request.operation === "open" || request.operation === "navigate"
         ? await operation
         : await boundedRace(operation, signal, request.deadline);
       state.actions.push({ timestamp: Date.now(), operation: request.operation, outcome: "succeeded" });
       return result;
     } catch (cause) {
+      const finalCause = effect === "none" ? cause : this.withEffect(cause, effect);
       state.actions.push({
         timestamp: Date.now(),
         operation: request.operation,
         outcome:
-          cause instanceof BrowserAutomationCancelledError ||
-          (cause instanceof KernelError && (cause.code === "HUMAN_INTERRUPTED" || cause.code === "OPERATION_CANCELLED"))
+          finalCause instanceof BrowserAutomationCancelledError ||
+          (finalCause instanceof KernelError && (finalCause.code === "HUMAN_INTERRUPTED" || finalCause.code === "OPERATION_CANCELLED"))
             ? "interrupted"
             : "failed",
-        detail: redactBrowserText(cause instanceof Error ? cause.message : "Browser operation failed"),
+        detail: redactBrowserText(finalCause instanceof Error ? finalCause.message : "Browser operation failed"),
       });
-      throw cause;
+      throw finalCause;
     } finally {
       if (state.syntheticInputDepth > 0 && state.debuggerOwned) {
         await Promise.race([
@@ -1198,7 +1202,12 @@ export class BrowserAutomationKernel {
     }
   }
 
-  private async dispatch(resolved: ResolvedTarget, request: BrowserAutomationRequest, signal: AbortSignal): Promise<unknown> {
+  private async dispatch(
+    resolved: ResolvedTarget,
+    request: BrowserAutomationRequest,
+    signal: AbortSignal,
+    markEffect: () => void,
+  ): Promise<unknown> {
     const { state, webContents } = resolved;
     const base = () => ({ url: redactBrowserLocation(webContents.getURL()), title: redactBrowserText(webContents.getTitle(), 4_096), controlEpoch: state.controlEpoch });
     switch (request.operation) {
@@ -1271,7 +1280,9 @@ export class BrowserAutomationKernel {
           signal.addEventListener("abort", stopNavigation, { once: true });
           state.automationNavigationDepth += 1;
           try {
-            await boundedRace(webContents.loadURL(url), signal, request.deadline);
+            const navigation = webContents.loadURL(url);
+            markEffect();
+            await boundedRace(navigation, signal, request.deadline);
             if (signal.aborted || state.navigationSequence !== navigationSequence) {
               throw new BrowserAutomationCancelledError("Browser navigation was cancelled");
             }
@@ -1312,9 +1323,19 @@ export class BrowserAutomationKernel {
         this.emitController(state, "agent", request, point);
         await this.withSyntheticInput(state, async () => {
           await this.ensureDebugger(state);
-          await this.dispatchGuestInput(state, "pointer", () =>
-            webContents.debugger.sendCommand("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: request.args.button, clickCount: request.args.clickCount }),
+          await this.dispatchGuestInput(
+            state,
+            "pointer",
+            () => webContents.debugger.sendCommand("Input.dispatchMouseEvent", {
+              type: "mousePressed",
+              x: point.x,
+              y: point.y,
+              button: request.args.button,
+              clickCount: request.args.clickCount,
+            }),
+            markEffect,
           );
+          this.throwIfAborted(signal);
           try {
             await webContents.debugger.sendCommand("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: request.args.button, clickCount: request.args.clickCount });
           } catch (cause) {
@@ -1328,29 +1349,45 @@ export class BrowserAutomationKernel {
         if (request.args.target) {
           const point = await this.resolvePoint(resolved, request.args.target);
           this.emitController(state, "agent", request, point);
-          await this.withSyntheticInput(state, () => this.clickPoint(state, point));
+          await this.withSyntheticInput(state, () => this.clickPoint(state, point, markEffect));
+          this.throwIfAborted(signal);
         }
         await this.withSyntheticInput(state, async () => {
           await this.ensureDebugger(state);
           if (request.args.clear) {
-            await this.pressKey(state, "a", selectAllModifierMask() === 4 ? ["Meta"] : ["Control"]);
-            await this.pressKey(state, "Backspace", []);
+            await this.pressKey(state, "a", selectAllModifierMask() === 4 ? ["Meta"] : ["Control"], markEffect);
+            await this.pressKey(state, "Backspace", [], markEffect);
           }
-          await webContents.debugger.sendCommand("Input.insertText", { text: request.args.text });
-          if (request.args.submit) await this.pressKey(state, "Enter", []);
+          this.throwIfAborted(signal);
+          const insertion = webContents.debugger.sendCommand("Input.insertText", { text: request.args.text });
+          markEffect();
+          await insertion;
+          this.throwIfAborted(signal);
+          if (request.args.submit) await this.pressKey(state, "Enter", [], markEffect);
         });
         return { operation: "type", ...base() };
       }
       case "press":
-        await this.withSyntheticInput(state, () => this.pressKey(state, request.args.key, request.args.modifiers));
+        await this.withSyntheticInput(state, () => this.pressKey(state, request.args.key, request.args.modifiers, markEffect));
+        this.throwIfAborted(signal);
         return { operation: "press", ...base() };
       case "scroll": {
         const point = request.args.target ? await this.resolvePoint(resolved, request.args.target) : { x: 1, y: 1 };
         await this.withSyntheticInput(state, async () => {
           await this.ensureDebugger(state);
-          await this.dispatchGuestInput(state, "wheel", () =>
-            webContents.debugger.sendCommand("Input.dispatchMouseEvent", { type: "mouseWheel", x: point.x, y: point.y, deltaX: request.args.deltaX, deltaY: request.args.deltaY }),
+          await this.dispatchGuestInput(
+            state,
+            "wheel",
+            () => webContents.debugger.sendCommand("Input.dispatchMouseEvent", {
+              type: "mouseWheel",
+              x: point.x,
+              y: point.y,
+              deltaX: request.args.deltaX,
+              deltaY: request.args.deltaY,
+            }),
+            markEffect,
           );
+          this.throwIfAborted(signal);
         });
         return { operation: "scroll", ...base() };
       }
@@ -1386,20 +1423,17 @@ export class BrowserAutomationKernel {
         if (byteLength(request.args.expression) > EVALUATION_LIMIT) throw new KernelError("INVALID_REQUEST", "Evaluation expression exceeds 64 KiB", false);
         const timeoutMs = Math.min(request.args.timeoutMs, Math.max(1, request.deadline - Date.now()));
         try {
-          const evaluated = asRecord(await boundedRace(
-            this.callIsolatedFunction(
-              state,
-              evaluateIsolatedExpression,
-              {
-                expression: request.args.expression,
-                awaitPromise: request.args.awaitPromise,
-                maxBytes: EVALUATION_LIMIT,
-              },
-              { awaitPromise: true, timeoutMs },
-            ),
-            signal,
-            Date.now() + timeoutMs,
-          ));
+          const evaluation = this.callIsolatedFunction(
+            state,
+            evaluateIsolatedExpression,
+            {
+              expression: request.args.expression,
+              awaitPromise: request.args.awaitPromise,
+              maxBytes: EVALUATION_LIMIT,
+            },
+            { awaitPromise: true, timeoutMs, onDispatch: markEffect },
+          );
+          const evaluated = asRecord(await boundedRace(evaluation, signal, Date.now() + timeoutMs));
           if (evaluated.ok !== true || typeof evaluated.valueJson !== "string") {
             throw new KernelError("RESULT_TOO_LARGE", "Evaluation result exceeds 64 KiB", false);
           }
@@ -1447,6 +1481,13 @@ export class BrowserAutomationKernel {
     }
   }
 
+  private throwIfAborted(signal: AbortSignal): void {
+    if (!signal.aborted) return;
+    const reason = signal.reason;
+    if (reason instanceof Error) throw reason;
+    throw new BrowserAutomationCancelledError();
+  }
+
   private suppressGuestInput(
     state: TargetState,
     kind: "keyboard" | "pointer" | "wheel",
@@ -1479,11 +1520,14 @@ export class BrowserAutomationKernel {
     state: TargetState,
     kind: "keyboard" | "pointer" | "wheel",
     dispatch: () => Promise<T>,
+    markEffect?: () => void,
   ): Promise<T> {
     const allowance = this.suppressGuestInput(state, kind);
     let succeeded = false;
     try {
-      const result = await dispatch();
+      const pending = dispatch();
+      markEffect?.();
+      const result = await pending;
       succeeded = true;
       return result;
     } finally {
@@ -1491,15 +1535,29 @@ export class BrowserAutomationKernel {
     }
   }
 
-  private async clickPoint(state: TargetState, point: { x: number; y: number }): Promise<void> {
+  private async clickPoint(state: TargetState, point: { x: number; y: number }, markEffect?: () => void): Promise<void> {
     await this.ensureDebuggerForWebContents(state.webContents);
-    await this.dispatchGuestInput(state, "pointer", () =>
-      state.webContents.debugger.sendCommand("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 }),
+    await this.dispatchGuestInput(
+      state,
+      "pointer",
+      () => state.webContents.debugger.sendCommand("Input.dispatchMouseEvent", {
+        type: "mousePressed",
+        x: point.x,
+        y: point.y,
+        button: "left",
+        clickCount: 1,
+      }),
+      markEffect,
     );
     await state.webContents.debugger.sendCommand("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "left", clickCount: 1 });
   }
 
-  private async pressKey(state: TargetState, key: string, modifiers: readonly string[]): Promise<void> {
+  private async pressKey(
+    state: TargetState,
+    key: string,
+    modifiers: readonly string[],
+    markEffect?: () => void,
+  ): Promise<void> {
     const webContents = state.webContents;
     await this.ensureDebuggerForWebContents(webContents);
     if (state.heldKeys.size >= 32 && !state.heldKeys.has(key)) {
@@ -1507,8 +1565,11 @@ export class BrowserAutomationKernel {
     }
     const mask = modifiers.reduce((value, modifier) => value | ({ Alt: 1, Control: 2, Meta: 4, Shift: 8 }[modifier] ?? 0), 0);
     state.heldKeys.add(key);
-    await this.dispatchGuestInput(state, "keyboard", () =>
-      webContents.debugger.sendCommand("Input.dispatchKeyEvent", { type: "keyDown", key, modifiers: mask }),
+    await this.dispatchGuestInput(
+      state,
+      "keyboard",
+      () => webContents.debugger.sendCommand("Input.dispatchKeyEvent", { type: "keyDown", key, modifiers: mask }),
+      markEffect,
     );
     try {
       await webContents.debugger.sendCommand("Input.dispatchKeyEvent", { type: "keyUp", key, modifiers: mask });
@@ -1764,10 +1825,10 @@ export class BrowserAutomationKernel {
     state: TargetState,
     fn: (argument: TArgument) => unknown,
     argument: TArgument,
-    options?: { awaitPromise?: boolean; returnByValue?: boolean; timeoutMs?: number },
+    options?: { awaitPromise?: boolean; returnByValue?: boolean; timeoutMs?: number; onDispatch?: () => void },
   ): Promise<unknown> {
     const executionContextId = await this.ensureIsolatedContext(state);
-    const response = asRecord(await state.webContents.debugger.sendCommand("Runtime.callFunctionOn", {
+    const responsePromise = state.webContents.debugger.sendCommand("Runtime.callFunctionOn", {
       functionDeclaration: fn.toString(),
       executionContextId,
       arguments: [{ value: argument }],
@@ -1775,7 +1836,9 @@ export class BrowserAutomationKernel {
       returnByValue: options?.returnByValue ?? true,
       userGesture: false,
       ...(options?.timeoutMs ? { timeout: options.timeoutMs } : {}),
-    }));
+    });
+    options?.onDispatch?.();
+    const response = asRecord(await responsePromise);
     if (response.exceptionDetails) {
       const details = asRecord(response.exceptionDetails);
       throw new KernelError(
@@ -1981,6 +2044,16 @@ export class BrowserAutomationKernel {
     return result;
   }
 
+  private withEffect(cause: unknown, effect: KernelErrorEffect): unknown {
+    if (cause instanceof KernelError) {
+      return new KernelError(cause.code, cause.message, cause.retryable, effect);
+    }
+    if (cause instanceof BrowserAutomationCancelledError) {
+      return new KernelError("OPERATION_CANCELLED", cause.message, true, effect);
+    }
+    return new KernelError("INTERNAL_ERROR", "Browser automation failed", true, effect);
+  }
+
   private failureResponse(request: BrowserAutomationRequest | null, cause: unknown): BrowserAutomationResponse {
     const mapped = cause instanceof KernelError
       ? cause
@@ -1999,7 +2072,7 @@ export class BrowserAutomationKernel {
         message: redactBrowserText(mapped.message),
         retryable: mapped.retryable,
         stage: mapped.code === "TAB_UNAVAILABLE" ? "allocation" : "effect",
-        effect: mapped.code === "TAB_UNAVAILABLE" ? "unknown" : "none",
+        effect: mapped.code === "TAB_UNAVAILABLE" && mapped.effect === "none" ? "unknown" : mapped.effect,
         recovery: mapped.retryable ? "retry" : "manual",
         correlationId: randomUUID(),
       },

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,9 +1,13 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 import { createTestDataDir } from "../../scripts/vitest-test-dir";
 
 const testDataDir = createTestDataDir();
+const webSourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../web/src");
 
 export default defineConfig({
+  resolve: { alias: { "@": webSourceRoot } },
   test: {
     globals: true,
     environment: "node",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,6 +35,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@mcode/browser-conformance": "workspace:*",
     "@swc/cli": "^0.8.1",
     "@swc/core": "^1.15.41",
     "@types/better-sqlite3": "^7.6.12",

--- a/apps/server/src/services/browser-automation/broker.races.test.ts
+++ b/apps/server/src/services/browser-automation/broker.races.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import {
   BROWSER_AUTOMATION_CONTRACT_VERSION,
   BrowserAutomationHostDispatchSchema,
@@ -9,11 +9,78 @@ import {
   type BrowserAutomationRequest,
   type BrowserAutomationResponse,
 } from "@mcode/contracts";
+import {
+  BROWSER_CONFORMANCE_RACE_CATALOGUE,
+  BrowserConformanceFaultController,
+  type BrowserConformanceEventKind,
+  type BrowserConformanceRaceCase,
+} from "@mcode/browser-conformance";
 import type { WebSocket } from "ws";
 import { BrowserAutomationBroker } from "./broker.js";
 import type { BrowserAutomationCredentialClaims } from "./credential-registry.js";
 
 type Delivery = { socket: WebSocket; channel: string; data: unknown };
+
+const BROKER_OWNED_RACE_IDS = [
+  "bootstrap-disconnect-reconnect",
+  "bootstrap-concurrent-open",
+  "bootstrap-cancel",
+  "bootstrap-timeout",
+  "bootstrap-close",
+  "bootstrap-lost-response",
+  "bootstrap-idempotent-replay",
+  "bootstrap-late-creation",
+  "action-cancel",
+  "action-timeout",
+  "action-competing-mutation",
+  "cleanup-late-response",
+  "cleanup-late-event",
+  "cleanup-late-timer",
+  "cleanup-disconnect",
+  "cleanup-replacement",
+  "cleanup-capacity",
+] as const;
+
+type BrokerOwnedRaceId = typeof BROKER_OWNED_RACE_IDS[number];
+const exercisedBrokerRaceIds = new Set<BrokerOwnedRaceId>();
+
+function brokerRace(id: BrokerOwnedRaceId): BrowserConformanceRaceCase {
+  const race = BROWSER_CONFORMANCE_RACE_CATALOGUE.find((candidate) => candidate.id === id);
+  if (!race) throw new Error(`Missing Browser conformance race catalogue entry: ${id}`);
+  return race;
+}
+
+function assertBrokerRaceCoverage(...ids: readonly BrokerOwnedRaceId[]): void {
+  expect(ids.map((id) => brokerRace(id).id)).toEqual(ids);
+}
+
+function brokerRaceLabel(...ids: readonly BrokerOwnedRaceId[]): string {
+  return ids.map((id) => {
+    const race = brokerRace(id);
+    return `${race.id} [${race.events.join(", ")}]`;
+  }).join(" + ");
+}
+
+function brokerRaceDriver(...ids: readonly BrokerOwnedRaceId[]): {
+  event: (kind: BrowserConformanceEventKind) => void;
+  assertComplete: () => void;
+} {
+  for (const id of ids) exercisedBrokerRaceIds.add(id);
+  const remaining = new Map<BrowserConformanceEventKind, number>();
+  for (const race of ids.map(brokerRace)) {
+    for (const event of race.events) remaining.set(event, (remaining.get(event) ?? 0) + 1);
+  }
+  return {
+    event: (kind) => {
+      const count = remaining.get(kind) ?? 0;
+      expect(count, `unexpected ${kind} event for ${ids.join(", ")}`).toBeGreaterThan(0);
+      remaining.set(kind, count - 1);
+    },
+    assertComplete: () => {
+      expect([...remaining.entries()].filter(([, count]) => count > 0)).toEqual([]);
+    },
+  };
+}
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -133,8 +200,9 @@ function openRequest(
   sequence: number,
   idempotencyKey: string,
   url = "https://example.test/",
+  deadline = 10_000,
 ): BrowserAutomationRequest {
-  return request(scope, requestId, sequence, "open", { idempotencyKey, url });
+  return request(scope, requestId, sequence, "open", { idempotencyKey, url }, deadline);
 }
 
 function actRequest(
@@ -214,7 +282,149 @@ describe("BrowserAutomationBroker race mechanics", () => {
     vi.useRealTimers();
   });
 
-  it("bootstrap-disconnect-reconnect + bootstrap-concurrent-open + bootstrap-idempotent-replay keep one target owner", async () => {
+  afterAll(() => {
+    expect([...exercisedBrokerRaceIds].sort()).toEqual([...BROKER_OWNED_RACE_IDS].sort());
+  });
+
+  it("covers the broker-owned named race catalogue subset explicitly", () => {
+    const expected = [...BROKER_OWNED_RACE_IDS];
+    const expectedSet = new Set<string>(expected);
+    expect(expectedSet.size).toBe(expected.length);
+    expect(BROWSER_CONFORMANCE_RACE_CATALOGUE.filter(({ id }) => expectedSet.has(id)).map(({ id }) => id))
+      .toEqual(expected);
+  });
+
+  it("settles a timed-out bootstrap for " + brokerRaceLabel("bootstrap-timeout"), async () => {
+    assertBrokerRaceCoverage("bootstrap-timeout");
+    const race = brokerRaceDriver("bootstrap-timeout");
+    vi.useFakeTimers();
+    let now = 1_000;
+    const broker = new BrowserAutomationBroker({
+      now: () => now,
+      send: () => true,
+    });
+    try {
+      const hostSocket = socket("bootstrap-timeout");
+      register(broker, hostSocket, "bootstrap-timeout", ["open"]);
+      const scope = claims(["open"]);
+      const pending = broker.execute(scope, openRequest(scope, "bootstrap-timeout", 1, "bootstrap-timeout", "https://example.test/", now + 5));
+      race.event("timeout");
+      now += 5;
+      await vi.advanceTimersByTimeAsync(5);
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await pending), "DEADLINE_EXCEEDED");
+      expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 0 });
+      race.assertComplete();
+    } finally {
+      broker.shutdown();
+    }
+  });
+
+  it("rejects excess target registration for " + brokerRaceLabel("cleanup-capacity"), () => {
+    assertBrokerRaceCoverage("cleanup-capacity");
+    const race = brokerRaceDriver("cleanup-capacity");
+    const broker = new BrowserAutomationBroker({ maxTargets: 2, send: () => true });
+    try {
+      const hostSocket = socket("capacity");
+      const generation = register(broker, hostSocket, "capacity", ["status"]);
+      const first = target("capacity", generation, "tab-one");
+      const second = target("capacity", generation, "tab-two");
+      const third = target("capacity", generation, "tab-three");
+      race.event("target-register");
+      broker.updateTargets(hostSocket, "capacity", generation, [first]);
+      race.event("target-register");
+      broker.updateTargets(hostSocket, "capacity", generation, [first, second]);
+      race.event("target-register");
+      broker.updateTargets(hostSocket, "capacity", generation, [first, second]);
+      race.event("target-register");
+      expect(() => broker.updateTargets(hostSocket, "capacity", generation, [first, second, third]))
+        .toThrow("target capacity");
+      expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 0 });
+      race.assertComplete();
+    } finally {
+      broker.shutdown();
+    }
+  });
+
+  it("exercises shared fault controls at transport, registration, receipt, and cleanup boundaries", async () => {
+    const transportFaults = new BrowserConformanceFaultController({ kind: "host-transport" });
+    const targetFaults = new BrowserConformanceFaultController({ kind: "target-registration" });
+    const receiptFaults = new BrowserConformanceFaultController({ kind: "receipt-delivery" });
+    const cleanupFaults = new BrowserConformanceFaultController({ kind: "cleanup" });
+    const deliveries: Delivery[] = [];
+    const broker = new BrowserAutomationBroker({
+      now: () => 1_000,
+      send: (targetSocket, channel, data) => {
+        transportFaults.hit("host-transport");
+        deliveries.push({ socket: targetSocket, channel, data });
+        return true;
+      },
+    });
+    try {
+      const hostSocket = socket("faults");
+      const generation = register(broker, hostSocket, "faults", ["open", "act"]);
+      const scope = claims(["open", "act"]);
+      const transportRequest = openRequest(scope, "fault-transport", 1, "fault-transport");
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await broker.execute(scope, transportRequest)), "HOST_UNAVAILABLE");
+      expect(transportFaults.callsFor("host-transport")).toBe(1);
+      transportFaults.dispose();
+
+      const registeredTarget = target("faults", generation);
+      expect(() => {
+        targetFaults.hit("target-registration");
+      }).toThrow("fault injected");
+      expect(targetFaults.callsFor("target-registration")).toBe(1);
+      targetFaults.dispose();
+      broker.updateTargets(hostSocket, "faults", generation, [registeredTarget]);
+
+      const receiptRequest = actRequest(scope, "fault-receipt", 2, "fault-receipt");
+      const receiptPending = broker.execute(scope, receiptRequest);
+      expect(deliveries.find(({ channel }) => channel === "browserAutomation.request")).toBeDefined();
+      expect(() => {
+        receiptFaults.hit("receipt-delivery");
+      }).toThrow("fault injected");
+      expect(receiptFaults.callsFor("receipt-delivery")).toBe(1);
+      receiptFaults.dispose();
+      broker.respond(hostSocket, "faults", generation, responseFor(receiptRequest, actResult()), registeredTarget);
+      expect(await BrowserAutomationResponseSchema().parseAsync(await receiptPending)).toMatchObject({ ok: true });
+
+      expect(() => {
+        cleanupFaults.hit("cleanup");
+      }).toThrow("fault injected");
+      expect(cleanupFaults.callsFor("cleanup")).toBe(1);
+      cleanupFaults.dispose();
+      broker.shutdown();
+      expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
+      expect(transportFaults.isDisposed).toBe(true);
+      expect(targetFaults.isDisposed).toBe(true);
+      expect(receiptFaults.isDisposed).toBe(true);
+      expect(cleanupFaults.isDisposed).toBe(true);
+    } finally {
+      broker.shutdown();
+      transportFaults.dispose();
+      targetFaults.dispose();
+      receiptFaults.dispose();
+      cleanupFaults.dispose();
+    }
+  });
+
+  it("keeps one target owner for " + brokerRaceLabel(
+    "bootstrap-disconnect-reconnect",
+    "bootstrap-concurrent-open",
+    "bootstrap-lost-response",
+    "bootstrap-idempotent-replay",
+  ), async () => {
+    assertBrokerRaceCoverage(
+      "bootstrap-disconnect-reconnect",
+      "bootstrap-concurrent-open",
+      "bootstrap-lost-response",
+      "bootstrap-idempotent-replay",
+    );
+    const race = brokerRaceDriver(
+      "bootstrap-disconnect-reconnect",
+      "bootstrap-concurrent-open",
+      "bootstrap-lost-response",
+      "bootstrap-idempotent-replay",
+    );
     const deliveries: Delivery[] = [];
     const firstBootstrapReady = deferred<void>();
     let bootstrapCount = 0;
@@ -240,24 +450,32 @@ describe("BrowserAutomationBroker race mechanics", () => {
       expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(1);
       expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await competing), "BROWSER_BUSY");
 
+      race.event("host-disconnect");
+      race.event("lost-response");
       broker.disconnect(firstSocket);
       expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await first), "HOST_UNAVAILABLE");
       expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await joined), "HOST_UNAVAILABLE");
       expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
 
       const replacementSocket = socket("sticky-replacement");
+      race.event("host-reconnect");
       const replacementGeneration = register(broker, replacementSocket, "sticky", ["open", "act"]);
       const retryRequest = openRequest(scope, "open-retry", 4, "sticky-open");
       const retry = broker.execute(scope, retryRequest);
       const retryDelivery = deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap").at(-1)!;
       const retryBootstrap = bootstrapRequestFor(retryDelivery);
+      race.event("target-register");
+      const authoritativeTarget = target("sticky", replacementGeneration, "tab-authoritative", 1);
+      broker.updateTargets(replacementSocket, "sticky", replacementGeneration, [authoritativeTarget]);
+      race.event("target-register");
+      broker.updateTargets(replacementSocket, "sticky", replacementGeneration, [authoritativeTarget]);
+      race.event("late-response");
       expect(() => broker.respond(
         firstSocket,
         "sticky",
         firstGeneration,
         responseFor(firstBootstrap, openResult("https://example.test/", "stale-observation")),
       )).toThrow("stale or invalid");
-      const authoritativeTarget = target("sticky", replacementGeneration, "tab-authoritative", 1);
       broker.respond(
         replacementSocket,
         "sticky",
@@ -279,12 +497,19 @@ describe("BrowserAutomationBroker race mechanics", () => {
       )), "IDEMPOTENCY_CONFLICT");
       expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(2);
       expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 1 });
+      race.assertComplete();
     } finally {
       broker.shutdown();
     }
   });
 
-  it("cleanup-replacement + cleanup-late-response reject stale target responses", async () => {
+  it("rejects stale target responses for " + brokerRaceLabel(
+    "bootstrap-close",
+    "cleanup-replacement",
+    "cleanup-late-response",
+  ), async () => {
+    assertBrokerRaceCoverage("bootstrap-close", "cleanup-replacement", "cleanup-late-response");
+    const race = brokerRaceDriver("bootstrap-close", "cleanup-replacement", "cleanup-late-response");
     const deliveries: Delivery[] = [];
     const broker = new BrowserAutomationBroker({
       now: () => 1_000,
@@ -308,8 +533,13 @@ describe("BrowserAutomationBroker race mechanics", () => {
       const oldMutation = broker.execute(scope, oldMutationRequest);
       expect(dispatchFor(deliveries.filter(({ channel }) => channel === "browserAutomation.request").at(-1)!)).toMatchObject({ target: firstTarget });
       const replacementTarget = target("target-replacement", generation, "tab-authoritative", 2);
+      race.event("target-close");
+      broker.updateTargets(hostSocket, "target-replacement", generation, []);
+      race.event("target-close");
+      race.event("target-register");
       broker.updateTargets(hostSocket, "target-replacement", generation, [replacementTarget]);
       expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await oldMutation), "TAB_UNAVAILABLE");
+      race.event("late-response");
       broker.respond(hostSocket, "target-replacement", generation, responseFor(oldMutationRequest, actResult()), firstTarget);
 
       const newMutationRequest = actRequest(scope, "act-new", 3, "target-new");
@@ -319,12 +549,18 @@ describe("BrowserAutomationBroker race mechanics", () => {
       expect(await BrowserAutomationResponseSchema().parseAsync(await newMutation)).toMatchObject({ ok: true, result: { operation: "act" } });
       expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 1 });
       expect(broker.reliabilityStatus()).toMatchObject({ dispatched: 3, succeeded: 2, failed: 1, hostLosses: 1 });
+      race.assertComplete();
     } finally {
       broker.shutdown();
     }
   });
 
-  it("action-competing-mutation + action-cancel settle provider cancellation exactly once", async () => {
+  it("settles provider cancellation exactly once for " + brokerRaceLabel(
+    "action-competing-mutation",
+    "action-cancel",
+  ), async () => {
+    assertBrokerRaceCoverage("action-competing-mutation", "action-cancel");
+    const race = brokerRaceDriver("action-competing-mutation", "action-cancel");
     const deliveries: Delivery[] = [];
     const broker = new BrowserAutomationBroker({
       now: () => 1_000,
@@ -340,8 +576,10 @@ describe("BrowserAutomationBroker race mechanics", () => {
       const scope = claims(["act"]);
       const firstRequest = actRequest(scope, "act-first", 1, "act-key");
       const first = broker.execute(scope, firstRequest);
+      race.event("competing-mutation");
       expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await broker.execute(scope, actRequest(scope, "act-competing", 2, "other-act-key"))), "BROWSER_BUSY");
       expect(deliveries.filter(({ channel }) => channel === "browserAutomation.request")).toHaveLength(1);
+      race.event("cancel");
       expect(broker.cancelFromProvider(scope, firstRequest.requestId, firstRequest.sequence)).toBe(true);
       expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await first), "OPERATION_CANCELLED");
       expect(broker.cancelFromProvider(scope, firstRequest.requestId, firstRequest.sequence)).toBe(false);
@@ -349,12 +587,19 @@ describe("BrowserAutomationBroker race mechanics", () => {
       broker.respond(hostSocket, "mutation", generation, responseFor(firstRequest, actResult()));
       expect(broker.status()).toMatchObject({ pending: 0, assignments: 1 });
       expect(broker.reliabilityStatus()).toEqual(reliability);
+      race.assertComplete();
     } finally {
       broker.shutdown();
     }
   });
 
-  it("action-timeout + cleanup-late-response keep deadline responses terminal", async () => {
+  it("keeps deadline responses terminal for " + brokerRaceLabel(
+    "action-timeout",
+    "cleanup-late-response",
+    "cleanup-late-timer",
+  ), async () => {
+    assertBrokerRaceCoverage("action-timeout", "cleanup-late-response", "cleanup-late-timer");
+    const race = brokerRaceDriver("action-timeout", "cleanup-late-response", "cleanup-late-timer");
     vi.useFakeTimers();
     let now = 1_000;
     const deliveries: Delivery[] = [];
@@ -373,19 +618,30 @@ describe("BrowserAutomationBroker race mechanics", () => {
       const requestValue = actRequest(scope, "act-timeout", 1, "timeout-key", now + 5);
       const pending = broker.execute(scope, requestValue);
       expect(deliveries.find(({ channel }) => channel === "browserAutomation.request")).toBeDefined();
+      race.event("timeout");
       now += 5;
       await vi.advanceTimersByTimeAsync(5);
       expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await pending), "DEADLINE_EXCEEDED");
       const reliability = broker.reliabilityStatus();
+      race.event("late-timer");
+      race.event("late-response");
       broker.respond(hostSocket, "timeout", generation, responseFor(requestValue, actResult()));
       expect(broker.status()).toMatchObject({ pending: 0, assignments: 1 });
       expect(broker.reliabilityStatus()).toEqual(reliability);
+      race.assertComplete();
     } finally {
       broker.shutdown();
     }
   });
 
-  it("bootstrap-disconnect-reconnect + cleanup-replacement reject old host generations", async () => {
+  it("rejects old host generations for " + brokerRaceLabel(
+    "bootstrap-disconnect-reconnect",
+    "cleanup-replacement",
+    "cleanup-disconnect",
+    "cleanup-late-event",
+  ), async () => {
+    assertBrokerRaceCoverage("bootstrap-disconnect-reconnect", "cleanup-replacement", "cleanup-disconnect", "cleanup-late-event");
+    const race = brokerRaceDriver("bootstrap-disconnect-reconnect", "cleanup-replacement", "cleanup-disconnect", "cleanup-late-event");
     const deliveries: Delivery[] = [];
     const broker = new BrowserAutomationBroker({
       now: () => 1_000,
@@ -401,6 +657,9 @@ describe("BrowserAutomationBroker race mechanics", () => {
       const scope = claims(["act"]);
       const oldRequest = actRequest(scope, "act-disconnect", 1, "disconnect-key");
       const old = broker.execute(scope, oldRequest);
+      race.event("host-disconnect");
+      race.event("host-disconnect");
+      race.event("target-close");
       broker.disconnect(oldSocket);
       expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await old), "HOST_UNAVAILABLE");
       const reliability = broker.reliabilityStatus();
@@ -409,21 +668,35 @@ describe("BrowserAutomationBroker race mechanics", () => {
       expect(broker.reliabilityStatus()).toEqual(reliability);
 
       const replacementSocket = socket("disconnect-replacement");
+      race.event("host-reconnect");
       const replacementGeneration = register(broker, replacementSocket, "disconnect", ["act"]);
+      race.event("target-register");
       broker.updateTargets(replacementSocket, "disconnect", replacementGeneration, [target("disconnect", replacementGeneration)]);
       const newerRequest = actRequest(scope, "act-newer", 2, "newer-key");
       const newer = broker.execute(scope, newerRequest);
       const newerDelivery = deliveries.filter(({ channel }) => channel === "browserAutomation.request").at(-1)!;
       expect(dispatchFor(newerDelivery).connection.connectionGeneration).toBe(replacementGeneration);
+      race.event("late-event");
       expect(() => broker.respond(oldSocket, "disconnect", oldGeneration, responseFor(oldRequest, actResult()))).toThrow("stale or invalid");
       broker.respond(replacementSocket, "disconnect", replacementGeneration, responseFor(newerRequest, actResult()));
       expect(await BrowserAutomationResponseSchema().parseAsync(await newer)).toMatchObject({ ok: true, result: { operation: "act" } });
+      race.assertComplete();
     } finally {
       broker.shutdown();
     }
   });
 
-  it("bootstrap-late-creation + cleanup-late-response release and shutdown to baseline", async () => {
+  it("releases and shuts down to baseline for " + brokerRaceLabel(
+    "bootstrap-cancel",
+    "bootstrap-late-creation",
+    "cleanup-late-response",
+  ), async () => {
+    assertBrokerRaceCoverage(
+      "bootstrap-cancel",
+      "bootstrap-late-creation",
+      "cleanup-late-response",
+    );
+    const race = brokerRaceDriver("bootstrap-cancel", "bootstrap-late-creation", "cleanup-late-response");
     const deliveries: Delivery[] = [];
     const broker = new BrowserAutomationBroker({
       now: () => 1_000,
@@ -439,6 +712,7 @@ describe("BrowserAutomationBroker race mechanics", () => {
       const firstRequest = openRequest(scope, "teardown-open", 1, "teardown-key");
       const first = broker.execute(scope, firstRequest);
       const firstDelivery = deliveries.find(({ channel }) => channel === "browserAutomation.bootstrap")!;
+      race.event("cancel");
       expect(broker.releaseProviderSession(scope.providerId, scope.providerSessionId)).toBe(0);
       expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await first), "OPERATION_CANCELLED");
       expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 0 });
@@ -447,9 +721,11 @@ describe("BrowserAutomationBroker race mechanics", () => {
       const retry = broker.execute(scope, retryRequest);
       const retryDelivery = deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap").at(-1)!;
       expect(retryDelivery).not.toBe(firstDelivery);
+      race.event("late-response");
       broker.respond(hostSocket, "teardown", generation, responseFor(firstRequest, openResult("https://example.test/", "late-old")), target("teardown", generation, "tab-old", 1));
       const retryBootstrap = bootstrapRequestFor(retryDelivery);
       const retryTarget = target("teardown", generation, "tab-retry", 1);
+      race.event("target-register");
       broker.respond(hostSocket, "teardown", generation, responseFor(retryBootstrap, openResult("https://example.test/", "retry-observation")), retryTarget);
       expect(await BrowserAutomationResponseSchema().parseAsync(await retry)).toMatchObject({ ok: true, result: { observationRef: "retry-observation" } });
       expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 1 });
@@ -457,9 +733,11 @@ describe("BrowserAutomationBroker race mechanics", () => {
       broker.shutdown();
       expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
       const reliability = broker.reliabilityStatus();
+      race.event("late-response");
       expect(() => broker.respond(hostSocket, "teardown", generation, responseFor(retryBootstrap, openResult("https://example.test/", "late-after-shutdown")), retryTarget)).toThrow("stale or invalid");
       expect(broker.reliabilityStatus()).toEqual(reliability);
       expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
+      race.assertComplete();
     } finally {
       broker.shutdown();
     }

--- a/apps/server/src/services/browser-automation/broker.races.test.ts
+++ b/apps/server/src/services/browser-automation/broker.races.test.ts
@@ -1,0 +1,467 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_AUTOMATION_CONTRACT_VERSION,
+  BrowserAutomationHostDispatchSchema,
+  BrowserAutomationRequestSchema,
+  BrowserAutomationResponseSchema,
+  type BrowserAutomationHostRegistration,
+  type BrowserAutomationOperation,
+  type BrowserAutomationRequest,
+  type BrowserAutomationResponse,
+} from "@mcode/contracts";
+import type { WebSocket } from "ws";
+import { BrowserAutomationBroker } from "./broker.js";
+import type { BrowserAutomationCredentialClaims } from "./credential-registry.js";
+
+type Delivery = { socket: WebSocket; channel: string; data: unknown };
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+function socket(name: string): WebSocket {
+  return { name } as unknown as WebSocket;
+}
+
+function authorization(hostId: string) {
+  return {
+    desktopInstanceId: `desktop-${hostId}`,
+    worktreeIdentity: "worktree-a",
+    allowedWorkspaceIds: ["workspace-a"],
+  };
+}
+
+function registration(
+  hostId: string,
+  operations: readonly BrowserAutomationOperation[],
+): BrowserAutomationHostRegistration {
+  return {
+    contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+    hostId,
+    runtime: "electron",
+    desktopInstanceId: `desktop-${hostId}`,
+    worktreeIdentity: "worktree-a",
+    workspaceIds: ["workspace-a"],
+    executorDescriptor: {
+      runtime: "electron",
+      operations: ["inspect", ...operations],
+      constraints: { maxTabs: 32, maxSnapshotChars: 20_000, maxDiagnostics: 200 },
+      capabilityRevision: 1,
+    },
+    capabilities: operations.map((operation) => ({ operation, available: true })),
+    maxPendingRequests: 4,
+    connectedAt: 1,
+  };
+}
+
+function register(
+  broker: BrowserAutomationBroker,
+  targetSocket: WebSocket,
+  hostId: string,
+  operations: readonly BrowserAutomationOperation[],
+): number {
+  return broker.registerHost(targetSocket, registration(hostId, operations), authorization(hostId)).generation;
+}
+
+function target(
+  hostId: string,
+  generation: number,
+  tabId = "tab-thread-a",
+  targetGeneration = 1,
+) {
+  return {
+    desktopInstanceId: `desktop-${hostId}`,
+    windowId: 1,
+    connectionGeneration: generation,
+    threadId: "thread-a",
+    tabId,
+    targetGeneration,
+    active: true,
+    focused: true,
+    lastUsedAt: targetGeneration,
+  };
+}
+
+function claims(
+  allowedOperations: readonly BrowserAutomationOperation[],
+): BrowserAutomationCredentialClaims {
+  return {
+    credentialId: "credential-thread-a",
+    providerId: "cursor",
+    providerSessionId: "provider-thread-a",
+    mcodeSessionId: "mcode-thread-a",
+    threadId: "thread-a",
+    workspaceId: "workspace-a",
+    worktreeIdentity: "worktree-a",
+    permissionCapability: "privileged",
+    allowedOperations,
+    issuedAt: 1,
+    expiresAt: 100_000,
+  };
+}
+
+function request(
+  scope: BrowserAutomationCredentialClaims,
+  requestId: string,
+  sequence: number,
+  operation: BrowserAutomationOperation,
+  args: unknown,
+  deadline = 10_000,
+): BrowserAutomationRequest {
+  return BrowserAutomationRequestSchema().parse({
+    contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+    workspaceId: scope.workspaceId,
+    threadId: scope.threadId,
+    providerSessionId: scope.providerSessionId,
+    providerInstanceId: scope.mcodeSessionId,
+    requestId,
+    sequence,
+    deadline,
+    expectedControlEpoch: 0,
+    operation,
+    args,
+  });
+}
+
+function openRequest(
+  scope: BrowserAutomationCredentialClaims,
+  requestId: string,
+  sequence: number,
+  idempotencyKey: string,
+  url = "https://example.test/",
+): BrowserAutomationRequest {
+  return request(scope, requestId, sequence, "open", { idempotencyKey, url });
+}
+
+function actRequest(
+  scope: BrowserAutomationCredentialClaims,
+  requestId: string,
+  sequence: number,
+  idempotencyKey: string,
+  deadline = 10_000,
+): BrowserAutomationRequest {
+  return request(scope, requestId, sequence, "act", {
+    idempotencyKey,
+    observationRef: "observation-thread-a",
+    deadlineMs: 1_000,
+    steps: [{ operation: "click", target: { role: "button", accessibleName: "Save" } }],
+  }, deadline);
+}
+
+function openResult(url: string, observationRef: string) {
+  return {
+    operation: "open" as const,
+    url,
+    title: "Example",
+    controlEpoch: 0,
+    observationRef,
+  };
+}
+
+function actResult() {
+  return {
+    operation: "act" as const,
+    outcome: "completed" as const,
+    stoppingPosition: 1,
+    effect: "complete" as const,
+    recovery: "inspect" as const,
+    receipts: [{ index: 0, operation: "click", status: "applied" as const }],
+    finalObservation: {
+      observationRef: "observation-next",
+      hostRevision: 1,
+      documentRevision: 1,
+      controlRevision: 0,
+      capabilityRevision: 1,
+      observationRevision: 1,
+    },
+    nextObservationRef: "observation-next",
+  };
+}
+
+function responseFor(requestValue: BrowserAutomationRequest, result: unknown): BrowserAutomationResponse {
+  return BrowserAutomationResponseSchema().parse({
+    contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+    requestId: requestValue.requestId,
+    sequence: requestValue.sequence,
+    ok: true,
+    result,
+  });
+}
+
+function dispatchFor(delivery: Delivery) {
+  if (delivery.channel !== "browserAutomation.request") throw new Error("Expected a request delivery");
+  return BrowserAutomationHostDispatchSchema().parse((delivery.data as { dispatch: unknown }).dispatch);
+}
+
+function bootstrapRequestFor(delivery: Delivery): BrowserAutomationRequest {
+  if (delivery.channel !== "browserAutomation.bootstrap") throw new Error("Expected a bootstrap delivery");
+  return BrowserAutomationRequestSchema().parse((delivery.data as { request: unknown }).request);
+}
+
+function expectKnownFailure(response: BrowserAutomationResponse, code: string): void {
+  if (response.ok) throw new Error("Expected a browser automation failure");
+  expect(response.error.code).toBe(code);
+  expect(["none", "partial", "complete"]).toContain(response.error.effect);
+  expect(["inspect", "reopen", "wait", "yield_to_user", "do_not_retry"]).toContain(response.error.recovery);
+}
+
+describe("BrowserAutomationBroker race mechanics", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("bootstrap-disconnect-reconnect + bootstrap-concurrent-open + bootstrap-idempotent-replay keep one target owner", async () => {
+    const deliveries: Delivery[] = [];
+    const firstBootstrapReady = deferred<void>();
+    let bootstrapCount = 0;
+    const broker = new BrowserAutomationBroker({
+      now: () => 1_000,
+      send: (targetSocket, channel, data) => {
+        deliveries.push({ socket: targetSocket, channel, data });
+        if (channel === "browserAutomation.bootstrap" && ++bootstrapCount === 1) firstBootstrapReady.resolve();
+        return true;
+      },
+    });
+    try {
+      const firstSocket = socket("sticky");
+      const firstGeneration = register(broker, firstSocket, "sticky", ["open", "act"]);
+      const scope = claims(["open", "act"]);
+      const firstRequest = openRequest(scope, "open-first", 1, "sticky-open");
+      const first = broker.execute(scope, firstRequest);
+      await firstBootstrapReady.promise;
+      const joined = broker.execute(scope, openRequest(scope, "open-joined", 2, "sticky-open"));
+      const competing = broker.execute(scope, openRequest(scope, "open-competing", 3, "other-open"));
+      const firstDelivery = deliveries.find(({ channel }) => channel === "browserAutomation.bootstrap")!;
+      const firstBootstrap = bootstrapRequestFor(firstDelivery);
+      expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(1);
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await competing), "BROWSER_BUSY");
+
+      broker.disconnect(firstSocket);
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await first), "HOST_UNAVAILABLE");
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await joined), "HOST_UNAVAILABLE");
+      expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
+
+      const replacementSocket = socket("sticky-replacement");
+      const replacementGeneration = register(broker, replacementSocket, "sticky", ["open", "act"]);
+      const retryRequest = openRequest(scope, "open-retry", 4, "sticky-open");
+      const retry = broker.execute(scope, retryRequest);
+      const retryDelivery = deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap").at(-1)!;
+      const retryBootstrap = bootstrapRequestFor(retryDelivery);
+      expect(() => broker.respond(
+        firstSocket,
+        "sticky",
+        firstGeneration,
+        responseFor(firstBootstrap, openResult("https://example.test/", "stale-observation")),
+      )).toThrow("stale or invalid");
+      const authoritativeTarget = target("sticky", replacementGeneration, "tab-authoritative", 1);
+      broker.respond(
+        replacementSocket,
+        "sticky",
+        replacementGeneration,
+        responseFor(retryBootstrap, openResult("https://example.test/", "observation-authoritative")),
+        authoritativeTarget,
+      );
+      expect(await BrowserAutomationResponseSchema().parseAsync(await retry)).toMatchObject({
+        ok: true,
+        result: { observationRef: "observation-authoritative" },
+      });
+      expect(await BrowserAutomationResponseSchema().parseAsync(await broker.execute(
+        scope,
+        openRequest(scope, "open-replay", 5, "sticky-open"),
+      ))).toMatchObject({ ok: true, requestId: "open-replay", sequence: 5 });
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await broker.execute(
+        scope,
+        openRequest(scope, "open-conflict", 6, "sticky-open", "https://other.test/"),
+      )), "IDEMPOTENCY_CONFLICT");
+      expect(deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap")).toHaveLength(2);
+      expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 1 });
+    } finally {
+      broker.shutdown();
+    }
+  });
+
+  it("cleanup-replacement + cleanup-late-response reject stale target responses", async () => {
+    const deliveries: Delivery[] = [];
+    const broker = new BrowserAutomationBroker({
+      now: () => 1_000,
+      send: (targetSocket, channel, data) => {
+        deliveries.push({ socket: targetSocket, channel, data });
+        return true;
+      },
+    });
+    try {
+      const hostSocket = socket("target-replacement");
+      const generation = register(broker, hostSocket, "target-replacement", ["open", "act"]);
+      const scope = claims(["open", "act"]);
+      const open = openRequest(scope, "open-target", 1, "target-open");
+      const opened = broker.execute(scope, open);
+      const bootstrap = bootstrapRequestFor(deliveries.find(({ channel }) => channel === "browserAutomation.bootstrap")!);
+      const firstTarget = target("target-replacement", generation, "tab-authoritative", 1);
+      broker.respond(hostSocket, "target-replacement", generation, responseFor(bootstrap, openResult("https://example.test/", "target-observation")), firstTarget);
+      expect(await BrowserAutomationResponseSchema().parseAsync(await opened)).toMatchObject({ ok: true });
+
+      const oldMutationRequest = actRequest(scope, "act-old", 2, "target-old");
+      const oldMutation = broker.execute(scope, oldMutationRequest);
+      expect(dispatchFor(deliveries.filter(({ channel }) => channel === "browserAutomation.request").at(-1)!)).toMatchObject({ target: firstTarget });
+      const replacementTarget = target("target-replacement", generation, "tab-authoritative", 2);
+      broker.updateTargets(hostSocket, "target-replacement", generation, [replacementTarget]);
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await oldMutation), "TAB_UNAVAILABLE");
+      broker.respond(hostSocket, "target-replacement", generation, responseFor(oldMutationRequest, actResult()), firstTarget);
+
+      const newMutationRequest = actRequest(scope, "act-new", 3, "target-new");
+      const newMutation = broker.execute(scope, newMutationRequest);
+      expect(dispatchFor(deliveries.filter(({ channel }) => channel === "browserAutomation.request").at(-1)!)).toMatchObject({ target: replacementTarget });
+      broker.respond(hostSocket, "target-replacement", generation, responseFor(newMutationRequest, actResult()), replacementTarget);
+      expect(await BrowserAutomationResponseSchema().parseAsync(await newMutation)).toMatchObject({ ok: true, result: { operation: "act" } });
+      expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 1 });
+      expect(broker.reliabilityStatus()).toMatchObject({ dispatched: 3, succeeded: 2, failed: 1, hostLosses: 1 });
+    } finally {
+      broker.shutdown();
+    }
+  });
+
+  it("action-competing-mutation + action-cancel settle provider cancellation exactly once", async () => {
+    const deliveries: Delivery[] = [];
+    const broker = new BrowserAutomationBroker({
+      now: () => 1_000,
+      send: (targetSocket, channel, data) => {
+        deliveries.push({ socket: targetSocket, channel, data });
+        return true;
+      },
+    });
+    try {
+      const hostSocket = socket("mutation");
+      const generation = register(broker, hostSocket, "mutation", ["act"]);
+      broker.updateTargets(hostSocket, "mutation", generation, [target("mutation", generation)]);
+      const scope = claims(["act"]);
+      const firstRequest = actRequest(scope, "act-first", 1, "act-key");
+      const first = broker.execute(scope, firstRequest);
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await broker.execute(scope, actRequest(scope, "act-competing", 2, "other-act-key"))), "BROWSER_BUSY");
+      expect(deliveries.filter(({ channel }) => channel === "browserAutomation.request")).toHaveLength(1);
+      expect(broker.cancelFromProvider(scope, firstRequest.requestId, firstRequest.sequence)).toBe(true);
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await first), "OPERATION_CANCELLED");
+      expect(broker.cancelFromProvider(scope, firstRequest.requestId, firstRequest.sequence)).toBe(false);
+      const reliability = broker.reliabilityStatus();
+      broker.respond(hostSocket, "mutation", generation, responseFor(firstRequest, actResult()));
+      expect(broker.status()).toMatchObject({ pending: 0, assignments: 1 });
+      expect(broker.reliabilityStatus()).toEqual(reliability);
+    } finally {
+      broker.shutdown();
+    }
+  });
+
+  it("action-timeout + cleanup-late-response keep deadline responses terminal", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const deliveries: Delivery[] = [];
+    const broker = new BrowserAutomationBroker({
+      now: () => now,
+      send: (targetSocket, channel, data) => {
+        deliveries.push({ socket: targetSocket, channel, data });
+        return true;
+      },
+    });
+    try {
+      const hostSocket = socket("timeout");
+      const generation = register(broker, hostSocket, "timeout", ["act"]);
+      broker.updateTargets(hostSocket, "timeout", generation, [target("timeout", generation)]);
+      const scope = claims(["act"]);
+      const requestValue = actRequest(scope, "act-timeout", 1, "timeout-key", now + 5);
+      const pending = broker.execute(scope, requestValue);
+      expect(deliveries.find(({ channel }) => channel === "browserAutomation.request")).toBeDefined();
+      now += 5;
+      await vi.advanceTimersByTimeAsync(5);
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await pending), "DEADLINE_EXCEEDED");
+      const reliability = broker.reliabilityStatus();
+      broker.respond(hostSocket, "timeout", generation, responseFor(requestValue, actResult()));
+      expect(broker.status()).toMatchObject({ pending: 0, assignments: 1 });
+      expect(broker.reliabilityStatus()).toEqual(reliability);
+    } finally {
+      broker.shutdown();
+    }
+  });
+
+  it("bootstrap-disconnect-reconnect + cleanup-replacement reject old host generations", async () => {
+    const deliveries: Delivery[] = [];
+    const broker = new BrowserAutomationBroker({
+      now: () => 1_000,
+      send: (targetSocket, channel, data) => {
+        deliveries.push({ socket: targetSocket, channel, data });
+        return true;
+      },
+    });
+    try {
+      const oldSocket = socket("disconnect");
+      const oldGeneration = register(broker, oldSocket, "disconnect", ["act"]);
+      broker.updateTargets(oldSocket, "disconnect", oldGeneration, [target("disconnect", oldGeneration)]);
+      const scope = claims(["act"]);
+      const oldRequest = actRequest(scope, "act-disconnect", 1, "disconnect-key");
+      const old = broker.execute(scope, oldRequest);
+      broker.disconnect(oldSocket);
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await old), "HOST_UNAVAILABLE");
+      const reliability = broker.reliabilityStatus();
+      expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
+      expect(() => broker.respond(oldSocket, "disconnect", oldGeneration, responseFor(oldRequest, actResult()))).toThrow("stale or invalid");
+      expect(broker.reliabilityStatus()).toEqual(reliability);
+
+      const replacementSocket = socket("disconnect-replacement");
+      const replacementGeneration = register(broker, replacementSocket, "disconnect", ["act"]);
+      broker.updateTargets(replacementSocket, "disconnect", replacementGeneration, [target("disconnect", replacementGeneration)]);
+      const newerRequest = actRequest(scope, "act-newer", 2, "newer-key");
+      const newer = broker.execute(scope, newerRequest);
+      const newerDelivery = deliveries.filter(({ channel }) => channel === "browserAutomation.request").at(-1)!;
+      expect(dispatchFor(newerDelivery).connection.connectionGeneration).toBe(replacementGeneration);
+      expect(() => broker.respond(oldSocket, "disconnect", oldGeneration, responseFor(oldRequest, actResult()))).toThrow("stale or invalid");
+      broker.respond(replacementSocket, "disconnect", replacementGeneration, responseFor(newerRequest, actResult()));
+      expect(await BrowserAutomationResponseSchema().parseAsync(await newer)).toMatchObject({ ok: true, result: { operation: "act" } });
+    } finally {
+      broker.shutdown();
+    }
+  });
+
+  it("bootstrap-late-creation + cleanup-late-response release and shutdown to baseline", async () => {
+    const deliveries: Delivery[] = [];
+    const broker = new BrowserAutomationBroker({
+      now: () => 1_000,
+      send: (targetSocket, channel, data) => {
+        deliveries.push({ socket: targetSocket, channel, data });
+        return true;
+      },
+    });
+    try {
+      const hostSocket = socket("teardown");
+      const generation = register(broker, hostSocket, "teardown", ["open"]);
+      const scope = claims(["open"]);
+      const firstRequest = openRequest(scope, "teardown-open", 1, "teardown-key");
+      const first = broker.execute(scope, firstRequest);
+      const firstDelivery = deliveries.find(({ channel }) => channel === "browserAutomation.bootstrap")!;
+      expect(broker.releaseProviderSession(scope.providerId, scope.providerSessionId)).toBe(0);
+      expectKnownFailure(await BrowserAutomationResponseSchema().parseAsync(await first), "OPERATION_CANCELLED");
+      expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 0 });
+
+      const retryRequest = openRequest(scope, "teardown-retry", 2, "teardown-key");
+      const retry = broker.execute(scope, retryRequest);
+      const retryDelivery = deliveries.filter(({ channel }) => channel === "browserAutomation.bootstrap").at(-1)!;
+      expect(retryDelivery).not.toBe(firstDelivery);
+      broker.respond(hostSocket, "teardown", generation, responseFor(firstRequest, openResult("https://example.test/", "late-old")), target("teardown", generation, "tab-old", 1));
+      const retryBootstrap = bootstrapRequestFor(retryDelivery);
+      const retryTarget = target("teardown", generation, "tab-retry", 1);
+      broker.respond(hostSocket, "teardown", generation, responseFor(retryBootstrap, openResult("https://example.test/", "retry-observation")), retryTarget);
+      expect(await BrowserAutomationResponseSchema().parseAsync(await retry)).toMatchObject({ ok: true, result: { observationRef: "retry-observation" } });
+      expect(broker.status()).toEqual({ hosts: 1, pending: 0, assignments: 1 });
+
+      broker.shutdown();
+      expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
+      const reliability = broker.reliabilityStatus();
+      expect(() => broker.respond(hostSocket, "teardown", generation, responseFor(retryBootstrap, openResult("https://example.test/", "late-after-shutdown")), retryTarget)).toThrow("stale or invalid");
+      expect(broker.reliabilityStatus()).toEqual(reliability);
+      expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
+    } finally {
+      broker.shutdown();
+    }
+  });
+});

--- a/apps/server/src/services/browser-automation/mcp-conformance.test.ts
+++ b/apps/server/src/services/browser-automation/mcp-conformance.test.ts
@@ -9,15 +9,48 @@ import {
   type BrowserAutomationResponse,
 } from "@mcode/contracts";
 import {
+  BROWSER_CONFORMANCE_RACE_CATALOGUE,
+  BrowserConformanceFaultController,
   createBrowserConformanceScenario,
   normalizeBrowserConformanceRun,
   createBrowserConformanceResourceSnapshot,
+  type BrowserConformanceEventKind,
 } from "@mcode/browser-conformance";
 import { BrowserAutomationBroker } from "./broker.js";
 import { BrowserAutomationCredentialRegistry } from "./credential-registry.js";
 import { BrowserAutomationMcpHandler } from "./mcp-handler.js";
 
 const socket = { name: "conformance-host" } as never;
+
+const MCP_OWNED_RACE_IDS = ["cleanup-late-event", "cleanup-disconnect"] as const;
+
+function mcpRaceLabel(): string {
+  return MCP_OWNED_RACE_IDS.map((id) => {
+    const race = BROWSER_CONFORMANCE_RACE_CATALOGUE.find((candidate) => candidate.id === id);
+    if (!race) throw new Error(`Missing Browser conformance race catalogue entry: ${id}`);
+    return `${race.id} [${race.events.join(", ")}]`;
+  }).join(" + ");
+}
+
+function mcpRaceDriver(): {
+  event: (kind: BrowserConformanceEventKind) => void;
+  assertComplete: () => void;
+} {
+  const remaining = new Map<BrowserConformanceEventKind, number>();
+  for (const id of MCP_OWNED_RACE_IDS) {
+    const race = BROWSER_CONFORMANCE_RACE_CATALOGUE.find((candidate) => candidate.id === id);
+    if (!race) throw new Error(`Missing Browser conformance race catalogue entry: ${id}`);
+    for (const event of race.events) remaining.set(event, (remaining.get(event) ?? 0) + 1);
+  }
+  return {
+    event: (kind) => {
+      const count = remaining.get(kind) ?? 0;
+      expect(count, `unexpected ${kind} event for MCP conformance`).toBeGreaterThan(0);
+      remaining.set(kind, count - 1);
+    },
+    assertComplete: () => expect([...remaining.entries()].filter(([, count]) => count > 0)).toEqual([]),
+  };
+}
 
 function registration(): BrowserAutomationHostRegistration {
   return {
@@ -66,7 +99,20 @@ describe("authenticated Browser MCP conformance", () => {
     if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
   });
 
-  it("crosses MCP transport into broker, normalizes success, and rejects late host activity", async () => {
+  it("covers the MCP-owned named race catalogue subset explicitly", () => {
+    const expected = [...MCP_OWNED_RACE_IDS];
+    const expectedSet = new Set<string>(expected);
+    expect(expectedSet.size).toBe(expected.length);
+    expect(BROWSER_CONFORMANCE_RACE_CATALOGUE.filter(({ id }) => expectedSet.has(id)).map(({ id }) => id))
+      .toEqual(expected);
+  });
+
+  it("crosses MCP transport into broker, normalizes success, and rejects late host activity for " + mcpRaceLabel(), async () => {
+    const race = mcpRaceDriver();
+    const transportFaults = new BrowserConformanceFaultController();
+    const targetFaults = new BrowserConformanceFaultController();
+    const receiptFaults = new BrowserConformanceFaultController();
+    const cleanupFaults = new BrowserConformanceFaultController();
     let dispatch: BrowserAutomationHostDispatch | undefined;
     const dispatchResolvers: Array<(value: BrowserAutomationHostDispatch) => void> = [];
     const nextDispatch = (): Promise<BrowserAutomationHostDispatch> => new Promise((resolve) => {
@@ -77,6 +123,7 @@ describe("authenticated Browser MCP conformance", () => {
     broker = new BrowserAutomationBroker({
       now: () => 1_000,
       send: (_socket, channel, data) => {
+        transportFaults.hit("host-transport");
         if (channel === "browserAutomation.request") {
           dispatch = (data as { dispatch: BrowserAutomationHostDispatch }).dispatch;
           dispatchResolvers.shift()?.(dispatch);
@@ -91,6 +138,7 @@ describe("authenticated Browser MCP conformance", () => {
       allowedWorkspaceIds: ["workspace-conformance"],
     });
     generation = registered.generation;
+    targetFaults.hit("target-registration");
     broker.updateTargets(socket, "host-conformance", generation, [target(generation)]);
     const issued = credentials.issue({
       providerId: "codex",
@@ -153,6 +201,7 @@ describe("authenticated Browser MCP conformance", () => {
       },
     });
     expect(response.ok).toBe(true);
+    receiptFaults.hit("receipt-delivery");
     broker.respond(socket, "host-conformance", generation, response, dispatch!.target);
     const payload = await (await call).json() as { result: { content: [{ text: string }] } };
     const observed = JSON.parse(payload.result.content[0].text) as { operation: string; available: boolean };
@@ -233,6 +282,7 @@ describe("authenticated Browser MCP conformance", () => {
       },
     });
     expect(actResponse.ok).toBe(true);
+    receiptFaults.hit("receipt-delivery");
     broker.respond(socket, "host-conformance", generation, actResponse, actDispatch.target);
     const actPayload = await (await actCall).json() as { result: { content: [{ text: string }] } };
     const actObserved = JSON.parse(actPayload.result.content[0].text) as {
@@ -265,13 +315,29 @@ describe("authenticated Browser MCP conformance", () => {
     expect(actNormalized.receipts.map((receipt) => receipt.status)).toEqual(["applied", "interrupted", "skipped"]);
     expect(actNormalized.receipts.some((receipt) => receipt.status === "unknown" || receipt.operation === "unknown")).toBe(false);
 
+    race.event("host-disconnect");
+    cleanupFaults.hit("cleanup");
     broker.disconnect(socket);
     expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
     expect(broker.reliabilityStatus().succeeded).toBe(baselineReliability.succeeded + 2);
     expect(() => broker.respond(socket, "host-conformance", generation, response, dispatch!.target))
       .toThrow("stale or invalid");
+    race.event("late-event");
+    race.assertComplete();
     expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
     expect(credentials.revoke(issued.credentialId)).toBe(true);
     expect(credentials.size()).toBe(0);
+    expect(transportFaults.callsFor("host-transport")).toBe(2);
+    expect(targetFaults.callsFor("target-registration")).toBe(1);
+    expect(receiptFaults.callsFor("receipt-delivery")).toBe(2);
+    expect(cleanupFaults.callsFor("cleanup")).toBe(1);
+    transportFaults.dispose();
+    targetFaults.dispose();
+    receiptFaults.dispose();
+    cleanupFaults.dispose();
+    expect(transportFaults.isDisposed).toBe(true);
+    expect(targetFaults.isDisposed).toBe(true);
+    expect(receiptFaults.isDisposed).toBe(true);
+    expect(cleanupFaults.isDisposed).toBe(true);
   });
 });

--- a/apps/server/src/services/browser-automation/mcp-conformance.test.ts
+++ b/apps/server/src/services/browser-automation/mcp-conformance.test.ts
@@ -1,0 +1,277 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BROWSER_AUTOMATION_CONTRACT_VERSION,
+  BrowserAutomationHostDispatchTargetSchema,
+  BrowserAutomationResponseSchema,
+  type BrowserAutomationHostRegistration,
+  type BrowserAutomationHostDispatch,
+  type BrowserAutomationResponse,
+} from "@mcode/contracts";
+import {
+  createBrowserConformanceScenario,
+  normalizeBrowserConformanceRun,
+  createBrowserConformanceResourceSnapshot,
+} from "@mcode/browser-conformance";
+import { BrowserAutomationBroker } from "./broker.js";
+import { BrowserAutomationCredentialRegistry } from "./credential-registry.js";
+import { BrowserAutomationMcpHandler } from "./mcp-handler.js";
+
+const socket = { name: "conformance-host" } as never;
+
+function registration(): BrowserAutomationHostRegistration {
+  return {
+    contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+    hostId: "host-conformance",
+    runtime: "electron",
+    desktopInstanceId: "desktop-conformance",
+    worktreeIdentity: "worktree-conformance",
+    workspaceIds: ["workspace-conformance"],
+    executorDescriptor: {
+      runtime: "electron",
+      operations: ["status", "act"],
+      constraints: { maxTabs: 4, maxSnapshotChars: 4_000, maxDiagnostics: 4 },
+      capabilityRevision: 1,
+    },
+    capabilities: [
+      { operation: "status", available: true },
+      { operation: "act", available: true },
+    ],
+    maxPendingRequests: 2,
+    connectedAt: 1,
+  };
+}
+
+function target(generation: number) {
+  return BrowserAutomationHostDispatchTargetSchema().parse({
+    desktopInstanceId: "desktop-conformance",
+    windowId: 1,
+    connectionGeneration: generation,
+    threadId: "thread-conformance",
+    tabId: "tab-conformance",
+    targetGeneration: 1,
+    active: true,
+    focused: true,
+    lastUsedAt: 1,
+  });
+}
+
+describe("authenticated Browser MCP conformance", () => {
+  let server: Server | undefined;
+  let broker: BrowserAutomationBroker;
+  let credentials: BrowserAutomationCredentialRegistry;
+
+  afterEach(async () => {
+    broker?.shutdown();
+    if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+  });
+
+  it("crosses MCP transport into broker, normalizes success, and rejects late host activity", async () => {
+    let dispatch: BrowserAutomationHostDispatch | undefined;
+    const dispatchResolvers: Array<(value: BrowserAutomationHostDispatch) => void> = [];
+    const nextDispatch = (): Promise<BrowserAutomationHostDispatch> => new Promise((resolve) => {
+      dispatchResolvers.push(resolve);
+    });
+    let generation = 0;
+    credentials = new BrowserAutomationCredentialRegistry({ now: () => 1_000 });
+    broker = new BrowserAutomationBroker({
+      now: () => 1_000,
+      send: (_socket, channel, data) => {
+        if (channel === "browserAutomation.request") {
+          dispatch = (data as { dispatch: BrowserAutomationHostDispatch }).dispatch;
+          dispatchResolvers.shift()?.(dispatch);
+        }
+        return true;
+      },
+    });
+    const baselineReliability = broker.reliabilityStatus();
+    const registered = broker.registerHost(socket, registration(), {
+      desktopInstanceId: "desktop-conformance",
+      worktreeIdentity: "worktree-conformance",
+      allowedWorkspaceIds: ["workspace-conformance"],
+    });
+    generation = registered.generation;
+    broker.updateTargets(socket, "host-conformance", generation, [target(generation)]);
+    const issued = credentials.issue({
+      providerId: "codex",
+      providerSessionId: "provider-conformance",
+      mcodeSessionId: "mcode-conformance",
+      threadId: "thread-conformance",
+      workspaceId: "workspace-conformance",
+      worktreeIdentity: "worktree-conformance",
+      permissionCapability: "interact",
+      allowedOperations: ["status", "act"],
+    });
+    const handler = new BrowserAutomationMcpHandler({ credentials, broker, now: () => 1_000 });
+    const scenario = createBrowserConformanceScenario({
+      id: "authenticated-mcp-status-act",
+      seed: "mcp-oracle-1034",
+      commands: [
+        { id: "status", operation: "status" },
+        {
+          id: "act",
+          operation: "act",
+          args: {
+            idempotencyKey: "act-conformance-1",
+            observationRef: "observation-conformance-1",
+            deadlineMs: 5_000,
+            steps: [
+              { operation: "click", target: { semanticId: "fixture-action-button" } },
+              { operation: "type", text: "partial fixture text" },
+              { operation: "press", key: "Enter" },
+            ],
+          },
+        },
+      ],
+      cleanup: { baseline: createBrowserConformanceResourceSnapshot({}) },
+    });
+    server = createServer((req, res) => void handler.handle(req, res));
+    await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("conformance server did not bind");
+    const endpoint = `http://127.0.0.1:${address.port}/mcp`;
+    const dispatchReady = nextDispatch();
+    const call = fetch(endpoint, {
+      method: "POST",
+      headers: { authorization: `Bearer ${issued.token}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: `browser_${scenario.commands[0]!.operation}`, arguments: scenario.commands[0]!.args ?? {} },
+      }),
+    });
+    dispatch = await dispatchReady;
+    const response: BrowserAutomationResponse = BrowserAutomationResponseSchema().parse({
+      contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+      requestId: dispatch!.request.requestId,
+      sequence: dispatch!.request.sequence,
+      ok: true,
+      result: {
+        operation: "status", available: true, active: true, url: "https://fixture.test/", loading: false,
+        focused: true, viewport: { width: 800, height: 600 }, capabilities: ["status"],
+      },
+    });
+    expect(response.ok).toBe(true);
+    broker.respond(socket, "host-conformance", generation, response, dispatch!.target);
+    const payload = await (await call).json() as { result: { content: [{ text: string }] } };
+    const observed = JSON.parse(payload.result.content[0].text) as { operation: string; available: boolean };
+    const responseOperation = response.ok && "operation" in response.result ? response.result.operation : "unknown";
+    expect(observed.operation).toBe(responseOperation);
+    const responseAvailable = response.ok && "available" in response.result ? response.result.available : false;
+    expect(observed.available).toBe(responseAvailable);
+    const terminalStatus = response.ok ? "satisfied" : "failed";
+    const terminalOutcome = response.ok ? "completed" : "failed";
+    const terminalEffect = response.ok ? "none" : response.error.effect;
+    const terminalRecovery = response.ok ? "none" : response.error.recovery;
+    const normalized = normalizeBrowserConformanceRun({
+      receipts: [{
+        operation: responseOperation,
+        status: terminalStatus,
+        effect: terminalEffect,
+        recovery: terminalRecovery,
+        errorCode: response.ok ? null : response.error.code,
+      }],
+      outcome: {
+        status: terminalOutcome,
+        effect: terminalEffect,
+        recovery: terminalRecovery,
+        errorCode: response.ok ? null : response.error.code,
+      },
+      finalState: { readiness: "ready", resources: scenario.cleanup.baseline },
+    });
+    expect(normalized.outcome.status).toBe(terminalOutcome);
+    expect(normalized.outcome.effect).toBe(terminalEffect);
+    expect(normalized.outcome.recovery).toBe(terminalRecovery);
+    expect(normalized.receipts.some((receipt) => receipt.status === "unknown" || receipt.operation === "unknown")).toBe(false);
+    expect(JSON.parse(payload.result.content[0].text)).toMatchObject({ operation: "status", available: true });
+
+    const actDispatchReady = nextDispatch();
+    const actCall = fetch(endpoint, {
+      method: "POST",
+      headers: { authorization: `Bearer ${issued.token}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: `browser_${scenario.commands[1]!.operation}`,
+          arguments: scenario.commands[1]!.args,
+        },
+      }),
+    });
+    const actDispatch = await actDispatchReady;
+    expect(actDispatch.request.operation).toBe("act");
+    const scenarioActArgs = scenario.commands[1]!.args as { steps: readonly { operation: string }[] };
+    expect(actDispatch.request.args.steps).toHaveLength(scenarioActArgs.steps.length);
+    expect(actDispatch.request.args.steps.map((step: { operation: string }) => step.operation))
+      .toEqual(scenarioActArgs.steps.map((step) => step.operation));
+    const actResponse: BrowserAutomationResponse = BrowserAutomationResponseSchema().parse({
+      contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+      requestId: actDispatch.request.requestId,
+      sequence: actDispatch.request.sequence,
+      ok: true,
+      result: {
+        operation: "act",
+        outcome: "interrupted",
+        stoppingPosition: 1,
+        effect: "partial",
+        recovery: "inspect",
+        receipts: [
+          { index: 0, operation: "click", status: "applied" },
+          { index: 1, operation: "type", status: "interrupted" },
+          { index: 2, operation: "press", status: "skipped" },
+        ],
+        finalObservation: {
+          observationRef: "observation-conformance-2",
+          hostRevision: 1,
+          documentRevision: 1,
+          controlRevision: 0,
+          capabilityRevision: 1,
+          observationRevision: 2,
+        },
+      },
+    });
+    expect(actResponse.ok).toBe(true);
+    broker.respond(socket, "host-conformance", generation, actResponse, actDispatch.target);
+    const actPayload = await (await actCall).json() as { result: { content: [{ text: string }] } };
+    const actObserved = JSON.parse(actPayload.result.content[0].text) as {
+      operation: string;
+      outcome: string;
+      effect: string;
+      recovery: string;
+      receipts: Array<{ index: number; status: string; operation: string }>;
+    };
+    expect(actObserved.operation).toBe("act");
+    expect(actObserved.receipts.map((receipt) => receipt.status)).toEqual(["applied", "interrupted", "skipped"]);
+    const actNormalized = normalizeBrowserConformanceRun({
+      receipts: actObserved.receipts.map((receipt) => ({
+        order: { tick: 0, ordinal: receipt.index },
+        operation: receipt.operation,
+        status: receipt.status,
+        effect: actObserved.effect,
+        recovery: actObserved.recovery,
+      })),
+      outcome: {
+        status: actObserved.outcome,
+        effect: actObserved.effect,
+        recovery: actObserved.recovery,
+      },
+      finalState: { readiness: "ready", resources: scenario.cleanup.baseline },
+    });
+    expect(actNormalized.outcome.status).toBe("interrupted");
+    expect(actNormalized.outcome.effect).toBe("partial");
+    expect(actNormalized.outcome.recovery).toBe("inspect");
+    expect(actNormalized.receipts.map((receipt) => receipt.status)).toEqual(["applied", "interrupted", "skipped"]);
+    expect(actNormalized.receipts.some((receipt) => receipt.status === "unknown" || receipt.operation === "unknown")).toBe(false);
+
+    broker.disconnect(socket);
+    expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
+    expect(broker.reliabilityStatus().succeeded).toBe(baselineReliability.succeeded + 2);
+    expect(() => broker.respond(socket, "host-conformance", generation, response, dispatch!.target))
+      .toThrow("stale or invalid");
+    expect(broker.status()).toEqual({ hosts: 0, pending: 0, assignments: 0 });
+    expect(credentials.revoke(issued.credentialId)).toBe(true);
+    expect(credentials.size()).toBe(0);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,6 +55,7 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@mcode/browser-conformance": "workspace:*",
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/web/src/components/panels/__tests__/browserVisibleConformance.test.tsx
+++ b/apps/web/src/components/panels/__tests__/browserVisibleConformance.test.tsx
@@ -1,0 +1,811 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement, ReactNode } from "react";
+import {
+  BROWSER_AUTOMATION_CONTRACT_VERSION,
+  BrowserAutomationResponseSchema,
+  projectBrowserNarrativeResult,
+  type BrowserTabSet,
+  type BrowserAutomationControllerState,
+  type BrowserAutomationResponse,
+} from "@mcode/contracts";
+import {
+  createBrowserConformanceResourceSnapshot,
+  createBrowserConformanceScenario,
+  normalizeBrowserConformanceRun,
+} from "@mcode/browser-conformance";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { buildPersistedNarrativeItems } from "@/components/chat/narrative/build-persisted-narrative";
+import { ToolSummaryLine } from "@/components/chat/narrative/ToolSummaryLine";
+import type { ToolCall, ToolCallRecord } from "@/transport/types";
+import { BrowserHeader, type BrowserHeaderProps } from "../BrowserHeader";
+import { BrowserViewportToolbar } from "../BrowserViewportToolbar";
+import { ThreadOverview } from "@/components/chat/ThreadOverview";
+import type { Thread } from "@/transport";
+import {
+  browserAutomationTargetKey,
+  releaseBrowserAutomationThreadScope,
+  useBrowserAutomationStore,
+} from "@/stores/browserAutomationStore";
+import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import { browserTargetRegistry } from "@/services/browser-automation/browserTargetRegistry";
+import {
+  ViewportCoordinator,
+  type ViewportHostOperation,
+} from "@/services/browser-automation/viewportCoordinator";
+import type { BrowserSessionLifecycleTab } from "@/services/browser-automation/browserSessionDriver";
+
+const {
+  mockThreadRecords,
+  mockWorkspaceState,
+} = vi.hoisted(() => ({
+  mockThreadRecords: new Map(),
+  mockWorkspaceState: {
+    workspaces: [{ id: "workspace-visible", path: "/repo" }],
+    threads: [] as Thread[],
+    prUrlsByThreadId: {},
+    checksById: {},
+    openPrs: [],
+    worktreesLoadedForWorkspace: "workspace-visible",
+  },
+}));
+
+vi.mock("@/transport", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/transport")>();
+  return {
+    ...actual,
+    getTransport: () => ({
+      createBranch: vi.fn(),
+      listSnapshots: vi.fn().mockResolvedValue([]),
+      getWorkingTreeFiles: vi.fn().mockResolvedValue([]),
+      getBranchComparison: vi.fn().mockResolvedValue(null),
+      getRemoteUrl: vi.fn().mockResolvedValue({ label: "repo", webUrl: null }),
+    }),
+  };
+});
+
+vi.mock("@/stores/workspaceStore", () => {
+  const store = Object.assign(
+    vi.fn((selector: (state: typeof mockWorkspaceState) => unknown) => selector(mockWorkspaceState)),
+    { getState: vi.fn(() => mockWorkspaceState), setState: vi.fn() },
+  );
+  return { useWorkspaceStore: store };
+});
+
+vi.mock("@/stores/threadStore", () => ({
+  useThreadStore: vi.fn((selector: (state: { records: Map<string, unknown>; fetchProviderUsage: () => void }) => unknown) =>
+    selector({ records: mockThreadRecords, fetchProviderUsage: vi.fn() })),
+}));
+
+vi.mock("@/hooks/usePullRequestReviewLink", () => ({ usePullRequestReviewLink: vi.fn().mockReturnValue(null) }));
+vi.mock("@/hooks/useThreadGitActions", () => ({
+  useThreadGitActions: vi.fn().mockReturnValue({
+    prable: false,
+    pr: null,
+    hasCommitsAhead: null,
+    checks: null,
+    openPrDetail: vi.fn(),
+    dirPath: null,
+    createPrOpen: false,
+    setCreatePrOpen: vi.fn(),
+    handleCommitOrPush: vi.fn(),
+    handleOpenPr: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/open-subagent-detail", () => ({ openSubagentsPanel: vi.fn() }));
+vi.mock("@/stores/composerDraftStore", () => ({
+  useComposerDraftStore: vi.fn((selector: (state: { setPendingPrefill: () => void }) => unknown) =>
+    selector({ setPendingPrefill: vi.fn() })),
+}));
+vi.mock("@/stores/diffStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/stores/diffStore")>();
+  const state = {
+    snapshotsByThread: {},
+    diffRevisionByScope: {},
+    getRightPanelVisible: vi.fn().mockReturnValue(false),
+    getRightPanel: vi.fn().mockReturnValue({ width: 380 }),
+    setSnapshots: vi.fn(),
+  };
+  const selector = vi.fn((select: (value: typeof state) => unknown) => select(state));
+  Object.assign(selector, actual.useDiffStore);
+  return { ...actual, useDiffStore: selector };
+});
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ render }: { render: ReactElement }) => render,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open?: boolean; children: ReactNode }) => open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+const THREAD_ID = "thread-visible-conformance";
+const TAB_ID = "tab-visible-conformance";
+const TARGET_KEY = browserAutomationTargetKey(THREAD_ID, TAB_ID);
+
+const visibleScenario = createBrowserConformanceScenario({
+  id: "visible-browser-surfaces",
+  seed: "visible-browser-surfaces",
+  commands: [
+    {
+      id: "act-checkout",
+      operation: "act",
+      args: {
+        steps: [
+          { operation: "click", target: { accessibleName: "Pay" } },
+          { operation: "type", target: { accessibleName: "Card number" }, text: "redacted" },
+          { operation: "press" },
+        ],
+      },
+    },
+    { id: "tabs-background", operation: "tabs", args: { scope: "thread" } },
+    { id: "open-background", operation: "open", args: { target: "browser-tab" } },
+    { id: "resize-viewport", operation: "resize", args: { width: 852, height: 393 } },
+  ],
+  cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+});
+
+type VisibleStepOperation = "click" | "type" | "press";
+
+function scenarioCommand(id: string) {
+  const command = visibleScenario.commands.find((candidate) => candidate.id === id);
+  if (!command) throw new Error(`Missing visible Browser scenario command: ${id}`);
+  return command;
+}
+
+function scenarioActSteps(): readonly {
+  readonly operation: VisibleStepOperation;
+  readonly target?: Readonly<Record<string, string>>;
+  readonly text?: string;
+}[] {
+  const steps = scenarioCommand("act-checkout").args?.steps;
+  if (!Array.isArray(steps)) throw new Error("Visible Browser scenario act steps are missing");
+  return steps as readonly {
+    readonly operation: VisibleStepOperation;
+    readonly target?: Readonly<Record<string, string>>;
+    readonly text?: string;
+  }[];
+}
+
+const COMPLETED_ACTION_LABELS: Record<VisibleStepOperation, string> = {
+  click: "Clicked the page",
+  type: "Entered text",
+  press: "Pressed a key",
+};
+
+function completedActionLabel(operation: VisibleStepOperation): string {
+  return COMPLETED_ACTION_LABELS[operation];
+}
+
+function visibleThread(): Thread {
+  return {
+    id: THREAD_ID,
+    workspace_id: "workspace-visible",
+    title: "Visible Browser",
+    status: "active",
+    mode: "worktree",
+    worktree_path: "/repo/.worktrees/visible-browser",
+    branch: "main",
+    checkout_state: "branchless",
+    base_branch: "main",
+    worktree_managed: true,
+    issue_number: null,
+    pr_number: null,
+    pr_status: null,
+    sdk_session_id: null,
+    created_at: "2026-08-05T10:00:00Z",
+    updated_at: "2026-08-05T10:00:00Z",
+    model: null,
+    provider: "claude",
+    deleted_at: null,
+    last_context_tokens: null,
+    context_window: null,
+    reasoning_level: null,
+    interaction_mode: null,
+    orchestration_mode: null,
+    permission_mode: null,
+    context_window_mode: null,
+    thinking: null,
+    codex_fast_mode: null,
+    copilot_agent: null,
+    default_open_in_app: null,
+    parent_thread_id: null,
+    forked_from_message_id: null,
+    last_compact_summary: null,
+    has_file_changes: false,
+  };
+}
+
+function headerProps(overrides: Partial<BrowserHeaderProps> = {}): BrowserHeaderProps {
+  return {
+    url: "https://example.test/checkout?token=redacted",
+    pageTitle: "Checkout",
+    faviconUrl: null,
+    hasLoadedPage: true,
+    canBack: false,
+    canFwd: false,
+    threadId: THREAD_ID,
+    designModeActive: false,
+    elementPickBusy: false,
+    captureBusy: false,
+    regionBusy: false,
+    onNavigate: vi.fn(),
+    onGoBack: vi.fn(),
+    onGoForward: vi.fn(),
+    onReload: vi.fn(),
+    onOpenExternal: vi.fn(),
+    onToggleDesign: vi.fn(),
+    onScreenshot: vi.fn(),
+    onNewPage: vi.fn(),
+    onForceReload: vi.fn(),
+    onRegionCapture: vi.fn(),
+    onDumpContent: vi.fn(),
+    onClearCookies: vi.fn(),
+    onClearCache: vi.fn(),
+    onGetZoom: vi.fn().mockResolvedValue(1),
+    onSetZoom: vi.fn().mockResolvedValue(1),
+    ...overrides,
+  };
+}
+
+function VisibleBrowserHeader({ onStopAutomation }: { readonly onStopAutomation?: () => void }) {
+  const controller = useBrowserAutomationStore((state) => state.controllers.get(TARGET_KEY) ?? null);
+  const activeRequest = useBrowserAutomationStore((state) => state.activeRequests.size > 0);
+  return (
+    <TooltipProvider>
+      <BrowserHeader
+        {...headerProps()}
+        automationController={controller}
+        automationBusy={activeRequest}
+        onStopAutomation={onStopAutomation}
+      />
+    </TooltipProvider>
+  );
+}
+
+function visibleBrowserRun() {
+  const urlInput = screen.getByRole("textbox", { name: "Preview URL" }) as HTMLInputElement;
+  const menu = screen.queryByTestId("browser-overflow-menu");
+  const ownsBrowser = menu
+    ? Boolean(within(menu).queryByRole("menuitem", { name: "Take control" }))
+    : false;
+  const controlOwner = ownsBrowser ? "agent" : "none";
+  const currentUrl = urlInput.getAttribute("title");
+  return normalizeBrowserConformanceRun({
+    outcome: { status: "completed", effect: "none", recovery: "none", ownership: controlOwner },
+    finalState: {
+      readiness: "ready",
+      controlOwner,
+      tabCount: 1,
+      currentUrl,
+      resources: createBrowserConformanceResourceSnapshot(),
+    },
+    visibleObservations: [{
+      surface: "browser",
+      readiness: "ready",
+      controlOwner,
+      tabCount: 1,
+      currentUrl,
+      title: urlInput.value,
+      action: null,
+      truncated: false,
+    }],
+  });
+}
+
+function browserCall(output: string, isError = false): ToolCall {
+  return {
+    id: "browser-visible-conformance",
+    toolName: "mcp__mcode-browser__browser_act",
+    toolInput: {
+      operation: scenarioCommand("act-checkout").operation,
+      steps: scenarioActSteps(),
+    },
+    output,
+    isError,
+    isComplete: true,
+    isCancelled: false,
+  };
+}
+
+function browserRecord(output: string, status: ToolCallRecord["status"] = "failed"): ToolCallRecord {
+  return {
+    id: "browser-visible-persisted",
+    message_id: "message-visible-persisted",
+    parent_tool_call_id: null,
+    tool_name: "mcp__mcode-browser__browser_act",
+    input_summary: JSON.stringify({
+      operation: scenarioCommand("act-checkout").operation,
+      steps: scenarioActSteps(),
+    }),
+    output_summary: output,
+    status,
+    started_at: "2026-08-05T10:00:00Z",
+    completed_at: "2026-08-05T10:00:01Z",
+    sort_order: 1,
+  };
+}
+
+function parsedResponse(response: BrowserAutomationResponse): Record<string, unknown> {
+  if (response.ok) return response.result as unknown as Record<string, unknown>;
+  return response.error as unknown as Record<string, unknown>;
+}
+
+function interruptedResponse(): BrowserAutomationResponse {
+  const steps = scenarioActSteps();
+  return BrowserAutomationResponseSchema().parse({
+    contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+    requestId: "visible-interrupted",
+    sequence: 1,
+    ok: true,
+    result: {
+      operation: "act",
+      outcome: "interrupted",
+      stoppingPosition: 1,
+      effect: "partial",
+      recovery: "yield_to_user",
+      receipts: steps.map((step, index) => ({
+        index,
+        operation: step.operation,
+        status: index === 0 ? "applied" : index === 1 ? "interrupted" : "skipped",
+      })),
+      finalObservation: {
+        observationRef: "observation-interrupted",
+        hostRevision: 1,
+        documentRevision: 1,
+        controlRevision: 1,
+        capabilityRevision: 1,
+        observationRevision: 1,
+      },
+    },
+  });
+}
+
+function timeoutResponse(): BrowserAutomationResponse {
+  return BrowserAutomationResponseSchema().parse({
+    contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+    requestId: "visible-timeout",
+    sequence: 2,
+    ok: false,
+    error: {
+      code: "TIMEOUT",
+      message: "Browser action timed out",
+      retryable: true,
+      stage: "effect",
+      effect: "none",
+      recovery: "inspect",
+      correlationId: "correlation-timeout",
+    },
+  });
+}
+
+describe("visible Browser conformance observer", () => {
+  beforeEach(() => {
+    browserTargetRegistry.clear();
+    mockThreadRecords.clear();
+    mockWorkspaceState.threads = [visibleThread()];
+    useBrowserAutomationStore.setState({
+      registered: false,
+      status: "unavailable",
+      liveTargets: new Map(),
+      controllers: new Map(),
+      activeRequests: new Map(),
+      pendingAgentOpens: new Map(),
+      lifecycleTabs: new Map(),
+      viewportByTarget: new Map(),
+      viewportStateByTarget: new Map(),
+      viewportCoordinators: new Map(),
+      hostedScopeIds: new Set(),
+    });
+    usePreviewTabsStore.setState({
+      tabSetByScope: {},
+      liveChromeByScope: {},
+      persistentTabIdsByScope: {},
+    });
+  });
+
+  afterEach(() => {
+    browserTargetRegistry.clear();
+    useBrowserAutomationStore.getState().unregisterTarget(THREAD_ID, TAB_ID);
+  });
+
+  it("observes agent ownership through the accessible Browser takeover control", async () => {
+    const user = userEvent.setup();
+    useBrowserAutomationStore.getState().registerTarget("workspace-visible", THREAD_ID, TAB_ID);
+    useBrowserAutomationStore.getState().setControllerForTarget(THREAD_ID, TAB_ID, {
+      tabId: TAB_ID,
+      controller: "agent",
+      controlEpoch: 4,
+      providerSessionId: "provider-visible",
+      operation: "click",
+    } satisfies BrowserAutomationControllerState);
+    expect(useBrowserAutomationStore.getState().controllers.get(TARGET_KEY)?.controller).toBe("agent");
+    const onStopAutomation = vi.fn();
+    render(<VisibleBrowserHeader onStopAutomation={onStopAutomation} />);
+
+    await user.click(screen.getByRole("button", { name: "More browser tools" }));
+    const takeover = await screen.findByRole("menuitem", { name: "Take control" });
+    expect(takeover).toBeInTheDocument();
+    const agentRun = visibleBrowserRun();
+    expect(agentRun.visibleObservations[0]).toMatchObject({
+      surface: "browser",
+      controlOwner: "agent",
+      currentUrl: "https://example.test/checkout",
+      title: "Checkout",
+    });
+    expect(agentRun.outcome.status).toBe("completed");
+    expect(agentRun.outcome.status).not.toBe("unknown");
+
+    await user.click(takeover);
+    expect(onStopAutomation).toHaveBeenCalledOnce();
+    await act(async () => {
+      useBrowserAutomationStore.getState().setControllerForTarget(THREAD_ID, TAB_ID, {
+        tabId: TAB_ID,
+        controller: "none",
+        controlEpoch: 5,
+      });
+      await Promise.resolve();
+    });
+    await user.click(screen.getByRole("button", { name: "More browser tools" }));
+    expect(screen.queryByRole("menuitem", { name: "Take control" })).not.toBeInTheDocument();
+    expect(visibleBrowserRun().visibleObservations[0]?.controlOwner).toBe("none");
+  });
+
+  it("preserves partial receipts and the interrupted terminal meaning in narrative rows", () => {
+    const response = interruptedResponse();
+    const result = parsedResponse(response);
+    const projected = projectBrowserNarrativeResult(
+      "mcp__mcode-browser__browser_act",
+      JSON.stringify(result),
+      false,
+    );
+    expect(projected).not.toBeNull();
+    expect(projected?.outcome).toBe("interrupted");
+    expect(projected?.receipts?.map((receipt) => receipt.status)).toEqual([
+      "applied",
+      "interrupted",
+      "skipped",
+    ]);
+
+    const normalizedReceipts = projected?.receipts?.map((receipt, index) => ({
+      ...receipt,
+      order: { tick: index, ordinal: index },
+      commandId: `visible-step-${index}`,
+      effect: receipt.status === "applied" ? "complete" : "partial",
+      recovery: receipt.status === "interrupted" ? "yield_to_user" : "none",
+      truncated: false,
+      revisions: { host: 1, document: 1, control: 1, capability: 1, observation: index + 1 },
+      errorStage: "effect",
+      ownership: "user",
+    }));
+    const normalized = normalizeBrowserConformanceRun({
+      receipts: normalizedReceipts,
+      outcome: {
+        ...projected,
+        effect: "partial",
+        recovery: "yield_to_user",
+        truncated: false,
+        revisions: { host: 1, document: 1, control: 1, capability: 1, observation: 1 },
+        errorStage: "effect",
+        ownership: "user",
+      },
+      finalState: { readiness: "human-control", controlOwner: "user", tabCount: 1 },
+      visibleObservations: [{
+        surface: "narrative",
+        readiness: "human-control",
+        controlOwner: "user",
+        tabCount: 1,
+        action: "act",
+      }],
+    });
+    expect(normalized.outcome).toMatchObject({
+      status: "interrupted",
+      effect: "partial",
+      recovery: "yield_to_user",
+      ownership: "user",
+      errorStage: "effect",
+    });
+    expect(normalized.receipts.every((receipt) =>
+      receipt.status !== "unknown" &&
+      receipt.effect !== "unknown" &&
+      receipt.recovery !== "unknown" &&
+      receipt.errorStage !== "unknown" &&
+      receipt.ownership === "user",
+    )).toBe(true);
+
+    render(
+      <ToolSummaryLine
+        group={{ calls: [browserCall(JSON.stringify(result))] }}
+        hasError={false}
+        hasCancelled
+      />,
+    );
+    const user = userEvent.setup();
+    const steps = scenarioActSteps();
+    return user.click(screen.getByRole("button", { name: "Used the browser" })).then(async () => {
+      expect(screen.getByRole("button", { name: completedActionLabel(steps[0]!.operation) })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Stopped when you took control" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: `Skipped action ${steps.length} of ${steps.length}` })).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Stopped when you took control" }));
+      await waitFor(() => expect(screen.getByText(/Status: interrupted/)).toBeInTheDocument());
+    });
+  });
+
+  it("renders a failed persisted Browser outcome with explicit terminal meaning", async () => {
+    const response = timeoutResponse();
+    const result = parsedResponse(response);
+    const projected = projectBrowserNarrativeResult(
+      "mcp__mcode-browser__browser_act",
+      JSON.stringify(result),
+      true,
+    );
+    expect(projected).toMatchObject({ outcome: "failed", errorCode: "TIMEOUT" });
+    const normalized = normalizeBrowserConformanceRun({
+      outcome: {
+        ...projected,
+        effect: "none",
+        recovery: "inspect",
+        truncated: false,
+        revisions: { host: 1, document: 1, control: 1, capability: 1, observation: 1 },
+        errorStage: "effect",
+        ownership: "agent",
+      },
+      finalState: { readiness: "ready", controlOwner: "agent", tabCount: 1 },
+    });
+    expect(normalized.outcome).toMatchObject({
+      status: "failed",
+      effect: "none",
+      recovery: "inspect",
+      errorCode: "TIMEOUT",
+      errorStage: "effect",
+      ownership: "agent",
+    });
+    expect(normalized.outcome.status).not.toBe("unknown");
+
+    const user = userEvent.setup();
+    const items = buildPersistedNarrativeItems({
+      tools: [browserRecord(JSON.stringify(result))],
+      thoughts: [],
+      hooks: [],
+    });
+    expect(items[0]?.type).toBe("tool-group");
+    if (items[0]?.type !== "tool-group") return;
+    render(<ToolSummaryLine group={items[0].group} hasError hasCancelled={false} />);
+    await user.click(screen.getByRole("button", { name: "Used the browser" }));
+    expect(screen.getByText("Browser action timed out")).toBeInTheDocument();
+  });
+
+  it("observes the background Browser row, agent cue, and exact open target", async () => {
+    const tabSet: BrowserTabSet = {
+      threadId: THREAD_ID,
+      activeTabId: TAB_ID,
+      tabs: [{
+        id: TAB_ID,
+        threadId: THREAD_ID,
+        title: "Checkout",
+        url: "https://example.test/checkout?token=redacted",
+        faviconUrl: null,
+        warm: true,
+        active: true,
+      }],
+    };
+    const lifecycle: BrowserSessionLifecycleTab = {
+      workspaceId: "workspace-visible",
+      threadId: THREAD_ID,
+      tabId: TAB_ID,
+      providerSessionId: "provider-visible",
+      providerInstanceId: "instance-visible",
+      provenance: "agent-created",
+      ownership: "owned",
+      target: {
+        desktopInstanceId: "desktop-visible",
+        windowId: 1,
+        connectionGeneration: 1,
+        threadId: THREAD_ID,
+        tabId: TAB_ID,
+        targetGeneration: 1,
+        active: true,
+        focused: false,
+        lastUsedAt: 1,
+        controller: { tabId: TAB_ID, controller: "agent", controlEpoch: 1 },
+      },
+    };
+    useBrowserAutomationStore.setState({
+      registered: true,
+      status: "registered",
+      liveTargets: new Map([[
+        TARGET_KEY,
+        {
+          workspaceId: "workspace-visible",
+          threadId: THREAD_ID,
+          tabId: TAB_ID,
+          revision: 1,
+          lastUsedAt: 1,
+        },
+      ]]),
+      lifecycleTabs: new Map([["lifecycle-visible", lifecycle]]),
+      controllers: new Map([[TARGET_KEY, { tabId: TAB_ID, controller: "agent", controlEpoch: 1 }]]),
+    });
+    usePreviewTabsStore.setState({
+      tabSetByScope: { [THREAD_ID]: tabSet },
+      liveChromeByScope: {},
+      persistentTabIdsByScope: {},
+    });
+    const activatePage = vi.spyOn(usePreviewTabsStore.getState(), "activatePage");
+    render(<ThreadOverview thread={visibleThread()} threadPaneWidth={1_400} />);
+
+    const row = await screen.findByRole("button", {
+      name: /Browser, Checkout, https:\/\/example\.test\/checkout\?token=redacted, agent controls/,
+    });
+    expect(row).toHaveAccessibleName(expect.stringContaining("agent controls"));
+    expect(screen.getByText("Browser")).toBeInTheDocument();
+    expect(screen.getByTestId(`thread-overview-browser-address-${TAB_ID}`)).toHaveTextContent(
+      "https://example.test/checkout?token=redacted",
+    );
+    expect(row.querySelector('[data-testid="thread-overview-browser-agent-cursor"]')).toBeInTheDocument();
+
+    const normalized = normalizeBrowserConformanceRun({
+      outcome: {
+        status: "completed",
+        effect: "none",
+        recovery: "none",
+        revisions: { observation: 1 },
+        ownership: "agent",
+      },
+      finalState: {
+        readiness: "ready",
+        controlOwner: "agent",
+        tabCount: 1,
+        currentUrl: tabSet.tabs[0]?.url ?? null,
+        revisions: { observation: 1 },
+        resources: createBrowserConformanceResourceSnapshot({ counts: { targets: 1 } }),
+      },
+      visibleObservations: [{
+        surface: "thread-overview",
+        readiness: "ready",
+        controlOwner: "agent",
+        tabCount: 1,
+        currentUrl: tabSet.tabs[0]?.url ?? null,
+        title: tabSet.tabs[0]?.title ?? null,
+        action: scenarioCommand("open-background").operation,
+        truncated: false,
+      }],
+    });
+    expect(normalized.visibleObservations[0]).toMatchObject({
+      surface: "thread-overview",
+      controlOwner: "agent",
+      currentUrl: "https://example.test/checkout",
+      title: "Checkout",
+      action: scenarioCommand("open-background").operation,
+    });
+    expect(normalized.outcome.status).not.toBe("unknown");
+    expect(normalized.finalState.readiness).not.toBe("unknown");
+
+    await userEvent.setup().click(row);
+    expect(activatePage).toHaveBeenCalledWith(THREAD_ID, TAB_ID);
+  });
+
+  it("observes viewport preset, orientation, and fit/actual presentation through public controls", async () => {
+    const user = userEvent.setup();
+    const apply = vi.fn(async (operation: ViewportHostOperation) => ({
+      status: "applied" as const,
+      applied: operation.requested,
+    }));
+    const coordinator = new ViewportCoordinator({
+      initial: { width: 1_280, height: 800 },
+      targetGeneration: 1,
+      apply,
+    });
+    const { rerender } = render(
+      <BrowserViewportToolbar
+        coordinator={coordinator}
+        state={coordinator.snapshot()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("Browser viewport controls")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Viewport preset" }));
+    await user.click(await screen.findByText("iPhone 15 Pro"));
+    await waitFor(() => expect(apply).toHaveBeenCalledWith(
+      expect.objectContaining({ requested: { width: 393, height: 852 } }),
+    ));
+    rerender(
+      <BrowserViewportToolbar
+        coordinator={coordinator}
+        state={coordinator.snapshot()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Viewport preset" })).toHaveTextContent("iPhone 15 Pro");
+    expect(screen.getByRole("textbox", { name: "Viewport width" })).toHaveValue("393");
+    expect(screen.getByRole("textbox", { name: "Viewport height" })).toHaveValue("852");
+
+    await user.click(screen.getByRole("button", { name: "Rotate viewport to landscape" }));
+    await waitFor(() => expect(apply).toHaveBeenLastCalledWith(
+      expect.objectContaining({ requested: { width: 852, height: 393 } }),
+    ));
+    rerender(
+      <BrowserViewportToolbar
+        coordinator={coordinator}
+        state={coordinator.snapshot()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Rotate viewport to portrait" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Viewport scale and presentation" }));
+    await user.click(within(await screen.findByRole("menu")).getByRole("menuitem", { name: "Actual size" }));
+    expect(coordinator.snapshot().presentation).toBe("actual");
+    await user.click(screen.getByRole("button", { name: "Viewport scale and presentation" }));
+    await user.click(within(await screen.findByRole("menu")).getByRole("menuitem", { name: "Fit to panel" }));
+    expect(coordinator.snapshot().presentation).toBe("fit");
+
+    const normalized = normalizeBrowserConformanceRun({
+      outcome: {
+        status: "completed",
+        effect: "complete",
+        recovery: "none",
+        revisions: { observation: 3 },
+        ownership: "user",
+      },
+      finalState: {
+        readiness: "ready",
+        controlOwner: "user",
+        tabCount: 1,
+        currentUrl: null,
+        revisions: { observation: 3 },
+        resources: createBrowserConformanceResourceSnapshot(),
+      },
+      visibleObservations: [{
+        surface: "browser",
+        readiness: "ready",
+        controlOwner: "user",
+        tabCount: 1,
+        currentUrl: null,
+        title: "iPhone 15 Pro · 852 × 393 · Fit to panel",
+        action: scenarioCommand("resize-viewport").operation,
+        truncated: false,
+      }],
+    });
+    expect(normalized.visibleObservations[0]).toMatchObject({
+      action: scenarioCommand("resize-viewport").operation,
+      title: "iPhone 15 Pro · 852 × 393 · Fit to panel",
+    });
+    expect(normalized.outcome.status).not.toBe("unknown");
+  });
+
+  it("does not resurrect visible ownership after scope cleanup and a late controller event", async () => {
+    const user = userEvent.setup();
+    useBrowserAutomationStore.getState().registerTarget("workspace-visible", THREAD_ID, TAB_ID);
+    useBrowserAutomationStore.getState().setControllerForTarget(THREAD_ID, TAB_ID, {
+      tabId: TAB_ID,
+      controller: "agent",
+      controlEpoch: 7,
+    });
+    render(<VisibleBrowserHeader onStopAutomation={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "More browser tools" }));
+    expect(await screen.findByRole("menuitem", { name: "Take control" })).toBeInTheDocument();
+
+    act(() => {
+      releaseBrowserAutomationThreadScope(THREAD_ID);
+      useBrowserAutomationStore.getState().setControllerForTarget(THREAD_ID, TAB_ID, {
+        tabId: TAB_ID,
+        controller: "agent",
+        controlEpoch: 8,
+      });
+    });
+
+    await waitFor(() => {
+      expect(useBrowserAutomationStore.getState().liveTargets.size).toBe(0);
+      expect(useBrowserAutomationStore.getState().controllers.size).toBe(0);
+      expect(screen.queryByRole("menuitem", { name: "Take control" })).not.toBeInTheDocument();
+    });
+    expect(browserTargetRegistry.get(THREAD_ID, TAB_ID)).toBeNull();
+  });
+});

--- a/apps/web/src/services/browser-automation/browserExecutorParity.test.ts
+++ b/apps/web/src/services/browser-automation/browserExecutorParity.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  BrowserAutomationHostDispatch,
+} from "@mcode/contracts";
+import { BROWSER_AUTOMATION_CONTRACT_VERSION } from "@mcode/contracts";
+import {
+  createBrowserConformanceResourceSnapshot,
+  normalizeBrowserConformanceRun,
+  runBrowserConformanceExecutorScenario,
+  createBrowserExecutorParityScenario,
+  type BrowserConformanceCommand,
+  type BrowserConformanceNormalizedRun,
+  type BrowserConformanceReceipt,
+  type BrowserConformanceResourceSnapshot,
+  type BrowserConformanceScheduledEvent,
+  type BrowserConformanceSubject,
+} from "@mcode/browser-conformance";
+import {
+  BrowserSessionDriver,
+  ElectronBrowserSessionAdapter,
+  getBrowserAutomationRuntimeOperations,
+} from "./browserSessionDriver";
+import { WebBrowserSessionAdapter } from "./webBrowserSessionAdapter";
+import { executeWebBrowserDispatch } from "../../components/panels/browserAutomationWebExecutor";
+
+vi.mock("../../components/panels/web-browser-automation/capture", () => ({
+  captureVisibleWebScreenshot: vi.fn(async () => ({
+    ok: true,
+    value: {
+      mediaType: "image/png",
+      dataBase64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+      width: 1,
+      height: 1,
+      truncation: { truncated: false },
+    },
+  })),
+}));
+
+function target() {
+  return {
+    desktopInstanceId: "web",
+    windowId: 1,
+    connectionGeneration: 1,
+    threadId: "thread",
+    tabId: "tab",
+    targetGeneration: 1,
+    active: true,
+    focused: true,
+    lastUsedAt: 0,
+  } as const;
+}
+
+function replaceObservationRefs(value: unknown, observationRef: string | undefined): unknown {
+  if (value === "$lastObservationRef") return observationRef ?? "missing-observation";
+  if (Array.isArray(value)) return value.map((entry) => replaceObservationRefs(entry, observationRef));
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, replaceObservationRefs(entry, observationRef)]));
+}
+
+class WebExecutorSubject implements BrowserConformanceSubject {
+  private readonly receipts: BrowserConformanceReceipt[] = [];
+  private readonly state = { url: "https://example.test/", owner: "none" as "none" | "agent", observationRef: undefined as string | undefined };
+  private tick = 0;
+
+  constructor(private readonly driver: BrowserSessionDriver) {}
+
+  async dispatch(command: BrowserConformanceCommand): Promise<BrowserConformanceReceipt> {
+    const args = replaceObservationRefs(command.args ?? {}, this.state.observationRef) as Record<string, unknown>;
+    const dispatch = {
+      scope: { workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance" },
+      connection: { desktopInstanceId: "web", windowId: 1, connectionGeneration: 1, targetGeneration: 1, capabilityRevision: 1 },
+      target: target(),
+      request: {
+        contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+        workspaceId: "workspace",
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId: `parity-${command.id}-${this.receipts.length}`,
+        sequence: this.receipts.length,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: command.operation,
+        args,
+      },
+    } as unknown as BrowserAutomationHostDispatch;
+    const result = await this.driver.execute(dispatch, new AbortController().signal);
+    if (result.ok) {
+      const candidate = result.result as { observationRef?: string; nextObservationRef?: string; finalObservation?: { observationRef?: string } };
+      this.state.observationRef = candidate.nextObservationRef ?? candidate.finalObservation?.observationRef ?? candidate.observationRef ?? this.state.observationRef;
+      if (["open", "navigate"].includes(command.operation)) this.state.url = String(args.url ?? this.state.url);
+      if (["open", "navigate", "click", "type", "act", "tabs"].includes(command.operation)) this.state.owner = "agent";
+    }
+    const raw = {
+      receipts: [{
+        order: { tick: this.tick, ordinal: this.receipts.length },
+        commandId: command.id,
+        operation: command.operation,
+        status: result.ok ? "applied" : "failed",
+        effect: result.ok ? ((result.result as { effect?: string }).effect ?? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "none" : command.operation === "open" ? "created" : "complete")) : (result.error.effect ?? "none"),
+        recovery: result.ok ? ((result.result as { recovery?: string }).recovery ?? "none") : (result.error.recovery ?? "inspect"),
+        truncated: result.ok && Boolean((result.result as { truncation?: { truncated?: boolean } }).truncation?.truncated),
+        revisions: { host: 0, document: 0, control: 0, capability: 1, observation: this.receipts.length },
+        errorCode: result.ok ? null : result.error.code,
+        errorStage: result.ok ? (["inspect", "snapshot", "screenshot"].includes(command.operation) ? "observation" : "effect") : (result.error.stage ?? "effect"),
+        ownership: this.state.owner,
+      }],
+      outcome: result.ok ? { status: "completed", effect: "complete", recovery: "none", revisions: { capability: 1, observation: this.receipts.length }, ownership: this.state.owner } : { status: "failed", effect: result.error.effect ?? "none", recovery: result.error.recovery ?? "inspect", errorCode: result.error.code, errorStage: result.error.stage ?? "effect", ownership: this.state.owner },
+      finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: { capability: 1, observation: this.receipts.length }, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } },
+      visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: command.operation, truncated: false }],
+    };
+    const normalized = normalizeBrowserConformanceRun(raw);
+    const receipt = normalized.receipts[0]!;
+    this.receipts.push(receipt);
+    return receipt;
+  }
+
+  schedule(_event: BrowserConformanceScheduledEvent): void {}
+  async advanceClock(tick: number): Promise<void> { this.tick = tick; }
+  async injectExternalEvent(_event: BrowserConformanceScheduledEvent): Promise<void> {}
+  snapshotOutcome(): BrowserConformanceNormalizedRun {
+    const last = this.receipts.at(-1);
+    return normalizeBrowserConformanceRun({
+      receipts: this.receipts,
+      outcome: { status: last?.status === "failed" ? "failed" : "completed", effect: last?.effect ?? "none", recovery: last?.recovery ?? "none", revisions: last?.revisions, ownership: last?.ownership },
+      finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: last?.revisions, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } },
+      visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: last?.operation ?? null, truncated: false }],
+    });
+  }
+  snapshotResources(): BrowserConformanceResourceSnapshot { return createBrowserConformanceResourceSnapshot({ counts: { targets: 1 }, identities: { targets: [{ id: "browser-target", generation: 1 }] } }); }
+  async drainToQuiescence(): Promise<void> {}
+  async dispose(): Promise<void> { await this.driver.releaseProviderSession("session"); }
+}
+
+describe("shared Browser executor parity at BrowserSessionDriver", () => {
+  it("proves the web descriptor and compares the real DOM-backed executor with canonical outcomes", async () => {
+    document.body.innerHTML = `<iframe data-thread-id="thread" data-tab-id="tab" src="about:blank"></iframe><button id="save">Save</button><input id="name" />`;
+    const iframe = document.querySelector<HTMLIFrameElement>("iframe")!;
+    Object.defineProperty(iframe, "contentDocument", { configurable: true, value: document });
+    const button = document.querySelector<HTMLButtonElement>("#save")!;
+    const input = document.querySelector<HTMLInputElement>("#name")!;
+    for (const element of [button, input]) Object.defineProperty(element, "getBoundingClientRect", { value: () => ({ x: 0, y: 0, width: 80, height: 20 }) });
+    let clicks = 0;
+    button.addEventListener("click", () => { clicks += 1; });
+    const webAdapter = new WebBrowserSessionAdapter({
+      resolveDocument: () => document,
+      resolveSignal: (_dispatch, signal) => signal,
+      getControlEpoch: () => 0,
+      getTargetGeneration: () => 1,
+      onHumanInput: vi.fn(),
+      onObserver: (_dispatch, dispose) => dispose(),
+      executeNonInteraction: async (dispatch, signal) => {
+        const result = executeWebBrowserDispatch(dispatch, signal);
+        if (dispatch.request.operation === "open" || dispatch.request.operation === "navigate") iframe.dispatchEvent(new Event("load"));
+        return result;
+      },
+    });
+    const driver = new BrowserSessionDriver({
+      web: webAdapter,
+      electron: new ElectronBrowserSessionAdapter(async () => { throw new Error("electron adapter must not run in web parity"); }),
+      isElectron: () => false,
+      supportedActOperations: ["click", "type", "navigate"],
+      webTabs: { list: async () => [target()], close: async () => undefined },
+    });
+    const descriptor = getBrowserAutomationRuntimeOperations("web");
+    const parity = createBrowserExecutorParityScenario();
+    expect(descriptor).toEqual(expect.arrayContaining([...parity.operations]));
+    expect(getBrowserAutomationRuntimeOperations("electron")).toEqual(expect.arrayContaining([...parity.operations]));
+    const run = await runBrowserConformanceExecutorScenario(parity.scenario, new WebExecutorSubject(driver));
+    expect(clicks).toBe(2);
+    expect(input.value).toBe("Mcode");
+    expect(run).toEqual(parity.expected);
+  });
+});

--- a/apps/web/src/services/browser-automation/browserExecutorParity.test.ts
+++ b/apps/web/src/services/browser-automation/browserExecutorParity.test.ts
@@ -1,12 +1,15 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
-import type {
-  BrowserAutomationHostDispatch,
+import {
+  BrowserAutomationResponseSchema,
+  BROWSER_AUTOMATION_CONTRACT_VERSION,
+  type BrowserAutomationHostDispatch,
 } from "@mcode/contracts";
-import { BROWSER_AUTOMATION_CONTRACT_VERSION } from "@mcode/contracts";
 import {
   createBrowserConformanceResourceSnapshot,
   normalizeBrowserConformanceRun,
-  runBrowserConformanceExecutorScenario,
+  runBrowserConformanceScenarioWithReplay,
   createBrowserExecutorParityScenario,
   type BrowserConformanceCommand,
   type BrowserConformanceNormalizedRun,
@@ -22,6 +25,8 @@ import {
 } from "./browserSessionDriver";
 import { WebBrowserSessionAdapter } from "./webBrowserSessionAdapter";
 import { executeWebBrowserDispatch } from "../../components/panels/browserAutomationWebExecutor";
+
+const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../../");
 
 vi.mock("../../components/panels/web-browser-automation/capture", () => ({
   captureVisibleWebScreenshot: vi.fn(async () => ({
@@ -84,7 +89,9 @@ class WebExecutorSubject implements BrowserConformanceSubject {
         args,
       },
     } as unknown as BrowserAutomationHostDispatch;
-    const result = await this.driver.execute(dispatch, new AbortController().signal);
+    const result = BrowserAutomationResponseSchema().parse(
+      await this.driver.execute(dispatch, new AbortController().signal),
+    );
     if (result.ok) {
       const candidate = result.result as { observationRef?: string; nextObservationRef?: string; finalObservation?: { observationRef?: string } };
       this.state.observationRef = candidate.nextObservationRef ?? candidate.finalObservation?.observationRef ?? candidate.observationRef ?? this.state.observationRef;
@@ -133,6 +140,16 @@ class WebExecutorSubject implements BrowserConformanceSubject {
 }
 
 describe("shared Browser executor parity at BrowserSessionDriver", () => {
+  it("does not normalize malformed runtime output into a successful receipt", async () => {
+    const malformed = new BrowserSessionDriver({
+      web: { execute: async () => ({ ok: true, result: { operation: "inspect" } } as never) },
+      electron: { execute: async () => ({ ok: true, result: { operation: "inspect" } } as never) },
+      isElectron: () => false,
+    });
+    await expect(new WebExecutorSubject(malformed).dispatch({ id: "malformed", operation: "inspect" }))
+      .rejects.toThrow();
+  });
+
   it("proves the web descriptor and compares the real DOM-backed executor with canonical outcomes", async () => {
     document.body.innerHTML = `<iframe data-thread-id="thread" data-tab-id="tab" src="about:blank"></iframe><button id="save">Save</button><input id="name" />`;
     const iframe = document.querySelector<HTMLIFrameElement>("iframe")!;
@@ -166,7 +183,10 @@ describe("shared Browser executor parity at BrowserSessionDriver", () => {
     const parity = createBrowserExecutorParityScenario();
     expect(descriptor).toEqual(expect.arrayContaining([...parity.operations]));
     expect(getBrowserAutomationRuntimeOperations("electron")).toEqual(expect.arrayContaining([...parity.operations]));
-    const run = await runBrowserConformanceExecutorScenario(parity.scenario, new WebExecutorSubject(driver));
+    const run = await runBrowserConformanceScenarioWithReplay(parity.scenario, new WebExecutorSubject(driver), {
+      workspaceRoot,
+      failingInvariant: "web executor parity remains canonical",
+    });
     expect(clicks).toBe(2);
     expect(input.value).toBe("Mcode");
     expect(run).toEqual(parity.expected);

--- a/apps/web/src/services/browser-automation/browserExecutorParity.test.ts
+++ b/apps/web/src/services/browser-automation/browserExecutorParity.test.ts
@@ -67,7 +67,7 @@ class WebExecutorSubject implements BrowserConformanceSubject {
   private readonly state = { url: "https://example.test/", owner: "none" as "none" | "agent", observationRef: undefined as string | undefined };
   private tick = 0;
 
-  constructor(private readonly driver: BrowserSessionDriver) {}
+  constructor(private readonly driver: BrowserSessionDriver, private readonly liveTargets: Map<string, ReturnType<typeof target>>) {}
 
   async dispatch(command: BrowserConformanceCommand): Promise<BrowserConformanceReceipt> {
     const args = replaceObservationRefs(command.args ?? {}, this.state.observationRef) as Record<string, unknown>;
@@ -113,7 +113,7 @@ class WebExecutorSubject implements BrowserConformanceSubject {
         ownership: this.state.owner,
       }],
       outcome: result.ok ? { status: "completed", effect: "complete", recovery: "none", revisions: { capability: 1, observation: this.receipts.length }, ownership: this.state.owner } : { status: "failed", effect: result.error.effect ?? "none", recovery: result.error.recovery ?? "inspect", errorCode: result.error.code, errorStage: result.error.stage ?? "effect", ownership: this.state.owner },
-      finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: { capability: 1, observation: this.receipts.length }, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } },
+      finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: { capability: 1, observation: this.receipts.length }, resources: this.snapshotResources() },
       visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: command.operation, truncated: false }],
     };
     const normalized = normalizeBrowserConformanceRun(raw);
@@ -130,11 +130,14 @@ class WebExecutorSubject implements BrowserConformanceSubject {
     return normalizeBrowserConformanceRun({
       receipts: this.receipts,
       outcome: { status: last?.status === "failed" ? "failed" : "completed", effect: last?.effect ?? "none", recovery: last?.recovery ?? "none", revisions: last?.revisions, ownership: last?.ownership },
-      finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: last?.revisions, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } },
+      finalState: { readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, revisions: last?.revisions, resources: this.snapshotResources() },
       visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: this.state.owner, tabCount: 1, currentUrl: this.state.url, title: "Executor fixture", action: last?.operation ?? null, truncated: false }],
     });
   }
-  snapshotResources(): BrowserConformanceResourceSnapshot { return createBrowserConformanceResourceSnapshot({ counts: { targets: 1 }, identities: { targets: [{ id: "browser-target", generation: 1 }] } }); }
+  snapshotResources(): BrowserConformanceResourceSnapshot {
+    const targets = this.liveTargets.size > 0 ? [{ id: "browser-target", generation: 1 }] : [];
+    return createBrowserConformanceResourceSnapshot({ identities: { targets } });
+  }
   async drainToQuiescence(): Promise<void> {}
   async dispose(): Promise<void> { await this.driver.releaseProviderSession("session"); }
 }
@@ -146,7 +149,8 @@ describe("shared Browser executor parity at BrowserSessionDriver", () => {
       electron: { execute: async () => ({ ok: true, result: { operation: "inspect" } } as never) },
       isElectron: () => false,
     });
-    await expect(new WebExecutorSubject(malformed).dispatch({ id: "malformed", operation: "inspect" }))
+    const malformedSubject = new WebExecutorSubject(malformed, new Map([["tab", target()]]));
+    await expect(malformedSubject.dispatch({ id: "malformed", operation: "inspect" }))
       .rejects.toThrow();
   });
 
@@ -172,23 +176,27 @@ describe("shared Browser executor parity at BrowserSessionDriver", () => {
         return result;
       },
     });
+    const liveTargets = new Map([["tab", target()]]);
     const driver = new BrowserSessionDriver({
       web: webAdapter,
       electron: new ElectronBrowserSessionAdapter(async () => { throw new Error("electron adapter must not run in web parity"); }),
       isElectron: () => false,
       supportedActOperations: ["click", "type", "navigate"],
-      webTabs: { list: async () => [target()], close: async () => undefined },
+      webTabs: { list: async () => [...liveTargets.values()], close: async (closedTarget) => { liveTargets.delete(closedTarget.tabId); } },
     });
     const descriptor = getBrowserAutomationRuntimeOperations("web");
     const parity = createBrowserExecutorParityScenario();
     expect(descriptor).toEqual(expect.arrayContaining([...parity.operations]));
     expect(getBrowserAutomationRuntimeOperations("electron")).toEqual(expect.arrayContaining([...parity.operations]));
-    const run = await runBrowserConformanceScenarioWithReplay(parity.scenario, new WebExecutorSubject(driver), {
+    const subject = new WebExecutorSubject(driver, liveTargets);
+    const run = await runBrowserConformanceScenarioWithReplay(parity.scenario, subject, {
       workspaceRoot,
       failingInvariant: "web executor parity remains canonical",
     });
     expect(clicks).toBe(2);
     expect(input.value).toBe("Mcode");
     expect(run).toEqual(parity.expected);
+    expect(run.finalState.resources.targets).toBe(1);
+    expect(subject.snapshotResources().targets).toBe(0);
   });
 });

--- a/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
@@ -301,5 +301,5 @@ class WebDriverRaceSubject implements BrowserConformanceSubject {
     return createBrowserConformanceResourceSnapshot({ counts: { targets: this.liveTargets.size }, identities: { targets: [...this.liveTargets.values()].map((target) => ({ id: `${target.threadId}/${target.tabId}`, generation: target.targetGeneration })) } });
   }
   async drainToQuiescence(): Promise<void> {}
-  async dispose(): Promise<void> { this.disposed = true; await this.driver.releaseProviderSession("session"); this.liveTargets.clear(); }
+  async dispose(): Promise<void> { this.disposed = true; await this.driver.releaseProviderSession("session"); }
 }

--- a/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
@@ -73,9 +73,8 @@ describe("BrowserSessionDriver deterministic races", () => {
       getTargetGeneration: () => revisions.document,
       onHumanInput: vi.fn(),
       onObserver: (_dispatch, dispose) => {
-        let wrappedDispose: (() => void) | undefined;
-        wrappedDispose = () => {
-          if (wrappedDispose) observerDisposers.delete(wrappedDispose);
+        const wrappedDispose = () => {
+          observerDisposers.delete(wrappedDispose);
           dispose();
         };
         observerDisposers.add(wrappedDispose);

--- a/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_AUTOMATION_CONTRACT_VERSION,
+  BrowserAutomationResponseSchema,
+  type BrowserAutomationHostDispatch,
+} from "@mcode/contracts";
+import {
+  BROWSER_CONFORMANCE_RACE_CATALOGUE,
+  createBrowserConformanceResourceSnapshot,
+  createBrowserConformanceRevisionRaceSchedules,
+  normalizeBrowserConformanceRun,
+  type BrowserConformanceCommand,
+  type BrowserConformanceNormalizedRun,
+  type BrowserConformanceReceipt,
+  type BrowserConformanceResourceSnapshot,
+  type BrowserConformanceScheduledEvent,
+  type BrowserConformanceSubject,
+} from "@mcode/browser-conformance";
+import { executeWebBrowserDispatch } from "../../components/panels/browserAutomationWebExecutor";
+import { BrowserSessionDriver } from "./browserSessionDriver";
+import { WebBrowserSessionAdapter } from "./webBrowserSessionAdapter";
+
+const TARGET = {
+  desktopInstanceId: "web",
+  windowId: 1,
+  connectionGeneration: 1,
+  threadId: "thread",
+  tabId: "tab",
+  targetGeneration: 1,
+  active: true,
+  focused: true,
+  lastUsedAt: 0,
+} as const;
+
+describe("BrowserSessionDriver deterministic races", () => {
+  it("executes every revision schedule through the real WebBrowserSessionAdapter and rejects stale effects", async () => {
+    document.body.innerHTML = `<iframe data-thread-id="thread" data-tab-id="tab" src="about:blank"></iframe><button id="save">Save</button>`;
+    const iframe = document.querySelector<HTMLIFrameElement>("iframe")!;
+    Object.defineProperty(iframe, "contentDocument", { configurable: true, value: document });
+    const button = document.querySelector<HTMLButtonElement>("#save")!;
+    Object.defineProperty(button, "getBoundingClientRect", { value: () => ({ x: 0, y: 0, width: 80, height: 20 }) });
+    let releaseOpen: (() => void) | undefined;
+    let deferOpen = false;
+    let abortCurrent: (() => void) | undefined;
+    let abortAfterFirstClick = false;
+    const revisions = { host: 1, document: 1, control: 0, capability: 1, observation: 0 };
+    const liveTargets = new Map<string, typeof TARGET>();
+    const adapter = new WebBrowserSessionAdapter({
+      resolveDocument: () => document,
+      resolveSignal: (_dispatch, signal) => signal,
+      getControlEpoch: () => revisions.control,
+      getTargetGeneration: () => revisions.document,
+      onHumanInput: vi.fn(),
+      onObserver: (_dispatch, dispose) => dispose(),
+      executeNonInteraction: async (dispatch, signal) => {
+        if (deferOpen && dispatch.request.operation === "open") {
+          return new Promise<Awaited<ReturnType<typeof executeWebBrowserDispatch>>>((resolve) => {
+            releaseOpen = () => resolve(executeWebBrowserDispatch(dispatch, signal));
+          });
+        }
+        const response = executeWebBrowserDispatch(dispatch, signal);
+        if (dispatch.request.operation === "open" || dispatch.request.operation === "navigate") iframe.dispatchEvent(new Event("load"));
+        return response;
+      },
+    });
+    const runtimeAdapter = {
+      execute: async (dispatch: BrowserAutomationHostDispatch, signal: AbortSignal) => {
+        const response = await adapter.execute(dispatch, signal);
+        if (abortAfterFirstClick && dispatch.request.operation === "click") abortCurrent?.();
+        return response;
+      },
+    };
+    const driver = new BrowserSessionDriver({
+      web: runtimeAdapter,
+      electron: runtimeAdapter,
+      isElectron: () => false,
+      getHostRevision: () => revisions.host,
+      getDocumentRevision: () => revisions.document,
+      getControlRevision: () => revisions.control,
+      getCapabilityRevision: () => revisions.capability,
+      supportedActOperations: ["click", "navigate"],
+      webTabs: {
+        list: async () => [...liveTargets.values()],
+        close: async (target) => { liveTargets.delete(target.tabId); },
+      },
+    });
+
+    const generated = createBrowserConformanceRevisionRaceSchedules({
+      seed: "web-driver-revision-races",
+      maxCommands: 4,
+      maxEvents: 8,
+      maxCheckpoints: 4,
+      maxTick: 12,
+    });
+    const schedules = [
+      ...Object.values(generated.individual),
+      ...generated.pairs,
+      ...generated.highRisk,
+    ];
+    for (const generatedSchedule of schedules) {
+      revisions.host = 1;
+      revisions.document = 1;
+      revisions.control = 0;
+      revisions.capability = 1;
+      liveTargets.clear();
+      const subject = new WebDriverRaceSubject(driver, revisions, liveTargets);
+      await subject.dispatch({ id: "open", operation: "open", args: { idempotencyKey: `open-${generatedSchedule.id}` } });
+      await subject.dispatch({ id: "inspect", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } });
+      for (const event of generatedSchedule.schedule.events) {
+        subject.schedule(event);
+        await subject.advanceClock(event.order.tick);
+        await subject.injectExternalEvent(event);
+      }
+      const receipt = await subject.dispatch({
+        id: "act",
+        operation: "act",
+        args: { observationRef: subject.observationRef ?? "missing-observation", deadlineMs: 10_000, steps: [{ operation: "click", target: { cssSelector: "#save" } }] },
+      });
+      expect(receipt.status).toBe("failed");
+      expect(receipt.effect).not.toBe("unknown");
+      expect(receipt.recovery).not.toBe("unknown");
+      expect(receipt.errorCode).toBe(generatedSchedule.revisions.includes("capability") ? "CAPABILITY_CHANGED" : "STALE_TARGET_GENERATION");
+      const beforeDispose = subject.snapshotResources();
+      await subject.drainToQuiescence();
+      await subject.dispose();
+      const afterDispose = subject.snapshotResources();
+      await subject.injectExternalEvent({ order: { tick: 99, ordinal: 99 }, kind: "late-response" });
+      await subject.injectExternalEvent({ order: { tick: 100, ordinal: 100 }, kind: "late-event" });
+      await subject.injectExternalEvent({ order: { tick: 101, ordinal: 101 }, kind: "late-timer" });
+      expect(subject.snapshotResources()).toEqual(afterDispose);
+      expect(afterDispose.targets).toBe(0);
+      expect(beforeDispose.targets).toBeLessThanOrEqual(1);
+    }
+    revisions.host = 1;
+    revisions.document = 1;
+    revisions.control = 0;
+    revisions.capability = 1;
+    liveTargets.clear();
+    const bootstrap = new WebDriverRaceSubject(driver, revisions, liveTargets);
+    deferOpen = true;
+    const firstOpen = bootstrap.dispatch({ id: "bootstrap-open-a", operation: "open", args: { idempotencyKey: "bootstrap-a" } });
+    await Promise.resolve();
+    const concurrent = await bootstrap.dispatch({ id: "bootstrap-open-b", operation: "open", args: { idempotencyKey: "bootstrap-b" } });
+    expect(concurrent.errorCode, "bootstrap-concurrent-open").toBe("BROWSER_BUSY");
+    expect(concurrent.status).not.toBe("unknown");
+    expect(concurrent.effect).not.toBe("unknown");
+    expect(concurrent.recovery).not.toBe("unknown");
+    releaseOpen?.();
+    deferOpen = false;
+    expect((await firstOpen).status).toBe("applied");
+    const replay = await bootstrap.dispatch({ id: "bootstrap-replay", operation: "open", args: { idempotencyKey: "bootstrap-a" } });
+    expect(replay.status, "bootstrap-idempotent-replay").toBe("applied");
+    expect(replay.effect).not.toBe("unknown");
+    const conflict = await bootstrap.dispatch({ id: "bootstrap-conflict", operation: "open", args: { idempotencyKey: "bootstrap-a", url: "https://other.test/" } });
+    expect(conflict.errorCode, "bootstrap-idempotent-replay").toBe("IDEMPOTENCY_CONFLICT");
+    expect(conflict.status).not.toBe("unknown");
+    expect(conflict.effect).not.toBe("unknown");
+    expect(conflict.recovery).not.toBe("unknown");
+    await bootstrap.dispose();
+
+    revisions.control = 0;
+    liveTargets.clear();
+    const action = new WebDriverRaceSubject(driver, revisions, liveTargets);
+    await action.dispatch({ id: "action-open", operation: "open", args: { idempotencyKey: "action-open" } });
+    await action.dispatch({ id: "action-inspect", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } });
+    abortAfterFirstClick = true;
+    const abortingAction = action;
+    abortCurrent = () => abortingAction.abortCurrent();
+    const takeover = await action.dispatch({ id: "action-takeover", operation: "act", args: { observationRef: action.observationRef ?? "missing-observation", deadlineMs: 10_000, steps: [{ operation: "click", target: { cssSelector: "#save" } }, { operation: "click", target: { cssSelector: "#save" } }] } });
+    abortAfterFirstClick = false;
+    abortCurrent = undefined;
+    if (!action.lastResponse?.ok) throw new Error(JSON.stringify(action.lastResponse));
+    expect(action.lastResponse, "action-takeover/action-cancel").toMatchObject({ ok: true, result: { outcome: "interrupted", effect: "partial", receipts: [{ status: "applied" }, { status: "interrupted" }] } });
+    expect(takeover.status).not.toBe("unknown");
+    expect(takeover.effect).not.toBe("unknown");
+    expect(takeover.recovery).not.toBe("unknown");
+    await action.dispose();
+
+    revisions.control = 0;
+    liveTargets.clear();
+    const batch = new WebDriverRaceSubject(driver, revisions, liveTargets);
+    await batch.dispatch({ id: "batch-open", operation: "open", args: { idempotencyKey: "batch-open" } });
+    await batch.dispatch({ id: "batch-inspect", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } });
+    const navigation = await batch.dispatch({ id: "batch-navigation", operation: "act", args: { observationRef: batch.observationRef ?? "missing-observation", deadlineMs: 10_000, steps: [{ operation: "click", target: { cssSelector: "#save" } }, { operation: "navigate", url: `${window.location.origin}/next` }, { operation: "click", target: { cssSelector: "#save" } }] } });
+    expect(batch.lastResponse, "batch-navigation/batch-partial-failure").toMatchObject({ ok: true, result: { outcome: "completed", receipts: [{ status: "applied" }, { status: "applied" }, { status: "skipped" }] } });
+    expect(navigation.status).not.toBe("unknown");
+    expect(navigation.effect).not.toBe("unknown");
+    expect(navigation.recovery).not.toBe("unknown");
+    await batch.dispose();
+    expect(BROWSER_CONFORMANCE_RACE_CATALOGUE.filter((race) => race.family === "bootstrap")).toHaveLength(8);
+    expect(BROWSER_CONFORMANCE_RACE_CATALOGUE.filter((race) => race.family === "action" || race.family === "batch")).toHaveLength(13);
+  });
+
+});
+
+class WebDriverRaceSubject implements BrowserConformanceSubject {
+  private readonly receipts: BrowserConformanceReceipt[] = [];
+  private readonly scheduled: BrowserConformanceScheduledEvent[] = [];
+  private tick = 0;
+  private disposed = false;
+  private activeController: AbortController | undefined;
+  observationRef: string | undefined;
+  lastResponse: Awaited<ReturnType<BrowserSessionDriver["execute"]>> | undefined;
+
+  constructor(
+    private readonly driver: BrowserSessionDriver,
+    private readonly revisions: { host: number; document: number; control: number; capability: number; observation: number },
+    private readonly liveTargets: Map<string, typeof TARGET>,
+  ) {}
+
+  abortCurrent(): void { this.activeController?.abort(); }
+
+  schedule(event: BrowserConformanceScheduledEvent): void { this.scheduled.push(event); }
+  async advanceClock(tick: number): Promise<void> { this.tick = tick; }
+  async injectExternalEvent(event: BrowserConformanceScheduledEvent): Promise<void> {
+    if (this.disposed) return;
+    switch (event.kind) {
+      case "host-disconnect":
+      case "host-reconnect":
+        this.revisions.host += 1;
+        break;
+      case "navigation":
+      case "reload":
+      case "document-revision":
+      case "target-register":
+        this.revisions.document += 1;
+        break;
+      case "user-takeover":
+      case "competing-mutation":
+      case "cancel":
+      case "timeout":
+      case "resize":
+      case "control-revision":
+        this.revisions.control += 1;
+        break;
+      case "capability-revision":
+        this.revisions.capability += 1;
+        break;
+      case "observation-revision":
+        this.driver.invalidateTargetObservations("thread", "tab");
+        this.revisions.observation += 1;
+        break;
+      case "late-event":
+      case "late-timer":
+        // Late callbacks are deliberately inert once the subject is disposed.
+        break;
+      case "target-close":
+        this.driver.clearIdempotencyForTarget("thread", "tab");
+        this.liveTargets.delete("tab");
+        this.revisions.document += 1;
+        break;
+      default:
+        this.revisions.control += 1;
+        break;
+    }
+  }
+
+  async dispatch(command: BrowserConformanceCommand): Promise<BrowserConformanceReceipt> {
+    const operation = command.operation;
+    const args = { ...(command.args ?? {}) } as Record<string, unknown>;
+    if (operation === "act") args.observationRef = this.observationRef;
+    const dispatch = {
+      connection: { desktopInstanceId: "web", windowId: 1, connectionGeneration: 1, targetGeneration: 1, capabilityRevision: 1 },
+      target: { ...TARGET, connectionGeneration: 1, targetGeneration: 1 },
+      request: {
+        contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+        workspaceId: "workspace", threadId: "thread", providerSessionId: "session", providerInstanceId: "instance",
+        requestId: `race-${command.id}-${this.receipts.length}`, sequence: this.receipts.length, deadline: 4_000_000_000_000,
+        expectedControlEpoch: 0, operation, args,
+      },
+    } as unknown as BrowserAutomationHostDispatch;
+    const controller = new AbortController();
+    this.activeController = controller;
+    let response: Awaited<ReturnType<BrowserSessionDriver["execute"]>>;
+    try {
+      response = BrowserAutomationResponseSchema().parse(await this.driver.execute(dispatch, controller.signal));
+    } finally {
+      if (this.activeController === controller) this.activeController = undefined;
+    }
+    this.lastResponse = response;
+    if (response.ok) {
+      const result = response.result as { observationRef?: string; nextObservationRef?: string; finalObservation?: { observationRef?: string } };
+      this.observationRef = result.nextObservationRef ?? result.finalObservation?.observationRef ?? result.observationRef ?? this.observationRef;
+      if (operation === "open") this.liveTargets.set("tab", TARGET);
+    }
+    const receipt = normalizeBrowserConformanceRun({ receipts: [{
+      order: { tick: this.tick, ordinal: this.receipts.length }, commandId: command.id, operation,
+      status: response.ok ? "applied" : "failed", effect: response.ok ? "complete" : response.error.effect,
+      recovery: response.ok ? "none" : response.error.recovery, errorCode: response.ok ? null : response.error.code,
+      errorStage: response.ok ? "effect" : response.error.stage, ownership: response.ok ? "agent" : "none",
+      revisions: this.revisions,
+    }] }).receipts[0]!;
+    this.receipts.push(receipt);
+    return receipt;
+  }
+
+  snapshotOutcome(): BrowserConformanceNormalizedRun {
+    return normalizeBrowserConformanceRun({ receipts: this.receipts, outcome: { status: this.receipts.at(-1)?.status === "failed" ? "failed" : "completed", effect: this.receipts.at(-1)?.effect ?? "none", recovery: this.receipts.at(-1)?.recovery ?? "none", revisions: this.revisions, ownership: this.receipts.at(-1)?.ownership ?? "none" }, finalState: { readiness: this.disposed ? "target-unavailable" : "ready", controlOwner: this.receipts.at(-1)?.ownership ?? "none", tabCount: this.liveTargets.size, currentUrl: null, revisions: this.revisions, resources: this.snapshotResources() } });
+  }
+  snapshotResources(): BrowserConformanceResourceSnapshot {
+    return createBrowserConformanceResourceSnapshot({ counts: { targets: this.liveTargets.size }, identities: { targets: [...this.liveTargets.values()].map((target) => ({ id: `${target.threadId}/${target.tabId}`, generation: target.targetGeneration })) } });
+  }
+  async drainToQuiescence(): Promise<void> {}
+  async dispose(): Promise<void> { this.disposed = true; await this.driver.releaseProviderSession("session"); this.liveTargets.clear(); }
+}

--- a/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BROWSER_AUTOMATION_CONTRACT_VERSION,
   BrowserAutomationResponseSchema,
@@ -6,9 +9,12 @@ import {
 } from "@mcode/contracts";
 import {
   BROWSER_CONFORMANCE_RACE_CATALOGUE,
+  createBrowserConformanceScenario,
   createBrowserConformanceResourceSnapshot,
+  createBrowserConformanceSchedule,
   createBrowserConformanceRevisionRaceSchedules,
   normalizeBrowserConformanceRun,
+  runBrowserConformanceScenarioWithReplay,
   type BrowserConformanceCommand,
   type BrowserConformanceNormalizedRun,
   type BrowserConformanceReceipt,
@@ -19,6 +25,12 @@ import {
 import { executeWebBrowserDispatch } from "../../components/panels/browserAutomationWebExecutor";
 import { BrowserSessionDriver } from "./browserSessionDriver";
 import { WebBrowserSessionAdapter } from "./webBrowserSessionAdapter";
+
+const replayRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(replayRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
 
 const TARGET = {
   desktopInstanceId: "web",
@@ -32,26 +44,42 @@ const TARGET = {
   lastUsedAt: 0,
 } as const;
 
+type BrowserMutationCounters = { clicks: number; inputs: number; navigations: number };
+
 describe("BrowserSessionDriver deterministic races", () => {
   it("executes every revision schedule through the real WebBrowserSessionAdapter and rejects stale effects", async () => {
-    document.body.innerHTML = `<iframe data-thread-id="thread" data-tab-id="tab" src="about:blank"></iframe><button id="save">Save</button>`;
+    document.body.innerHTML = `<iframe data-thread-id="thread" data-tab-id="tab" src="about:blank"></iframe><button id="save">Save</button><input id="name" />`;
     const iframe = document.querySelector<HTMLIFrameElement>("iframe")!;
     Object.defineProperty(iframe, "contentDocument", { configurable: true, value: document });
     const button = document.querySelector<HTMLButtonElement>("#save")!;
+    const input = document.querySelector<HTMLInputElement>("#name")!;
     Object.defineProperty(button, "getBoundingClientRect", { value: () => ({ x: 0, y: 0, width: 80, height: 20 }) });
+    Object.defineProperty(input, "getBoundingClientRect", { value: () => ({ x: 0, y: 0, width: 80, height: 20 }) });
+    const mutationCounters: BrowserMutationCounters = { clicks: 0, inputs: 0, navigations: 0 };
+    const observerDisposers = new Set<() => void>();
+    button.addEventListener("click", () => { mutationCounters.clicks += 1; });
+    input.addEventListener("input", () => { mutationCounters.inputs += 1; });
+    iframe.addEventListener("load", () => { mutationCounters.navigations += 1; });
     let releaseOpen: (() => void) | undefined;
     let deferOpen = false;
     let abortCurrent: (() => void) | undefined;
     let abortAfterFirstClick = false;
     const revisions = { host: 1, document: 1, control: 0, capability: 1, observation: 0 };
-    const liveTargets = new Map<string, typeof TARGET>();
+    let liveTargets = new Map<string, typeof TARGET>([["tab", TARGET]]);
     const adapter = new WebBrowserSessionAdapter({
       resolveDocument: () => document,
       resolveSignal: (_dispatch, signal) => signal,
       getControlEpoch: () => revisions.control,
       getTargetGeneration: () => revisions.document,
       onHumanInput: vi.fn(),
-      onObserver: (_dispatch, dispose) => dispose(),
+      onObserver: (_dispatch, dispose) => {
+        let wrappedDispose: (() => void) | undefined;
+        wrappedDispose = () => {
+          if (wrappedDispose) observerDisposers.delete(wrappedDispose);
+          dispose();
+        };
+        observerDisposers.add(wrappedDispose);
+      },
       executeNonInteraction: async (dispatch, signal) => {
         if (deferOpen && dispatch.request.operation === "open") {
           return new Promise<Awaited<ReturnType<typeof executeWebBrowserDispatch>>>((resolve) => {
@@ -90,52 +118,70 @@ describe("BrowserSessionDriver deterministic races", () => {
       maxCommands: 4,
       maxEvents: 8,
       maxCheckpoints: 4,
-      maxTick: 12,
+      maxTick: 0,
     });
     const schedules = [
       ...Object.values(generated.individual),
       ...generated.pairs,
       ...generated.highRisk,
     ];
+    const replayRoot = await mkdtemp(join(tmpdir(), "mcode-web-browser-races-"));
+    replayRoots.push(replayRoot);
     for (const generatedSchedule of schedules) {
       revisions.host = 1;
       revisions.document = 1;
       revisions.control = 0;
       revisions.capability = 1;
-      liveTargets.clear();
-      const subject = new WebDriverRaceSubject(driver, revisions, liveTargets);
+      liveTargets = new Map([["tab", TARGET]]);
+      const subject = new WebDriverRaceSubject(driver, revisions, liveTargets, {
+        host: 0,
+        document: 0,
+        control: 0,
+        capability: 0,
+        observation: 0,
+      }, mutationCounters, observerDisposers);
       await subject.dispatch({ id: "open", operation: "open", args: { idempotencyKey: `open-${generatedSchedule.id}` } });
-      await subject.dispatch({ id: "inspect", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } });
-      for (const event of generatedSchedule.schedule.events) {
-        subject.schedule(event);
-        await subject.advanceClock(event.order.tick);
-        await subject.injectExternalEvent(event);
-      }
-      const receipt = await subject.dispatch({
-        id: "act",
-        operation: "act",
-        args: { observationRef: subject.observationRef ?? "missing-observation", deadlineMs: 10_000, steps: [{ operation: "click", target: { cssSelector: "#save" } }] },
+      const scenario = createBrowserConformanceScenario({
+        id: `web-driver-${generatedSchedule.id}`,
+        seed: generatedSchedule.schedule.seed,
+        commands: [
+          { id: "inspect", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } },
+          {
+            id: "act",
+            operation: "act",
+            args: {
+              observationRef: "$lastObservationRef",
+              deadlineMs: 10_000,
+              steps: [{ operation: "click", target: { cssSelector: "#save" } }],
+            },
+          },
+        ],
+        schedule: generatedSchedule.schedule,
+        cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
       });
-      expect(receipt.status).toBe("failed");
-      expect(receipt.effect).not.toBe("unknown");
-      expect(receipt.recovery).not.toBe("unknown");
-      expect(receipt.errorCode).toBe(generatedSchedule.revisions.includes("capability") ? "CAPABILITY_CHANGED" : "STALE_TARGET_GENERATION");
-      const beforeDispose = subject.snapshotResources();
-      await subject.drainToQuiescence();
-      await subject.dispose();
-      const afterDispose = subject.snapshotResources();
-      await subject.injectExternalEvent({ order: { tick: 99, ordinal: 99 }, kind: "late-response" });
-      await subject.injectExternalEvent({ order: { tick: 100, ordinal: 100 }, kind: "late-event" });
-      await subject.injectExternalEvent({ order: { tick: 101, ordinal: 101 }, kind: "late-timer" });
-      expect(subject.snapshotResources()).toEqual(afterDispose);
-      expect(afterDispose.targets).toBe(0);
-      expect(beforeDispose.targets).toBeLessThanOrEqual(1);
+      const run = await runBrowserConformanceScenarioWithReplay(scenario, subject, {
+        workspaceRoot: replayRoot,
+        fileName: `web-${generatedSchedule.id}.json`,
+        failingInvariant: "web BrowserSessionDriver seeded revision schedule remains bounded",
+      });
+      expect(run.outcome.status, generatedSchedule.id).not.toBe("unknown");
+      expect(run.finalState.resources.targets, generatedSchedule.id).toBe(1);
+      expect(run.finalState.resources.requests, generatedSchedule.id).toBeGreaterThan(0);
+      expect(run.receipts.every((receipt) => receipt.status !== "unknown" && receipt.effect !== "unknown" && receipt.recovery !== "unknown"), generatedSchedule.id).toBe(true);
+      const terminalReceipt = run.receipts.at(-1);
+      expect(terminalReceipt?.status, generatedSchedule.id).toBe("failed");
+      expect(terminalReceipt?.errorCode, generatedSchedule.id).toBe(
+        generatedSchedule.revisions.includes("capability") ? "CAPABILITY_CHANGED" : "STALE_TARGET_GENERATION",
+      );
+      expect(terminalReceipt?.effect, generatedSchedule.id).toBe("none");
+      expect(subject.mutationSnapshotBeforeAct(), generatedSchedule.id).toEqual(mutationCounters);
+      expect(subject.snapshotResources(), generatedSchedule.id).toEqual(createBrowserConformanceResourceSnapshot());
     }
     revisions.host = 1;
     revisions.document = 1;
     revisions.control = 0;
     revisions.capability = 1;
-    liveTargets.clear();
+    liveTargets = new Map([["tab", TARGET]]);
     const bootstrap = new WebDriverRaceSubject(driver, revisions, liveTargets);
     deferOpen = true;
     const firstOpen = bootstrap.dispatch({ id: "bootstrap-open-a", operation: "open", args: { idempotencyKey: "bootstrap-a" } });
@@ -159,7 +205,7 @@ describe("BrowserSessionDriver deterministic races", () => {
     await bootstrap.dispose();
 
     revisions.control = 0;
-    liveTargets.clear();
+    liveTargets = new Map([["tab", TARGET]]);
     const action = new WebDriverRaceSubject(driver, revisions, liveTargets);
     await action.dispatch({ id: "action-open", operation: "open", args: { idempotencyKey: "action-open" } });
     await action.dispatch({ id: "action-inspect", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } });
@@ -177,7 +223,7 @@ describe("BrowserSessionDriver deterministic races", () => {
     await action.dispose();
 
     revisions.control = 0;
-    liveTargets.clear();
+    liveTargets = new Map([["tab", TARGET]]);
     const batch = new WebDriverRaceSubject(driver, revisions, liveTargets);
     await batch.dispatch({ id: "batch-open", operation: "open", args: { idempotencyKey: "batch-open" } });
     await batch.dispatch({ id: "batch-inspect", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } });
@@ -187,8 +233,63 @@ describe("BrowserSessionDriver deterministic races", () => {
     expect(navigation.effect).not.toBe("unknown");
     expect(navigation.recovery).not.toBe("unknown");
     await batch.dispose();
-    expect(BROWSER_CONFORMANCE_RACE_CATALOGUE.filter((race) => race.family === "bootstrap")).toHaveLength(8);
-    expect(BROWSER_CONFORMANCE_RACE_CATALOGUE.filter((race) => race.family === "action" || race.family === "batch")).toHaveLength(13);
+    const exercisedRaceIds = new Set<string>();
+    for (const race of BROWSER_CONFORMANCE_RACE_CATALOGUE) {
+      revisions.host = 1;
+      revisions.document = 1;
+      revisions.control = 0;
+      revisions.capability = 1;
+      liveTargets = new Map([["tab", TARGET]]);
+      const raceSubject = new WebDriverRaceSubject(driver, revisions, liveTargets, {
+        host: 0,
+        document: 0,
+        control: 0,
+        capability: 0,
+        observation: 0,
+      }, mutationCounters, observerDisposers);
+      await raceSubject.dispatch({ id: `${race.id}-open`, operation: "open", args: { idempotencyKey: `${race.id}-open` } });
+      const schedule = createBrowserConformanceSchedule({
+        seed: race.id,
+        maxCommands: 2,
+        maxEvents: race.events.length,
+        maxCheckpoints: 0,
+        maxTick: 0,
+        eventCount: 0,
+      });
+      const scenario = createBrowserConformanceScenario({
+        id: `web-catalogue-${race.id}`,
+        seed: race.id,
+        commands: [
+          { id: `${race.id}-inspect`, operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } },
+          {
+            id: `${race.id}-act`,
+            operation: "act",
+            args: {
+              observationRef: "$lastObservationRef",
+              deadlineMs: 10_000,
+              steps: [{ operation: "click", target: { cssSelector: "#save" } }],
+            },
+          },
+        ],
+        schedule: {
+          ...schedule,
+          events: race.events.map((kind, ordinal) => ({ order: { tick: 0, ordinal }, kind } as BrowserConformanceScheduledEvent)),
+        },
+        cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+      });
+      const run = await runBrowserConformanceScenarioWithReplay(scenario, raceSubject, {
+        workspaceRoot: replayRoot,
+        fileName: `web-catalogue-${race.id}.json`,
+        failingInvariant: race.invariant,
+      });
+      expect(run.outcome.status, race.id).not.toBe("unknown");
+      expect(run.finalState.resources.requests, race.id).toBeGreaterThan(0);
+      expect(run.receipts.every((receipt) => receipt.status !== "unknown" && receipt.effect !== "unknown" && receipt.recovery !== "unknown"), race.id).toBe(true);
+      if (race.id === "bootstrap-idempotent-replay") expect(run.finalState.resources.listeners, race.id).toBeGreaterThan(0);
+      expect(raceSubject.snapshotResources().listeners, race.id).toBe(0);
+      exercisedRaceIds.add(race.id);
+    }
+    expect(exercisedRaceIds).toEqual(new Set(BROWSER_CONFORMANCE_RACE_CATALOGUE.map((race) => race.id)));
   });
 
 });
@@ -196,6 +297,16 @@ describe("BrowserSessionDriver deterministic races", () => {
 class WebDriverRaceSubject implements BrowserConformanceSubject {
   private readonly receipts: BrowserConformanceReceipt[] = [];
   private readonly scheduled: BrowserConformanceScheduledEvent[] = [];
+  private readonly requestLeases = new Set<string>();
+  private readonly timerLeases = new Set<number>();
+  private readonly heldInputLeases = new Set<string>();
+  private readonly controllerLeases = new Set<string>();
+  private readonly replayEntries = new Map<string, string>();
+  private readonly registryEntries = new Map<string, string>();
+  private readonly bufferEntries = new Set<string>();
+  private readonly mutationCounters?: BrowserMutationCounters;
+  private readonly observerDisposers?: Set<() => void>;
+  private preActMutationCounters: BrowserMutationCounters | undefined;
   private tick = 0;
   private disposed = false;
   private activeController: AbortController | undefined;
@@ -206,24 +317,47 @@ class WebDriverRaceSubject implements BrowserConformanceSubject {
     private readonly driver: BrowserSessionDriver,
     private readonly revisions: { host: number; document: number; control: number; capability: number; observation: number },
     private readonly liveTargets: Map<string, typeof TARGET>,
-  ) {}
+    observedRevisions = { ...revisions },
+    mutationCounters?: BrowserMutationCounters,
+    observerDisposers?: Set<() => void>,
+  ) {
+    this.observedRevisions = observedRevisions;
+    this.mutationCounters = mutationCounters;
+    this.observerDisposers = observerDisposers;
+  }
+
+  private readonly observedRevisions: { host: number; document: number; control: number; capability: number; observation: number };
+
+  private bumpRevision(key: keyof typeof this.revisions): void {
+    this.revisions[key] += 1;
+    this.observedRevisions[key] += 1;
+  }
 
   abortCurrent(): void { this.activeController?.abort(); }
 
-  schedule(event: BrowserConformanceScheduledEvent): void { this.scheduled.push(event); }
-  async advanceClock(tick: number): Promise<void> { this.tick = tick; }
+  mutationSnapshotBeforeAct(): BrowserMutationCounters | undefined {
+    return this.preActMutationCounters;
+  }
+
+  schedule(event: BrowserConformanceScheduledEvent): void {
+    this.scheduled.push(event);
+  }
+  async advanceClock(tick: number): Promise<void> {
+    this.tick = tick;
+    this.timerLeases.add(tick);
+  }
   async injectExternalEvent(event: BrowserConformanceScheduledEvent): Promise<void> {
     if (this.disposed) return;
     switch (event.kind) {
       case "host-disconnect":
       case "host-reconnect":
-        this.revisions.host += 1;
+        this.bumpRevision("host");
         break;
       case "navigation":
       case "reload":
       case "document-revision":
       case "target-register":
-        this.revisions.document += 1;
+        this.bumpRevision("document");
         break;
       case "user-takeover":
       case "competing-mutation":
@@ -231,34 +365,45 @@ class WebDriverRaceSubject implements BrowserConformanceSubject {
       case "timeout":
       case "resize":
       case "control-revision":
-        this.revisions.control += 1;
+        this.bumpRevision("control");
         break;
       case "capability-revision":
-        this.revisions.capability += 1;
+        this.bumpRevision("capability");
         break;
       case "observation-revision":
         this.driver.invalidateTargetObservations("thread", "tab");
-        this.revisions.observation += 1;
+        this.bumpRevision("observation");
         break;
       case "late-event":
       case "late-timer":
-        // Late callbacks are deliberately inert once the subject is disposed.
+      case "late-response":
+      case "lost-response":
+        // Late responses carry no new authority revision and disposed callbacks stay inert.
         break;
       case "target-close":
         this.driver.clearIdempotencyForTarget("thread", "tab");
         this.liveTargets.delete("tab");
-        this.revisions.document += 1;
+        this.bumpRevision("document");
         break;
       default:
-        this.revisions.control += 1;
+        this.bumpRevision("control");
         break;
     }
   }
 
   async dispatch(command: BrowserConformanceCommand): Promise<BrowserConformanceReceipt> {
+    if (command.operation === "act" && this.mutationCounters) this.preActMutationCounters = { ...this.mutationCounters };
+    const requestKey = `${command.id}:${this.receipts.length}`;
+    this.requestLeases.add(requestKey);
+    this.bufferEntries.add(requestKey);
+    this.registryEntries.set("provider-session", "active");
+    if (command.operation === "act") {
+      this.heldInputLeases.add(requestKey);
+      this.controllerLeases.add(requestKey);
+    }
     const operation = command.operation;
     const args = { ...(command.args ?? {}) } as Record<string, unknown>;
-    if (operation === "act") args.observationRef = this.observationRef;
+    if (operation === "act") args.observationRef = this.observationRef ?? "missing-observation";
     const dispatch = {
       connection: { desktopInstanceId: "web", windowId: 1, connectionGeneration: 1, targetGeneration: 1, capabilityRevision: 1 },
       target: { ...TARGET, connectionGeneration: 1, targetGeneration: 1 },
@@ -281,6 +426,7 @@ class WebDriverRaceSubject implements BrowserConformanceSubject {
     if (response.ok) {
       const result = response.result as { observationRef?: string; nextObservationRef?: string; finalObservation?: { observationRef?: string } };
       this.observationRef = result.nextObservationRef ?? result.finalObservation?.observationRef ?? result.observationRef ?? this.observationRef;
+      if (this.observationRef) this.replayEntries.set(this.observationRef, requestKey);
       if (operation === "open") this.liveTargets.set("tab", TARGET);
     }
     const receipt = normalizeBrowserConformanceRun({ receipts: [{
@@ -288,18 +434,46 @@ class WebDriverRaceSubject implements BrowserConformanceSubject {
       status: response.ok ? "applied" : "failed", effect: response.ok ? "complete" : response.error.effect,
       recovery: response.ok ? "none" : response.error.recovery, errorCode: response.ok ? null : response.error.code,
       errorStage: response.ok ? "effect" : response.error.stage, ownership: response.ok ? "agent" : "none",
-      revisions: this.revisions,
+      revisions: this.observedRevisions,
     }] }).receipts[0]!;
     this.receipts.push(receipt);
     return receipt;
   }
 
   snapshotOutcome(): BrowserConformanceNormalizedRun {
-    return normalizeBrowserConformanceRun({ receipts: this.receipts, outcome: { status: this.receipts.at(-1)?.status === "failed" ? "failed" : "completed", effect: this.receipts.at(-1)?.effect ?? "none", recovery: this.receipts.at(-1)?.recovery ?? "none", revisions: this.revisions, ownership: this.receipts.at(-1)?.ownership ?? "none" }, finalState: { readiness: this.disposed ? "target-unavailable" : "ready", controlOwner: this.receipts.at(-1)?.ownership ?? "none", tabCount: this.liveTargets.size, currentUrl: null, revisions: this.revisions, resources: this.snapshotResources() } });
+    return normalizeBrowserConformanceRun({ receipts: this.receipts, outcome: { status: this.receipts.at(-1)?.status === "failed" ? "failed" : "completed", effect: this.receipts.at(-1)?.effect ?? "none", recovery: this.receipts.at(-1)?.recovery ?? "none", revisions: this.observedRevisions, ownership: this.receipts.at(-1)?.ownership ?? "none" }, finalState: { readiness: this.disposed ? "target-unavailable" : "ready", controlOwner: this.receipts.at(-1)?.ownership ?? "none", tabCount: this.liveTargets.size, currentUrl: null, revisions: this.observedRevisions, resources: this.snapshotResources() } });
   }
   snapshotResources(): BrowserConformanceResourceSnapshot {
-    return createBrowserConformanceResourceSnapshot({ counts: { targets: this.liveTargets.size }, identities: { targets: [...this.liveTargets.values()].map((target) => ({ id: `${target.threadId}/${target.tabId}`, generation: target.targetGeneration })) } });
+    return createBrowserConformanceResourceSnapshot({
+      counts: {
+        requests: this.requestLeases.size,
+        queues: this.scheduled.length,
+        timers: this.timerLeases.size,
+        listeners: this.observerDisposers?.size ?? 0,
+        heldInput: this.heldInputLeases.size,
+        controllerLeases: this.controllerLeases.size,
+        targets: this.liveTargets.size,
+        replayEntries: this.replayEntries.size,
+        registries: this.registryEntries.size,
+        buffers: this.bufferEntries.size,
+      },
+      identities: { targets: [...this.liveTargets.values()].map((target) => ({ id: `${target.threadId}/${target.tabId}`, generation: target.targetGeneration })) },
+    });
   }
   async drainToQuiescence(): Promise<void> {}
-  async dispose(): Promise<void> { this.disposed = true; await this.driver.releaseProviderSession("session"); }
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    await this.driver.releaseProviderSession("session");
+    for (const dispose of this.observerDisposers ?? []) dispose();
+    this.observerDisposers?.clear();
+    this.requestLeases.clear();
+    this.scheduled.length = 0;
+    this.timerLeases.clear();
+    this.heldInputLeases.clear();
+    this.controllerLeases.clear();
+    this.replayEntries.clear();
+    this.registryEntries.clear();
+    this.bufferEntries.clear();
+  }
 }

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -4,6 +4,7 @@ import type {
   BrowserAutomationHostDispatchTarget,
   BrowserAutomationResponse,
 } from "@mcode/contracts";
+import { BrowserAutomationResponseSchema } from "@mcode/contracts";
 import {
   BrowserSessionDriver,
   ElectronBrowserSessionAdapter,
@@ -808,7 +809,7 @@ describe("BrowserSessionDriver", () => {
 
     await expect(pending).resolves.toMatchObject({
       ok: false,
-      error: { code: "OPERATION_CANCELLED", effect: "unknown", recovery: "inspect" },
+      error: { code: "OPERATION_CANCELLED", effect: "closed", recovery: "inspect" },
     });
     const refreshed = await driver.execute(inspectTabDispatch(tab2, "refresh", 6), new AbortController().signal);
     const refreshedRef = (refreshed as { result: { observationRef: string } }).result.observationRef;
@@ -877,7 +878,7 @@ describe("BrowserSessionDriver", () => {
 
     await expect(pending).resolves.toMatchObject({
       ok: false,
-      error: { code: "OPERATION_CANCELLED", effect: "unknown", recovery: "inspect" },
+      error: { code: "OPERATION_CANCELLED", effect: "closed", recovery: "inspect" },
     });
     const refreshed = await driver.execute(inspectTabDispatch(tab2, "refresh", 6), new AbortController().signal);
     const refreshedRef = (refreshed as { result: { observationRef: string } }).result.observationRef;
@@ -926,7 +927,7 @@ describe("BrowserSessionDriver", () => {
         code: "TAB_UNAVAILABLE",
         retryable: true,
         stage: "effect",
-        effect: "unknown",
+        effect: "preserved",
         recovery: "inspect",
       },
     });
@@ -936,6 +937,169 @@ describe("BrowserSessionDriver", () => {
     const retried = await driver.execute(tabsDispatch(target, "retry-close", 5, refreshedRef, { action: "close", tabId: "tab-1" }), new AbortController().signal);
     expect(retried).toMatchObject({ ok: true, result: { tabs: [] } });
     expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves ownership when tab close resolves but reconciliation retains the target", async () => {
+    const target = browserTarget("tab-1");
+    const liveTargets = new Map([[target.tabId, target]]);
+    const close = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockImplementation(async (value: BrowserAutomationHostDispatchTarget) => {
+        liveTargets.delete(value.tabId);
+      });
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "open") liveTargets.set(value.target.tabId, value.target);
+      return {
+        contractVersion: 1,
+        requestId: value.request.requestId,
+        sequence: value.request.sequence,
+        ok: true,
+        result: value.request.operation === "inspect"
+          ? { operation: "inspect", tabs: [...liveTargets.values()] }
+          : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+      } as unknown as BrowserAutomationResponse;
+    });
+    const projections: BrowserSessionLifecycleTab[][] = [];
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      webTabs: { list: async () => [...liveTargets.values()], close },
+      onLifecycleChange: (tabs) => projections.push([...tabs]),
+    });
+    await driver.execute(openTabDispatch(target, "open", 1), new AbortController().signal);
+    const inspected = BrowserAutomationResponseSchema().parse(
+      await driver.execute(inspectTabDispatch(target, "inspect", 2), new AbortController().signal),
+    );
+    const inspectedRef = inspected.ok && inspected.result.operation === "inspect" ? inspected.result.observationRef! : "";
+    const retained = BrowserAutomationResponseSchema().parse(
+      await driver.execute(tabsDispatch(target, "close", 3, inspectedRef, { action: "close", tabId: target.tabId }), new AbortController().signal),
+    );
+    expect(retained).toMatchObject({ ok: false, error: { code: "TAB_UNAVAILABLE", effect: "preserved", retryable: true } });
+    expect(projections.at(-1)).toEqual([expect.objectContaining({ tabId: target.tabId, ownership: "owned" })]);
+
+    const refreshed = BrowserAutomationResponseSchema().parse(
+      await driver.execute(inspectTabDispatch(target, "refresh", 4), new AbortController().signal),
+    );
+    const refreshedRef = refreshed.ok && refreshed.result.operation === "inspect" ? refreshed.result.observationRef! : "";
+    const closed = BrowserAutomationResponseSchema().parse(
+      await driver.execute(tabsDispatch(target, "retry-close", 5, refreshedRef, { action: "close", tabId: target.tabId }), new AbortController().signal),
+    );
+    expect(closed).toMatchObject({ ok: true, result: { tabs: [] } });
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not adopt a same-tab replacement generation after close", async () => {
+    const target = browserTarget("tab-1");
+    const replacement = { ...target, targetGeneration: target.targetGeneration + 1 };
+    const liveTargets = new Map([[target.tabId, target]]);
+    const close = vi.fn(async (value: BrowserAutomationHostDispatchTarget) => {
+      liveTargets.set(value.tabId, replacement);
+    });
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "open") liveTargets.set(value.target.tabId, value.target);
+      return {
+        contractVersion: 1,
+        requestId: value.request.requestId,
+        sequence: value.request.sequence,
+        ok: true,
+        result: value.request.operation === "inspect"
+          ? { operation: "inspect", tabs: [...liveTargets.values()] }
+          : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+      } as unknown as BrowserAutomationResponse;
+    });
+    const projections: BrowserSessionLifecycleTab[][] = [];
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      webTabs: { list: async () => [...liveTargets.values()], close },
+      onLifecycleChange: (tabs) => projections.push([...tabs]),
+    });
+    await driver.execute(openTabDispatch(target, "open", 1), new AbortController().signal);
+    const inspected = await driver.execute(inspectTabDispatch(target, "inspect", 2), new AbortController().signal);
+    const observationRef = (inspected as { result: { observationRef: string } }).result.observationRef;
+    const closed = await driver.execute(
+      tabsDispatch(target, "close", 3, observationRef, { action: "close", tabId: target.tabId }),
+      new AbortController().signal,
+    );
+    expect(closed).toMatchObject({ ok: true, result: { tabs: [] } });
+    expect(projections.at(-1)).toEqual([]);
+    await driver.releaseProviderSession("session");
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("retains agent ownership for provider-session cleanup retry after close failure", async () => {
+    const target = browserTarget("tab-1");
+    const liveTargets = new Map([[target.tabId, target]]);
+    const close = vi.fn()
+      .mockRejectedValueOnce(new Error("close failed"))
+      .mockImplementation(async (value: BrowserAutomationHostDispatchTarget) => {
+        liveTargets.delete(value.tabId);
+      });
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "open") liveTargets.set(value.target.tabId, value.target);
+      return {
+        contractVersion: 1,
+        requestId: value.request.requestId,
+        sequence: value.request.sequence,
+        ok: true,
+        result: value.request.operation === "inspect"
+          ? { operation: "inspect", tabs: [...liveTargets.values()] }
+          : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+      } as unknown as BrowserAutomationResponse;
+    });
+    const projections: BrowserSessionLifecycleTab[][] = [];
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      webTabs: { list: async () => [...liveTargets.values()], close },
+      onLifecycleChange: (tabs) => projections.push([...tabs]),
+    });
+    await driver.execute(openTabDispatch(target, "open", 1), new AbortController().signal);
+    await driver.releaseProviderSession("session");
+    expect(projections.at(-1)).toEqual([expect.objectContaining({ tabId: target.tabId, ownership: "owned" })]);
+    expect(close).toHaveBeenCalledOnce();
+
+    await driver.releaseProviderSession("session");
+    expect(projections.at(-1)).toEqual([]);
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops a retained session when provider cleanup sees a late replacement generation", async () => {
+    const target = browserTarget("tab-1");
+    const replacement = { ...target, targetGeneration: target.targetGeneration + 1 };
+    const liveTargets = new Map([[target.tabId, target]]);
+    const close = vi.fn(async (value: BrowserAutomationHostDispatchTarget) => {
+      liveTargets.set(value.tabId, replacement);
+    });
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "open") liveTargets.set(value.target.tabId, value.target);
+      return {
+        contractVersion: 1,
+        requestId: value.request.requestId,
+        sequence: value.request.sequence,
+        ok: true,
+        result: value.request.operation === "inspect"
+          ? { operation: "inspect", tabs: [...liveTargets.values()] }
+          : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
+      } as unknown as BrowserAutomationResponse;
+    });
+    const projections: BrowserSessionLifecycleTab[][] = [];
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      webTabs: { list: async () => [...liveTargets.values()], close },
+      onLifecycleChange: (tabs) => projections.push([...tabs]),
+    });
+    await driver.execute(openTabDispatch(target, "open", 1), new AbortController().signal);
+    await driver.releaseProviderSession("session");
+    expect(projections.at(-1)).toEqual([]);
+    await driver.releaseProviderSession("session");
+    expect(close).toHaveBeenCalledOnce();
+    expect(liveTargets.get(target.tabId)).toEqual(replacement);
   });
 
   it("claims and releases user tabs without physically closing them", async () => {
@@ -986,6 +1150,7 @@ describe("BrowserSessionDriver", () => {
   it("implicitly claims a user tab after browser_navigate and leaves it open during release", async () => {
     const agent = { threadId: "thread", tabId: "agent-tab", windowId: 1, connectionGeneration: 1, targetGeneration: 1 };
     const user = { threadId: "thread", tabId: "user-tab", windowId: 1, connectionGeneration: 1, targetGeneration: 4 };
+    const liveTargets = new Map([[agent.tabId, agent], [user.tabId, user]]);
     const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => ({
       contractVersion: 1,
       requestId: value.request.requestId,
@@ -993,13 +1158,15 @@ describe("BrowserSessionDriver", () => {
       ok: true,
       result: { operation: value.request.operation },
     }) as BrowserAutomationResponse);
-    const close = vi.fn();
+    const close = vi.fn(async (target: BrowserAutomationHostDispatchTarget) => {
+      liveTargets.delete(target.tabId);
+    });
     const projections: BrowserSessionLifecycleTab[][] = [];
     const driver = new BrowserSessionDriver({
       web: { execute },
       electron: { execute },
       isElectron: () => false,
-      webTabs: { list: async () => [agent, user] as never, close },
+      webTabs: { list: async () => [...liveTargets.values()] as never, close },
       onLifecycleChange: (tabs) => projections.push([...tabs]),
     });
     const open = await driver.execute({
@@ -1134,6 +1301,7 @@ describe("BrowserSessionDriver", () => {
   it("publishes lifecycle projection changes for agent-owned and claimed tabs", async () => {
     const current = { threadId: "thread", tabId: "agent-tab", windowId: 1, connectionGeneration: 1, targetGeneration: 1 };
     const user = { threadId: "thread", tabId: "user-tab", windowId: 1, connectionGeneration: 1, targetGeneration: 4 };
+    const liveTargets = new Map([[current.tabId, current], [user.tabId, user]]);
     const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => ({
       contractVersion: 1,
       requestId: value.request.requestId,
@@ -1148,7 +1316,10 @@ describe("BrowserSessionDriver", () => {
       web: { execute },
       electron: { execute },
       isElectron: () => false,
-      webTabs: { list: async () => [current, user] as never, close: vi.fn() },
+      webTabs: {
+        list: async () => [...liveTargets.values()] as never,
+        close: vi.fn(async (target: BrowserAutomationHostDispatchTarget) => { liveTargets.delete(target.tabId); }),
+      },
       onLifecycleChange: (tabs) => projections.push([...tabs]),
     });
     const base = {
@@ -1207,7 +1378,9 @@ describe("BrowserSessionDriver", () => {
           : { operation: "open", url: "about:blank", title: "", controlEpoch: 0 },
       } as BrowserAutomationResponse;
     });
-    const close = vi.fn();
+    const close = vi.fn(async (target: BrowserAutomationHostDispatchTarget) => {
+      liveTargets.delete(target.tabId);
+    });
     const driver = new BrowserSessionDriver({
       web: { execute }, electron: { execute }, isElectron: () => false,
       webTabs: { list: async () => [...liveTargets.values()], close },
@@ -1269,6 +1442,7 @@ describe("BrowserSessionDriver", () => {
     const run = async (electronRuntime: boolean) => {
       const webClose = vi.fn();
       const electronClose = vi.fn();
+      let closed = false;
       const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => ({
         contractVersion: 1,
         requestId: value.request.requestId,
@@ -1278,8 +1452,8 @@ describe("BrowserSessionDriver", () => {
       }) as BrowserAutomationResponse);
       const driver = new BrowserSessionDriver({
         web: { execute }, electron: { execute }, isElectron: () => electronRuntime,
-        webTabs: { list: async (value) => [value.target], close: webClose },
-        electronTabs: { list: async (value) => [value.target], close: electronClose },
+        webTabs: { list: async (value) => closed ? [] : [value.target], close: async (target) => { closed = true; webClose(target); } },
+        electronTabs: { list: async (value) => closed ? [] : [value.target], close: async (target) => { closed = true; electronClose(target); } },
       });
       const opened = {
         connection: { connectionGeneration: 1, capabilityRevision: 1 },

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -120,6 +120,7 @@ interface ProviderTabSession {
   readonly workspaceId: string;
   readonly providerSessionId: string;
   readonly providerInstanceId: string;
+  lastDispatch: BrowserAutomationHostDispatch;
   current: BrowserAutomationHostDispatchTarget | null;
   readonly tabs: Map<string, ControlledTab>;
 }
@@ -829,7 +830,7 @@ export class BrowserSessionDriver {
     } else if ((request.args.action === "release" || request.args.action === "close") && requestedTabId) {
       const controlled = session.tabs.get(requestedTabId);
       if (request.args.action === "close" && controlled?.provenance === "agent-created") {
-        const closeResult = await this.closeControlledTab(dispatch, session, adapter, requestedTabId, controlled, signal);
+        const closeResult = await this.closeControlledTab(dispatch, session, adapter, requestedTabId, controlled, signal, liveTargets);
         if (closeResult) return closeResult;
       } else if (controlled) {
         if (signal.aborted) {
@@ -848,7 +849,7 @@ export class BrowserSessionDriver {
           ? requested === "handoff" || requested === "deliverable" ? requested : "release"
           : requested ?? "close";
         if (disposition === "close") {
-          const closeResult = await this.closeControlledTab(dispatch, session, adapter, tabId, controlled, signal);
+          const closeResult = await this.closeControlledTab(dispatch, session, adapter, tabId, controlled, signal, liveTargets);
           if (closeResult) return closeResult;
         } else {
           if (signal.aborted) {
@@ -932,30 +933,99 @@ export class BrowserSessionDriver {
     tabId: string,
     controlled: ControlledTab,
     signal: AbortSignal,
+    liveTargets?: Map<string, BrowserAutomationHostDispatchTarget>,
   ): Promise<BrowserAutomationResponse | null> {
     if (signal.aborted) {
       return this.tabCancellation(dispatch, "Browser tab mutation was interrupted before closing the tab");
     }
+    if (!adapter) {
+      this.preserveControlledTab(session, tabId, controlled);
+      return this.tabCloseFailure(dispatch, new Error("Browser tab lifecycle adapter is unavailable"), signal, "preserved");
+    }
+    let closeCause: unknown;
     try {
-      await adapter?.close(controlled.target);
+      await adapter.close(controlled.target);
     } catch (cause) {
-      return this.tabCloseFailure(dispatch, cause, signal);
+      closeCause = cause;
     }
-    session.tabs.delete(tabId);
-    if (session.current?.tabId === tabId) session.current = null;
+    const effect = await this.reconcileClosedTab(dispatch, session, adapter, tabId, controlled, liveTargets);
+    if (effect === "preserved") {
+      return this.tabCloseFailure(
+        dispatch,
+        closeCause ?? new Error("Browser tab close did not remove the target"),
+        signal,
+        effect,
+      );
+    }
     if (signal.aborted) {
-      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted after closing the tab", "unknown");
+      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted after closing the tab", effect);
     }
+    if (closeCause) return this.tabCloseFailure(dispatch, closeCause, signal, effect);
     return null;
+  }
+
+  private async reconcileClosedTab(
+    dispatch: BrowserAutomationHostDispatch,
+    session: ProviderTabSession,
+    adapter: BrowserSessionTabLifecycleAdapter,
+    tabId: string,
+    controlled: ControlledTab,
+    liveTargets?: Map<string, BrowserAutomationHostDispatchTarget>,
+  ): Promise<"closed" | "preserved"> {
+    let liveTargetList: readonly BrowserAutomationHostDispatchTarget[];
+    try {
+      liveTargetList = await adapter.list(dispatch);
+    } catch {
+      // A failed reconciliation cannot prove that the physical target closed.
+      this.preserveControlledTab(session, tabId, controlled);
+      return "preserved";
+    }
+    if (liveTargets) {
+      liveTargets.clear();
+      for (const target of liveTargetList) liveTargets.set(target.tabId, target);
+    }
+    const liveTarget = liveTargetList.find((target) => this.sameTargetIdentity(target, controlled.target));
+    if (!liveTarget) {
+      session.tabs.delete(tabId);
+      if (session.current?.tabId === tabId) session.current = null;
+      this.publishLifecycleProjectionInternal();
+      return "closed";
+    }
+    this.preserveControlledTab(session, tabId, controlled, liveTarget);
+    return "preserved";
+  }
+
+  private sameTargetIdentity(
+    left: BrowserAutomationHostDispatchTarget,
+    right: BrowserAutomationHostDispatchTarget,
+  ): boolean {
+    return left.desktopInstanceId === right.desktopInstanceId &&
+      left.windowId === right.windowId &&
+      left.connectionGeneration === right.connectionGeneration &&
+      left.threadId === right.threadId &&
+      left.tabId === right.tabId &&
+      left.targetGeneration === right.targetGeneration;
+  }
+
+  private preserveControlledTab(
+    session: ProviderTabSession,
+    tabId: string,
+    controlled: ControlledTab,
+    target: BrowserAutomationHostDispatchTarget = controlled.target,
+  ): void {
+    session.tabs.set(tabId, { ...controlled, target });
+    if (session.current?.tabId === tabId) session.current = target;
+    this.publishLifecycleProjectionInternal();
   }
 
   private tabCloseFailure(
     dispatch: BrowserAutomationHostDispatch,
     cause: unknown,
     signal: AbortSignal,
+    effect: "closed" | "preserved",
   ): BrowserAutomationResponse {
     if (signal.aborted || this.isCancellation(cause)) {
-      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted while closing the tab", "unknown");
+      return this.tabCancellation(dispatch, "Browser tab mutation was interrupted while closing the tab", effect);
     }
     const detail = sanitizePublicDetail(cause instanceof Error ? cause.message : cause);
     return {
@@ -968,7 +1038,7 @@ export class BrowserSessionDriver {
         message: detail ? `Browser tab close failed: ${detail}` : "Browser tab close failed",
         retryable: true,
         stage: "effect",
-        effect: "unknown",
+        effect,
         recovery: "inspect",
       },
     };
@@ -1113,10 +1183,13 @@ export class BrowserSessionDriver {
         workspaceId: dispatch.request.workspaceId,
         providerSessionId: dispatch.request.providerSessionId,
         providerInstanceId: dispatch.request.providerInstanceId,
+        lastDispatch: dispatch,
         current: null,
         tabs: new Map(),
       };
       this.tabSessions.set(key, session);
+    } else {
+      session.lastDispatch = dispatch;
     }
     return session;
   }
@@ -1134,15 +1207,29 @@ export class BrowserSessionDriver {
           observationTargetKey(session.current.threadId, session.current.tabId),
         );
       }
+      const retained = new Map<string, ControlledTab>();
       for (const tab of session.tabs.values()) {
         this.clearHumanInteractionTarget(
           observationTargetKey(tab.target.threadId, tab.target.tabId),
         );
-        if (tab.provenance === "agent-created" && tab.ownership !== "released") {
-          await adapter?.close(tab.target);
+        if (tab.provenance !== "agent-created" || tab.ownership === "released") continue;
+        if (!adapter) {
+          retained.set(tab.tabId, tab);
+          continue;
         }
+        try {
+          await adapter.close(tab.target);
+        } catch { /* Reconciliation decides whether retryable ownership remains. */ }
+        const effect = await this.reconcileClosedTab(session.lastDispatch, session, adapter, tab.tabId, tab);
+        if (effect === "preserved") retained.set(tab.tabId, session.tabs.get(tab.tabId) ?? tab);
       }
-      this.tabSessions.delete(key);
+      if (retained.size === 0) {
+        this.tabSessions.delete(key);
+      } else {
+        session.tabs.clear();
+        for (const [tabId, tab] of retained) session.tabs.set(tabId, tab);
+        if (!session.current || !retained.has(session.current.tabId)) session.current = null;
+      }
     }
     this.publishLifecycleProjectionInternal();
   }
@@ -1191,7 +1278,7 @@ export class BrowserSessionDriver {
   private tabCancellation(
     dispatch: BrowserAutomationHostDispatch,
     message: string,
-    effect: "none" | "unknown" = "none",
+    effect: "none" | "closed" | "preserved" = "none",
   ): BrowserAutomationResponse {
     return {
       contractVersion: dispatch.request.contractVersion,

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "electron-builder": "^25.1.0",
         "electron-mksnapshot": "35.7.5",
         "esbuild": "^0.27.0",
+        "jsdom": "^29.0.1",
         "png-to-ico": "^3.0.1",
         "png2icons": "^2.0.1",
         "resedit": "^3.0.2",
@@ -71,6 +72,7 @@
         "zod": "^3.24.2",
       },
       "devDependencies": {
+        "@mcode/browser-conformance": "workspace:*",
         "@swc/cli": "^0.8.1",
         "@swc/core": "^1.15.41",
         "@types/better-sqlite3": "^7.6.12",

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@electron/fuses": "^2.1.1",
+        "@mcode/browser-conformance": "workspace:*",
         "@resvg/resvg-js": "^2.6.2",
         "@types/uuid": "^10.0.0",
         "@types/which": "^3.0.4",
@@ -128,6 +129,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@mcode/browser-conformance": "workspace:*",
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",

--- a/bun.lock
+++ b/bun.lock
@@ -149,6 +149,18 @@
         "vitest": "^4.1.0",
       },
     },
+    "packages/browser-conformance": {
+      "name": "@mcode/browser-conformance",
+      "version": "0.0.1",
+      "dependencies": {
+        "@mcode/contracts": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^22.19.17",
+        "typescript": "^5.8.0",
+        "vitest": "^4.1.0",
+      },
+    },
     "packages/contracts": {
       "name": "@mcode/contracts",
       "version": "0.0.1",
@@ -550,6 +562,8 @@
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
     "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
+
+    "@mcode/browser-conformance": ["@mcode/browser-conformance@workspace:packages/browser-conformance"],
 
     "@mcode/contracts": ["@mcode/contracts@workspace:packages/contracts"],
 

--- a/packages/browser-conformance/package.json
+++ b/packages/browser-conformance/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@mcode/browser-conformance",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@mcode/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/browser-conformance/src/__tests__/cleanup.test.ts
+++ b/packages/browser-conformance/src/__tests__/cleanup.test.ts
@@ -30,4 +30,15 @@ describe("Browser conformance cleanup baselines", () => {
     expect(checkBrowserConformanceCleanup({ baseline, allowedGrowth: { replayEntries: 1 } }, final).ok).toBe(true);
     expect(checkBrowserConformanceCleanup({ baseline }, final).ok).toBe(false);
   });
+
+  it("rejects duplicate identities and identity cardinality mismatches", () => {
+    expect(() => createBrowserConformanceResourceSnapshot({
+      counts: { targets: 1 },
+      identities: { targets: [{ id: "target-a", generation: 1 }, { id: "target-a", generation: 1 }] },
+    })).toThrow(/duplicates|cardinality/);
+    expect(() => createBrowserConformanceResourceSnapshot({
+      counts: { targets: 1 },
+      identities: { targets: [{ id: "target-a", generation: 1 }, { id: "target-b", generation: 1 }] },
+    })).toThrow(/cardinality/);
+  });
 });

--- a/packages/browser-conformance/src/__tests__/cleanup.test.ts
+++ b/packages/browser-conformance/src/__tests__/cleanup.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkBrowserConformanceCleanup,
+  compareBrowserConformanceCleanup,
+  createBrowserConformanceResourceSnapshot,
+} from "../index.js";
+
+describe("Browser conformance cleanup baselines", () => {
+  it("requires baseline identities and generations to return", () => {
+    const baseline = createBrowserConformanceResourceSnapshot({
+      identities: { targets: [{ id: "target-a", generation: 4 }] },
+    });
+    const final = createBrowserConformanceResourceSnapshot({
+      identities: { targets: [{ id: "target-a", generation: 5 }] },
+    });
+
+    const result = compareBrowserConformanceCleanup(baseline, final);
+    expect(result.ok).toBe(false);
+    expect(result.violations).toEqual([
+      expect.objectContaining({ resource: "targets", reason: "identity" }),
+    ]);
+  });
+
+  it("allows only explicitly declared bounded growth", () => {
+    const baseline = createBrowserConformanceResourceSnapshot();
+    const final = createBrowserConformanceResourceSnapshot({
+      identities: { replayEntries: [{ id: "replay-1", generation: 1 }] },
+    });
+
+    expect(checkBrowserConformanceCleanup({ baseline, allowedGrowth: { replayEntries: 1 } }, final).ok).toBe(true);
+    expect(checkBrowserConformanceCleanup({ baseline }, final).ok).toBe(false);
+  });
+});

--- a/packages/browser-conformance/src/__tests__/model-boundaries.test.ts
+++ b/packages/browser-conformance/src/__tests__/model-boundaries.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS,
+  BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_TICK,
   BROWSER_CONFORMANCE_GENERATOR_VERSION,
   BROWSER_CONFORMANCE_SCENARIO_VERSION,
   createBrowserConformanceScenario,
@@ -28,5 +30,57 @@ describe("Browser conformance scenario boundaries", () => {
       },
       cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
     })).toThrow(/order|bounds/);
+  });
+
+  it("rejects hard-cap overflow in commands, schedule bounds, and custom items", () => {
+    const baseline = createBrowserConformanceSchedule({ seed: 12, maxCommands: 1, maxEvents: 0, maxCheckpoints: 0, maxTick: 0 });
+    const cleanup = { baseline: createBrowserConformanceResourceSnapshot() };
+    const commands = Array.from({ length: BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS + 1 }, (_, index) => ({
+      id: `inspect-${index}`,
+      operation: "inspect" as const,
+    }));
+    expect(() => createBrowserConformanceScenario({ id: "too-many-commands", seed: 12, commands, schedule: baseline, cleanup }))
+      .toThrow(/bounds/);
+
+    for (const [key, value] of [
+      ["maxCommands", BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS + 1],
+      ["maxEvents", BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS + 1],
+      ["maxCheckpoints", BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS + 1],
+      ["maxTick", BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_TICK + 1],
+    ] as const) {
+      const schedule = { ...baseline, bounds: { ...baseline.bounds, [key]: value } };
+      expect(() => createBrowserConformanceScenario({
+        id: `too-large-${key}`,
+        seed: 12,
+        commands: [{ id: "inspect", operation: "inspect" }],
+        schedule,
+        cleanup,
+      })).toThrow(/bounds/);
+    }
+
+    const tooManyEvents = Array.from({ length: BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS + 1 }, (_, ordinal) => ({
+      order: { tick: 0, ordinal },
+      kind: "timeout" as const,
+    }));
+    expect(() => createBrowserConformanceScenario({
+      id: "too-many-events",
+      seed: 12,
+      commands: [{ id: "inspect", operation: "inspect" }],
+      schedule: { ...baseline, bounds: { ...baseline.bounds, maxEvents: BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS + 1 }, events: tooManyEvents },
+      cleanup,
+    })).toThrow(/bounds|order/);
+
+    const tooManyCheckpoints = Array.from({ length: BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS + 1 }, (_, ordinal) => ({
+      id: `checkpoint-${ordinal}`,
+      order: { tick: 0, ordinal },
+      label: "checkpoint",
+    }));
+    expect(() => createBrowserConformanceScenario({
+      id: "too-many-checkpoints",
+      seed: 12,
+      commands: [{ id: "inspect", operation: "inspect" }],
+      schedule: { ...baseline, bounds: { ...baseline.bounds, maxCheckpoints: BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS + 1 }, checkpoints: tooManyCheckpoints },
+      cleanup,
+    })).toThrow(/bounds|order/);
   });
 });

--- a/packages/browser-conformance/src/__tests__/model-boundaries.test.ts
+++ b/packages/browser-conformance/src/__tests__/model-boundaries.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSER_CONFORMANCE_GENERATOR_VERSION,
+  BROWSER_CONFORMANCE_SCENARIO_VERSION,
+  createBrowserConformanceScenario,
+  createBrowserConformanceSchedule,
+  createBrowserConformanceResourceSnapshot,
+} from "../index.js";
+
+describe("Browser conformance scenario boundaries", () => {
+  it("rejects mismatched schedule metadata and out-of-bound total-order entries", () => {
+    const base = createBrowserConformanceSchedule({ seed: 11, maxCommands: 1, maxEvents: 1, eventCount: 1 });
+    expect(() => createBrowserConformanceScenario({
+      id: "invalid-version",
+      seed: 11,
+      commands: [],
+      schedule: { ...base, version: BROWSER_CONFORMANCE_SCENARIO_VERSION + 1 as 1 },
+      cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+    })).toThrow(/metadata/);
+    expect(() => createBrowserConformanceScenario({
+      id: "invalid-order",
+      seed: 11,
+      commands: [],
+      schedule: {
+        ...base,
+        generatorVersion: BROWSER_CONFORMANCE_GENERATOR_VERSION,
+        events: [{ ...base.events[0], order: { tick: base.bounds.maxTick + 1, ordinal: 0 } }],
+      },
+      cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+    })).toThrow(/order|bounds/);
+  });
+});

--- a/packages/browser-conformance/src/__tests__/normalize.test.ts
+++ b/packages/browser-conformance/src/__tests__/normalize.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { normalizeBrowserConformanceRun } from "../index.js";
+
+describe("Browser conformance normalization", () => {
+  it("keeps receipts, effects, recovery, truncation, ownership, and revisions while dropping dynamic fields", () => {
+    const normalized = normalizeBrowserConformanceRun({
+      receipts: [{
+        requestId: "runtime-request-123",
+        timestamp: 123456,
+        operation: "browser_act",
+        status: "interrupted",
+        effect: "partial",
+        recovery: "yield_to_user",
+        truncated: true,
+        revisions: { host: 2, document: 3, control: 4, capability: 5, observation: 6 },
+        errorCode: "USER_TAKEOVER",
+        errorStage: "effect",
+        ownership: "user",
+        exception: "do not retain this arbitrary string",
+        order: { tick: 8, ordinal: 1 },
+      }],
+      outcome: {
+        status: "interrupted",
+        effect: "partial",
+        recovery: "yield_to_user",
+        truncated: true,
+        revisions: { host: 2, document: 3, control: 4, capability: 5, observation: 6 },
+        errorCode: "USER_TAKEOVER",
+        errorStage: "effect",
+        ownership: "user",
+      },
+      finalState: {
+        readiness: "human-control",
+        controlOwner: "user",
+        tabCount: 1,
+        currentUrl: "https://example.test/path?secret=redact#fragment",
+        resources: { requests: 0, queues: 0, timers: 0, listeners: 0, heldInput: 0, controllerLeases: 0, targets: 0, replayEntries: 0, registries: 0, buffers: 0 },
+      },
+    });
+
+    expect(normalized.receipts[0]).toMatchObject({
+      operation: "act",
+      status: "interrupted",
+      effect: "partial",
+      recovery: "yield_to_user",
+      truncated: true,
+      errorCode: "USER_TAKEOVER",
+      errorStage: "effect",
+      ownership: "user",
+      revisions: { host: 2, document: 3, control: 4, capability: 5, observation: 6 },
+    });
+    expect(normalized.finalState.currentUrl).toBe("https://example.test/path");
+    expect(JSON.stringify(normalized)).not.toContain("runtime-request-123");
+    expect(JSON.stringify(normalized)).not.toContain("123456");
+  });
+
+  it("does not turn malformed outcomes into false success", () => {
+    const normalized = normalizeBrowserConformanceRun({ outcome: { status: "completed-ish" } });
+    expect(normalized.outcome.status).toBe("unknown");
+    expect(normalized.outcome.effect).toBe("unknown");
+    expect(normalized.outcome.recovery).toBe("unknown");
+  });
+});

--- a/packages/browser-conformance/src/__tests__/production-boundary.test.ts
+++ b/packages/browser-conformance/src/__tests__/production-boundary.test.ts
@@ -1,0 +1,41 @@
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+describe("Browser conformance production boundary", () => {
+  it("has no production dependency on app runtimes and imports no adapter code", async () => {
+    const packageJson = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as {
+      dependencies?: Record<string, string>;
+      exports?: Record<string, string>;
+      scripts?: Record<string, string>;
+    };
+    expect(Object.keys(packageJson.dependencies ?? {})).toEqual(["@mcode/contracts"]);
+    expect(packageJson.exports).toEqual({ ".": "./src/index.ts" });
+    expect(packageJson.scripts?.build).toBeUndefined();
+
+    const sourceFiles = await readdir(join(packageRoot, "src"), { recursive: true });
+    for (const file of sourceFiles.filter((value): value is string => value.endsWith(".ts") && !value.includes("__tests__"))) {
+      const source = await readFile(join(packageRoot, "src", file), "utf8");
+      expect(source).not.toMatch(/apps[\\/]?(?:web|server|desktop)/i);
+      expect(source).not.toMatch(/Browser(?:SessionDriver|AutomationKernel|AutomationMcpHandler|AutomationBroker)/);
+    }
+
+    for (const workspaceRoot of ["apps", "packages"]) {
+      const workspaces = await readdir(join(packageRoot, "..", "..", workspaceRoot), { withFileTypes: true });
+      for (const workspace of workspaces.filter((entry) => entry.isDirectory() && entry.name !== "browser-conformance")) {
+        const manifestPath = join(packageRoot, "..", "..", workspaceRoot, workspace.name, "package.json");
+        try {
+          const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+            dependencies?: Record<string, string>;
+          };
+          expect(manifest.dependencies?.["@mcode/browser-conformance"]).toBeUndefined();
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        }
+      }
+    }
+  });
+});

--- a/packages/browser-conformance/src/__tests__/races.test.ts
+++ b/packages/browser-conformance/src/__tests__/races.test.ts
@@ -1,0 +1,370 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BROWSER_CONFORMANCE_EVENT_KINDS,
+  BROWSER_CONFORMANCE_HIGH_RISK_REVISION_COMBINATIONS,
+  BROWSER_CONFORMANCE_RACE_CATALOGUE,
+  createBrowserConformanceRaceSchedules,
+  createBrowserConformanceResourceSnapshot,
+  createBrowserConformanceScenario,
+  createBrowserConformanceSchedule,
+  createBrowserConformanceRevisionRaceSchedules,
+  createBrowserExecutorParityScenario,
+  normalizeBrowserConformanceRun,
+  runBrowserConformanceScenarioWithReplay,
+  runBrowserConformanceExecutorScenario,
+  type BrowserConformanceNormalizedRun,
+  type BrowserConformanceReceipt,
+  type BrowserConformanceResourceSnapshot,
+  type BrowserConformanceScheduledEvent,
+  type BrowserConformanceSubject,
+} from "../index.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("Browser conformance named races", () => {
+  it("keeps every reviewed race named, categorized, and non-unknown", () => {
+    expect(BROWSER_CONFORMANCE_RACE_CATALOGUE).toHaveLength(32);
+    expect(new Set(BROWSER_CONFORMANCE_RACE_CATALOGUE.map((race) => race.id)).size)
+      .toBe(BROWSER_CONFORMANCE_RACE_CATALOGUE.length);
+    expect(new Set(BROWSER_CONFORMANCE_RACE_CATALOGUE.map((race) => race.family)))
+      .toEqual(new Set(["bootstrap", "action", "observation", "batch", "cleanup"]));
+    for (const race of BROWSER_CONFORMANCE_RACE_CATALOGUE) {
+      expect(race.id).toMatch(/^[a-z0-9-]+$/);
+      expect(race.events.length).toBeGreaterThan(0);
+      expect(race.invariant).not.toMatch(/unknown/i);
+      expect(race.invariant).toMatch(/(?:one|exactly|known|without|cannot|does not|invalidat|reject|preserv|stop|release|inert|generation|owner|effect|outcome)/i);
+      for (const event of race.events) expect(BROWSER_CONFORMANCE_EVENT_KINDS).toContain(event);
+    }
+  });
+
+  it("covers each race meaning explicitly", () => {
+    const ids = new Set(BROWSER_CONFORMANCE_RACE_CATALOGUE.map((race) => race.id));
+    for (const id of [
+      "bootstrap-disconnect-reconnect", "bootstrap-concurrent-open", "bootstrap-cancel", "bootstrap-timeout",
+      "bootstrap-close", "bootstrap-lost-response", "bootstrap-idempotent-replay", "bootstrap-late-creation",
+      "action-takeover", "action-navigation", "action-reload", "action-close", "action-resize", "action-cancel",
+      "action-timeout", "action-competing-mutation", "observation-host-revision", "observation-document-revision",
+      "observation-control-revision", "observation-capability-revision", "observation-observation-revision",
+      "batch-invalidation", "batch-navigation", "batch-partial-failure", "batch-deadline", "batch-cancel-between-steps",
+      "cleanup-late-response", "cleanup-late-event", "cleanup-late-timer", "cleanup-disconnect", "cleanup-replacement",
+      "cleanup-capacity",
+    ]) expect(ids).toContain(id);
+    expect(BROWSER_CONFORMANCE_RACE_CATALOGUE.find((race) => race.id === "cleanup-late-event")?.events)
+      .toEqual(["late-event"]);
+    expect(BROWSER_CONFORMANCE_RACE_CATALOGUE.find((race) => race.id === "cleanup-late-timer")?.events)
+      .toEqual(["late-timer"]);
+  });
+
+  it("generates bounded byte-for-byte schedules for every revision, pair, and high-risk set", async () => {
+    const options = { seed: "revision-race-seed", maxCommands: 3, maxEvents: 8, maxCheckpoints: 4, maxTick: 12 } as const;
+    const first = createBrowserConformanceRevisionRaceSchedules(options);
+    const second = createBrowserConformanceRaceSchedules(options);
+    const differentSeed = createBrowserConformanceRevisionRaceSchedules({ ...options, seed: "revision-race-seed-2" });
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+    expect(JSON.stringify(first)).not.toBe(JSON.stringify(differentSeed));
+    expect(Object.keys(first.individual)).toHaveLength(5);
+    expect(first.pairs).toHaveLength(10);
+    expect(first.highRisk).toHaveLength(BROWSER_CONFORMANCE_HIGH_RISK_REVISION_COMBINATIONS.length);
+    const schedules = [
+      ...Object.values(first.individual),
+      ...first.pairs,
+      ...first.highRisk,
+    ];
+    for (const generated of schedules) {
+      const { schedule } = generated;
+      expect(schedule.events.length).toBeLessThanOrEqual(schedule.bounds.maxEvents);
+      expect(schedule.checkpoints.length).toBeLessThanOrEqual(schedule.bounds.maxCheckpoints);
+      expect(schedule.events.every((event) => event.order.tick <= schedule.bounds.maxTick)).toBe(true);
+      expect(schedule.events.map((event) => event.revision)).toEqual(generated.revisions);
+      expect(new Set(schedule.events.map((event) => event.revision))).toEqual(new Set(generated.revisions));
+      expect(new Set([
+        ...schedule.events.map((event) => `${event.order.tick}:${event.order.ordinal}`),
+        ...schedule.checkpoints.map((checkpoint) => `${checkpoint.order.tick}:${checkpoint.order.ordinal}`),
+      ]).size).toBe(schedule.events.length + schedule.checkpoints.length);
+
+      const subject = new RecordingSubject();
+      await executeScheduledSubject(subject, schedule);
+      expect(subject.injectedEvents.map((event) => `${event.kind}:${event.revision ?? ""}`))
+        .toEqual(schedule.events.map((event) => `${event.kind}:${event.revision ?? ""}`));
+    }
+  });
+
+  it.each([
+    ["completed", undefined],
+    ["failed", "timeout"],
+    ["interrupted", "cancel"],
+    ["failed", "host-disconnect"],
+  ] as const)("does not resurrect resources after terminal %s activity", async (status, terminalEvent) => {
+    const subject = new TerminalSubject(status);
+    const baseline = subject.snapshotResources();
+    if (terminalEvent) await subject.injectExternalEvent({ order: { tick: 0, ordinal: 0 }, kind: terminalEvent });
+    await subject.dispatch({ id: "terminal", operation: "open" });
+    await subject.drainToQuiescence();
+    await subject.dispose();
+    const postDispose = subject.snapshotResources();
+    await subject.injectExternalEvent({ order: { tick: 1, ordinal: 1 }, kind: "late-response" });
+    await subject.injectExternalEvent({ order: { tick: 2, ordinal: 2 }, kind: "target-register" });
+    await subject.drainToQuiescence();
+    expect(subject.snapshotResources()).toEqual(postDispose);
+    expect(postDispose).toEqual(createBrowserConformanceResourceSnapshot());
+    expect(subject.snapshotOutcome().outcome.status).not.toBe("unknown");
+    expect(subject.snapshotOutcome().outcome.effect).not.toBe("unknown");
+    expect(baseline.revisions).toEqual(createBrowserConformanceResourceSnapshot().revisions);
+  });
+
+  it("writes a bounded sanitized replay for each thrown scenario invariant", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mcode-browser-race-replay-"));
+    temporaryRoots.push(root);
+    const race = BROWSER_CONFORMANCE_RACE_CATALOGUE.find((entry) => entry.id === "cleanup-late-response")!;
+    const subject = new RecordingSubject(true);
+    const scenario = createBrowserConformanceScenario({
+      id: race.id,
+      seed: "replay-race-seed",
+      commands: [{ id: "race", operation: "inspect", args: { typedText: "do-not-retain" } }],
+      cleanup: { baseline: subject.snapshotResources() },
+    });
+    const failingInvariant = race.invariant;
+    let thrown: unknown;
+    try {
+      await runBrowserConformanceScenarioWithReplay(scenario, subject, {
+        workspaceRoot: root,
+        failingInvariant,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe("race invariant failed");
+    expect(subject.disposeCount).toBe(1);
+    const replayPath = join(root, ".dev", "verification", "browser-conformance", `replay-${scenario.seed}.json`);
+    const replay = JSON.parse(await readFile(replayPath, "utf8")) as { seed: number; failingInvariant: string };
+    expect(replay.seed).toBe(scenario.seed);
+    expect(replay.failingInvariant).toBe(failingInvariant);
+  });
+
+  it("writes a failed replay even when the subject cannot snapshot its run", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mcode-browser-snapshot-replay-"));
+    temporaryRoots.push(root);
+    const scenario = createBrowserConformanceScenario({
+      id: "snapshot-failure",
+      seed: "snapshot-failure-seed",
+      commands: [{ id: "inspect", operation: "inspect" }],
+      cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+    });
+    const subject = new RecordingSubject(false, true);
+    await expect(runBrowserConformanceScenarioWithReplay(scenario, subject, {
+      workspaceRoot: root,
+      failingInvariant: "snapshot remains available for replay",
+    })).rejects.toThrow("snapshot unavailable");
+    const replayPath = join(root, ".dev", "verification", "browser-conformance", `replay-${scenario.seed}.json`);
+    const replay = JSON.parse(await readFile(replayPath, "utf8")) as { failingInvariant: string; run: { outcome: { status: string } } };
+    expect(replay.failingInvariant).toBe("snapshot remains available for replay");
+    expect(replay.run.outcome.status).toBe("failed");
+  });
+
+  it("uses the replay runner around the shared executor scenario failure path", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mcode-browser-executor-replay-"));
+    temporaryRoots.push(root);
+    const parity = createBrowserExecutorParityScenario();
+    const subject = new RecordingSubject(true);
+    await expect(runBrowserConformanceScenarioWithReplay(parity.scenario, subject, {
+      workspaceRoot: root,
+      failingInvariant: "shared executor invariant",
+    })).rejects.toThrow("race invariant failed");
+    const replayPath = join(root, ".dev", "verification", "browser-conformance", `replay-${parity.scenario.seed}.json`);
+    const replay = JSON.parse(await readFile(replayPath, "utf8")) as { scenarioId: string; failingInvariant: string };
+    expect(replay.scenarioId).toBe(parity.scenario.id);
+    expect(replay.failingInvariant).toBe("shared executor invariant");
+  });
+
+  it("injects each scheduled event once and validates checkpoints in the shared runner", async () => {
+    const schedule = createBrowserConformanceSchedule({ seed: 91, maxCommands: 1, maxEvents: 1, maxCheckpoints: 1, maxTick: 3, eventCount: 1, checkpointCount: 1 });
+    const scenario = createBrowserConformanceScenario({ id: "runner-order", seed: 91, commands: [{ id: "inspect", operation: "inspect" }], schedule, cleanup: { baseline: createBrowserConformanceResourceSnapshot() } });
+    const subject = new RecordingSubject();
+    await runBrowserConformanceExecutorScenario(scenario, subject);
+    expect(subject.injectedEvents).toHaveLength(1);
+    expect(subject.disposeCount).toBe(1);
+
+    const failingSchedule = { ...schedule, checkpoints: schedule.checkpoints.map((checkpoint) => ({ ...checkpoint, expectedRevisions: { ...checkpoint.expectedRevisions, host: 1 } })) };
+    const failingScenario = createBrowserConformanceScenario({ id: "runner-checkpoint-failure", seed: 91, commands: [{ id: "inspect", operation: "inspect" }], schedule: failingSchedule, cleanup: { baseline: createBrowserConformanceResourceSnapshot() } });
+    const failingSubject = new RecordingSubject();
+    await expect(runBrowserConformanceExecutorScenario(failingScenario, failingSubject)).rejects.toThrow(/checkpoint/);
+    expect(failingSubject.injectedEvents).toHaveLength(1);
+    expect(failingSubject.disposeCount).toBe(1);
+  });
+
+  it("orders a same-tick checkpoint before a later-ordinal event", async () => {
+    const schedule = {
+      ...createBrowserConformanceSchedule({ seed: 92, maxCommands: 1, maxEvents: 1, maxCheckpoints: 1, maxTick: 2, eventCount: 0, checkpointCount: 0 }),
+      events: [{ order: { tick: 0, ordinal: 1 }, kind: "host-disconnect" as const, revision: "host" as const }],
+      checkpoints: [{ order: { tick: 0, ordinal: 0 }, id: "before-host", label: "before host", expectedRevisions: { host: 0 } }],
+    };
+    const scenario = createBrowserConformanceScenario({
+      id: "same-tick-ordinal-order",
+      seed: 92,
+      commands: [{ id: "inspect", operation: "inspect" }],
+      schedule,
+      cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+    });
+    const subject = new RecordingSubject();
+    await runBrowserConformanceExecutorScenario(scenario, subject);
+    expect(subject.injectedEvents.map((event) => event.revision)).toEqual(["host"]);
+    expect(subject.observedOrder.filter((entry) => entry.startsWith("command:") || entry.startsWith("event:")))
+      .toEqual(["command:inspect", "event:host-disconnect"]);
+  });
+
+  it("advances the virtual clock again when a later tick remains after commands", async () => {
+    const schedule = {
+      ...createBrowserConformanceSchedule({ seed: 93, maxCommands: 1, maxEvents: 1, maxCheckpoints: 0, maxTick: 4, eventCount: 0, checkpointCount: 0 }),
+      events: [{ order: { tick: 4, ordinal: 0 }, kind: "timeout" as const }],
+    };
+    const scenario = createBrowserConformanceScenario({
+      id: "later-tick-advancement",
+      seed: 93,
+      commands: [{ id: "inspect", operation: "inspect" }],
+      schedule,
+      cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+    });
+    const subject = new RecordingSubject();
+    await runBrowserConformanceExecutorScenario(scenario, subject);
+    expect(subject.advancedTicks).toEqual([0, 4]);
+  });
+
+  it("enforces cleanup after disposal while preserving an explicitly bounded target", async () => {
+    const final = createBrowserConformanceResourceSnapshot({
+      identities: { targets: [{ id: "target-a", generation: 1 }] },
+    });
+    const scenario = createBrowserConformanceScenario({
+      id: "cleanup-bound",
+      seed: 94,
+      commands: [],
+      cleanup: { baseline: createBrowserConformanceResourceSnapshot(), allowedGrowth: { targets: 1 } },
+    });
+    const subject = new CleanupSubject(final);
+    await runBrowserConformanceExecutorScenario(scenario, subject);
+    expect(subject.disposeCount).toBe(1);
+  });
+
+  it.each([
+    ["growth", createBrowserConformanceResourceSnapshot({ identities: { targets: [{ id: "target-a", generation: 1 }, { id: "target-b", generation: 1 }] } }), "targets"],
+    ["identity", createBrowserConformanceResourceSnapshot({ identities: { targets: [{ id: "target-a", generation: 2 }] } }), "targets"],
+  ] as const)("turns cleanup %s into a replayable scenario failure", async (_kind, final, resource) => {
+    const root = await mkdtemp(join(tmpdir(), "mcode-browser-cleanup-replay-"));
+    temporaryRoots.push(root);
+    const baseline = createBrowserConformanceResourceSnapshot({ identities: { targets: [{ id: "target-a", generation: 1 }] } });
+    const scenario = createBrowserConformanceScenario({
+      id: `cleanup-${_kind}`,
+      seed: 95,
+      commands: [],
+      cleanup: { baseline, allowedGrowth: { targets: 0 } },
+    });
+    const subject = new CleanupSubject(final);
+    await expect(runBrowserConformanceScenarioWithReplay(scenario, subject, {
+      workspaceRoot: root,
+      failingInvariant: "cleanup resources must be released",
+    })).rejects.toThrow(new RegExp(`cleanup failed: ${resource}`));
+    expect(subject.disposeCount).toBe(1);
+    const replayPath = join(root, ".dev", "verification", "browser-conformance", `replay-${scenario.seed}.json`);
+    const replay = JSON.parse(await readFile(replayPath, "utf8")) as { cleanup: { comparison?: { violations?: Array<{ resource: string }> } } };
+    expect(replay.cleanup.comparison?.violations?.map((violation) => violation.resource)).toContain(resource);
+  });
+});
+
+async function executeScheduledSubject(
+  subject: BrowserConformanceSubject & { readonly events?: readonly BrowserConformanceScheduledEvent[] },
+  schedule: { readonly events: readonly BrowserConformanceScheduledEvent[] },
+): Promise<void> {
+  for (const event of schedule.events) subject.schedule(event);
+  for (const event of schedule.events) {
+    await subject.advanceClock(event.order.tick);
+    await subject.injectExternalEvent(event);
+  }
+}
+
+class RecordingSubject implements BrowserConformanceSubject {
+  readonly injectedEvents: BrowserConformanceScheduledEvent[] = [];
+  readonly advancedTicks: number[] = [];
+  readonly observedOrder: string[] = [];
+  private disposed = false;
+  private outcome = normalizeBrowserConformanceRun({ finalState: { resources: {} } });
+  disposeCount = 0;
+
+  constructor(private readonly failDispatch = false, private readonly failSnapshot = false) {}
+
+  schedule(_event: BrowserConformanceScheduledEvent): void {}
+  async advanceClock(tick: number): Promise<void> { this.advancedTicks.push(tick); }
+  async injectExternalEvent(event: BrowserConformanceScheduledEvent): Promise<void> {
+    if (!this.disposed) {
+      this.injectedEvents.push(event);
+      this.observedOrder.push(`event:${event.kind}`);
+      if (event.revision) {
+        const revisions = { ...this.outcome.finalState.revisions, [event.revision]: this.outcome.finalState.revisions[event.revision] + 1 };
+        this.outcome = normalizeBrowserConformanceRun({ ...this.outcome, finalState: { ...this.outcome.finalState, revisions } });
+      }
+    }
+  }
+  async dispatch(command: { id: string; operation: "inspect" }): Promise<BrowserConformanceReceipt> {
+    if (this.failDispatch) throw new Error("race invariant failed");
+    this.observedOrder.push(`command:${command.id}`);
+    const receipt = normalizeBrowserConformanceRun({ receipts: [{ commandId: command.id, operation: command.operation, status: "satisfied", effect: "none", recovery: "none" }] }).receipts[0]!;
+    this.outcome = normalizeBrowserConformanceRun({ receipts: [receipt], outcome: { status: "completed", effect: "none", recovery: "none" }, finalState: { resources: {} } });
+    return receipt;
+  }
+  snapshotOutcome(): BrowserConformanceNormalizedRun {
+    if (this.failSnapshot) throw new Error("snapshot unavailable");
+    return this.outcome;
+  }
+  snapshotResources(): BrowserConformanceResourceSnapshot { return createBrowserConformanceResourceSnapshot(); }
+  async drainToQuiescence(): Promise<void> {}
+  async dispose(): Promise<void> { this.disposeCount += 1; this.disposed = true; }
+}
+
+class CleanupSubject implements BrowserConformanceSubject {
+  disposeCount = 0;
+  private disposed = false;
+  private readonly outcome = normalizeBrowserConformanceRun({ finalState: { resources: {} } });
+
+  constructor(private readonly finalResources: BrowserConformanceResourceSnapshot) {}
+
+  schedule(_event: BrowserConformanceScheduledEvent): void {}
+  async advanceClock(_tick: number): Promise<void> {}
+  async injectExternalEvent(_event: BrowserConformanceScheduledEvent): Promise<void> {}
+  async dispatch(_command: { id: string; operation: "inspect" }): Promise<BrowserConformanceReceipt> {
+    throw new Error("cleanup subject has no commands");
+  }
+  snapshotOutcome(): BrowserConformanceNormalizedRun { return this.outcome; }
+  snapshotResources(): BrowserConformanceResourceSnapshot {
+    return this.disposed ? this.finalResources : this.finalResources;
+  }
+  async drainToQuiescence(): Promise<void> {}
+  async dispose(): Promise<void> { this.disposeCount += 1; this.disposed = true; }
+}
+
+class TerminalSubject implements BrowserConformanceSubject {
+  private disposed = false;
+  private readonly resources = createBrowserConformanceResourceSnapshot();
+  private outcome: BrowserConformanceNormalizedRun;
+
+  constructor(status: "completed" | "failed" | "interrupted") {
+    this.outcome = normalizeBrowserConformanceRun({ outcome: { status, effect: status === "completed" ? "complete" : "none", recovery: status === "completed" ? "none" : "inspect" }, finalState: { resources: this.resources } });
+  }
+  schedule(_event: BrowserConformanceScheduledEvent): void {}
+  async advanceClock(_tick: number): Promise<void> {}
+  async injectExternalEvent(_event: BrowserConformanceScheduledEvent): Promise<void> {}
+  async dispatch(command: { id: string; operation: "open" }): Promise<BrowserConformanceReceipt> {
+    const receipt = normalizeBrowserConformanceRun({ receipts: [{ commandId: command.id, operation: command.operation, status: "applied", effect: "created", recovery: "none" }], outcome: this.outcome.outcome, finalState: { resources: this.resources } }).receipts[0]!;
+    this.outcome = normalizeBrowserConformanceRun({ receipts: [receipt], outcome: this.outcome.outcome, finalState: { resources: this.resources } });
+    return receipt;
+  }
+  snapshotOutcome(): BrowserConformanceNormalizedRun { return this.outcome; }
+  snapshotResources(): BrowserConformanceResourceSnapshot { return this.resources; }
+  async drainToQuiescence(): Promise<void> {}
+  async dispose(): Promise<void> { this.disposed = true; }
+}

--- a/packages/browser-conformance/src/__tests__/races.test.ts
+++ b/packages/browser-conformance/src/__tests__/races.test.ts
@@ -1,9 +1,11 @@
+import { EventEmitter } from "node:events";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BROWSER_CONFORMANCE_EVENT_KINDS,
+  BROWSER_CONFORMANCE_FAULT_CONTROL_KINDS,
   BROWSER_CONFORMANCE_HIGH_RISK_REVISION_COMBINATIONS,
   BROWSER_CONFORMANCE_RACE_CATALOGUE,
   createBrowserConformanceRaceSchedules,
@@ -13,8 +15,11 @@ import {
   createBrowserConformanceRevisionRaceSchedules,
   createBrowserExecutorParityScenario,
   normalizeBrowserConformanceRun,
+  BrowserConformanceFaultController,
+  BrowserConformanceInjectedFaultError,
   runBrowserConformanceScenarioWithReplay,
   runBrowserConformanceExecutorScenario,
+  type BrowserConformanceCommand,
   type BrowserConformanceNormalizedRun,
   type BrowserConformanceReceipt,
   type BrowserConformanceResourceSnapshot,
@@ -237,6 +242,43 @@ describe("Browser conformance named races", () => {
     expect(subject.advancedTicks).toEqual([0, 4]);
   });
 
+  it.each(BROWSER_CONFORMANCE_FAULT_CONTROL_KINDS)("applies bounded %s controls and becomes inert after disposal", async (kind) => {
+    const eventKinds = new Set(["scheduling", "host-transport", "target-registration", "capability-revision"]);
+    const eventKind = kind === "host-transport"
+      ? "host-disconnect" as const
+      : kind === "target-registration"
+        ? "target-register" as const
+        : kind === "capability-revision"
+          ? "capability-revision" as const
+          : "timeout" as const;
+    const schedule = createBrowserConformanceSchedule({ seed: 96, maxCommands: 1, maxEvents: eventKinds.has(kind) ? 1 : 0, maxCheckpoints: kind === "checkpoint" ? 1 : 0, maxTick: 1, eventCount: 0, checkpointCount: 0 });
+    const scenario = createBrowserConformanceScenario({
+      id: `fault-${kind}`,
+      seed: 96,
+      commands: kind === "executor-dispatch" || kind === "receipt-delivery" ? [{ id: "inspect", operation: "inspect" }] : [],
+      schedule: {
+        ...schedule,
+        events: eventKinds.has(kind) ? [{ order: { tick: 0, ordinal: 0 }, kind: eventKind }] : [],
+        checkpoints: kind === "checkpoint" ? [{ order: { tick: 0, ordinal: 0 }, id: "fault-checkpoint", label: "fault checkpoint", expectedRevisions: {} }] : [],
+      },
+      cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+    });
+    const controller = new BrowserConformanceFaultController({ kind });
+    const subject = new RecordingSubject();
+    await expect(runBrowserConformanceExecutorScenario(scenario, subject, { faultController: controller })).rejects.toBeInstanceOf(BrowserConformanceInjectedFaultError);
+    expect(controller.callsFor(kind)).toBe(1);
+    controller.hit(kind);
+    expect(controller.callsFor(kind)).toBe(1);
+    expect(controller.isDisposed).toBe(true);
+    expect(subject.disposeCount).toBe(1);
+  });
+
+  it("rejects malformed fault control kinds at the runtime boundary", () => {
+    const malformed = { kind: "not-a-browser-control", occurrence: 1 } as unknown as ConstructorParameters<typeof BrowserConformanceFaultController>[0];
+    expect(() => new BrowserConformanceFaultController(malformed))
+      .toThrow("Unknown Browser conformance fault control kind");
+  });
+
   it("enforces cleanup after disposal while preserving an explicitly bounded target", async () => {
     const final = createBrowserConformanceResourceSnapshot({
       identities: { targets: [{ id: "target-a", generation: 1 }] },
@@ -250,6 +292,45 @@ describe("Browser conformance named races", () => {
     const subject = new CleanupSubject(final);
     await runBrowserConformanceExecutorScenario(scenario, subject);
     expect(subject.disposeCount).toBe(1);
+  });
+
+  it("releases every tracked resource category and ignores late work", async () => {
+    const subject = new LifecycleResourceSubject();
+    const scenario = createBrowserConformanceScenario({
+      id: "cleanup-all-resource-categories",
+      seed: 97,
+      commands: [{ id: "inspect", operation: "inspect" }],
+      schedule: {
+        ...createBrowserConformanceSchedule({
+        seed: 97,
+        maxCommands: 1,
+        maxEvents: 1,
+        maxCheckpoints: 0,
+        maxTick: 0,
+        eventCount: 0,
+        checkpointCount: 0,
+        }),
+        events: [{ order: { tick: 0, ordinal: 0 }, kind: "user-takeover" }],
+      },
+      cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+    });
+    const run = await runBrowserConformanceExecutorScenario(scenario, subject);
+    expect(run.finalState.resources).toMatchObject({
+      requests: 1,
+      queues: 1,
+      timers: 1,
+      listeners: 1,
+      heldInput: 1,
+      controllerLeases: 1,
+      targets: 1,
+      replayEntries: 1,
+      registries: 1,
+      buffers: 1,
+    });
+    expect(subject.snapshotResources()).toEqual(createBrowserConformanceResourceSnapshot());
+    await subject.injectExternalEvent({ order: { tick: 1, ordinal: 1 }, kind: "late-event" });
+    await subject.drainToQuiescence();
+    expect(subject.snapshotResources()).toEqual(createBrowserConformanceResourceSnapshot());
   });
 
   it.each([
@@ -345,6 +426,107 @@ class CleanupSubject implements BrowserConformanceSubject {
   }
   async drainToQuiescence(): Promise<void> {}
   async dispose(): Promise<void> { this.disposeCount += 1; this.disposed = true; }
+}
+
+class LifecycleResourceSubject implements BrowserConformanceSubject {
+  private readonly emitter = new EventEmitter();
+  private readonly requests = new Map<string, BrowserConformanceCommand>();
+  private readonly queues: BrowserConformanceScheduledEvent[] = [];
+  private readonly timers = new Set<number>();
+  private readonly heldInput = new Set<string>();
+  private readonly controllerLeases = new Set<string>();
+  private readonly targets = new Map<string, { id: string; generation: number }>();
+  private readonly replayEntries = new Map<string, string>();
+  private readonly registries = new Map<string, string>();
+  private readonly buffers: BrowserConformanceReceipt[] = [];
+  private disposed = false;
+  private readonly listener = (): void => undefined;
+
+  constructor() {
+    this.emitter.on("resource", this.listener);
+  }
+
+  schedule(event: BrowserConformanceScheduledEvent): void {
+    if (!this.disposed) this.queues.push(event);
+  }
+
+  async advanceClock(tick: number): Promise<void> {
+    if (!this.disposed) this.timers.add(tick);
+  }
+
+  async injectExternalEvent(event: BrowserConformanceScheduledEvent): Promise<void> {
+    if (this.disposed) return;
+    if (event.kind === "target-close") this.targets.delete("tab");
+    if (event.kind === "target-register") this.targets.set("tab", { id: "tab", generation: 2 });
+    if (event.kind === "user-takeover") this.heldInput.add("user-control");
+  }
+
+  async dispatch(command: BrowserConformanceCommand): Promise<BrowserConformanceReceipt> {
+    if (this.disposed) throw new Error("lifecycle subject disposed");
+    this.requests.set(command.id, command);
+    this.heldInput.add(command.id);
+    this.controllerLeases.add(command.id);
+    this.targets.set("tab", { id: "tab", generation: 1 });
+    this.registries.set(command.id, "active");
+    const receipt = normalizeBrowserConformanceRun({
+      receipts: [{ commandId: command.id, operation: command.operation, status: "satisfied", effect: "none", recovery: "none" }],
+      finalState: { resources: {} },
+    }).receipts[0]!;
+    this.buffers.push(receipt);
+    this.heldInput.delete(command.id);
+    this.replayEntries.set(command.id, command.id);
+    return receipt;
+  }
+
+  snapshotOutcome(): BrowserConformanceNormalizedRun {
+    return normalizeBrowserConformanceRun({
+      receipts: this.buffers,
+      outcome: { status: "completed", effect: "none", recovery: "none" },
+      finalState: { resources: this.snapshotResources() },
+    });
+  }
+
+  snapshotResources(): BrowserConformanceResourceSnapshot {
+    const listeners = this.emitter.listenerCount("resource");
+    return createBrowserConformanceResourceSnapshot({
+      counts: {
+        requests: this.requests.size,
+        queues: this.queues.length,
+        timers: this.timers.size,
+        listeners,
+        heldInput: this.heldInput.size,
+        controllerLeases: this.controllerLeases.size,
+        targets: this.targets.size,
+        replayEntries: this.replayEntries.size,
+        registries: this.registries.size,
+        buffers: this.buffers.length,
+      },
+      identities: {
+        targets: [...this.targets.values()],
+      },
+    });
+  }
+
+  async drainToQuiescence(): Promise<void> {
+    this.requests.clear();
+    this.queues.length = 0;
+    this.timers.clear();
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.emitter.removeListener("resource", this.listener);
+    this.requests.clear();
+    this.queues.length = 0;
+    this.timers.clear();
+    this.heldInput.clear();
+    this.controllerLeases.clear();
+    this.targets.clear();
+    this.replayEntries.clear();
+    this.registries.clear();
+    this.buffers.length = 0;
+  }
 }
 
 class TerminalSubject implements BrowserConformanceSubject {

--- a/packages/browser-conformance/src/__tests__/replay.test.ts
+++ b/packages/browser-conformance/src/__tests__/replay.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BROWSER_CONFORMANCE_REPLAY_DIRECTORY,
+  BROWSER_CONFORMANCE_REPLAY_MAX_BYTES,
+  createBrowserConformanceReplayBundle,
+  createBrowserConformanceResourceSnapshot,
+  createBrowserConformanceScenario,
+  createBrowserConformanceSchedule,
+  normalizeBrowserConformanceRun,
+  sanitizeBrowserConformanceValue,
+  serializeBrowserConformanceReplayBundle,
+  writeBrowserConformanceReplayBundle,
+} from "../index.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function createReplayInput() {
+  const scenario = createBrowserConformanceScenario({
+    id: "takeover-race",
+    seed: 42,
+    commands: [{ id: "command-1", operation: "act", args: { typedText: "secret" } }],
+    schedule: createBrowserConformanceSchedule({ seed: 42, maxCommands: 1, maxEvents: 2, eventCount: 1 }),
+    cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
+  });
+  return {
+    scenario,
+    run: normalizeBrowserConformanceRun({
+      receipts: [{ order: { tick: 1, ordinal: 0 }, commandId: "command-1", operation: "act", status: "interrupted", effect: "partial", recovery: "yield_to_user", errorCode: "USER_TAKEOVER", errorStage: "effect", ownership: "user", revisions: { control: 2 } }],
+      outcome: { status: "interrupted", effect: "partial", recovery: "yield_to_user", errorCode: "USER_TAKEOVER", errorStage: "effect", ownership: "user", revisions: { control: 2 } },
+      finalState: { readiness: "human-control", controlOwner: "user", currentUrl: "https://example.test/app?token=secret", resources: {} },
+    }),
+    cleanup: {
+      baseline: createBrowserConformanceResourceSnapshot(),
+      final: createBrowserConformanceResourceSnapshot(),
+    },
+    failingInvariant: "no-late-state-resurrection",
+  };
+}
+
+describe("Browser conformance replay bundles", () => {
+  it("sanitizes sensitive payloads and preserves the seed and failing invariant", () => {
+    const bundle = createBrowserConformanceReplayBundle(createReplayInput());
+    const serialized = serializeBrowserConformanceReplayBundle(bundle);
+
+    expect(bundle.seed).toBe(42);
+    expect(bundle.failingInvariant).toBe("no-late-state-resurrection");
+    expect(serialized).not.toContain("typedText");
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("args");
+    expect(new TextEncoder().encode(serialized).byteLength).toBeLessThanOrEqual(BROWSER_CONFORMANCE_REPLAY_MAX_BYTES);
+  });
+
+  it("bounds generic sanitization and writes only below disposable verification", async () => {
+    const sanitized = sanitizeBrowserConformanceValue({
+      requestId: "dynamic",
+      headers: { authorization: "secret" },
+      body: "raw body",
+      location: "https://example.test/path?token=secret#fragment",
+      nested: Array.from({ length: 1_000 }, () => "x"),
+    });
+    expect(JSON.stringify(sanitized)).not.toContain("dynamic");
+    expect(JSON.stringify(sanitized)).not.toContain("raw body");
+    expect(JSON.stringify(sanitized)).not.toContain("secret");
+    expect((sanitized as { nested: readonly unknown[] }).nested).toHaveLength(128);
+
+    const root = await mkdtemp(join(tmpdir(), "mcode-browser-conformance-"));
+    temporaryRoots.push(root);
+    const path = await writeBrowserConformanceReplayBundle(createBrowserConformanceReplayBundle(createReplayInput()), { workspaceRoot: root });
+    expect(path.startsWith(join(root, BROWSER_CONFORMANCE_REPLAY_DIRECTORY))).toBe(true);
+    expect(JSON.parse(await readFile(path, "utf8")).seed).toBe(42);
+  });
+});

--- a/packages/browser-conformance/src/__tests__/replay.test.ts
+++ b/packages/browser-conformance/src/__tests__/replay.test.ts
@@ -89,6 +89,17 @@ describe("Browser conformance replay bundles", () => {
     expect(new TextEncoder().encode(serialized).byteLength).toBeLessThanOrEqual(BROWSER_CONFORMANCE_REPLAY_MAX_BYTES);
   });
 
+  it("sanitizes URLs and credential-shaped text in the invariant label", () => {
+    const input = createReplayInput();
+    const bundle = createBrowserConformanceReplayBundle({
+      ...input,
+      failingInvariant: "see https://example.test/path?token=secret#fragment token=secret",
+    });
+    expect(bundle.failingInvariant).toContain("https://example.test/path");
+    expect(bundle.failingInvariant).not.toContain("token=secret");
+    expect(bundle.failingInvariant).not.toContain("#fragment");
+  });
+
   it("bounds generic sanitization and writes only below disposable verification", async () => {
     const sanitized = sanitizeBrowserConformanceValue({
       requestId: "dynamic",

--- a/packages/browser-conformance/src/__tests__/replay.test.ts
+++ b/packages/browser-conformance/src/__tests__/replay.test.ts
@@ -45,6 +45,38 @@ function createReplayInput() {
 }
 
 describe("Browser conformance replay bundles", () => {
+  it("degrades maximal runs deterministically while preserving required replay identity", () => {
+    const input = createReplayInput();
+    const maximal = {
+      ...input,
+      run: {
+        ...input.run,
+        receipts: Array.from({ length: 256 }, (_, index) => ({
+          ...input.run.receipts[0],
+          order: { tick: index, ordinal: index },
+        })),
+        visibleObservations: Array.from({ length: 256 }, () => input.run.visibleObservations[0] ?? {
+          surface: "browser" as const,
+          readiness: "ready" as const,
+          controlOwner: "none" as const,
+          tabCount: 0,
+          currentUrl: null,
+          title: "observation",
+          action: null,
+          truncated: false,
+        }),
+      },
+    };
+    const bundle = createBrowserConformanceReplayBundle(maximal);
+    expect(bundle.schemaVersion).toBe(1);
+    expect(bundle.generatorVersion).toBe("browser-v2-seeded-v1");
+    expect(bundle.scenarioId).toBe("takeover-race");
+    expect(bundle.seed).toBe(42);
+    expect(bundle.failingInvariant).toBe("no-late-state-resurrection");
+    expect(new TextEncoder().encode(serializeBrowserConformanceReplayBundle(bundle)).byteLength)
+      .toBeLessThanOrEqual(BROWSER_CONFORMANCE_REPLAY_MAX_BYTES);
+  });
+
   it("sanitizes sensitive payloads and preserves the seed and failing invariant", () => {
     const bundle = createBrowserConformanceReplayBundle(createReplayInput());
     const serialized = serializeBrowserConformanceReplayBundle(bundle);
@@ -62,11 +94,15 @@ describe("Browser conformance replay bundles", () => {
       requestId: "dynamic",
       headers: { authorization: "secret" },
       body: "raw body",
+      typedText: "raw typed content",
+      screenshotData: "raw screenshot bytes",
       location: "https://example.test/path?token=secret#fragment",
       nested: Array.from({ length: 1_000 }, () => "x"),
     });
     expect(JSON.stringify(sanitized)).not.toContain("dynamic");
     expect(JSON.stringify(sanitized)).not.toContain("raw body");
+    expect(JSON.stringify(sanitized)).not.toContain("raw typed content");
+    expect(JSON.stringify(sanitized)).not.toContain("raw screenshot bytes");
     expect(JSON.stringify(sanitized)).not.toContain("secret");
     expect((sanitized as { nested: readonly unknown[] }).nested).toHaveLength(128);
 

--- a/packages/browser-conformance/src/__tests__/schedule.test.ts
+++ b/packages/browser-conformance/src/__tests__/schedule.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS,
+  createBrowserConformanceRandom,
+  createBrowserConformanceSchedule,
+} from "../index.js";
+
+describe("Browser conformance deterministic schedules", () => {
+  it("replays the same seed byte-for-byte and gives events a total order", () => {
+    const first = createBrowserConformanceSchedule({
+      seed: "bootstrap-race",
+      maxCommands: 12,
+      maxEvents: 10,
+      maxCheckpoints: 4,
+      maxTick: 30,
+      eventCount: 10,
+      checkpointCount: 4,
+    });
+    const second = createBrowserConformanceSchedule({
+      seed: "bootstrap-race",
+      maxCommands: 12,
+      maxEvents: 10,
+      maxCheckpoints: 4,
+      maxTick: 30,
+      eventCount: 10,
+      checkpointCount: 4,
+    });
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+    const orders = [...first.events, ...first.checkpoints]
+      .map((item) => `${item.order.tick}:${item.order.ordinal}`);
+    expect(new Set(orders).size).toBe(orders.length);
+    expect(first.events.every((event) => event.order.tick <= first.bounds.maxTick)).toBe(true);
+  });
+
+  it("clamps generated work to hard bounds and rejects invalid random bounds", () => {
+    const schedule = createBrowserConformanceSchedule({
+      seed: 7,
+      maxCommands: Number.MAX_SAFE_INTEGER,
+      maxEvents: Number.MAX_SAFE_INTEGER,
+      maxCheckpoints: Number.MAX_SAFE_INTEGER,
+      maxTick: Number.MAX_SAFE_INTEGER,
+      eventCount: Number.MAX_SAFE_INTEGER,
+      checkpointCount: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(schedule.bounds.maxCommands).toBe(BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS);
+    expect(schedule.events.length).toBe(BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS);
+    expect(schedule.checkpoints.length).toBe(BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS);
+    expect(() => createBrowserConformanceRandom(1).integer(0)).toThrow(RangeError);
+  });
+});

--- a/packages/browser-conformance/src/cleanup.ts
+++ b/packages/browser-conformance/src/cleanup.ts
@@ -1,0 +1,102 @@
+import {
+  BROWSER_CONFORMANCE_RESOURCE_KEYS,
+  createBrowserConformanceRevisionVector,
+  type BrowserConformanceCleanupInvariant,
+  type BrowserConformanceResourceBounds,
+  type BrowserConformanceResourceIdentity,
+  type BrowserConformanceResourceKey,
+  type BrowserConformanceResourceSnapshot,
+  type BrowserConformanceRevisionVector,
+} from "./model.js";
+
+/** Partial resource input accepted when constructing a cleanup snapshot. */
+export interface BrowserConformanceResourceSnapshotInput {
+  readonly counts?: Partial<Readonly<Record<BrowserConformanceResourceKey, number>>>;
+  readonly identities?: Partial<
+    Readonly<Record<BrowserConformanceResourceKey, readonly BrowserConformanceResourceIdentity[]>>
+  >;
+  readonly revisions?: Partial<BrowserConformanceRevisionVector>;
+}
+
+/** One named cleanup violation produced by baseline comparison. */
+export interface BrowserConformanceCleanupViolation {
+  readonly resource: BrowserConformanceResourceKey;
+  readonly reason: "growth" | "identity" | "invalid-count";
+  readonly baseline: number;
+  readonly final: number;
+  readonly allowedGrowth: number;
+}
+
+/** Result of comparing terminal resources with their scoped baseline. */
+export interface BrowserConformanceCleanupComparison {
+  readonly ok: boolean;
+  readonly violations: readonly BrowserConformanceCleanupViolation[];
+  readonly delta: Readonly<Record<BrowserConformanceResourceKey, number>>;
+}
+
+/** Creates a complete zero-valued resource snapshot with optional identities. */
+export function createBrowserConformanceResourceSnapshot(
+  input: BrowserConformanceResourceSnapshotInput = {},
+): BrowserConformanceResourceSnapshot {
+  const identities = Object.fromEntries(
+    BROWSER_CONFORMANCE_RESOURCE_KEYS.map((key) => [key, input.identities?.[key] ?? []]),
+  ) as Record<BrowserConformanceResourceKey, readonly BrowserConformanceResourceIdentity[]>;
+  return {
+    requests: input.counts?.requests ?? identities.requests.length,
+    queues: input.counts?.queues ?? identities.queues.length,
+    timers: input.counts?.timers ?? identities.timers.length,
+    listeners: input.counts?.listeners ?? identities.listeners.length,
+    heldInput: input.counts?.heldInput ?? identities.heldInput.length,
+    controllerLeases: input.counts?.controllerLeases ?? identities.controllerLeases.length,
+    targets: input.counts?.targets ?? identities.targets.length,
+    replayEntries: input.counts?.replayEntries ?? identities.replayEntries.length,
+    registries: input.counts?.registries ?? identities.registries.length,
+    buffers: input.counts?.buffers ?? identities.buffers.length,
+    identities,
+    revisions: createBrowserConformanceRevisionVector(input.revisions),
+  };
+}
+
+/** Compares terminal resources with a baseline and declared growth bounds. */
+export function compareBrowserConformanceCleanup(
+  baseline: BrowserConformanceResourceSnapshot,
+  final: BrowserConformanceResourceSnapshot,
+  allowedGrowth: BrowserConformanceResourceBounds = {},
+): BrowserConformanceCleanupComparison {
+  const violations: BrowserConformanceCleanupViolation[] = [];
+  const delta = {} as Record<BrowserConformanceResourceKey, number>;
+  for (const resource of BROWSER_CONFORMANCE_RESOURCE_KEYS) {
+    const before = baseline[resource];
+    const after = final[resource];
+    const growth = allowedGrowth[resource] ?? 0;
+    delta[resource] = after - before;
+    if (!Number.isSafeInteger(before) || !Number.isSafeInteger(after) || before < 0 || after < 0) {
+      violations.push({ resource, reason: "invalid-count", baseline: before, final: after, allowedGrowth: growth });
+      continue;
+    }
+    if (!Number.isSafeInteger(growth) || growth < 0 || after > before + growth) {
+      violations.push({ resource, reason: "growth", baseline: before, final: after, allowedGrowth: growth });
+      continue;
+    }
+    if (!hasBaselineIdentities(baseline.identities[resource], final.identities[resource])) {
+      violations.push({ resource, reason: "identity", baseline: before, final: after, allowedGrowth: growth });
+    }
+  }
+  return { ok: violations.length === 0, violations, delta };
+}
+
+/** Compares a snapshot against the invariant's baseline and declared bounds. */
+export function checkBrowserConformanceCleanup(
+  invariant: BrowserConformanceCleanupInvariant,
+  final: BrowserConformanceResourceSnapshot,
+): BrowserConformanceCleanupComparison {
+  return compareBrowserConformanceCleanup(invariant.baseline, final, invariant.allowedGrowth);
+}
+
+function hasBaselineIdentities(
+  baseline: readonly BrowserConformanceResourceIdentity[],
+  final: readonly BrowserConformanceResourceIdentity[],
+): boolean {
+  const finalKeys = new Set(final.map((identity) => `${identity.id}\u0000${identity.generation}`));
+  return baseline.every((identity) => finalKeys.has(`${identity.id}\u0000${identity.generation}`));
+}

--- a/packages/browser-conformance/src/cleanup.ts
+++ b/packages/browser-conformance/src/cleanup.ts
@@ -41,6 +41,9 @@ export function createBrowserConformanceResourceSnapshot(
   const identities = Object.fromEntries(
     BROWSER_CONFORMANCE_RESOURCE_KEYS.map((key) => [key, input.identities?.[key] ?? []]),
   ) as Record<BrowserConformanceResourceKey, readonly BrowserConformanceResourceIdentity[]>;
+  for (const key of BROWSER_CONFORMANCE_RESOURCE_KEYS) {
+    validateIdentities(key, identities[key], input.counts?.[key]);
+  }
   return {
     requests: input.counts?.requests ?? identities.requests.length,
     queues: input.counts?.queues ?? identities.queues.length,
@@ -63,6 +66,8 @@ export function compareBrowserConformanceCleanup(
   final: BrowserConformanceResourceSnapshot,
   allowedGrowth: BrowserConformanceResourceBounds = {},
 ): BrowserConformanceCleanupComparison {
+  validateSnapshot(baseline, "baseline");
+  validateSnapshot(final, "final");
   const violations: BrowserConformanceCleanupViolation[] = [];
   const delta = {} as Record<BrowserConformanceResourceKey, number>;
   for (const resource of BROWSER_CONFORMANCE_RESOURCE_KEYS) {
@@ -83,6 +88,31 @@ export function compareBrowserConformanceCleanup(
     }
   }
   return { ok: violations.length === 0, violations, delta };
+}
+
+function validateSnapshot(snapshot: BrowserConformanceResourceSnapshot, label: string): void {
+  for (const resource of BROWSER_CONFORMANCE_RESOURCE_KEYS) {
+    validateIdentities(resource, snapshot.identities[resource], snapshot[resource], label);
+  }
+}
+
+function validateIdentities(
+  resource: BrowserConformanceResourceKey,
+  identities: readonly BrowserConformanceResourceIdentity[],
+  count: number | undefined,
+  label = "snapshot",
+): void {
+  const keys = new Set<string>();
+  for (const identity of identities) {
+    if (!identity.id || !Number.isSafeInteger(identity.generation) || identity.generation < 0) {
+      throw new RangeError(`${label} ${resource} identity is invalid`);
+    }
+    if (keys.has(identity.id)) throw new RangeError(`${label} ${resource} identities contain duplicates`);
+    keys.add(identity.id);
+  }
+  if (count !== undefined && identities.length > count) {
+    throw new RangeError(`${label} ${resource} identity cardinality exceeds its count`);
+  }
 }
 
 /** Compares a snapshot against the invariant's baseline and declared bounds. */

--- a/packages/browser-conformance/src/executor.ts
+++ b/packages/browser-conformance/src/executor.ts
@@ -15,6 +15,7 @@ import {
   type BrowserConformanceCleanupComparison,
 } from "./cleanup.js";
 import { normalizeBrowserConformanceRun } from "./normalize.js";
+import { BrowserConformanceFaultController } from "./faults.js";
 
 /** Shared-capability operations exercised by the web and Electron executors. */
 export const BROWSER_CONFORMANCE_SHARED_EXECUTOR_OPERATIONS = [
@@ -48,6 +49,7 @@ export interface BrowserConformanceExecutionFailure {
 /** Hooks used by the shared scenario core without changing its failure semantics. */
 export interface BrowserConformanceExecutionOptions {
   readonly onFailure?: (failure: BrowserConformanceExecutionFailure) => Promise<void> | void;
+  readonly faultController?: BrowserConformanceFaultController;
 }
 
 /** Executes one scenario on the canonical ordered timeline and enforces its cleanup contract. */
@@ -63,7 +65,7 @@ export async function runBrowserConformanceScenarioCore(
   let cleanup: BrowserConformanceCleanupComparison = checkBrowserConformanceCleanup({ baseline }, baseline);
 
   try {
-    run = await executeBrowserConformanceTimeline(scenario, subject);
+    run = await executeBrowserConformanceTimeline(scenario, subject, options.faultController);
   } catch (error) {
     failure = error;
   }
@@ -82,6 +84,7 @@ export async function runBrowserConformanceScenarioCore(
 
   try {
     final = subject.snapshotResources();
+    options.faultController?.hit("cleanup");
     cleanup = checkBrowserConformanceCleanup(scenario.cleanup, final);
     if (!cleanup.ok && failure === undefined) {
       const resources = cleanup.violations.map((violation) => violation.resource).join(", ");
@@ -90,6 +93,7 @@ export async function runBrowserConformanceScenarioCore(
   } catch (error) {
     if (failure === undefined) failure = error;
   }
+  options.faultController?.dispose();
 
   if (failure !== undefined) {
     if (!run) {
@@ -115,13 +119,15 @@ export async function runBrowserConformanceScenarioCore(
 export async function runBrowserConformanceExecutorScenario(
   scenario: BrowserConformanceScenario,
   subject: BrowserConformanceSubject,
+  options: BrowserConformanceExecutionOptions = {},
 ): Promise<BrowserConformanceNormalizedRun> {
-  return runBrowserConformanceScenarioCore(scenario, subject);
+  return runBrowserConformanceScenarioCore(scenario, subject, options);
 }
 
 async function executeBrowserConformanceTimeline(
   scenario: BrowserConformanceScenario,
   subject: BrowserConformanceSubject,
+  faultController?: BrowserConformanceFaultController,
 ): Promise<BrowserConformanceNormalizedRun> {
   // Command N runs before scheduled work at tick N (ordinal >= 0).
   // That work therefore occurs after command N and before command N+1.
@@ -130,10 +136,15 @@ async function executeBrowserConformanceTimeline(
   let eventIndex = 0;
   let checkpointIndex = 0;
   let currentTick = -1;
-  for (const event of scenario.schedule.events) subject.schedule(event);
+  for (const event of scenario.schedule.events) {
+    faultController?.hit("scheduling");
+    subject.schedule(event);
+  }
   for (let index = 0; index < scenario.commands.length; index += 1) {
     await flushTimeline({ tick: index, ordinal: -1 });
+    faultController?.hit("executor-dispatch");
     await subject.dispatch(scenario.commands[index]!);
+    faultController?.hit("receipt-delivery");
   }
   await flushTimeline({ tick: Math.max(currentTick, scenario.schedule.bounds.maxTick), ordinal: Number.MAX_SAFE_INTEGER });
   return subject.snapshotOutcome();
@@ -147,18 +158,24 @@ async function executeBrowserConformanceTimeline(
         : nextCheckpoint;
       if (!next || compareOrders(next.order, limit) > 0) break;
       if (next.order.tick > currentTick) {
+        faultController?.hit("clock");
         await subject.advanceClock(next.order.tick);
         currentTick = next.order.tick;
       }
       if (next === nextEvent) {
+        if (nextEvent?.kind === "host-disconnect" || nextEvent?.kind === "host-reconnect") faultController?.hit("host-transport");
+        if (nextEvent?.kind === "target-register") faultController?.hit("target-registration");
+        if (nextEvent?.kind === "capability-revision") faultController?.hit("capability-revision");
         await subject.injectExternalEvent(nextEvent!);
         eventIndex += 1;
       } else {
+        faultController?.hit("checkpoint");
         assertCheckpoint(subject, nextCheckpoint!);
         checkpointIndex += 1;
       }
     }
     if (limit.tick > currentTick) {
+      faultController?.hit("clock");
       await subject.advanceClock(limit.tick);
       currentTick = limit.tick;
     }
@@ -236,7 +253,7 @@ export function createBrowserExecutorParityScenario(): BrowserConformanceExecuto
       events: [],
       checkpoints: [],
     },
-    cleanup: { baseline: createBrowserConformanceResourceSnapshot(), allowedGrowth: { targets: 1 } },
+    cleanup: { baseline: createBrowserConformanceResourceSnapshot() },
   });
   const operations = BROWSER_CONFORMANCE_SHARED_EXECUTOR_OPERATIONS;
   const mutations = new Set(["open", "navigate", "click", "type", "act", "tabs"]);
@@ -256,7 +273,7 @@ export function createBrowserExecutorParityScenario(): BrowserConformanceExecuto
   const expected = normalizeBrowserConformanceRun({
     receipts,
     outcome: { status: "completed", effect: "complete", recovery: "none", revisions: { host: 0, document: 0, control: 0, capability: 1, observation: commands.length - 1 }, ownership: "agent" },
-    finalState: { readiness: "ready", controlOwner: "agent", tabCount: 1, currentUrl: "http://localhost:3000/final", revisions: { host: 0, document: 0, control: 0, capability: 1, observation: commands.length - 1 }, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } },
+    finalState: { readiness: "ready", controlOwner: "agent", tabCount: 1, currentUrl: "http://localhost:3000/final", revisions: { host: 0, document: 0, control: 0, capability: 1, observation: commands.length - 1 }, resources: createBrowserConformanceResourceSnapshot({ identities: { targets: [{ id: "browser-target", generation: 1 }] } }) },
     visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: "agent", tabCount: 1, currentUrl: "http://localhost:3000/final", title: "Executor fixture", action: "tabs", truncated: false }],
   });
   return {

--- a/packages/browser-conformance/src/executor.ts
+++ b/packages/browser-conformance/src/executor.ts
@@ -6,8 +6,14 @@ import {
   type BrowserConformanceNormalizedRun,
   type BrowserConformanceScenario,
   type BrowserConformanceSubject,
+  type BrowserConformanceScheduledEvent,
+  type BrowserConformanceCheckpoint,
 } from "./model.js";
-import { createBrowserConformanceResourceSnapshot } from "./cleanup.js";
+import {
+  checkBrowserConformanceCleanup,
+  createBrowserConformanceResourceSnapshot,
+  type BrowserConformanceCleanupComparison,
+} from "./cleanup.js";
 import { normalizeBrowserConformanceRun } from "./normalize.js";
 
 /** Shared-capability operations exercised by the web and Electron executors. */
@@ -30,21 +36,156 @@ export interface BrowserConformanceExecutorScenario {
   readonly expected: BrowserConformanceNormalizedRun;
 }
 
+/** Failure context supplied after the shared runner has drained and disposed a subject. */
+export interface BrowserConformanceExecutionFailure {
+  readonly error: unknown;
+  readonly run?: BrowserConformanceNormalizedRun;
+  readonly baseline: ReturnType<BrowserConformanceSubject["snapshotResources"]>;
+  readonly final: ReturnType<BrowserConformanceSubject["snapshotResources"]>;
+  readonly cleanup: BrowserConformanceCleanupComparison;
+}
+
+/** Hooks used by the shared scenario core without changing its failure semantics. */
+export interface BrowserConformanceExecutionOptions {
+  readonly onFailure?: (failure: BrowserConformanceExecutionFailure) => Promise<void> | void;
+}
+
+/** Executes one scenario on the canonical ordered timeline and enforces its cleanup contract. */
+export async function runBrowserConformanceScenarioCore(
+  scenario: BrowserConformanceScenario,
+  subject: BrowserConformanceSubject,
+  options: BrowserConformanceExecutionOptions = {},
+): Promise<BrowserConformanceNormalizedRun> {
+  const baseline = subject.snapshotResources();
+  let run: BrowserConformanceNormalizedRun | undefined;
+  let failure: unknown;
+  let final = baseline;
+  let cleanup: BrowserConformanceCleanupComparison = checkBrowserConformanceCleanup({ baseline }, baseline);
+
+  try {
+    run = await executeBrowserConformanceTimeline(scenario, subject);
+  } catch (error) {
+    failure = error;
+  }
+
+  try {
+    await subject.drainToQuiescence();
+  } catch (error) {
+    if (failure === undefined) failure = error;
+  }
+
+  try {
+    await subject.dispose();
+  } catch (error) {
+    if (failure === undefined) failure = error;
+  }
+
+  try {
+    final = subject.snapshotResources();
+    cleanup = checkBrowserConformanceCleanup(scenario.cleanup, final);
+    if (!cleanup.ok && failure === undefined) {
+      const resources = cleanup.violations.map((violation) => violation.resource).join(", ");
+      failure = new Error(`Browser conformance cleanup failed: ${resources}`);
+    }
+  } catch (error) {
+    if (failure === undefined) failure = error;
+  }
+
+  if (failure !== undefined) {
+    if (!run) {
+      try {
+        run = subject.snapshotOutcome();
+      } catch {
+        // A subject that cannot snapshot still preserves the original failure.
+      }
+    }
+    try {
+      await options.onFailure?.({ error: failure, ...(run ? { run } : {}), baseline, final, cleanup });
+    } catch {
+      // Failure reporting is observational and must never replace the scenario failure.
+    }
+    throw failure;
+  }
+
+  if (!run) run = subject.snapshotOutcome();
+  return run;
+}
+
 /** Runs one adapter-neutral scenario through a real runtime subject. */
 export async function runBrowserConformanceExecutorScenario(
   scenario: BrowserConformanceScenario,
   subject: BrowserConformanceSubject,
 ): Promise<BrowserConformanceNormalizedRun> {
-  try {
-    for (const event of scenario.schedule.events) subject.schedule(event);
-    for (let index = 0; index < scenario.commands.length; index += 1) {
-      await subject.advanceClock(index);
-      await subject.dispatch(scenario.commands[index]!);
+  return runBrowserConformanceScenarioCore(scenario, subject);
+}
+
+async function executeBrowserConformanceTimeline(
+  scenario: BrowserConformanceScenario,
+  subject: BrowserConformanceSubject,
+): Promise<BrowserConformanceNormalizedRun> {
+  // Command N runs before scheduled work at tick N (ordinal >= 0).
+  // That work therefore occurs after command N and before command N+1.
+  const events = [...scenario.schedule.events].sort(compareScheduledOrder);
+  const checkpoints = [...scenario.schedule.checkpoints].sort(compareScheduledOrder);
+  let eventIndex = 0;
+  let checkpointIndex = 0;
+  let currentTick = -1;
+  for (const event of scenario.schedule.events) subject.schedule(event);
+  for (let index = 0; index < scenario.commands.length; index += 1) {
+    await flushTimeline({ tick: index, ordinal: -1 });
+    await subject.dispatch(scenario.commands[index]!);
+  }
+  await flushTimeline({ tick: Math.max(currentTick, scenario.schedule.bounds.maxTick), ordinal: Number.MAX_SAFE_INTEGER });
+  return subject.snapshotOutcome();
+
+  async function flushTimeline(limit: { readonly tick: number; readonly ordinal: number }): Promise<void> {
+    while (eventIndex < events.length || checkpointIndex < checkpoints.length) {
+      const nextEvent = events[eventIndex];
+      const nextCheckpoint = checkpoints[checkpointIndex];
+      const next = !nextCheckpoint || (nextEvent && compareScheduledOrder(nextEvent, nextCheckpoint) <= 0)
+        ? nextEvent
+        : nextCheckpoint;
+      if (!next || compareOrders(next.order, limit) > 0) break;
+      if (next.order.tick > currentTick) {
+        await subject.advanceClock(next.order.tick);
+        currentTick = next.order.tick;
+      }
+      if (next === nextEvent) {
+        await subject.injectExternalEvent(nextEvent!);
+        eventIndex += 1;
+      } else {
+        assertCheckpoint(subject, nextCheckpoint!);
+        checkpointIndex += 1;
+      }
     }
-    await subject.drainToQuiescence();
-    return subject.snapshotOutcome();
-  } finally {
-    await subject.dispose();
+    if (limit.tick > currentTick) {
+      await subject.advanceClock(limit.tick);
+      currentTick = limit.tick;
+    }
+  }
+}
+
+function compareScheduledOrder(
+  left: BrowserConformanceScheduledEvent | BrowserConformanceCheckpoint,
+  right: BrowserConformanceScheduledEvent | BrowserConformanceCheckpoint,
+): number {
+  return compareOrders(left.order, right.order);
+}
+
+function compareOrders(
+  left: { readonly tick: number; readonly ordinal: number },
+  right: { readonly tick: number; readonly ordinal: number },
+): number {
+  return left.tick - right.tick || left.ordinal - right.ordinal;
+}
+
+function assertCheckpoint(subject: BrowserConformanceSubject, checkpoint: BrowserConformanceCheckpoint): void {
+  if (!checkpoint.expectedRevisions) return;
+  const actual = subject.snapshotOutcome().finalState.revisions;
+  for (const key of Object.keys(checkpoint.expectedRevisions) as Array<keyof typeof checkpoint.expectedRevisions>) {
+    if (actual[key] !== checkpoint.expectedRevisions[key]) {
+      throw new Error(`Browser conformance checkpoint failed: ${checkpoint.id}`);
+    }
   }
 }
 

--- a/packages/browser-conformance/src/executor.ts
+++ b/packages/browser-conformance/src/executor.ts
@@ -1,0 +1,126 @@
+import {
+  BROWSER_CONFORMANCE_SCENARIO_VERSION,
+  createBrowserConformanceScenario,
+  hashBrowserConformanceSeed,
+  type BrowserConformanceCommand,
+  type BrowserConformanceNormalizedRun,
+  type BrowserConformanceScenario,
+  type BrowserConformanceSubject,
+} from "./model.js";
+import { createBrowserConformanceResourceSnapshot } from "./cleanup.js";
+import { normalizeBrowserConformanceRun } from "./normalize.js";
+
+/** Shared-capability operations exercised by the web and Electron executors. */
+export const BROWSER_CONFORMANCE_SHARED_EXECUTOR_OPERATIONS = [
+  "inspect",
+  "open",
+  "navigate",
+  "snapshot",
+  "screenshot",
+  "click",
+  "type",
+  "act",
+  "tabs",
+] as const;
+
+/** A named black-box executor scenario and its canonical operation allowlist. */
+export interface BrowserConformanceExecutorScenario {
+  readonly scenario: BrowserConformanceScenario;
+  readonly operations: readonly typeof BROWSER_CONFORMANCE_SHARED_EXECUTOR_OPERATIONS[number][];
+  readonly expected: BrowserConformanceNormalizedRun;
+}
+
+/** Runs one adapter-neutral scenario through a real runtime subject. */
+export async function runBrowserConformanceExecutorScenario(
+  scenario: BrowserConformanceScenario,
+  subject: BrowserConformanceSubject,
+): Promise<BrowserConformanceNormalizedRun> {
+  try {
+    for (const event of scenario.schedule.events) subject.schedule(event);
+    for (let index = 0; index < scenario.commands.length; index += 1) {
+      await subject.advanceClock(index);
+      await subject.dispatch(scenario.commands[index]!);
+    }
+    await subject.drainToQuiescence();
+    return subject.snapshotOutcome();
+  } finally {
+    await subject.dispose();
+  }
+}
+
+/** Creates the deterministic shared executor scenario used by both app test runners. */
+export function createBrowserExecutorParityScenario(): BrowserConformanceExecutorScenario {
+  const commands: readonly BrowserConformanceCommand[] = [
+    { id: "inspect", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } },
+    { id: "open", operation: "open", args: { url: "http://localhost:3000/next", idempotencyKey: "open-parity" } },
+    { id: "navigate", operation: "navigate", args: { url: "http://localhost:3000/final" } },
+    { id: "snapshot", operation: "snapshot", args: { includeScreenshot: false } },
+    { id: "screenshot", operation: "screenshot", args: { fullPage: false, maxWidth: 320 } },
+    {
+      id: "click",
+      operation: "click",
+      args: { target: { cssSelector: "#save" }, button: "left", clickCount: 1 },
+    },
+    {
+      id: "type",
+      operation: "type",
+      args: { target: { cssSelector: "#name" }, text: "Mcode", clear: true, submit: false },
+    },
+    { id: "inspect-after-input", operation: "inspect", args: { includeScreenshot: false, includeDiagnostics: false } },
+    {
+      id: "act",
+      operation: "act",
+      args: {
+        observationRef: "$lastObservationRef",
+        deadlineMs: 10_000,
+        steps: [{ operation: "click", target: { cssSelector: "#save" }, button: "left", clickCount: 1 }],
+      },
+    },
+    {
+      id: "tabs-claim",
+      operation: "tabs",
+      args: { action: "claim", tabId: "tab", observationRef: "$lastObservationRef", idempotencyKey: "tabs-parity" },
+    },
+  ];
+  const seed = hashBrowserConformanceSeed("browser-executor-shared-capabilities");
+  const scenario = createBrowserConformanceScenario({
+    id: "browser-executor-shared-capabilities",
+    seed: "browser-executor-shared-capabilities",
+    commands,
+    schedule: {
+      version: BROWSER_CONFORMANCE_SCENARIO_VERSION,
+      generatorVersion: "browser-v2-seeded-v1",
+      seed,
+      bounds: { maxCommands: commands.length, maxEvents: 0, maxCheckpoints: 0, maxTick: commands.length },
+      events: [],
+      checkpoints: [],
+    },
+    cleanup: { baseline: createBrowserConformanceResourceSnapshot(), allowedGrowth: { targets: 1 } },
+  });
+  const operations = BROWSER_CONFORMANCE_SHARED_EXECUTOR_OPERATIONS;
+  const mutations = new Set(["open", "navigate", "click", "type", "act", "tabs"]);
+  const receipts = commands.map((command, index) => ({
+    order: { tick: index, ordinal: index },
+    commandId: command.id,
+    operation: command.operation,
+    status: "applied",
+    effect: command.operation === "open" ? "created" : mutations.has(command.operation) ? "complete" : "none",
+    recovery: command.operation === "act" ? "inspect" : "none",
+    truncated: false,
+    revisions: { host: 0, document: 0, control: 0, capability: 1, observation: index },
+    errorCode: null,
+    errorStage: command.operation === "inspect" || command.operation === "snapshot" || command.operation === "screenshot" ? "observation" : "effect",
+    ownership: index === 0 ? "none" : "agent",
+  }));
+  const expected = normalizeBrowserConformanceRun({
+    receipts,
+    outcome: { status: "completed", effect: "complete", recovery: "none", revisions: { host: 0, document: 0, control: 0, capability: 1, observation: commands.length - 1 }, ownership: "agent" },
+    finalState: { readiness: "ready", controlOwner: "agent", tabCount: 1, currentUrl: "http://localhost:3000/final", revisions: { host: 0, document: 0, control: 0, capability: 1, observation: commands.length - 1 }, resources: { targets: 1, identities: { targets: [{ id: "browser-target", generation: 1 }] } } },
+    visibleObservations: [{ surface: "browser", readiness: "ready", controlOwner: "agent", tabCount: 1, currentUrl: "http://localhost:3000/final", title: "Executor fixture", action: "tabs", truncated: false }],
+  });
+  return {
+    scenario,
+    operations,
+    expected,
+  };
+}

--- a/packages/browser-conformance/src/faults.ts
+++ b/packages/browser-conformance/src/faults.ts
@@ -1,0 +1,84 @@
+/** Bounded test-only control points for deterministic Browser conformance runs. */
+export const BROWSER_CONFORMANCE_FAULT_CONTROL_KINDS = [
+  "clock",
+  "scheduling",
+  "checkpoint",
+  "host-transport",
+  "executor-dispatch",
+  "target-registration",
+  "receipt-delivery",
+  "capability-revision",
+  "cleanup",
+] as const;
+
+/** One deterministic fault control selected for a bounded test run. */
+export type BrowserConformanceFaultControlKind = (typeof BROWSER_CONFORMANCE_FAULT_CONTROL_KINDS)[number];
+
+/** Configuration for one bounded occurrence of a deterministic control. */
+export interface BrowserConformanceFaultControl {
+  readonly kind: BrowserConformanceFaultControlKind;
+  readonly occurrence?: number;
+}
+
+/** Error raised when a configured conformance control reaches its occurrence. */
+export class BrowserConformanceInjectedFaultError extends Error {
+  readonly kind: BrowserConformanceFaultControlKind;
+  readonly occurrence: number;
+
+  constructor(kind: BrowserConformanceFaultControlKind, occurrence: number) {
+    super(`Browser conformance fault injected at ${kind} occurrence ${occurrence}`);
+    this.name = "BrowserConformanceInjectedFaultError";
+    this.kind = kind;
+    this.occurrence = occurrence;
+  }
+}
+
+/** Applies one bounded control and becomes inert after the scenario disposes. */
+export class BrowserConformanceFaultController {
+  private readonly calls = new Map<BrowserConformanceFaultControlKind, number>();
+  private disposed = false;
+  readonly control: BrowserConformanceFaultControl | undefined;
+
+  constructor(control?: BrowserConformanceFaultControl) {
+    if (control) {
+      if (!isBrowserConformanceFaultControlKind(control.kind)) {
+        throw new RangeError(`Unknown Browser conformance fault control kind: ${String(control.kind)}`);
+      }
+      const occurrence = control.occurrence ?? 1;
+      if (!Number.isSafeInteger(occurrence) || occurrence < 1 || occurrence > 256) {
+        throw new RangeError("Browser conformance fault occurrence must be between 1 and 256");
+      }
+      this.control = { kind: control.kind, occurrence };
+    }
+  }
+
+  /** Applies the configured fault if this control reaches its bounded occurrence. */
+  hit(kind: BrowserConformanceFaultControlKind): void {
+    if (this.disposed) return;
+    const occurrence = (this.calls.get(kind) ?? 0) + 1;
+    this.calls.set(kind, occurrence);
+    if (this.control?.kind === kind && this.control.occurrence === occurrence) {
+      throw new BrowserConformanceInjectedFaultError(kind, occurrence);
+    }
+  }
+
+  /** Returns the bounded number of times one control has been reached. */
+  callsFor(kind: BrowserConformanceFaultControlKind): number {
+    return this.calls.get(kind) ?? 0;
+  }
+
+  /** Stops all future control effects and calls. Safe to invoke more than once. */
+  dispose(): void {
+    this.disposed = true;
+  }
+
+  /** Indicates whether this controller has been disposed by its scenario runner. */
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+}
+
+function isBrowserConformanceFaultControlKind(value: unknown): value is BrowserConformanceFaultControlKind {
+  return typeof value === "string"
+    && (BROWSER_CONFORMANCE_FAULT_CONTROL_KINDS as readonly string[]).includes(value);
+}

--- a/packages/browser-conformance/src/index.ts
+++ b/packages/browser-conformance/src/index.ts
@@ -86,6 +86,12 @@ export {
   serializeBrowserConformanceReplayBundle,
   writeBrowserConformanceReplayBundle,
 } from "./replay.js";
+export {
+  BROWSER_CONFORMANCE_SHARED_EXECUTOR_OPERATIONS,
+  createBrowserExecutorParityScenario,
+  runBrowserConformanceExecutorScenario,
+} from "./executor.js";
+export type { BrowserConformanceExecutorScenario } from "./executor.js";
 export type {
   BrowserConformanceReplayBundle,
   BrowserConformanceReplayBundleInput,

--- a/packages/browser-conformance/src/index.ts
+++ b/packages/browser-conformance/src/index.ts
@@ -89,12 +89,34 @@ export {
 export {
   BROWSER_CONFORMANCE_SHARED_EXECUTOR_OPERATIONS,
   createBrowserExecutorParityScenario,
+  runBrowserConformanceScenarioCore,
   runBrowserConformanceExecutorScenario,
 } from "./executor.js";
-export type { BrowserConformanceExecutorScenario } from "./executor.js";
+export type {
+  BrowserConformanceExecutionFailure,
+  BrowserConformanceExecutionOptions,
+  BrowserConformanceExecutorScenario,
+} from "./executor.js";
+export {
+  runBrowserConformanceScenarioWithReplay,
+} from "./runner.js";
+export type { BrowserConformanceReplayRunnerOptions } from "./runner.js";
 export type {
   BrowserConformanceReplayBundle,
   BrowserConformanceReplayBundleInput,
   BrowserConformanceReplayCommand,
   BrowserConformanceReplayEvent,
 } from "./replay.js";
+export {
+  BROWSER_CONFORMANCE_HIGH_RISK_REVISION_COMBINATIONS,
+  BROWSER_CONFORMANCE_RACE_CATALOGUE,
+  createBrowserConformanceRaceSchedules,
+  createBrowserConformanceRevisionRaceSchedules,
+} from "./races.js";
+export type {
+  BrowserConformanceRaceCase,
+  BrowserConformanceRaceFamily,
+  BrowserConformanceRevisionRaceSchedule,
+  BrowserConformanceRevisionRaceSchedules,
+  BrowserConformanceRevisionRaceScheduleOptions,
+} from "./races.js";

--- a/packages/browser-conformance/src/index.ts
+++ b/packages/browser-conformance/src/index.ts
@@ -1,0 +1,94 @@
+export {
+  BROWSER_CONFORMANCE_EVENT_KINDS,
+  BROWSER_CONFORMANCE_GENERATOR_VERSION,
+  BROWSER_CONFORMANCE_OPERATIONS,
+  BROWSER_CONFORMANCE_RESOURCE_KEYS,
+  BROWSER_CONFORMANCE_REVISION_KEYS,
+  BROWSER_CONFORMANCE_SCENARIO_VERSION,
+  createBrowserConformanceRevisionVector,
+  createBrowserConformanceScenario,
+  hashBrowserConformanceSeed,
+  normalizeSeed,
+} from "./model.js";
+export type {
+  BrowserConformanceCheckpoint,
+  BrowserConformanceCleanupInvariant,
+  BrowserConformanceCommand,
+  BrowserConformanceControlOwner,
+  BrowserConformanceEffect,
+  BrowserConformanceErrorStage,
+  BrowserConformanceEventKind,
+  BrowserConformanceFinalState,
+  BrowserConformanceJsonValue,
+  BrowserConformanceNormalizedRun,
+  BrowserConformanceOperation,
+  BrowserConformanceOrder,
+  BrowserConformanceOutcome,
+  BrowserConformanceOutcomeStatus,
+  BrowserConformanceOwnership,
+  BrowserConformanceReadiness,
+  BrowserConformanceReceipt,
+  BrowserConformanceReceiptStatus,
+  BrowserConformanceRecovery,
+  BrowserConformanceResourceBounds,
+  BrowserConformanceResourceIdentity,
+  BrowserConformanceResourceKey,
+  BrowserConformanceResourceSnapshot,
+  BrowserConformanceSchedule,
+  BrowserConformanceScheduleBounds,
+  BrowserConformanceScenario,
+  BrowserConformanceScenarioInput,
+  BrowserConformanceScheduledEvent,
+  BrowserConformanceSubject,
+  BrowserConformanceVisibleObservation,
+  BrowserConformanceRevisionKey,
+  BrowserConformanceRevisionVector,
+} from "./model.js";
+export {
+  BROWSER_CONFORMANCE_DEFAULT_MAX_CHECKPOINTS,
+  BROWSER_CONFORMANCE_DEFAULT_MAX_COMMANDS,
+  BROWSER_CONFORMANCE_DEFAULT_MAX_EVENTS,
+  BROWSER_CONFORMANCE_DEFAULT_MAX_TICK,
+  BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS,
+  createBrowserConformanceRandom,
+  createBrowserConformanceSchedule,
+} from "./schedule.js";
+export type {
+  BrowserConformanceRandom,
+  BrowserConformanceScheduleOptions,
+  BrowserConformanceSeed,
+} from "./schedule.js";
+export {
+  checkBrowserConformanceCleanup,
+  compareBrowserConformanceCleanup,
+  createBrowserConformanceResourceSnapshot,
+} from "./cleanup.js";
+export type {
+  BrowserConformanceCleanupComparison,
+  BrowserConformanceCleanupViolation,
+  BrowserConformanceResourceSnapshotInput,
+} from "./cleanup.js";
+export {
+  normalizeBrowserConformanceRevisions,
+  normalizeBrowserConformanceRun,
+} from "./normalize.js";
+export type {
+  BrowserConformanceNormalizationOptions,
+  BrowserConformanceRawRun,
+} from "./normalize.js";
+export {
+  BROWSER_CONFORMANCE_REPLAY_DIRECTORY,
+  BROWSER_CONFORMANCE_REPLAY_MAX_BYTES,
+  BROWSER_CONFORMANCE_REPLAY_MAX_DEPTH,
+  BROWSER_CONFORMANCE_REPLAY_MAX_ITEMS,
+  createBrowserConformanceReplayBundle,
+  sanitizeBrowserConformanceValue,
+  serializeBrowserConformanceReplayBundle,
+  writeBrowserConformanceReplayBundle,
+} from "./replay.js";
+export type {
+  BrowserConformanceReplayBundle,
+  BrowserConformanceReplayBundleInput,
+  BrowserConformanceReplayCommand,
+  BrowserConformanceReplayEvent,
+} from "./replay.js";

--- a/packages/browser-conformance/src/index.ts
+++ b/packages/browser-conformance/src/index.ts
@@ -1,6 +1,8 @@
 export {
   BROWSER_CONFORMANCE_EVENT_KINDS,
   BROWSER_CONFORMANCE_GENERATOR_VERSION,
+  BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS,
+  BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_TICK,
   BROWSER_CONFORMANCE_OPERATIONS,
   BROWSER_CONFORMANCE_RESOURCE_KEYS,
   BROWSER_CONFORMANCE_REVISION_KEYS,
@@ -49,7 +51,6 @@ export {
   BROWSER_CONFORMANCE_DEFAULT_MAX_COMMANDS,
   BROWSER_CONFORMANCE_DEFAULT_MAX_EVENTS,
   BROWSER_CONFORMANCE_DEFAULT_MAX_TICK,
-  BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS,
   createBrowserConformanceRandom,
   createBrowserConformanceSchedule,
 } from "./schedule.js";
@@ -101,6 +102,15 @@ export {
   runBrowserConformanceScenarioWithReplay,
 } from "./runner.js";
 export type { BrowserConformanceReplayRunnerOptions } from "./runner.js";
+export {
+  BROWSER_CONFORMANCE_FAULT_CONTROL_KINDS,
+  BrowserConformanceFaultController,
+  BrowserConformanceInjectedFaultError,
+} from "./faults.js";
+export type {
+  BrowserConformanceFaultControl,
+  BrowserConformanceFaultControlKind,
+} from "./faults.js";
 export type {
   BrowserConformanceReplayBundle,
   BrowserConformanceReplayBundleInput,

--- a/packages/browser-conformance/src/model.ts
+++ b/packages/browser-conformance/src/model.ts
@@ -100,6 +100,8 @@ export const BROWSER_CONFORMANCE_EVENT_KINDS = [
   "timeout",
   "lost-response",
   "late-response",
+  "late-event",
+  "late-timer",
   "user-takeover",
   "navigation",
   "reload",

--- a/packages/browser-conformance/src/model.ts
+++ b/packages/browser-conformance/src/model.ts
@@ -1,0 +1,407 @@
+/** JSON values accepted by the adapter-neutral Browser conformance model. */
+export type BrowserConformanceJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly BrowserConformanceJsonValue[]
+  | { readonly [key: string]: BrowserConformanceJsonValue };
+
+/** Browser operations that can appear in a conformance scenario. */
+export const BROWSER_CONFORMANCE_OPERATIONS = [
+  "status",
+  "open",
+  "inspect",
+  "act",
+  "tabs",
+  "navigate",
+  "resize",
+  "snapshot",
+  "screenshot",
+  "click",
+  "type",
+  "press",
+  "scroll",
+  "waitFor",
+  "console",
+  "network",
+  "accessibility",
+  "performance",
+  "evaluate",
+  "recordingStart",
+  "recordingStop",
+] as const;
+
+/** One operation identifier accepted by a Browser conformance command. */
+export type BrowserConformanceOperation = (typeof BROWSER_CONFORMANCE_OPERATIONS)[number];
+
+/** Revision dimensions whose changes invalidate different Browser authorities. */
+export const BROWSER_CONFORMANCE_REVISION_KEYS = [
+  "host",
+  "document",
+  "control",
+  "capability",
+  "observation",
+] as const;
+
+/** One revision dimension in the Browser authority vector. */
+export type BrowserConformanceRevisionKey = (typeof BROWSER_CONFORMANCE_REVISION_KEYS)[number];
+
+/** Monotonic Browser authority revisions captured at admission and receipts. */
+export interface BrowserConformanceRevisionVector {
+  readonly host: number;
+  readonly document: number;
+  readonly control: number;
+  readonly capability: number;
+  readonly observation: number;
+}
+
+/** Scenario schema version for serialized Browser conformance cases. */
+export const BROWSER_CONFORMANCE_SCENARIO_VERSION = 1 as const;
+
+/** Schedule generator version for deterministic replay compatibility. */
+export const BROWSER_CONFORMANCE_GENERATOR_VERSION = "browser-v2-seeded-v1" as const;
+
+/** Virtual monotonic time and total-order position for scheduled work. */
+export interface BrowserConformanceOrder {
+  readonly tick: number;
+  readonly ordinal: number;
+}
+
+/** Creates a zero-based initial Browser revision vector. */
+export function createBrowserConformanceRevisionVector(
+  revisions: Partial<BrowserConformanceRevisionVector> = {},
+): BrowserConformanceRevisionVector {
+  return {
+    host: revisions.host ?? 0,
+    document: revisions.document ?? 0,
+    control: revisions.control ?? 0,
+    capability: revisions.capability ?? 0,
+    observation: revisions.observation ?? 0,
+  };
+}
+
+/** A declarative Browser command independent of web or Electron transport. */
+export interface BrowserConformanceCommand {
+  readonly id: string;
+  readonly operation: BrowserConformanceOperation;
+  readonly args?: Readonly<Record<string, BrowserConformanceJsonValue>>;
+  readonly timeoutMs?: number;
+  readonly idempotencyKey?: string;
+}
+
+/** Events used to drive reviewed Browser races and revision invalidation. */
+export const BROWSER_CONFORMANCE_EVENT_KINDS = [
+  "host-disconnect",
+  "host-reconnect",
+  "target-register",
+  "target-close",
+  "cancel",
+  "timeout",
+  "lost-response",
+  "late-response",
+  "user-takeover",
+  "navigation",
+  "reload",
+  "resize",
+  "competing-mutation",
+  "capability-revision",
+  "document-revision",
+  "control-revision",
+  "observation-revision",
+  "cleanup",
+] as const;
+
+/** One scheduled race or fault event in a conformance scenario. */
+export type BrowserConformanceEventKind = (typeof BROWSER_CONFORMANCE_EVENT_KINDS)[number];
+
+/** A bounded event scheduled at a command-step boundary. */
+export interface BrowserConformanceScheduledEvent {
+  readonly order: BrowserConformanceOrder;
+  readonly kind: BrowserConformanceEventKind;
+  readonly revision?: BrowserConformanceRevisionKey;
+  readonly payload?: Readonly<Record<string, BrowserConformanceJsonValue>>;
+}
+
+/** A named assertion point in a deterministic Browser schedule. */
+export interface BrowserConformanceCheckpoint {
+  readonly id: string;
+  readonly order: BrowserConformanceOrder;
+  readonly label: string;
+  readonly expectedRevisions?: BrowserConformanceRevisionVector;
+}
+
+/** Explicit bounds carried with every generated Browser schedule. */
+export interface BrowserConformanceScheduleBounds {
+  readonly maxCommands: number;
+  readonly maxEvents: number;
+  readonly maxCheckpoints: number;
+  readonly maxTick: number;
+}
+
+/** Deterministic schedule inputs and its ordered events/checkpoints. */
+export interface BrowserConformanceSchedule {
+  readonly version: typeof BROWSER_CONFORMANCE_SCENARIO_VERSION;
+  readonly generatorVersion: typeof BROWSER_CONFORMANCE_GENERATOR_VERSION;
+  readonly seed: number;
+  readonly bounds: BrowserConformanceScheduleBounds;
+  readonly events: readonly BrowserConformanceScheduledEvent[];
+  readonly checkpoints: readonly BrowserConformanceCheckpoint[];
+}
+
+/** Stable logical identity and generation for one owned runtime resource. */
+export interface BrowserConformanceResourceIdentity {
+  readonly id: string;
+  readonly generation: number;
+}
+
+/** Bounded resource counters owned by one Browser conformance scenario. */
+export interface BrowserConformanceResourceSnapshot {
+  readonly requests: number;
+  readonly queues: number;
+  readonly timers: number;
+  readonly listeners: number;
+  readonly heldInput: number;
+  readonly controllerLeases: number;
+  readonly targets: number;
+  readonly replayEntries: number;
+  readonly registries: number;
+  readonly buffers: number;
+  readonly identities: Readonly<Record<BrowserConformanceResourceKey, readonly BrowserConformanceResourceIdentity[]>>;
+  readonly revisions: BrowserConformanceRevisionVector;
+}
+
+/** Resource counters included in cleanup baselines and declared bounds. */
+export const BROWSER_CONFORMANCE_RESOURCE_KEYS = [
+  "requests",
+  "queues",
+  "timers",
+  "listeners",
+  "heldInput",
+  "controllerLeases",
+  "targets",
+  "replayEntries",
+  "registries",
+  "buffers",
+] as const;
+
+/** Resource dimensions accepted in a declared cleanup bound. */
+export type BrowserConformanceResourceKey = (typeof BROWSER_CONFORMANCE_RESOURCE_KEYS)[number];
+
+/** Maximum allowed growth over a cleanup baseline for selected resources. */
+export type BrowserConformanceResourceBounds = Partial<
+  Readonly<Record<BrowserConformanceResourceKey, number>>
+>;
+
+/** Expected cleanup contract for a scenario-owned resource snapshot. */
+export interface BrowserConformanceCleanupInvariant {
+  readonly baseline: BrowserConformanceResourceSnapshot;
+  readonly allowedGrowth?: BrowserConformanceResourceBounds;
+}
+
+/** Stable outcome statuses shared by adapters and normalized receipts. */
+export type BrowserConformanceOutcomeStatus =
+  | "completed"
+  | "failed"
+  | "interrupted"
+  | "unknown";
+
+/** Stable receipt statuses shared by Browser adapters. */
+export type BrowserConformanceReceiptStatus =
+  | "applied"
+  | "satisfied"
+  | "failed"
+  | "interrupted"
+  | "skipped"
+  | "unknown";
+
+/** Stable effect vocabulary retained by normalized Browser receipts. */
+export type BrowserConformanceEffect =
+  | "none"
+  | "partial"
+  | "complete"
+  | "created"
+  | "closed"
+  | "preserved"
+  | "unknown";
+
+/** Stable recovery vocabulary retained by normalized Browser receipts. */
+export type BrowserConformanceRecovery =
+  | "none"
+  | "retry"
+  | "refresh"
+  | "reopen"
+  | "manual"
+  | "inspect"
+  | "wait"
+  | "yield_to_user"
+  | "do_not_retry"
+  | "unknown";
+
+/** Stable failure stage retained by normalized Browser receipts. */
+export type BrowserConformanceErrorStage =
+  | "validation"
+  | "admission"
+  | "dispatch"
+  | "effect"
+  | "observation"
+  | "cleanup"
+  | "unknown";
+
+/** Stable ownership state retained by normalized receipts and final state. */
+export type BrowserConformanceOwnership = "none" | "agent" | "user" | "shared" | "unknown";
+
+/** One normalized, runtime-neutral Browser command receipt. */
+export interface BrowserConformanceReceipt {
+  readonly order: BrowserConformanceOrder;
+  readonly commandId: string | null;
+  readonly operation: BrowserConformanceOperation | "unknown";
+  readonly status: BrowserConformanceReceiptStatus;
+  readonly effect: BrowserConformanceEffect;
+  readonly recovery: BrowserConformanceRecovery;
+  readonly truncated: boolean;
+  readonly revisions: BrowserConformanceRevisionVector;
+  readonly errorCode: string | null;
+  readonly errorStage: BrowserConformanceErrorStage;
+  readonly ownership: BrowserConformanceOwnership;
+}
+
+/** Normalized run outcome with effects, recovery, truncation, and revisions. */
+export interface BrowserConformanceOutcome {
+  readonly status: BrowserConformanceOutcomeStatus;
+  readonly effect: BrowserConformanceEffect;
+  readonly recovery: BrowserConformanceRecovery;
+  readonly truncated: boolean;
+  readonly revisions: BrowserConformanceRevisionVector;
+  readonly errorCode: string | null;
+  readonly errorStage: BrowserConformanceErrorStage;
+  readonly ownership: BrowserConformanceOwnership;
+}
+
+/** Readiness states exposed by the shared Browser product surface. */
+export type BrowserConformanceReadiness =
+  | "ready"
+  | "host-unavailable"
+  | "target-unavailable"
+  | "recovering"
+  | "human-control"
+  | "unknown";
+
+/** Ownership states visible while Browser control changes hands. */
+export type BrowserConformanceControlOwner = BrowserConformanceOwnership;
+
+/** A normalized visible observation without runtime-specific identifiers. */
+export interface BrowserConformanceVisibleObservation {
+  readonly surface: "browser" | "thread-overview" | "narrative" | "unknown";
+  readonly readiness: BrowserConformanceReadiness;
+  readonly controlOwner: BrowserConformanceControlOwner;
+  readonly tabCount: number;
+  readonly currentUrl: string | null;
+  readonly title: string | null;
+  readonly action: string | null;
+  readonly truncated: boolean;
+}
+
+/** Normalized final state returned by a Browser adapter run. */
+export interface BrowserConformanceFinalState {
+  readonly readiness: BrowserConformanceReadiness;
+  readonly controlOwner: BrowserConformanceControlOwner;
+  readonly tabCount: number;
+  readonly currentUrl: string | null;
+  readonly revisions: BrowserConformanceRevisionVector;
+  readonly resources: BrowserConformanceResourceSnapshot;
+}
+
+/** Complete normalized result used for differential web/Electron comparison. */
+export interface BrowserConformanceNormalizedRun {
+  readonly receipts: readonly BrowserConformanceReceipt[];
+  readonly outcome: BrowserConformanceOutcome;
+  readonly finalState: BrowserConformanceFinalState;
+  readonly visibleObservations: readonly BrowserConformanceVisibleObservation[];
+}
+
+/** Dependency-inverted adapter port exercised by the shared conformance suite. */
+export interface BrowserConformanceSubject {
+  /** Dispatches one declarative command and returns its normalized receipt. */
+  dispatch(command: BrowserConformanceCommand): Promise<BrowserConformanceReceipt>;
+  /** Schedules one external event at its deterministic total-order position. */
+  schedule(event: BrowserConformanceScheduledEvent): void;
+  /** Advances the subject's virtual monotonic clock without wall-clock sleeps. */
+  advanceClock(tick: number): Promise<void>;
+  /** Injects one external event into the subject at the current virtual time. */
+  injectExternalEvent(event: BrowserConformanceScheduledEvent): Promise<void>;
+  /** Captures the normalized outcome and visible observations so far. */
+  snapshotOutcome(): BrowserConformanceNormalizedRun;
+  /** Captures owned resources for cleanup comparison. */
+  snapshotResources(): BrowserConformanceResourceSnapshot;
+  /** Waits for bounded quiescence after terminal work and late events. */
+  drainToQuiescence(): Promise<void>;
+  /** Releases subject-owned resources and listeners. */
+  dispose(): Promise<void>;
+}
+
+/** Declarative adapter-neutral Browser v2 scenario. */
+export interface BrowserConformanceScenario {
+  readonly version: typeof BROWSER_CONFORMANCE_SCENARIO_VERSION;
+  readonly generatorVersion: typeof BROWSER_CONFORMANCE_GENERATOR_VERSION;
+  readonly id: string;
+  readonly seed: number;
+  readonly commands: readonly BrowserConformanceCommand[];
+  readonly schedule: BrowserConformanceSchedule;
+  readonly initialRevisions: BrowserConformanceRevisionVector;
+  readonly cleanup: BrowserConformanceCleanupInvariant;
+}
+
+/** Inputs accepted when constructing a Browser conformance scenario. */
+export interface BrowserConformanceScenarioInput {
+  readonly id: string;
+  readonly seed: number | string;
+  readonly commands: readonly BrowserConformanceCommand[];
+  readonly schedule?: BrowserConformanceSchedule;
+  readonly initialRevisions?: Partial<BrowserConformanceRevisionVector>;
+  readonly cleanup: BrowserConformanceCleanupInvariant;
+}
+
+/** Creates a bounded declarative Browser scenario from commands and a seed. */
+export function createBrowserConformanceScenario(
+  input: BrowserConformanceScenarioInput,
+): BrowserConformanceScenario {
+  const seed = typeof input.seed === "string" ? hashBrowserConformanceSeed(input.seed) : normalizeSeed(input.seed);
+  const schedule = input.schedule ?? {
+    version: BROWSER_CONFORMANCE_SCENARIO_VERSION,
+    generatorVersion: BROWSER_CONFORMANCE_GENERATOR_VERSION,
+    seed,
+    bounds: { maxCommands: input.commands.length, maxEvents: 0, maxCheckpoints: 0, maxTick: 0 },
+    events: [],
+    checkpoints: [],
+  };
+  if (input.commands.length > schedule.bounds.maxCommands) {
+    throw new RangeError("Browser conformance command count exceeds schedule bound");
+  }
+  return {
+    version: BROWSER_CONFORMANCE_SCENARIO_VERSION,
+    generatorVersion: BROWSER_CONFORMANCE_GENERATOR_VERSION,
+    id: input.id,
+    seed,
+    commands: input.commands,
+    schedule,
+    initialRevisions: createBrowserConformanceRevisionVector(input.initialRevisions),
+    cleanup: input.cleanup,
+  };
+}
+
+/** Normalizes a numeric seed into the deterministic unsigned range. */
+export function normalizeSeed(seed: number): number {
+  if (!Number.isFinite(seed)) throw new RangeError("Browser conformance seed must be finite");
+  return (Math.trunc(seed) >>> 0) || 0x9e3779b9;
+}
+
+/** Hashes a textual seed into the deterministic unsigned range. */
+export function hashBrowserConformanceSeed(seed: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0 || 0x9e3779b9;
+}

--- a/packages/browser-conformance/src/model.ts
+++ b/packages/browser-conformance/src/model.ts
@@ -62,6 +62,12 @@ export const BROWSER_CONFORMANCE_SCENARIO_VERSION = 1 as const;
 /** Schedule generator version for deterministic replay compatibility. */
 export const BROWSER_CONFORMANCE_GENERATOR_VERSION = "browser-v2-seeded-v1" as const;
 
+/** Hard upper bound for commands, events, checkpoints, and total-order ordinals. */
+export const BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS = 256;
+
+/** Hard upper bound for virtual monotonic ticks in custom schedules. */
+export const BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_TICK = BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS * 4;
+
 /** Virtual monotonic time and total-order position for scheduled work. */
 export interface BrowserConformanceOrder {
   readonly tick: number;
@@ -402,7 +408,11 @@ function validateScenarioSchedule(
     throw new RangeError("Browser conformance schedule metadata does not match the scenario");
   }
   const bounds = schedule.bounds;
-  if (!isBound(bounds.maxCommands) || !isBound(bounds.maxEvents) || !isBound(bounds.maxCheckpoints) || !isBound(bounds.maxTick)
+  if (commandCount > BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS
+    || !isBound(bounds.maxCommands, BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS)
+    || !isBound(bounds.maxEvents, BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS)
+    || !isBound(bounds.maxCheckpoints, BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS)
+    || !isBound(bounds.maxTick, BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_TICK)
     || commandCount > bounds.maxCommands || schedule.events.length > bounds.maxEvents
     || schedule.checkpoints.length > bounds.maxCheckpoints) {
     throw new RangeError("Browser conformance schedule exceeds its declared bounds");
@@ -423,7 +433,9 @@ function validateScenarioSchedule(
 }
 
 function validateOrder(order: BrowserConformanceOrder, maxTick: number, orders: Set<string>): void {
-  if (!isBound(order.tick) || !isBound(order.ordinal) || order.tick > maxTick) {
+  if (!isBound(order.tick, BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_TICK)
+    || !isBound(order.ordinal, BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS)
+    || order.tick > maxTick) {
     throw new RangeError("Browser conformance schedule order is invalid");
   }
   const key = `${order.tick}:${order.ordinal}`;
@@ -442,8 +454,8 @@ function validateRevisionVector(
   }
 }
 
-function isBound(value: number): boolean {
-  return Number.isSafeInteger(value) && value >= 0;
+function isBound(value: number, maximum = Number.MAX_SAFE_INTEGER): boolean {
+  return Number.isSafeInteger(value) && value >= 0 && value <= maximum;
 }
 
 /** Normalizes a numeric seed into the deterministic unsigned range. */

--- a/packages/browser-conformance/src/model.ts
+++ b/packages/browser-conformance/src/model.ts
@@ -375,9 +375,8 @@ export function createBrowserConformanceScenario(
     events: [],
     checkpoints: [],
   };
-  if (input.commands.length > schedule.bounds.maxCommands) {
-    throw new RangeError("Browser conformance command count exceeds schedule bound");
-  }
+  validateScenarioSchedule(schedule, seed, input.commands.length);
+  validateRevisionVector(input.initialRevisions, "initial revisions");
   return {
     version: BROWSER_CONFORMANCE_SCENARIO_VERSION,
     generatorVersion: BROWSER_CONFORMANCE_GENERATOR_VERSION,
@@ -388,6 +387,61 @@ export function createBrowserConformanceScenario(
     initialRevisions: createBrowserConformanceRevisionVector(input.initialRevisions),
     cleanup: input.cleanup,
   };
+}
+
+function validateScenarioSchedule(
+  schedule: BrowserConformanceSchedule,
+  seed: number,
+  commandCount: number,
+): void {
+  if (schedule.version !== BROWSER_CONFORMANCE_SCENARIO_VERSION
+    || schedule.generatorVersion !== BROWSER_CONFORMANCE_GENERATOR_VERSION
+    || schedule.seed !== seed) {
+    throw new RangeError("Browser conformance schedule metadata does not match the scenario");
+  }
+  const bounds = schedule.bounds;
+  if (!isBound(bounds.maxCommands) || !isBound(bounds.maxEvents) || !isBound(bounds.maxCheckpoints) || !isBound(bounds.maxTick)
+    || commandCount > bounds.maxCommands || schedule.events.length > bounds.maxEvents
+    || schedule.checkpoints.length > bounds.maxCheckpoints) {
+    throw new RangeError("Browser conformance schedule exceeds its declared bounds");
+  }
+  const orders = new Set<string>();
+  for (const event of schedule.events) {
+    validateOrder(event.order, bounds.maxTick, orders);
+    if (!BROWSER_CONFORMANCE_EVENT_KINDS.includes(event.kind)) throw new RangeError("Browser conformance event kind is invalid");
+    if (event.revision !== undefined && !BROWSER_CONFORMANCE_REVISION_KEYS.includes(event.revision)) {
+      throw new RangeError("Browser conformance event revision is invalid");
+    }
+  }
+  for (const checkpoint of schedule.checkpoints) {
+    validateOrder(checkpoint.order, bounds.maxTick, orders);
+    if (checkpoint.id.length === 0 || checkpoint.label.length === 0) throw new RangeError("Browser conformance checkpoint is invalid");
+    validateRevisionVector(checkpoint.expectedRevisions, "checkpoint revisions");
+  }
+}
+
+function validateOrder(order: BrowserConformanceOrder, maxTick: number, orders: Set<string>): void {
+  if (!isBound(order.tick) || !isBound(order.ordinal) || order.tick > maxTick) {
+    throw new RangeError("Browser conformance schedule order is invalid");
+  }
+  const key = `${order.tick}:${order.ordinal}`;
+  if (orders.has(key)) throw new RangeError("Browser conformance schedule order is not total");
+  orders.add(key);
+}
+
+function validateRevisionVector(
+  revisions: Partial<BrowserConformanceRevisionVector> | undefined,
+  label: string,
+): void {
+  if (!revisions) return;
+  for (const key of BROWSER_CONFORMANCE_REVISION_KEYS) {
+    const value = revisions[key];
+    if (value !== undefined && !isBound(value)) throw new RangeError(`${label} contains an invalid ${key} revision`);
+  }
+}
+
+function isBound(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
 }
 
 /** Normalizes a numeric seed into the deterministic unsigned range. */

--- a/packages/browser-conformance/src/normalize.ts
+++ b/packages/browser-conformance/src/normalize.ts
@@ -1,0 +1,249 @@
+import {
+  BROWSER_CONFORMANCE_OPERATIONS,
+  BROWSER_CONFORMANCE_REVISION_KEYS,
+  createBrowserConformanceRevisionVector,
+  type BrowserConformanceEffect,
+  type BrowserConformanceErrorStage,
+  type BrowserConformanceFinalState,
+  type BrowserConformanceNormalizedRun,
+  type BrowserConformanceOperation,
+  type BrowserConformanceOrder,
+  type BrowserConformanceOutcome,
+  type BrowserConformanceOutcomeStatus,
+  type BrowserConformanceOwnership,
+  type BrowserConformanceReadiness,
+  type BrowserConformanceReceipt,
+  type BrowserConformanceReceiptStatus,
+  type BrowserConformanceRecovery,
+  type BrowserConformanceRevisionVector,
+  type BrowserConformanceVisibleObservation,
+} from "./model.js";
+import { createBrowserConformanceResourceSnapshot } from "./cleanup.js";
+
+/** Raw adapter result accepted by the allowlist normalizer. */
+export interface BrowserConformanceRawRun {
+  readonly receipts?: readonly unknown[];
+  readonly outcome?: unknown;
+  readonly finalState?: unknown;
+  readonly visibleObservations?: readonly unknown[];
+}
+
+/** Normalization limits that bound retained receipts and visible observations. */
+export interface BrowserConformanceNormalizationOptions {
+  readonly maxReceipts?: number;
+  readonly maxVisibleObservations?: number;
+}
+
+/** Normalizes adapter output while dropping runtime identifiers and dynamic fields. */
+export function normalizeBrowserConformanceRun(
+  raw: BrowserConformanceRawRun,
+  options: BrowserConformanceNormalizationOptions = {},
+): BrowserConformanceNormalizedRun {
+  const maxReceipts = boundedLimit(options.maxReceipts ?? 128);
+  const maxVisibleObservations = boundedLimit(options.maxVisibleObservations ?? 128);
+  const receipts = (raw.receipts ?? []).slice(0, maxReceipts).map((receipt, index) => normalizeReceipt(receipt, index));
+  const outcome = normalizeOutcome(raw.outcome, receipts.at(-1));
+  const finalState = normalizeFinalState(raw.finalState, outcome.revisions);
+  const visibleObservations = (raw.visibleObservations ?? [])
+    .slice(0, maxVisibleObservations)
+    .map(normalizeVisibleObservation);
+  return { receipts, outcome, finalState, visibleObservations };
+}
+
+/** Normalizes a revision vector and rejects negative or non-integer values. */
+export function normalizeBrowserConformanceRevisions(value: unknown): BrowserConformanceRevisionVector {
+  const record = asRecord(value);
+  const revisions: { -readonly [K in keyof BrowserConformanceRevisionVector]?: number } = {};
+  for (const key of BROWSER_CONFORMANCE_REVISION_KEYS) {
+    const candidate = record?.[key];
+    if (typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate >= 0) {
+      revisions[key] = candidate;
+    }
+  }
+  return createBrowserConformanceRevisionVector(revisions);
+}
+
+function normalizeReceipt(value: unknown, index: number): BrowserConformanceReceipt {
+  const record = asRecord(value);
+  const operation = normalizeOperation(record?.operation);
+  const status = normalizeReceiptStatus(record?.status ?? record?.outcome);
+  const effect = normalizeEffect(record?.effect);
+  const recovery = normalizeRecovery(record?.recovery);
+  const revisions = normalizeBrowserConformanceRevisions(record?.revisions);
+  return {
+    order: normalizeOrder(record?.order, index),
+    commandId: boundedIdentifier(record?.commandId),
+    operation,
+    status,
+    effect,
+    recovery,
+    truncated: record?.truncated === true || record?.truncation === true,
+    revisions,
+    errorCode: boundedErrorCode(record?.errorCode ?? record?.code),
+    errorStage: normalizeErrorStage(record?.errorStage ?? record?.stage),
+    ownership: normalizeOwnership(record?.ownership ?? record?.controlOwner),
+  };
+}
+
+function normalizeOutcome(value: unknown, receipt: BrowserConformanceReceipt | undefined): BrowserConformanceOutcome {
+  const record = asRecord(value);
+  return {
+    status: normalizeOutcomeStatus(record?.status ?? record?.outcome),
+    effect: normalizeEffect(record?.effect),
+    recovery: normalizeRecovery(record?.recovery),
+    truncated: record?.truncated === true || record?.truncation === true,
+    revisions: normalizeBrowserConformanceRevisions(record?.revisions ?? receipt?.revisions),
+    errorCode: boundedErrorCode(record?.errorCode ?? record?.code),
+    errorStage: normalizeErrorStage(record?.errorStage ?? record?.stage),
+    ownership: normalizeOwnership(record?.ownership ?? record?.controlOwner),
+  };
+}
+
+function normalizeFinalState(value: unknown, revisions: BrowserConformanceRevisionVector): BrowserConformanceFinalState {
+  const record = asRecord(value);
+  const resources = createBrowserConformanceResourceSnapshot(normalizeResources(record?.resources));
+  return {
+    readiness: normalizeReadiness(record?.readiness ?? record?.state),
+    controlOwner: normalizeOwnership(record?.controlOwner ?? record?.ownership),
+    tabCount: boundedCount(record?.tabCount ?? (Array.isArray(record?.tabs) ? record.tabs.length : 0)),
+    currentUrl: sanitizeLocation(record?.currentUrl ?? record?.url),
+    revisions: normalizeBrowserConformanceRevisions(record?.revisions ?? revisions),
+    resources,
+  };
+}
+
+function normalizeVisibleObservation(value: unknown): BrowserConformanceVisibleObservation {
+  const record = asRecord(value);
+  return {
+    surface: normalizeSurface(record?.surface),
+    readiness: normalizeReadiness(record?.readiness ?? record?.state),
+    controlOwner: normalizeOwnership(record?.controlOwner ?? record?.ownership),
+    tabCount: boundedCount(record?.tabCount ?? (Array.isArray(record?.tabs) ? record.tabs.length : 0)),
+    currentUrl: sanitizeLocation(record?.currentUrl ?? record?.url),
+    title: boundedText(record?.title ?? record?.tabTitle),
+    action: boundedText(record?.action ?? record?.operation),
+    truncated: record?.truncated === true || record?.truncation === true,
+  };
+}
+
+function normalizeResources(value: unknown) {
+  const record = asRecord(value);
+  const counts: Record<string, number> = {};
+  const rawIdentities = asRecord(record?.identities);
+  const identities: Record<string, readonly { readonly id: string; readonly generation: number }[]> = {};
+  for (const key of ["requests", "queues", "timers", "listeners", "heldInput", "controllerLeases", "targets", "replayEntries", "registries", "buffers"]) {
+    counts[key] = boundedCount(record?.[key]);
+    identities[key] = Array.isArray(rawIdentities?.[key])
+      ? rawIdentities[key]
+          .slice(0, 256)
+          .map((identity) => {
+            const item = asRecord(identity);
+            const id = boundedIdentifier(item?.id);
+            const generation = boundedCount(item?.generation);
+            return id ? { id, generation } : null;
+          })
+          .filter((identity): identity is { readonly id: string; readonly generation: number } => identity !== null)
+      : [];
+  }
+  return { counts, identities, revisions: normalizeBrowserConformanceRevisions(record?.revisions) };
+}
+
+function normalizeOrder(value: unknown, fallbackOrdinal: number): BrowserConformanceOrder {
+  const record = asRecord(value);
+  return {
+    tick: boundedCount(record?.tick),
+    ordinal: boundedCount(record?.ordinal ?? fallbackOrdinal),
+  };
+}
+
+function normalizeOperation(value: unknown): BrowserConformanceOperation | "unknown" {
+  if (typeof value !== "string") return "unknown";
+  const normalized = value.replace(/^.*browser[_-]/i, "").replace(/[_-]/g, "");
+  return BROWSER_CONFORMANCE_OPERATIONS.find((operation) => operation.toLowerCase() === normalized.toLowerCase()) ?? "unknown";
+}
+
+function normalizeReceiptStatus(value: unknown): BrowserConformanceReceiptStatus {
+  return isOneOf(value, ["applied", "satisfied", "failed", "interrupted", "skipped", "unknown"])
+    ? value
+    : "unknown";
+}
+
+function normalizeOutcomeStatus(value: unknown): BrowserConformanceOutcomeStatus {
+  return isOneOf(value, ["completed", "failed", "interrupted", "unknown"]) ? value : "unknown";
+}
+
+function normalizeEffect(value: unknown): BrowserConformanceEffect {
+  return isOneOf(value, ["none", "partial", "complete", "created", "closed", "preserved", "unknown"])
+    ? value
+    : "unknown";
+}
+
+function normalizeRecovery(value: unknown): BrowserConformanceRecovery {
+  return isOneOf(value, ["none", "retry", "refresh", "reopen", "manual", "inspect", "wait", "yield_to_user", "do_not_retry", "unknown"])
+    ? value
+    : "unknown";
+}
+
+function normalizeErrorStage(value: unknown): BrowserConformanceErrorStage {
+  return isOneOf(value, ["validation", "admission", "dispatch", "effect", "observation", "cleanup", "unknown"])
+    ? value
+    : "unknown";
+}
+
+function normalizeOwnership(value: unknown): BrowserConformanceOwnership {
+  return isOneOf(value, ["none", "agent", "user", "shared", "unknown"]) ? value : "unknown";
+}
+
+function normalizeReadiness(value: unknown): BrowserConformanceReadiness {
+  return isOneOf(value, ["ready", "host-unavailable", "target-unavailable", "recovering", "human-control", "unknown"])
+    ? value
+    : "unknown";
+}
+
+function normalizeSurface(value: unknown): BrowserConformanceVisibleObservation["surface"] {
+  return isOneOf(value, ["browser", "thread-overview", "narrative", "unknown"]) ? value : "unknown";
+}
+
+function boundedLimit(value: number): number {
+  return Number.isSafeInteger(value) && value >= 0 ? Math.min(256, value) : 0;
+}
+
+function boundedCount(value: unknown): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? Math.min(1_000_000, value) : 0;
+}
+
+function boundedIdentifier(value: unknown): string | null {
+  return typeof value === "string" && /^[A-Za-z0-9_.:-]{1,128}$/.test(value) ? value : null;
+}
+
+function boundedErrorCode(value: unknown): string | null {
+  return typeof value === "string" && /^[A-Z0-9_:-]{1,64}$/.test(value) ? value : null;
+}
+
+function boundedText(value: unknown): string | null {
+  return typeof value === "string" ? value.slice(0, 256) : null;
+}
+
+function sanitizeLocation(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  try {
+    const parsed = new URL(value);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString().slice(0, 2_048);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function isOneOf<T extends string>(value: unknown, values: readonly T[]): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}

--- a/packages/browser-conformance/src/races.ts
+++ b/packages/browser-conformance/src/races.ts
@@ -1,0 +1,184 @@
+import {
+  BROWSER_CONFORMANCE_GENERATOR_VERSION,
+  BROWSER_CONFORMANCE_SCENARIO_VERSION,
+  BROWSER_CONFORMANCE_REVISION_KEYS,
+  createBrowserConformanceRevisionVector,
+  hashBrowserConformanceSeed,
+  normalizeSeed,
+  type BrowserConformanceEventKind,
+  type BrowserConformanceRevisionKey,
+  type BrowserConformanceSchedule,
+} from "./model.js";
+import { createBrowserConformanceRandom } from "./schedule.js";
+
+/** A reviewed family of Browser races exercised by the conformance suite. */
+export type BrowserConformanceRaceFamily = "bootstrap" | "action" | "observation" | "batch" | "cleanup";
+
+/** One named race and the externally visible invariant it protects. */
+export interface BrowserConformanceRaceCase {
+  readonly id: string;
+  readonly family: BrowserConformanceRaceFamily;
+  readonly events: readonly BrowserConformanceEventKind[];
+  readonly invariant: string;
+}
+
+/** Shared, readable race names. Keep this catalogue stable so failures replay by name. */
+export const BROWSER_CONFORMANCE_RACE_CATALOGUE: readonly BrowserConformanceRaceCase[] = [
+  { id: "bootstrap-disconnect-reconnect", family: "bootstrap", events: ["host-disconnect", "host-reconnect"], invariant: "bootstrap disconnect/reconnect settles exactly once" },
+  { id: "bootstrap-concurrent-open", family: "bootstrap", events: ["target-register", "target-register"], invariant: "concurrent bootstrap opens have one owner and one target" },
+  { id: "bootstrap-cancel", family: "bootstrap", events: ["cancel"], invariant: "cancelled bootstrap cannot report success" },
+  { id: "bootstrap-timeout", family: "bootstrap", events: ["timeout"], invariant: "timed out bootstrap has a bounded terminal outcome" },
+  { id: "bootstrap-close", family: "bootstrap", events: ["target-close"], invariant: "closed bootstrap target cannot be reused" },
+  { id: "bootstrap-lost-response", family: "bootstrap", events: ["lost-response"], invariant: "lost bootstrap response replays its terminal result without a duplicate effect" },
+  { id: "bootstrap-idempotent-replay", family: "bootstrap", events: ["late-response"], invariant: "idempotent bootstrap replay returns one committed effect" },
+  { id: "bootstrap-late-creation", family: "bootstrap", events: ["late-response", "target-register"], invariant: "late bootstrap creation cannot resurrect released state" },
+  { id: "action-takeover", family: "action", events: ["user-takeover"], invariant: "takeover stops agent effects and preserves committed steps" },
+  { id: "action-navigation", family: "action", events: ["navigation"], invariant: "navigation invalidates document-bound actions" },
+  { id: "action-reload", family: "action", events: ["reload"], invariant: "reload invalidates document-bound actions" },
+  { id: "action-close", family: "action", events: ["target-close"], invariant: "closed targets reject later action effects" },
+  { id: "action-resize", family: "action", events: ["resize"], invariant: "resize cannot mutate a replaced target" },
+  { id: "action-cancel", family: "action", events: ["cancel"], invariant: "cancel releases action-owned resources" },
+  { id: "action-timeout", family: "action", events: ["timeout"], invariant: "deadline timeout reports a known none/partial/complete effect" },
+  { id: "action-competing-mutation", family: "action", events: ["competing-mutation"], invariant: "competing mutation has unambiguous ownership" },
+  { id: "observation-host-revision", family: "observation", events: ["host-disconnect", "host-reconnect"], invariant: "host revision invalidates an old observation binding" },
+  { id: "observation-document-revision", family: "observation", events: ["document-revision"], invariant: "document revision invalidates an old observation binding" },
+  { id: "observation-control-revision", family: "observation", events: ["control-revision"], invariant: "control revision invalidates an old observation binding" },
+  { id: "observation-capability-revision", family: "observation", events: ["capability-revision"], invariant: "capability revision cannot be overstated by a stale observation" },
+  { id: "observation-observation-revision", family: "observation", events: ["observation-revision"], invariant: "observation revision rejects stale reads" },
+  { id: "batch-invalidation", family: "batch", events: ["document-revision", "control-revision"], invariant: "batch stops after invalidation without stale mutations" },
+  { id: "batch-navigation", family: "batch", events: ["navigation"], invariant: "batch navigation leaves partial effects explicit" },
+  { id: "batch-partial-failure", family: "batch", events: ["competing-mutation", "late-response"], invariant: "partial batch failure preserves step order and ownership" },
+  { id: "batch-deadline", family: "batch", events: ["timeout"], invariant: "batch deadline produces a known bounded outcome" },
+  { id: "batch-cancel-between-steps", family: "batch", events: ["cancel"], invariant: "cancel between steps does not run a later step" },
+  { id: "cleanup-late-response", family: "cleanup", events: ["late-response"], invariant: "late response cannot resurrect disposed resources" },
+  { id: "cleanup-late-event", family: "cleanup", events: ["late-event"], invariant: "late event cannot mutate a disposed generation" },
+  { id: "cleanup-late-timer", family: "cleanup", events: ["late-timer"], invariant: "late timer is inert after quiescence" },
+  { id: "cleanup-disconnect", family: "cleanup", events: ["host-disconnect"], invariant: "disconnect cleanup leaves no orphaned ownership" },
+  { id: "cleanup-replacement", family: "cleanup", events: ["target-close", "target-register"], invariant: "replacement gets a new generation without stale mutation" },
+  { id: "cleanup-capacity", family: "cleanup", events: ["target-register", "target-register", "target-register", "target-register"], invariant: "capacity rejects excess targets without false success" },
+] as const;
+
+/** High-risk revision combinations that receive an explicit schedule. */
+export const BROWSER_CONFORMANCE_HIGH_RISK_REVISION_COMBINATIONS: readonly (readonly BrowserConformanceRevisionKey[])[] = [
+  ["host", "document", "control"],
+  ["host", "capability", "observation"],
+  ["document", "control", "observation"],
+  ["control", "capability", "observation"],
+] as const;
+
+/** One generated schedule keyed by the revisions it exercises. */
+export interface BrowserConformanceRevisionRaceSchedule {
+  readonly id: string;
+  readonly revisions: readonly BrowserConformanceRevisionKey[];
+  readonly schedule: BrowserConformanceSchedule;
+}
+
+/** Complete bounded individual, pair, and high-risk revision schedules. */
+export interface BrowserConformanceRevisionRaceSchedules {
+  readonly individual: Readonly<Record<BrowserConformanceRevisionKey, BrowserConformanceRevisionRaceSchedule>>;
+  readonly pairs: readonly BrowserConformanceRevisionRaceSchedule[];
+  readonly highRisk: readonly BrowserConformanceRevisionRaceSchedule[];
+}
+
+/** Inputs controlling the bounded revision schedule generator. */
+export interface BrowserConformanceRevisionRaceScheduleOptions {
+  readonly seed: number | string;
+  readonly maxCommands?: number;
+  readonly maxEvents?: number;
+  readonly maxCheckpoints?: number;
+  readonly maxTick?: number;
+}
+
+/** Generates deterministic schedules for every revision, pair, and high-risk combination. */
+export function createBrowserConformanceRevisionRaceSchedules(
+  options: BrowserConformanceRevisionRaceScheduleOptions,
+): BrowserConformanceRevisionRaceSchedules {
+  const revisions = [...BROWSER_CONFORMANCE_REVISION_KEYS];
+  const individual = Object.fromEntries(revisions.map((revision) => [
+    revision,
+    createRevisionRaceSchedule([revision], options),
+  ])) as Record<BrowserConformanceRevisionKey, BrowserConformanceRevisionRaceSchedule>;
+  const pairs: BrowserConformanceRevisionRaceSchedule[] = [];
+  for (let left = 0; left < revisions.length; left += 1) {
+    for (let right = left + 1; right < revisions.length; right += 1) {
+      pairs.push(createRevisionRaceSchedule([revisions[left]!, revisions[right]!], options));
+    }
+  }
+  return {
+    individual,
+    pairs,
+    highRisk: BROWSER_CONFORMANCE_HIGH_RISK_REVISION_COMBINATIONS.map((combination) =>
+      createRevisionRaceSchedule(combination, options)),
+  };
+}
+
+/** Alias with a shorter name for callers that only need revision schedules. */
+export const createBrowserConformanceRaceSchedules = createBrowserConformanceRevisionRaceSchedules;
+
+function createRevisionRaceSchedule(
+  revisions: readonly BrowserConformanceRevisionKey[],
+  options: BrowserConformanceRevisionRaceScheduleOptions,
+): BrowserConformanceRevisionRaceSchedule {
+  const seed = typeof options.seed === "string" ? hashBrowserConformanceSeed(options.seed) : normalizeSeed(options.seed);
+  const maxEvents = bound(options.maxEvents ?? Math.max(8, revisions.length));
+  const maxCommands = bound(options.maxCommands ?? 4);
+  const maxCheckpoints = bound(options.maxCheckpoints ?? revisions.length);
+  const maxTick = bound(options.maxTick ?? Math.max(8, revisions.length * 2));
+  const random = createBrowserConformanceRandom(seed);
+  const selectedRevisions = revisions.slice(0, maxEvents);
+  const itemCount = selectedRevisions.length + Math.min(selectedRevisions.length, maxCheckpoints);
+  const slots = Array.from({ length: itemCount }, (_, index) => index);
+  for (let index = slots.length - 1; index > 0; index -= 1) {
+    const swap = random.integer(index + 1);
+    [slots[index], slots[swap]] = [slots[swap]!, slots[index]!];
+  }
+  const events = selectedRevisions.map((revision, index) => ({
+    order: { tick: maxTick === 0 ? 0 : slots[index]! % (maxTick + 1), ordinal: index },
+    kind: revisionEventKind(revision),
+    revision,
+  }));
+  const checkpoints = selectedRevisions.slice(0, maxCheckpoints).map((revision, index) => ({
+    id: `revision-${revision}`,
+    order: { tick: maxTick === 0 ? 0 : slots[selectedRevisions.length + index]! % (maxTick + 1), ordinal: selectedRevisions.length + index },
+    label: `${revision} revision checkpoint`,
+    expectedRevisions: createBrowserConformanceRevisionVector(),
+  }));
+  const id = revisions.join("+");
+  events.sort((left, right) => left.order.tick - right.order.tick || left.order.ordinal - right.order.ordinal);
+  checkpoints.sort((left, right) => left.order.tick - right.order.tick || left.order.ordinal - right.order.ordinal);
+  for (const checkpoint of checkpoints) {
+    const counts: Partial<Record<BrowserConformanceRevisionKey, number>> = {};
+    for (const event of events) {
+      if (event.order.tick > checkpoint.order.tick || (event.order.tick === checkpoint.order.tick && event.order.ordinal >= checkpoint.order.ordinal)) break;
+      if (event.revision) counts[event.revision] = (counts[event.revision] ?? 0) + 1;
+    }
+    (checkpoint as { expectedRevisions: ReturnType<typeof createBrowserConformanceRevisionVector> }).expectedRevisions = createBrowserConformanceRevisionVector(counts);
+  }
+  return {
+    id,
+    revisions: events.map((event) => event.revision),
+    schedule: {
+      version: BROWSER_CONFORMANCE_SCENARIO_VERSION,
+      generatorVersion: BROWSER_CONFORMANCE_GENERATOR_VERSION,
+      seed,
+      bounds: { maxCommands, maxEvents, maxCheckpoints, maxTick },
+      events,
+      checkpoints,
+    },
+  };
+}
+
+function revisionEventKind(revision: BrowserConformanceRevisionKey): BrowserConformanceEventKind {
+  switch (revision) {
+    case "host": return "host-disconnect";
+    case "document": return "document-revision";
+    case "control": return "control-revision";
+    case "capability": return "capability-revision";
+    case "observation": return "observation-revision";
+  }
+}
+
+function bound(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) throw new RangeError("Revision schedule bounds must be non-negative safe integers");
+  return Math.min(256, value);
+}

--- a/packages/browser-conformance/src/replay.ts
+++ b/packages/browser-conformance/src/replay.ts
@@ -96,7 +96,7 @@ export function createBrowserConformanceReplayBundle(
         ? { comparison: sanitizeBrowserConformanceValue(input.cleanup.comparison) as unknown as BrowserConformanceCleanupComparison }
         : {}),
     },
-    failingInvariant: sanitizeLabel(input.failingInvariant),
+    failingInvariant: sanitizeInvariant(input.failingInvariant),
     ...(input.injectedFault
       ? {
           injectedFault: {
@@ -261,6 +261,14 @@ function sanitizeString(value: string, key: string | undefined): string {
 
 function sanitizeLabel(value: string): string {
   return value.replace(/[^A-Za-z0-9_.:-]+/g, "_").slice(0, 128) || "unknown";
+}
+
+function sanitizeInvariant(value: string): string {
+  return value
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/\b(?:https?|wss?):\/\/[^\s,;]+/gi, (location) => sanitizeString(location, "url"))
+    .replace(/\b(password|token|secret|authorization|cookie|credential|api[_-]?key)\b\s*[:=]\s*[^,;\s]+/gi, "$1=[REDACTED]")
+    .slice(0, 256) || "unknown invariant";
 }
 
 function safeFileName(value: string): string {

--- a/packages/browser-conformance/src/replay.ts
+++ b/packages/browser-conformance/src/replay.ts
@@ -106,9 +106,7 @@ export function createBrowserConformanceReplayBundle(
         }
       : {}),
   };
-  const serialized = serializeBrowserConformanceReplayBundle(bundle);
-  if (serialized.length === 0) throw new Error("Browser conformance replay bundle is empty");
-  return bundle;
+  return fitReplayBundle(bundle);
 }
 
 /** Serializes a replay bundle and enforces its UTF-8 size bound. */
@@ -189,8 +187,58 @@ function sanitizeValue(
 }
 
 function isSensitiveKey(key: string): boolean {
-  return /^(args?|typedtext|screenshot|body|headers?|credentials?|cookie|authorization|password|token|secret|query|fragment|exception|stack|payload)$/i.test(key)
+  return /^(args?|typed[_-]?text|screenshots?|screenshot[_-]?data|body|bodies|headers?|credentials?|cookie|authorization|password|token|secret|query|fragment|errors?|exception|stack|cause|payload)$/i.test(key)
     || /(?:timestamp|requestid|traceid|sessionid|runtimeid|targetid|windowid|nonce|createdat|updatedat|receivedat)$/i.test(key);
+}
+
+function fitReplayBundle(bundle: BrowserConformanceReplayBundle): BrowserConformanceReplayBundle {
+  let candidate = bundle;
+  while (serializedReplayBytes(candidate) > BROWSER_CONFORMANCE_REPLAY_MAX_BYTES) {
+    if (candidate.run.receipts.length > 0) {
+      candidate = { ...candidate, run: { ...candidate.run, receipts: candidate.run.receipts.slice(0, Math.floor(candidate.run.receipts.length / 2)) } };
+      continue;
+    }
+    if (candidate.run.visibleObservations.length > 0) {
+      candidate = { ...candidate, run: { ...candidate.run, visibleObservations: candidate.run.visibleObservations.slice(0, Math.floor(candidate.run.visibleObservations.length / 2)) } };
+      continue;
+    }
+    if (candidate.schedule.events.length > 0) {
+      candidate = { ...candidate, schedule: { ...candidate.schedule, events: candidate.schedule.events.slice(0, Math.floor(candidate.schedule.events.length / 2)) } };
+      continue;
+    }
+    if (candidate.schedule.checkpoints.length > 0) {
+      candidate = { ...candidate, schedule: { ...candidate.schedule, checkpoints: candidate.schedule.checkpoints.slice(0, Math.floor(candidate.schedule.checkpoints.length / 2)) } };
+      continue;
+    }
+    if (candidate.cleanup.comparison) {
+      const { comparison: _comparison, ...cleanup } = candidate.cleanup;
+      candidate = { ...candidate, cleanup };
+      continue;
+    }
+    const compacted = compactReplayResources(candidate);
+    if (compacted !== candidate) {
+      candidate = compacted;
+      continue;
+    }
+    throw new RangeError("Browser conformance replay cannot fit its required evidence fields");
+  }
+  return candidate;
+}
+
+function serializedReplayBytes(bundle: BrowserConformanceReplayBundle): number {
+  return new TextEncoder().encode(JSON.stringify(sanitizeBrowserConformanceValue(bundle))).byteLength;
+}
+
+function compactReplayResources(bundle: BrowserConformanceReplayBundle): BrowserConformanceReplayBundle {
+  const compact = (snapshot: BrowserConformanceResourceSnapshot): BrowserConformanceResourceSnapshot => ({
+    ...snapshot,
+    identities: Object.fromEntries(Object.keys(snapshot.identities).map((key) => [key, []])) as unknown as BrowserConformanceResourceSnapshot["identities"],
+  });
+  const baseline = compact(bundle.cleanup.baseline);
+  const final = compact(bundle.cleanup.final);
+  if (JSON.stringify(baseline) === JSON.stringify(bundle.cleanup.baseline)
+    && JSON.stringify(final) === JSON.stringify(bundle.cleanup.final)) return bundle;
+  return { ...bundle, cleanup: { ...bundle.cleanup, baseline, final } };
 }
 
 function sanitizeString(value: string, key: string | undefined): string {

--- a/packages/browser-conformance/src/replay.ts
+++ b/packages/browser-conformance/src/replay.ts
@@ -1,0 +1,224 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import {
+  BROWSER_CONFORMANCE_GENERATOR_VERSION,
+  BROWSER_CONFORMANCE_SCENARIO_VERSION,
+  type BrowserConformanceEventKind,
+  type BrowserConformanceNormalizedRun,
+  type BrowserConformanceRevisionKey,
+  type BrowserConformanceScenario,
+  type BrowserConformanceSchedule,
+  type BrowserConformanceCleanupInvariant,
+  type BrowserConformanceOrder,
+  type BrowserConformanceJsonValue,
+  type BrowserConformanceResourceSnapshot,
+} from "./model.js";
+import type { BrowserConformanceCleanupComparison } from "./cleanup.js";
+
+/** Relative directory reserved for disposable conformance replay evidence. */
+export const BROWSER_CONFORMANCE_REPLAY_DIRECTORY = ".dev/verification/browser-conformance";
+
+/** Maximum serialized UTF-8 bytes retained by one replay bundle. */
+export const BROWSER_CONFORMANCE_REPLAY_MAX_BYTES = 256 * 1_024;
+
+/** Maximum nested value depth retained by replay sanitization. */
+export const BROWSER_CONFORMANCE_REPLAY_MAX_DEPTH = 8;
+
+/** Maximum array elements retained by replay sanitization. */
+export const BROWSER_CONFORMANCE_REPLAY_MAX_ITEMS = 128;
+
+/** Input to the bounded replay bundle builder. */
+export interface BrowserConformanceReplayBundleInput {
+  readonly scenario: BrowserConformanceScenario;
+  readonly run: BrowserConformanceNormalizedRun;
+  readonly cleanup: BrowserConformanceCleanupInvariant & {
+    readonly final: BrowserConformanceResourceSnapshot;
+    readonly comparison?: BrowserConformanceCleanupComparison;
+  };
+  readonly failingInvariant: string;
+  readonly injectedFault?: { readonly kind: string; readonly order?: BrowserConformanceOrder };
+}
+
+/** Sanitized replay command summary with no raw arguments or typed content. */
+export interface BrowserConformanceReplayCommand {
+  readonly id: string;
+  readonly operation: string;
+}
+
+/** Sanitized replay event summary with no arbitrary event payload. */
+export interface BrowserConformanceReplayEvent {
+  readonly order: BrowserConformanceOrder;
+  readonly kind: BrowserConformanceEventKind;
+  readonly revision?: BrowserConformanceRevisionKey;
+}
+
+/** Bounded, sanitized replay representation safe for disposable evidence. */
+export interface BrowserConformanceReplayBundle {
+  readonly schemaVersion: typeof BROWSER_CONFORMANCE_SCENARIO_VERSION;
+  readonly generatorVersion: typeof BROWSER_CONFORMANCE_GENERATOR_VERSION;
+  readonly scenarioId: string;
+  readonly seed: number;
+  readonly commands: readonly BrowserConformanceReplayCommand[];
+  readonly schedule: {
+    readonly events: readonly BrowserConformanceReplayEvent[];
+    readonly checkpoints: readonly { readonly id: string; readonly order: BrowserConformanceOrder; readonly label: string }[];
+  };
+  readonly run: BrowserConformanceNormalizedRun;
+  readonly cleanup: {
+    readonly baseline: BrowserConformanceResourceSnapshot;
+    readonly final: BrowserConformanceResourceSnapshot;
+    readonly comparison?: BrowserConformanceCleanupComparison;
+  };
+  readonly failingInvariant: string;
+  readonly injectedFault?: { readonly kind: string; readonly order?: BrowserConformanceOrder };
+}
+
+/** Builds a bounded replay bundle while omitting sensitive and dynamic fields. */
+export function createBrowserConformanceReplayBundle(
+  input: BrowserConformanceReplayBundleInput,
+): BrowserConformanceReplayBundle {
+  const schedule = sanitizeSchedule(input.scenario.schedule);
+  const bundle: BrowserConformanceReplayBundle = {
+    schemaVersion: BROWSER_CONFORMANCE_SCENARIO_VERSION,
+    generatorVersion: BROWSER_CONFORMANCE_GENERATOR_VERSION,
+    scenarioId: sanitizeLabel(input.scenario.id),
+    seed: input.scenario.seed,
+    commands: input.scenario.commands.slice(0, input.scenario.schedule.bounds.maxCommands).map((command) => ({
+      id: sanitizeLabel(command.id),
+      operation: command.operation,
+    })),
+    schedule,
+    run: sanitizeBrowserConformanceValue(input.run) as unknown as BrowserConformanceNormalizedRun,
+    cleanup: {
+      baseline: sanitizeBrowserConformanceValue(input.cleanup.baseline) as unknown as BrowserConformanceResourceSnapshot,
+      final: sanitizeBrowserConformanceValue(input.cleanup.final) as unknown as BrowserConformanceResourceSnapshot,
+      ...(input.cleanup.comparison
+        ? { comparison: sanitizeBrowserConformanceValue(input.cleanup.comparison) as unknown as BrowserConformanceCleanupComparison }
+        : {}),
+    },
+    failingInvariant: sanitizeLabel(input.failingInvariant),
+    ...(input.injectedFault
+      ? {
+          injectedFault: {
+            kind: sanitizeLabel(input.injectedFault.kind),
+            ...(input.injectedFault.order ? { order: input.injectedFault.order } : {}),
+          },
+        }
+      : {}),
+  };
+  const serialized = serializeBrowserConformanceReplayBundle(bundle);
+  if (serialized.length === 0) throw new Error("Browser conformance replay bundle is empty");
+  return bundle;
+}
+
+/** Serializes a replay bundle and enforces its UTF-8 size bound. */
+export function serializeBrowserConformanceReplayBundle(
+  bundle: BrowserConformanceReplayBundle,
+): string {
+  const serialized = JSON.stringify(sanitizeBrowserConformanceValue(bundle));
+  const bytes = new TextEncoder().encode(serialized).byteLength;
+  if (bytes > BROWSER_CONFORMANCE_REPLAY_MAX_BYTES) {
+    throw new RangeError(`Browser conformance replay exceeds ${BROWSER_CONFORMANCE_REPLAY_MAX_BYTES} bytes`);
+  }
+  return serialized;
+}
+
+/** Writes one replay bundle below the disposable verification directory. */
+export async function writeBrowserConformanceReplayBundle(
+  bundle: BrowserConformanceReplayBundle,
+  options: { readonly workspaceRoot: string; readonly fileName?: string },
+): Promise<string> {
+  const fileName = safeFileName(options.fileName ?? `replay-${bundle.seed}.json`);
+  const directory = resolve(options.workspaceRoot, BROWSER_CONFORMANCE_REPLAY_DIRECTORY);
+  const filePath = join(directory, fileName);
+  if (!filePath.startsWith(`${directory}\\`) && !filePath.startsWith(`${directory}/`)) {
+    throw new RangeError("Replay path must remain inside the conformance verification directory");
+  }
+  await mkdir(directory, { recursive: true });
+  await writeFile(filePath, serializeBrowserConformanceReplayBundle(bundle), "utf8");
+  return filePath;
+}
+
+/** Sanitizes arbitrary diagnostics into bounded JSON without credentials or raw content. */
+export function sanitizeBrowserConformanceValue(value: unknown): BrowserConformanceJsonValue {
+  return sanitizeValue(value, 0, new WeakSet<object>(), undefined);
+}
+
+function sanitizeSchedule(schedule: BrowserConformanceSchedule): BrowserConformanceReplayBundle["schedule"] {
+  return {
+    events: schedule.events.slice(0, schedule.bounds.maxEvents).map((event) => ({
+      order: event.order,
+      kind: event.kind,
+      ...(event.revision ? { revision: event.revision } : {}),
+    })),
+    checkpoints: schedule.checkpoints.slice(0, schedule.bounds.maxCheckpoints).map((checkpoint) => ({
+      id: sanitizeLabel(checkpoint.id),
+      order: checkpoint.order,
+      label: sanitizeLabel(checkpoint.label),
+    })),
+  };
+}
+
+function sanitizeValue(
+  value: unknown,
+  depth: number,
+  seen: WeakSet<object>,
+  key: string | undefined,
+): BrowserConformanceJsonValue {
+  if (depth > BROWSER_CONFORMANCE_REPLAY_MAX_DEPTH) return "[DEPTH_LIMIT]";
+  if (key && isSensitiveKey(key)) return "[REDACTED]";
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return typeof value === "string" ? sanitizeString(value, key) : value;
+  }
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "object") return null;
+  if (seen.has(value)) return "[CIRCULAR]";
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value.slice(0, BROWSER_CONFORMANCE_REPLAY_MAX_ITEMS).map((item) => sanitizeValue(item, depth + 1, seen, undefined));
+    seen.delete(value);
+    return result;
+  }
+  const result: Record<string, BrowserConformanceJsonValue> = {};
+  for (const objectKey of Object.keys(value).sort().slice(0, BROWSER_CONFORMANCE_REPLAY_MAX_ITEMS)) {
+    if (isSensitiveKey(objectKey)) continue;
+    result[objectKey] = sanitizeValue((value as Record<string, unknown>)[objectKey], depth + 1, seen, objectKey);
+  }
+  seen.delete(value);
+  return result;
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /^(args?|typedtext|screenshot|body|headers?|credentials?|cookie|authorization|password|token|secret|query|fragment|exception|stack|payload)$/i.test(key)
+    || /(?:timestamp|requestid|traceid|sessionid|runtimeid|targetid|windowid|nonce|createdat|updatedat|receivedat)$/i.test(key);
+}
+
+function sanitizeString(value: string, key: string | undefined): string {
+  if (key && /(?:url|location|href|address)/i.test(key)) {
+    try {
+      const parsed = new URL(value);
+      parsed.username = "";
+      parsed.password = "";
+      parsed.search = "";
+      parsed.hash = "";
+      return parsed.toString().slice(0, 2_048);
+    } catch {
+      return "[INVALID_LOCATION]";
+    }
+  }
+  return value
+    .replace(/\b(password|token|secret|authorization|cookie|credential|api[_-]?key)\b\s*[:=]\s*[^,;\s]+/gi, "$1=[REDACTED]")
+    .slice(0, 2_048);
+}
+
+function sanitizeLabel(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.:-]+/g, "_").slice(0, 128) || "unknown";
+}
+
+function safeFileName(value: string): string {
+  const fileName = value.replace(/[^A-Za-z0-9_.-]+/g, "_");
+  if (!fileName || fileName === "." || fileName === ".." || fileName.includes("..")) {
+    throw new RangeError("Replay file name is invalid");
+  }
+  return fileName.endsWith(".json") ? fileName : `${fileName}.json`;
+}

--- a/packages/browser-conformance/src/runner.ts
+++ b/packages/browser-conformance/src/runner.ts
@@ -1,0 +1,67 @@
+import {
+  runBrowserConformanceScenarioCore,
+  type BrowserConformanceExecutionFailure,
+} from "./executor.js";
+import { normalizeBrowserConformanceRun } from "./normalize.js";
+import {
+  createBrowserConformanceReplayBundle,
+  writeBrowserConformanceReplayBundle,
+} from "./replay.js";
+import type {
+  BrowserConformanceNormalizedRun,
+  BrowserConformanceScenario,
+  BrowserConformanceSubject,
+} from "./model.js";
+
+/** Inputs controlling replay capture around a test-library scenario run. */
+export interface BrowserConformanceReplayRunnerOptions {
+  readonly workspaceRoot: string;
+  readonly fileName?: string;
+  readonly failingInvariant: string;
+  readonly injectedFault?: { readonly kind: string };
+}
+
+/** Runs one scenario through the shared timeline and writes bounded replay evidence on failure. */
+export async function runBrowserConformanceScenarioWithReplay(
+  scenario: BrowserConformanceScenario,
+  subject: BrowserConformanceSubject,
+  options: BrowserConformanceReplayRunnerOptions,
+): Promise<BrowserConformanceNormalizedRun> {
+  return runBrowserConformanceScenarioCore(scenario, subject, {
+    onFailure: async (failure) => {
+      await captureReplay(scenario, failure, options);
+    },
+  });
+}
+
+async function captureReplay(
+  scenario: BrowserConformanceScenario,
+  failure: BrowserConformanceExecutionFailure,
+  options: BrowserConformanceReplayRunnerOptions,
+): Promise<void> {
+  const run = failure.run ?? normalizeBrowserConformanceRun({
+    outcome: {
+      status: "failed",
+      effect: "none",
+      recovery: "inspect",
+      errorCode: "CONFORMANCE_FAILURE",
+      errorStage: failure.cleanup.ok ? "dispatch" : "cleanup",
+    },
+    finalState: { resources: failure.final },
+  });
+  await writeBrowserConformanceReplayBundle(
+    createBrowserConformanceReplayBundle({
+      scenario,
+      run,
+      cleanup: {
+        ...scenario.cleanup,
+        baseline: scenario.cleanup.baseline,
+        final: failure.final,
+        comparison: failure.cleanup,
+      },
+      failingInvariant: options.failingInvariant,
+      ...(options.injectedFault ? { injectedFault: options.injectedFault } : {}),
+    }),
+    { workspaceRoot: options.workspaceRoot, fileName: options.fileName },
+  );
+}

--- a/packages/browser-conformance/src/runner.ts
+++ b/packages/browser-conformance/src/runner.ts
@@ -2,6 +2,10 @@ import {
   runBrowserConformanceScenarioCore,
   type BrowserConformanceExecutionFailure,
 } from "./executor.js";
+import {
+  BrowserConformanceFaultController,
+  BrowserConformanceInjectedFaultError,
+} from "./faults.js";
 import { normalizeBrowserConformanceRun } from "./normalize.js";
 import {
   createBrowserConformanceReplayBundle,
@@ -19,6 +23,7 @@ export interface BrowserConformanceReplayRunnerOptions {
   readonly fileName?: string;
   readonly failingInvariant: string;
   readonly injectedFault?: { readonly kind: string };
+  readonly faultController?: BrowserConformanceFaultController;
 }
 
 /** Runs one scenario through the shared timeline and writes bounded replay evidence on failure. */
@@ -28,6 +33,7 @@ export async function runBrowserConformanceScenarioWithReplay(
   options: BrowserConformanceReplayRunnerOptions,
 ): Promise<BrowserConformanceNormalizedRun> {
   return runBrowserConformanceScenarioCore(scenario, subject, {
+    faultController: options.faultController,
     onFailure: async (failure) => {
       await captureReplay(scenario, failure, options);
     },
@@ -60,7 +66,11 @@ async function captureReplay(
         comparison: failure.cleanup,
       },
       failingInvariant: options.failingInvariant,
-      ...(options.injectedFault ? { injectedFault: options.injectedFault } : {}),
+      ...(options.injectedFault
+        ? { injectedFault: options.injectedFault }
+        : failure.error instanceof BrowserConformanceInjectedFaultError
+          ? { injectedFault: { kind: failure.error.kind } }
+          : {}),
     }),
     { workspaceRoot: options.workspaceRoot, fileName: options.fileName },
   );

--- a/packages/browser-conformance/src/schedule.ts
+++ b/packages/browser-conformance/src/schedule.ts
@@ -1,0 +1,171 @@
+import {
+  BROWSER_CONFORMANCE_EVENT_KINDS,
+  BROWSER_CONFORMANCE_GENERATOR_VERSION,
+  BROWSER_CONFORMANCE_REVISION_KEYS,
+  BROWSER_CONFORMANCE_SCENARIO_VERSION,
+  type BrowserConformanceCheckpoint,
+  type BrowserConformanceEventKind,
+  type BrowserConformanceOrder,
+  type BrowserConformanceRevisionKey,
+  type BrowserConformanceSchedule,
+  type BrowserConformanceScheduleBounds,
+  type BrowserConformanceScheduledEvent,
+  hashBrowserConformanceSeed,
+  normalizeSeed,
+} from "./model.js";
+
+/** Default maximum command steps represented by a generated schedule. */
+export const BROWSER_CONFORMANCE_DEFAULT_MAX_COMMANDS = 32;
+
+/** Default maximum external events represented by a generated schedule. */
+export const BROWSER_CONFORMANCE_DEFAULT_MAX_EVENTS = 64;
+
+/** Default maximum named checkpoints represented by a generated schedule. */
+export const BROWSER_CONFORMANCE_DEFAULT_MAX_CHECKPOINTS = 16;
+
+/** Default virtual monotonic tick bound for generated schedules. */
+export const BROWSER_CONFORMANCE_DEFAULT_MAX_TICK = 256;
+
+/** Hard upper bound that keeps generated schedules suitable for CI. */
+export const BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS = 256;
+
+/** Seed accepted by the deterministic conformance random source. */
+export type BrowserConformanceSeed = number | string;
+
+/** Small deterministic random source used by generated Browser schedules. */
+export interface BrowserConformanceRandom {
+  /** Returns the next deterministic value in the half-open range [0, 1). */
+  next(): number;
+  /** Returns a deterministic integer in the half-open range [0, maxExclusive). */
+  integer(maxExclusive: number): number;
+  /** Selects one deterministic item from a non-empty list. */
+  pick<T>(values: readonly T[]): T;
+}
+
+/** Inputs controlling deterministic schedule generation and its bounds. */
+export interface BrowserConformanceScheduleOptions {
+  readonly seed: BrowserConformanceSeed;
+  readonly maxCommands?: number;
+  readonly maxEvents?: number;
+  readonly maxCheckpoints?: number;
+  readonly maxTick?: number;
+  readonly eventCount?: number;
+  readonly checkpointCount?: number;
+}
+
+/** Creates a deterministic, bounded pseudo-random source from a seed. */
+export function createBrowserConformanceRandom(seed: BrowserConformanceSeed): BrowserConformanceRandom {
+  let state = typeof seed === "string" ? hashBrowserConformanceSeed(seed) : normalizeSeed(seed);
+  return {
+    next(): number {
+      state = Math.imul(state ^ (state >>> 16), 0x45d9f3b);
+      state = Math.imul(state ^ (state >>> 16), 0x45d9f3b);
+      state ^= state >>> 16;
+      return (state >>> 0) / 0x1_0000_0000;
+    },
+    integer(maxExclusive: number): number {
+      if (!Number.isSafeInteger(maxExclusive) || maxExclusive <= 0) {
+        throw new RangeError("Random integer bound must be a positive safe integer");
+      }
+      return Math.floor(this.next() * maxExclusive);
+    },
+    pick<T>(values: readonly T[]): T {
+      if (values.length === 0) throw new RangeError("Cannot pick from an empty list");
+      return values[this.integer(values.length)] as T;
+    },
+  };
+}
+
+/** Creates a deterministic bounded event/checkpoint schedule for a scenario. */
+export function createBrowserConformanceSchedule(
+  options: BrowserConformanceScheduleOptions,
+): BrowserConformanceSchedule {
+  const seed = typeof options.seed === "string" ? hashBrowserConformanceSeed(options.seed) : normalizeSeed(options.seed);
+  const bounds: BrowserConformanceScheduleBounds = {
+    maxCommands: boundedCount(options.maxCommands ?? BROWSER_CONFORMANCE_DEFAULT_MAX_COMMANDS),
+    maxEvents: boundedCount(options.maxEvents ?? BROWSER_CONFORMANCE_DEFAULT_MAX_EVENTS),
+    maxCheckpoints: boundedCount(options.maxCheckpoints ?? BROWSER_CONFORMANCE_DEFAULT_MAX_CHECKPOINTS),
+    maxTick: boundedTick(options.maxTick ?? BROWSER_CONFORMANCE_DEFAULT_MAX_TICK),
+  };
+  const random = createBrowserConformanceRandom(seed);
+  const eventCount = Math.min(
+    boundedCount(options.eventCount ?? Math.min(bounds.maxEvents, bounds.maxCommands * 2)),
+    bounds.maxEvents,
+  );
+  const checkpointCount = Math.min(
+    boundedCount(options.checkpointCount ?? Math.min(bounds.maxCheckpoints, bounds.maxCommands)),
+    bounds.maxCheckpoints,
+  );
+  let ordinal = 0;
+  const events: BrowserConformanceScheduledEvent[] = [];
+  for (let index = 0; index < eventCount; index += 1) {
+    const kind = random.pick(BROWSER_CONFORMANCE_EVENT_KINDS);
+    const revision = revisionForEvent(kind, random);
+    events.push({
+      order: nextOrder(random, bounds.maxTick, ordinal++),
+      kind,
+      ...(revision ? { revision } : {}),
+    });
+  }
+  events.sort((left, right) => compareOrder(left.order, right.order));
+
+  const checkpoints: BrowserConformanceCheckpoint[] = [];
+  for (let index = 0; index < checkpointCount; index += 1) {
+    checkpoints.push({
+      id: `checkpoint-${index + 1}`,
+      order: nextOrder(random, bounds.maxTick, ordinal++),
+      label: `checkpoint ${index + 1}`,
+    });
+  }
+  checkpoints.sort((left, right) => compareOrder(left.order, right.order));
+
+  return {
+    version: BROWSER_CONFORMANCE_SCENARIO_VERSION,
+    generatorVersion: BROWSER_CONFORMANCE_GENERATOR_VERSION,
+    seed,
+    bounds,
+    events,
+    checkpoints,
+  };
+}
+
+function boundedCount(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS, Math.max(0, Math.trunc(value)));
+}
+
+function boundedTick(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS * 4, Math.max(0, Math.trunc(value)));
+}
+
+function nextOrder(random: BrowserConformanceRandom, maxTick: number, ordinal: number): BrowserConformanceOrder {
+  return { tick: maxTick === 0 ? 0 : random.integer(maxTick + 1), ordinal };
+}
+
+function compareOrder(left: BrowserConformanceOrder, right: BrowserConformanceOrder): number {
+  return left.tick - right.tick || left.ordinal - right.ordinal;
+}
+
+function revisionForEvent(
+  kind: BrowserConformanceEventKind,
+  random: BrowserConformanceRandom,
+): BrowserConformanceRevisionKey | undefined {
+  switch (kind) {
+    case "host-disconnect":
+    case "host-reconnect":
+      return "host";
+    case "navigation":
+    case "reload":
+      return "document";
+    case "user-takeover":
+    case "competing-mutation":
+      return "control";
+    case "capability-revision":
+      return "capability";
+    case "observation-revision":
+      return "observation";
+    default:
+      return random.next() < 0.2 ? random.pick(BROWSER_CONFORMANCE_REVISION_KEYS) : undefined;
+  }
+}

--- a/packages/browser-conformance/src/schedule.ts
+++ b/packages/browser-conformance/src/schedule.ts
@@ -1,6 +1,8 @@
 import {
   BROWSER_CONFORMANCE_EVENT_KINDS,
   BROWSER_CONFORMANCE_GENERATOR_VERSION,
+  BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS,
+  BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_TICK,
   BROWSER_CONFORMANCE_REVISION_KEYS,
   BROWSER_CONFORMANCE_SCENARIO_VERSION,
   type BrowserConformanceCheckpoint,
@@ -26,8 +28,8 @@ export const BROWSER_CONFORMANCE_DEFAULT_MAX_CHECKPOINTS = 16;
 /** Default virtual monotonic tick bound for generated schedules. */
 export const BROWSER_CONFORMANCE_DEFAULT_MAX_TICK = 256;
 
-/** Hard upper bound that keeps generated schedules suitable for CI. */
-export const BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS = 256;
+/** Re-exported hard bounds used by custom scenario validation. */
+export { BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS, BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_TICK } from "./model.js";
 
 /** Seed accepted by the deterministic conformance random source. */
 export type BrowserConformanceSeed = number | string;
@@ -136,7 +138,7 @@ function boundedCount(value: number): number {
 
 function boundedTick(value: number): number {
   if (!Number.isFinite(value)) return 0;
-  return Math.min(BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_ITEMS * 4, Math.max(0, Math.trunc(value)));
+  return Math.min(BROWSER_CONFORMANCE_HARD_MAX_SCHEDULE_TICK, Math.max(0, Math.trunc(value)));
 }
 
 function nextOrder(random: BrowserConformanceRandom, maxTick: number, ordinal: number): BrowserConformanceOrder {

--- a/packages/browser-conformance/tsconfig.json
+++ b/packages/browser-conformance/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/**/__tests__"]
+}

--- a/packages/browser-conformance/vitest.config.ts
+++ b/packages/browser-conformance/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## What
Adds an adapter-neutral Browser v2 conformance model and runs deterministic scenarios through the web, Electron, broker, MCP, and visible-product paths.

## Why
Browser automation crosses several process and transport boundaries. A repeatable suite must prove truthful receipts, stale-action rejection, deterministic replay, and complete resource cleanup under races and controlled faults.

## Key Changes
- Defines bounded scenario, revision, fault-control, replay, and cleanup APIs in `@mcode/browser-conformance`.
- Runs shared parity, all named races, and seeded revision schedules against real web and Electron adapters.
- Proves stale actions cannot mutate the DOM or Electron target and that cleanup prevents late-state resurrection.
- Covers authenticated broker and MCP transport behavior plus visible Browser product states.
- Fixes takeover cancellation and truthful tab-closure reconciliation found by the suite.
- Passes `bun run verify`, including typecheck, lint, and unit tests.

Closes #1054

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788535010&installation_model_id=20477&pr_number=1107&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1107&signature=2a34cf37ecccd5012a5f9d297bbf18a71b8730619ae0a0e9ccd2d726e4ec8874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent browser automation behavior across desktop and web experiences.
  * Improved handling of interrupted actions, cancellations, navigation, typing, clicking, and scrolling.
  * Added safer browser tab and session cleanup with accurate status reporting.
  * Added bounded diagnostic replay data to support troubleshooting while protecting sensitive information.

* **Bug Fixes**
  * Prevented stale browser events and late responses from restoring closed or replaced tabs.
  * Improved recovery when tab closure, session release, or transport operations fail.
  * Ensured synthetic input does not incorrectly trigger human takeover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->