### PR TITLE
fix(browser): stabilize preview lifecycle and panel overlays

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
@@ -817,6 +817,45 @@ describe("BrowserAutomationKernel", () => {
     });
   });
 
+  it("accepts an aborted load after the requested navigation commits", async () => {
+    const targetUrl = "https://www.google.test/search?q=browser";
+    const committedUrl = `${targetUrl}&source=redirect`;
+    currentWebContents!.loadURL.mockImplementationOnce(async () => {
+      currentWebContents!.url = committedUrl;
+      throw Object.assign(new Error("ERR_ABORTED (-3)"), {
+        code: "ERR_ABORTED",
+        errno: -3,
+      });
+    });
+
+    await expect(kernel.execute(
+      event(),
+      payload(request("navigate", { url: targetUrl }, { requestId: "redirect-committed" })),
+    )).resolves.toMatchObject({
+      ok: true,
+      result: { operation: "navigate", url: committedUrl },
+    });
+  });
+
+  it("rejects an aborted load that leaves the previous page unchanged", async () => {
+    currentWebContents!.loadURL.mockRejectedValueOnce(Object.assign(new Error("ERR_ABORTED (-3)"), {
+      code: "ERR_ABORTED",
+      errno: -3,
+    }));
+
+    await expect(kernel.execute(
+      event(),
+      payload(request(
+        "navigate",
+        { url: "https://other.test/" },
+        { requestId: "redirect-not-committed" },
+      )),
+    )).resolves.toMatchObject({
+      ok: false,
+      error: { code: "NAVIGATION_FAILED" },
+    });
+  });
+
   it("stops every timed-out navigation before returning its error response", async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -480,6 +480,19 @@ describe("preview-browser", () => {
       expectBackgroundBounds(bounds);
     });
 
+    it("recreates an invalidated tab view after a normal hide/show cycle", async () => {
+      const win = createWindow();
+      await showPreview(win);
+      const invalidatedView = createdViews[0]!;
+      (invalidatedView as unknown as { webContents: undefined }).webContents = undefined;
+
+      await hidePreview(win);
+      await expect(showPreview(win)).resolves.not.toThrow();
+
+      expect(createdViews.length).toBeGreaterThan(1);
+      expect(createdViews.at(-1)).not.toBe(invalidatedView);
+    });
+
     it("does not reload the page when re-showing the same thread", async () => {
       const win = createWindow();
       await showPreview(win, { url: "https://example.com" });
@@ -595,6 +608,23 @@ describe("preview-browser", () => {
 
       expect(win.contentView.removeChildView).toHaveBeenCalled();
       expect(view.webContents.close).toHaveBeenCalled();
+    });
+
+    it("does not crash when Electron invalidates a tab view during window teardown", async () => {
+      const win = createWindow();
+      await showPreview(win);
+
+      const view = createdViews[0]!;
+      // Electron can clear the child view's webContents before the window
+      // close handler reaches disposePreviewForWindow.
+      (view as unknown as { webContents: undefined }).webContents = undefined;
+      testWindows = testWindows.filter((candidate) => candidate !== win);
+
+      try {
+        expect(() => disposePreviewForWindow(win as never)).not.toThrow();
+      } finally {
+        sessions.delete(win.id);
+      }
     });
   });
 

--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -149,6 +149,23 @@ function asRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
 }
 
+function isCommittedAbortedNavigation(
+  cause: unknown,
+  webContents: WebContents,
+  requestedUrl: string,
+  previousUrl: string,
+): boolean {
+  const error = asRecord(cause);
+  if (error.code !== "ERR_ABORTED" && error.errno !== -3) return false;
+  const committedUrl = webContents.getURL();
+  if (!committedUrl || committedUrl.startsWith("about:") || committedUrl.startsWith("chrome-error:")) {
+    return false;
+  }
+  // Redirecting pages can reject loadURL after Chromium has already committed
+  // the requested page. A still-unchanged page is a real aborted navigation.
+  return committedUrl === requestedUrl || committedUrl !== previousUrl;
+}
+
 function createAbortPromise(signal: AbortSignal): Promise<never> {
   return new Promise((_, reject) => {
     if (signal.aborted) {
@@ -1262,6 +1279,7 @@ export class BrowserAutomationKernel {
       case "navigate": {
         const url = request.operation === "navigate" ? request.args.url : request.args.url;
         if (url) {
+          const previousUrl = webContents.getURL();
           const navigationSequence = ++state.navigationSequence;
           const stopNavigation = () => {
             if (state.navigationSequence !== navigationSequence) return;
@@ -1285,7 +1303,9 @@ export class BrowserAutomationKernel {
               throw cause;
             }
             if (cause instanceof KernelError) throw cause;
-            throw new KernelError("NAVIGATION_FAILED", "Browser navigation failed", true);
+            if (!isCommittedAbortedNavigation(cause, webContents, url, previousUrl)) {
+              throw new KernelError("NAVIGATION_FAILED", "Browser navigation failed", true);
+            }
           } finally {
             signal.removeEventListener("abort", stopNavigation);
             state.automationNavigationDepth -= 1;

--- a/apps/desktop/src/main/preview/preview-lifecycle.ts
+++ b/apps/desktop/src/main/preview/preview-lifecycle.ts
@@ -71,6 +71,14 @@ export function unmountView(win: BrowserWindow, view: WebContentsView): void {
   }
 }
 
+function clearActiveViewState(s: PreviewSession, view: WebContentsView): void {
+  if (s.view !== view) return;
+  s.view = null;
+  s.scrollbarCssKey = null;
+  s.consoleBuffer.length = 0;
+  s.failedRequestBuffer.length = 0;
+}
+
 /**
  * Removes all preview-related webContents listeners from a WebContentsView so
  * teardown does not fire stale callbacks after the view is detached.
@@ -455,12 +463,7 @@ export function disposeTabView(win: BrowserWindow, s: PreviewSession, tab: TabSt
     /* guest may already be torn down */
   }
   tab.view = null;
-  if (s.view === v) {
-    s.view = null;
-    s.scrollbarCssKey = null;
-    s.consoleBuffer.length = 0;
-    s.failedRequestBuffer.length = 0;
-  }
+  clearActiveViewState(s, v);
 }
 
 /**
@@ -493,6 +496,11 @@ async function injectPreviewScrollbarStyles(s: PreviewSession): Promise<void> {
  * remaining outside the visible content view.
  */
 export function hidePreview(win: BrowserWindow, s: PreviewSession): void {
+  const activeView = s.view;
+  if (activeView && !activeView.webContents) {
+    if (!win.isDestroyed()) unmountView(win, activeView);
+    clearActiveViewState(s, activeView);
+  }
   abortOverlayCapture(s, "capture-interrupted");
   clearIdle(s);
   if (!win.isDestroyed()) {
@@ -500,7 +508,14 @@ export function hidePreview(win: BrowserWindow, s: PreviewSession): void {
     for (const set of s.tabsByThread.values()) {
       for (const tab of set.tabs) {
         const view = tab.view;
-        if (!view || view.webContents.isDestroyed()) continue;
+        if (!view) continue;
+        const webContents = view.webContents;
+        if (!webContents || webContents.isDestroyed()) {
+          unmountView(win, view);
+          tab.view = null;
+          clearActiveViewState(s, view);
+          continue;
+        }
         const bounds = backgroundBoundsForTarget(win, s, tab.threadId, tab.id);
         if (!bounds) {
           unmountView(win, view);
@@ -527,10 +542,11 @@ export function parkPreview(win: BrowserWindow, s: PreviewSession): void {
   hidePreview(win, s);
   clearDiscardTimers(s);
   // Save the active tab's URL before disposing so a later restore can reload.
-  if (s.view && !s.view.webContents.isDestroyed()) {
+  const activeWebContents = s.view?.webContents;
+  if (activeWebContents && !activeWebContents.isDestroyed()) {
     try {
-      void removeEpPickHighlighter(s.view.webContents);
-      const parked = s.view.webContents.getURL();
+      void removeEpPickHighlighter(activeWebContents);
+      const parked = activeWebContents.getURL();
       void validateResumeUrl(isAllowedPreviewUrl(parked) ? parked : null).then((safe) => {
         if (!win.isDestroyed()) s.resumePreviewUrl = safe;
       });

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -830,6 +830,165 @@ describe("BrowserAutomationBroker", () => {
     await expect(navigated).resolves.toMatchObject({ ok: true });
   });
 
+  it("allows one retry for a failed navigation and rejects further attempts", async () => {
+    const deliveries: Array<{ dispatch: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        if (channel === "browserAutomation.request") deliveries.push(data as { dispatch: any });
+        return true;
+      },
+    }));
+    const hostSocket = socket("navigation-retry-budget");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("navigation-retry-budget", "workspace-a"),
+      capabilities: [{ operation: "navigate", available: true }],
+    }, authorization("navigation-retry-budget")).generation;
+    updateTargets(broker, hostSocket, "navigation-retry-budget", generation, ["thread-a"]);
+    const scope = {
+      ...claims("thread-a", "workspace-a"),
+      allowedOperations: ["navigate" as const],
+    };
+    const navigate = (sequence: number) => broker.execute(scope, {
+      ...request(scope, sequence),
+      operation: "navigate",
+      args: { url: "https://example.test/challenge" },
+    });
+    const failLatest = (): void => {
+      const delivery = deliveries.at(-1)!.dispatch;
+      broker.respond(hostSocket, "navigation-retry-budget", generation, {
+        contractVersion: 1,
+        requestId: delivery.request.requestId,
+        sequence: delivery.request.sequence,
+        ok: false,
+        error: {
+          code: "NAVIGATION_FAILED",
+          message: "Browser navigation failed",
+          retryable: true,
+          stage: "effect",
+          effect: "none",
+          recovery: "retry",
+        },
+      });
+    };
+
+    const first = navigate(1);
+    failLatest();
+    await expect(first).resolves.toMatchObject({
+      ok: false,
+      error: { code: "NAVIGATION_FAILED", retryable: true, recovery: "retry" },
+    });
+
+    const retry = navigate(2);
+    failLatest();
+    await expect(retry).resolves.toMatchObject({
+      ok: false,
+      error: { code: "NAVIGATION_FAILED", retryable: false, recovery: "do_not_retry" },
+    });
+
+    await expect(navigate(3)).resolves.toMatchObject({
+      ok: false,
+      error: { code: "NAVIGATION_FAILED", retryable: false, recovery: "do_not_retry" },
+    });
+    expect(deliveries).toHaveLength(2);
+  });
+
+  it("does not direct navigation retries after the browser host disconnects", async () => {
+    const broker = new BrowserAutomationBroker(options({ now: () => 10 }));
+    const hostSocket = socket("navigation-host-loss");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("navigation-host-loss", "workspace-a"),
+      capabilities: [{ operation: "navigate", available: true }],
+    }, authorization("navigation-host-loss")).generation;
+    updateTargets(broker, hostSocket, "navigation-host-loss", generation, ["thread-a"]);
+    const scope = {
+      ...claims("thread-a", "workspace-a"),
+      allowedOperations: ["navigate" as const],
+    };
+    const pending = broker.execute(scope, {
+      ...request(scope),
+      operation: "navigate",
+      args: { url: "https://example.test/challenge" },
+    });
+
+    broker.disconnect(hostSocket);
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      error: { code: "HOST_UNAVAILABLE", recovery: "wait" },
+    });
+  });
+
+  it("resets the navigation retry budget after a successful load", async () => {
+    const deliveries: Array<{ dispatch: any }> = [];
+    const broker = new BrowserAutomationBroker(options({
+      now: () => 10,
+      send: (_socket, channel, data) => {
+        if (channel === "browserAutomation.request") deliveries.push(data as { dispatch: any });
+        return true;
+      },
+    }));
+    const hostSocket = socket("navigation-retry-reset");
+    const generation = broker.registerHost(hostSocket, {
+      ...registration("navigation-retry-reset", "workspace-a"),
+      capabilities: [{ operation: "navigate", available: true }],
+    }, authorization("navigation-retry-reset")).generation;
+    updateTargets(broker, hostSocket, "navigation-retry-reset", generation, ["thread-a"]);
+    const scope = {
+      ...claims("thread-a", "workspace-a"),
+      allowedOperations: ["navigate" as const],
+    };
+    const navigate = (sequence: number) => broker.execute(scope, {
+      ...request(scope, sequence),
+      operation: "navigate",
+      args: { url: "https://example.test/recovered" },
+    });
+
+    const first = navigate(1);
+    const firstDelivery = deliveries.at(-1)!.dispatch;
+    broker.respond(hostSocket, "navigation-retry-reset", generation, {
+      contractVersion: 1,
+      requestId: firstDelivery.request.requestId,
+      sequence: firstDelivery.request.sequence,
+      ok: false,
+      error: { code: "NAVIGATION_FAILED", message: "failed", retryable: true },
+    });
+    await expect(first).resolves.toMatchObject({ ok: false });
+
+    const recovered = navigate(2);
+    const recoveredDelivery = deliveries.at(-1)!.dispatch;
+    broker.respond(hostSocket, "navigation-retry-reset", generation, {
+      contractVersion: 1,
+      requestId: recoveredDelivery.request.requestId,
+      sequence: recoveredDelivery.request.sequence,
+      ok: true,
+      result: {
+        operation: "navigate",
+        url: "https://example.test/recovered",
+        title: "Recovered",
+        controlEpoch: 0,
+      },
+    });
+    await expect(recovered).resolves.toMatchObject({ ok: true });
+
+    const afterSuccess = navigate(3);
+    expect(deliveries).toHaveLength(3);
+    const finalDelivery = deliveries.at(-1)!.dispatch;
+    broker.respond(hostSocket, "navigation-retry-reset", generation, {
+      contractVersion: 1,
+      requestId: finalDelivery.request.requestId,
+      sequence: finalDelivery.request.sequence,
+      ok: true,
+      result: {
+        operation: "navigate",
+        url: "https://example.test/recovered",
+        title: "Recovered again",
+        controlEpoch: 0,
+      },
+    });
+    await expect(afterSuccess).resolves.toMatchObject({ ok: true });
+  });
+
   it("settles non-open work when an assigned target advances generations", async () => {
     let delivery: any;
     const broker = new BrowserAutomationBroker(options({

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -40,6 +40,12 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
   startedAt: number;
   credentialOperations: readonly BrowserAutomationOperation[];
+  navigationAttemptKey?: string;
+}
+
+interface NavigationAttemptRecord {
+  attempts: number;
+  lastAttemptAt: number;
 }
 
 interface OpenReplayRecord {
@@ -120,6 +126,10 @@ const BROWSER_V2_OPERATIONS = new Set<BrowserAutomationOperation>([
   "tabs",
   "evaluate",
 ]);
+const NAVIGATION_MAX_RETRIES = 1;
+const NAVIGATION_MAX_ATTEMPTS = NAVIGATION_MAX_RETRIES + 1;
+const NAVIGATION_RETRY_WINDOW_MS = 60_000;
+const NAVIGATION_ATTEMPT_RECORD_LIMIT = 256;
 
 function browserV2Recovery(code: BrowserAutomationErrorCode): "inspect" | "reopen" | "wait" | "yield_to_user" | "do_not_retry" {
   switch (code) {
@@ -142,9 +152,11 @@ function browserV2Recovery(code: BrowserAutomationErrorCode): "inspect" | "reope
 }
 
 function legacyBrowserRecovery(
+  operation: BrowserAutomationOperation,
   code: BrowserAutomationErrorCode,
   retryable: boolean,
 ): "inspect" | "wait" | "retry" | "manual" {
+  if (operation === "navigate" && code === "HOST_UNAVAILABLE") return "wait";
   if (code === "BROWSER_BUSY") return "wait";
   if (code === "CAPABILITY_CHANGED") return "inspect";
   return retryable ? "retry" : "manual";
@@ -159,7 +171,7 @@ function failure(
   const browserV2Request = BROWSER_V2_OPERATIONS.has(request.operation);
   const recovery = browserV2Request
     ? browserV2Recovery(code)
-    : legacyBrowserRecovery(code, retryable);
+    : legacyBrowserRecovery(request.operation, code, retryable);
   return {
     contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
     requestId: request.requestId,
@@ -232,6 +244,46 @@ function evaluateReplayKey(providerId: string, request: Extract<BrowserAutomatio
 
 function hashExpression(expression: string): string {
   return createHash("sha256").update(expression, "utf8").digest("hex");
+}
+
+function navigationAttemptKey(
+  providerId: string,
+  request: Extract<BrowserAutomationRequest, { operation: "navigate" }>,
+  host: RegisteredHost,
+  target: BrowserAutomationHostDispatchTarget,
+): string {
+  const normalizedUrl = new URL(request.args.url).toString();
+  return JSON.stringify([
+    providerId,
+    request.providerSessionId,
+    request.workspaceId,
+    request.threadId,
+    host.registration.hostId,
+    host.generation,
+    target.tabId,
+    createHash("sha256").update(normalizedUrl, "utf8").digest("hex"),
+  ]);
+}
+
+function navigationRetryLimitFailure(
+  request: Extract<BrowserAutomationRequest, { operation: "navigate" }>,
+): BrowserAutomationResponse {
+  const response = failure(
+    request,
+    "NAVIGATION_FAILED",
+    "Browser navigation retry limit reached",
+    false,
+  );
+  if (response.ok) return response;
+  return {
+    ...response,
+    error: {
+      ...response.error,
+      stage: "effect",
+      effect: "none",
+      recovery: "do_not_retry",
+    },
+  };
 }
 
 function tabsReplayKey(providerId: string, request: Extract<BrowserAutomationRequest, { operation: "tabs" }>): string {
@@ -397,6 +449,7 @@ export class BrowserAutomationBroker {
   private readonly browserMutations = new Map<string, string>();
   private readonly tabsReplay = new Map<string, TabsReplayRecord>();
   private readonly sessionHosts = new Map<string, RegisteredHost>();
+  private readonly navigationAttempts = new Map<string, NavigationAttemptRecord>();
   private nextGeneration = 1;
   private readonly reliability: BrowserAutomationReliabilityCounters = {
     dispatched: 0,
@@ -1023,6 +1076,16 @@ export class BrowserAutomationBroker {
     if (this.pending.has(key)) {
       return finishImmediately(failure(request, "INVALID_REQUEST", "Browser request correlation is already pending", false));
     }
+    const navigationRequest = request.operation === "navigate" ? request : undefined;
+    const retryKey = navigationRequest
+      ? navigationAttemptKey(claims.providerId, navigationRequest, host, target)
+      : undefined;
+    const priorNavigationAttempts = retryKey
+      ? (this.navigationAttempts.get(retryKey)?.attempts ?? 0)
+      : 0;
+    if (navigationRequest && priorNavigationAttempts >= NAVIGATION_MAX_ATTEMPTS) {
+      return finishImmediately(navigationRetryLimitFailure(navigationRequest));
+    }
 
     return new Promise((resolve) => {
       const timeoutMs = Math.max(1, Math.min(60_000, request.deadline - this.now()));
@@ -1057,6 +1120,28 @@ export class BrowserAutomationBroker {
       if (preflightError) {
         this.settle(key, pending, preflightError);
         return;
+      }
+      if (retryKey && navigationRequest) {
+        const prior = this.navigationAttempts.get(retryKey);
+        if ((prior?.attempts ?? 0) >= NAVIGATION_MAX_ATTEMPTS) {
+          this.settle(
+            key,
+            pending,
+            navigationRetryLimitFailure(navigationRequest),
+          );
+          return;
+        }
+        pending.navigationAttemptKey = retryKey;
+        this.navigationAttempts.delete(retryKey);
+        this.navigationAttempts.set(retryKey, {
+          attempts: (prior?.attempts ?? 0) + 1,
+          lastAttemptAt: this.now(),
+        });
+        while (this.navigationAttempts.size > NAVIGATION_ATTEMPT_RECORD_LIMIT) {
+          const oldest = this.navigationAttempts.keys().next().value as string | undefined;
+          if (!oldest) break;
+          this.navigationAttempts.delete(oldest);
+        }
       }
       const sent = this.trySend(host.socket, "browserAutomation.request", {
         hostId: host.registration.hostId,
@@ -1112,6 +1197,7 @@ export class BrowserAutomationBroker {
     this.browserMutations.clear();
     this.tabsReplay.clear();
     this.sessionHosts.clear();
+    this.navigationAttempts.clear();
   }
 
   /** Returns bounded broker counts for status and tests. */
@@ -1209,6 +1295,12 @@ export class BrowserAutomationBroker {
     for (const key of this.tabsReplay.keys()) {
       const parts = JSON.parse(key) as string[];
       if (parts[0] === providerId && parts[1] === providerSessionId) this.tabsReplay.delete(key);
+    }
+    for (const key of this.navigationAttempts.keys()) {
+      const parts = JSON.parse(key) as string[];
+      if (parts[0] === providerId && parts[1] === providerSessionId) {
+        this.navigationAttempts.delete(key);
+      }
     }
     this.browserMutations.delete(sessionRoutingKey(providerId, providerSessionId));
     return removed;
@@ -1456,9 +1548,43 @@ export class BrowserAutomationBroker {
     if (!this.pending.delete(key)) return;
     clearTimeout(pending.timer);
     pending.host.pending = Math.max(0, pending.host.pending - 1);
+    const boundedResponse = this.applyNavigationRetryPolicy(pending, response);
     const latencyMs = Math.max(0, this.now() - pending.startedAt);
-    this.recordOutcome(response, latencyMs);
-    pending.resolve(response);
+    this.recordOutcome(boundedResponse, latencyMs);
+    pending.resolve(boundedResponse);
+  }
+
+  private applyNavigationRetryPolicy(
+    pending: PendingRequest,
+    response: BrowserAutomationResponse,
+  ): BrowserAutomationResponse {
+    if (pending.request.operation !== "navigate") return response;
+    const retryKey = pending.navigationAttemptKey;
+    if (response.ok) {
+      if (retryKey) this.navigationAttempts.delete(retryKey);
+      return response;
+    }
+    if (response.error.code === "HOST_UNAVAILABLE") {
+      return {
+        ...response,
+        error: { ...response.error, recovery: "wait" },
+      };
+    }
+    if (
+      response.error.code === "NAVIGATION_FAILED" &&
+      retryKey &&
+      (this.navigationAttempts.get(retryKey)?.attempts ?? 0) >= NAVIGATION_MAX_ATTEMPTS
+    ) {
+      return {
+        ...response,
+        error: {
+          ...response.error,
+          retryable: false,
+          recovery: "do_not_retry",
+        },
+      };
+    }
+    return response;
   }
 
   private updateTabsAssignment(
@@ -1671,6 +1797,11 @@ export class BrowserAutomationBroker {
     }
     for (const [key, assignment] of this.assignments) {
       if (now - assignment.lastUsedAt >= this.assignmentTtlMs) this.assignments.delete(key);
+    }
+    for (const [key, record] of this.navigationAttempts) {
+      if (now - record.lastAttemptAt >= NAVIGATION_RETRY_WINDOW_MS) {
+        this.navigationAttempts.delete(key);
+      }
     }
   }
 

--- a/apps/web/src/__tests__/diffStore.test.ts
+++ b/apps/web/src/__tests__/diffStore.test.ts
@@ -408,6 +408,20 @@ describe("diffStore", () => {
       setRightPanelWidth("ws-1", null, 100);
       expect(getRightPanel("ws-1").width).toBe(PANEL_MIN_WIDTH);
     });
+
+    it("preserves store identity when the effective width and source are unchanged", () => {
+      const { setRightPanelWidth } = useDiffStore.getState();
+      setRightPanelWidth("ws-1", null, 500, "user");
+      const previousState = useDiffStore.getState();
+      const subscriber = vi.fn();
+      const unsubscribe = useDiffStore.subscribe(subscriber);
+
+      setRightPanelWidth("ws-1", null, 500, "user");
+
+      expect(useDiffStore.getState()).toBe(previousState);
+      expect(subscriber).not.toHaveBeenCalled();
+      unsubscribe();
+    });
   });
 
   describe("maxPanelWidthInSplit", () => {

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -218,17 +218,39 @@ describe("ActivityRail expansion", () => {
     expect(rail).toHaveAttribute("data-expanded", "false");
   });
 
-  it("floats the expanded rail above preview content without suppressing it", () => {
-    const { unmount } = renderRail();
+  it("suppresses preview while the expanded rail overlaps its bounds and releases on collapse", () => {
+    renderRail();
     const rail = screen.getByTestId("activity-rail");
 
     fireEvent.pointerEnter(rail, { pointerType: "mouse" });
     act(() => vi.advanceTimersByTime(EXPECTED_EXPAND_DELAY_MS));
     expect(rail).toHaveAttribute("data-expanded", "true");
     expect(rail).toHaveClass("z-30");
+    expect(usePreviewSuppressionStore.getState().count).toBe(1);
+
+    fireEvent.pointerLeave(rail, { pointerType: "mouse" });
+    act(() => vi.advanceTimersByTime(EXPECTED_COLLAPSE_DELAY_MS));
+    expect(rail).toHaveAttribute("data-expanded", "false");
     expect(usePreviewSuppressionStore.getState().count).toBe(0);
+  });
+
+  it("keeps preview suppressed for an expanded rail and its add-tab menu, then cleans up on close and unmount", () => {
+    const { unmount } = renderRail();
+    const rail = screen.getByTestId("activity-rail");
+
+    fireEvent.focus(screen.getByRole("button", { name: "Terminal" }));
+    expect(rail).toHaveAttribute("data-expanded", "true");
+    expect(usePreviewSuppressionStore.getState().count).toBe(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "New tab" }));
+    expect(screen.getByRole("menuitem", { name: "Browser" })).toBeInTheDocument();
+    expect(usePreviewSuppressionStore.getState().count).toBe(2);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Browser" }));
+    expect(usePreviewSuppressionStore.getState().count).toBe(1);
 
     unmount();
+    expect(usePreviewSuppressionStore.getState().count).toBe(0);
   });
 
   it("uses the amber pointer favicon and accessible name for an agent-controlled page", () => {

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -97,12 +97,12 @@ describe("ActivityRail expansion", () => {
     const rail = screen.getByTestId("activity-rail");
 
     expect(rail).toHaveClass("z-30", "w-12", "flex-none");
-    expect(rail.firstElementChild).toHaveClass("absolute", "w-12");
+    expect(rail.firstElementChild).toHaveClass("absolute", "w-full");
 
     fireEvent.focus(screen.getByRole("button", { name: "Terminal" }));
 
-    expect(rail.firstElementChild).toHaveClass("w-40");
-    expect(rail).toHaveClass("w-12");
+    expect(rail.firstElementChild).toHaveClass("w-full");
+    expect(rail).toHaveClass("w-40", "-mr-28");
   });
 
   it("anchors trailing controls right and reserves their label space", () => {
@@ -251,6 +251,78 @@ describe("ActivityRail expansion", () => {
 
     unmount();
     expect(usePreviewSuppressionStore.getState().count).toBe(0);
+  });
+
+  it("gives the expanded rail a real hit-test box over the renderer guest seam", () => {
+    const guestPointerDown = vi.fn();
+    render(
+      <div
+        data-testid="preview-compositing-root"
+        className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden"
+      >
+        <div
+          data-testid="renderer-guest"
+          className="absolute inset-0 z-0"
+          onPointerDown={guestPointerDown}
+        />
+        <div
+          data-testid="browser-automation-overlay"
+          className="pointer-events-none absolute inset-0 z-20"
+        />
+        <span
+          data-testid="browser-automation-pointer"
+          className="pointer-events-none absolute z-30"
+        />
+        {railElement()}
+      </div>,
+    );
+
+    const rail = screen.getByTestId("activity-rail");
+    const railOverlay = rail.firstElementChild;
+    const guest = screen.getByTestId("renderer-guest");
+    const terminal = screen.getByRole("button", { name: "Terminal" });
+    expect(rail).toHaveClass("w-12");
+    expect(rail).not.toHaveClass("-mr-28");
+
+    const originalElementFromPoint = document.elementFromPoint;
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: (x: number) => {
+        const expanded = rail.classList.contains("w-40");
+        if (expanded && x < 160) return terminal;
+        if (x >= 48) return guest;
+        return rail;
+      },
+    });
+
+    try {
+      fireEvent.pointerEnter(rail, { pointerType: "mouse" });
+      act(() => vi.advanceTimersByTime(EXPECTED_EXPAND_DELAY_MS));
+
+      expect(rail).toHaveAttribute("data-expanded", "true");
+      expect(rail).toHaveClass("w-40", "-mr-28", "z-30");
+      expect(railOverlay).toHaveClass("absolute", "w-full");
+      expect(document.elementFromPoint(100, 200)).toBe(terminal);
+      expect(document.elementFromPoint(300, 200)).toBe(guest);
+      expect(guest).toBeVisible();
+      expect(guest).not.toHaveClass("invisible", "pointer-events-none");
+
+      fireEvent.click(terminal);
+      expect(handlers.onSelect).toHaveBeenCalledWith(rightPanelSingletonId("terminal"));
+      fireEvent.pointerDown(guest, { clientX: 300, clientY: 200 });
+      expect(guestPointerDown).toHaveBeenCalledTimes(1);
+
+      fireEvent.pointerLeave(rail, { pointerType: "mouse" });
+      act(() => vi.advanceTimersByTime(EXPECTED_COLLAPSE_DELAY_MS));
+      expect(rail).toHaveAttribute("data-expanded", "false");
+      expect(rail).toHaveClass("w-12");
+      expect(rail).not.toHaveClass("-mr-28");
+    } finally {
+      Object.defineProperty(document, "elementFromPoint", {
+        configurable: true,
+        value: originalElementFromPoint,
+      });
+    }
   });
 
   it("uses the amber pointer favicon and accessible name for an agent-controlled page", () => {

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -92,6 +92,25 @@ describe("ActivityRail expansion", () => {
     expect(rail).toHaveAttribute("data-expanded", "false");
   });
 
+  it("publishes expansion changes so renderer guests can yield the floating overlap", () => {
+    const onExpandedChange = vi.fn();
+    render(
+      <ActivityRail
+        {...railElement().props}
+        onExpandedChange={onExpandedChange}
+      />,
+    );
+    const rail = screen.getByTestId("activity-rail");
+
+    fireEvent.pointerEnter(rail, { pointerType: "mouse" });
+    act(() => vi.advanceTimersByTime(EXPECTED_EXPAND_DELAY_MS));
+    expect(onExpandedChange).toHaveBeenLastCalledWith(true);
+
+    fireEvent.pointerLeave(rail, { pointerType: "mouse" });
+    act(() => vi.advanceTimersByTime(EXPECTED_COLLAPSE_DELAY_MS));
+    expect(onExpandedChange).toHaveBeenLastCalledWith(false);
+  });
+
   it("keeps a fixed collapsed footprint above right-panel content", () => {
     renderRail();
     const rail = screen.getByTestId("activity-rail");

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -741,7 +741,10 @@ export function ActivityRail({
       ref={railRef}
       data-testid="activity-rail"
       data-expanded={expanded ? "true" : "false"}
-      className="relative z-30 w-12 flex-none bg-background"
+      className={cn(
+        "relative z-30 flex-none bg-background transition-[width,margin-right] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:duration-0 motion-reduce:transition-none",
+        expanded ? "w-40 -mr-28" : "w-12",
+      )}
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}
       onFocusCapture={onFocusCapture}
@@ -749,8 +752,8 @@ export function ActivityRail({
     >
       <div
         className={cn(
-          "absolute inset-y-0 left-0 flex w-12 flex-col items-stretch gap-0.5 overflow-hidden bg-background px-1.5 py-2 transition-[width] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:duration-0 motion-reduce:transition-none",
-          expanded && "w-40 border-r border-border/50",
+          "absolute inset-y-0 left-0 flex w-full flex-col items-stretch gap-0.5 overflow-hidden bg-background px-1.5 py-2",
+          expanded && "border-r border-border/50",
         )}
       >
       {/* Panel-level actions stay at the rail head so they remain the first tab

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -38,6 +38,7 @@ import {
   isBrowserAutomationAgentControlled,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
+import { usePreviewSuppressionStore } from "@/stores/previewSuppressionStore";
 import { cn } from "@/lib/utils";
 
 /** Legacy task completion payload kept for tab API compatibility. */
@@ -505,10 +506,21 @@ function RailAddControl({
   onCreate: (id: RightPanelTab) => void;
   readonly terminalCapReached?: boolean;
 }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const incrementPreviewSuppression = usePreviewSuppressionStore((s) => s.increment);
+  const decrementPreviewSuppression = usePreviewSuppressionStore((s) => s.decrement);
   const shown = shownTabTypes(scope, openTabs);
   const creatable = creatableTypes(scope, openTabs).filter(
     (type) => !(terminalCapReached && type.id === "terminal"),
   );
+
+  // The portaled options can overlap the native preview even when the rail itself is collapsed.
+  const suppressPreview = menuOpen && creatable.length > 1;
+  useEffect(() => {
+    if (!suppressPreview) return;
+    incrementPreviewSuppression();
+    return () => decrementPreviewSuppression();
+  }, [decrementPreviewSuppression, incrementPreviewSuppression, suppressPreview]);
 
   // Nothing openable hides the control entirely, even if a coming-soon teaser remains.
   if (creatable.length === 0) return null;
@@ -540,7 +552,7 @@ function RailAddControl({
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
       <DropdownMenuTrigger
         render={
           <Button
@@ -682,6 +694,14 @@ export function ActivityRail({
       if (!pointerWithinRef.current && !focusWithin) setExpanded(false);
     }, RAIL_COLLAPSE_DELAY_MS);
   }, [clearCollapseTimer, clearExpandTimer]);
+
+  const incrementPreviewSuppression = usePreviewSuppressionStore((s) => s.increment);
+  const decrementPreviewSuppression = usePreviewSuppressionStore((s) => s.decrement);
+  useEffect(() => {
+    if (!expanded) return;
+    incrementPreviewSuppression();
+    return () => decrementPreviewSuppression();
+  }, [decrementPreviewSuppression, expanded, incrementPreviewSuppression]);
 
   useEffect(
     () => () => {

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -56,6 +56,9 @@ const RAIL_EXPAND_DELAY_MS = 140;
 /** Grace period that keeps the rail open while the pointer moves between rows. */
 const RAIL_COLLAPSE_DELAY_MS = 250;
 
+/** Width that the expanded rail floats over Browser content beyond its collapsed footprint. */
+export const ACTIVITY_RAIL_FLOATING_OVERLAP_PX = 112;
+
 /** Shared trailing anchor for expanded-rail actions. */
 const RAIL_TRAILING_CONTROL_CLASS = "absolute right-0 top-0";
 /** Pointer and keyboard reorder boundary for one top-level rail instance. */
@@ -631,6 +634,7 @@ export function ActivityRail({
   terminalLabels,
   onSelectBrowserPage,
   onCloseBrowserPage,
+  onExpandedChange,
 }: {
   readonly tabInstances: readonly RightPanelTabInstance[];
   readonly activeTabId: string | null;
@@ -654,6 +658,8 @@ export function ActivityRail({
   readonly terminalLabels?: Readonly<Record<string, string>>;
   onSelectBrowserPage: (instanceId: string, pageId: string) => void;
   onCloseBrowserPage: (pageId: string) => void;
+  /** Publishes the floating state so renderer guests can yield the overlap region. */
+  readonly onExpandedChange?: (expanded: boolean) => void;
 }) {
   const openTabs = tabInstances.map((instance) => instance.type);
   const [expanded, setExpanded] = useState(false);
@@ -702,6 +708,10 @@ export function ActivityRail({
     incrementPreviewSuppression();
     return () => decrementPreviewSuppression();
   }, [decrementPreviewSuppression, expanded, incrementPreviewSuppression]);
+
+  useEffect(() => {
+    onExpandedChange?.(expanded);
+  }, [expanded, onExpandedChange]);
 
   useEffect(
     () => () => {

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -3123,7 +3123,7 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
         {agentControlsBrowser ? (
           <div
             data-testid="browser-automation-overlay"
-            className="pointer-events-none absolute inset-0 z-20 rounded-tl-md border-2 border-primary"
+            className="pointer-events-none absolute inset-0 z-20 rounded-tl-md"
             style={{
               backgroundImage: [
                 "linear-gradient(to right, color-mix(in oklab, var(--primary) 26%, transparent), transparent 32px)",
@@ -3132,7 +3132,6 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
                 "linear-gradient(to top, color-mix(in oklab, var(--primary) 26%, transparent), transparent 32px)",
               ].join(", "),
               boxShadow: [
-                "inset 0 0 0 1px color-mix(in oklab, var(--primary) 88%, white 12%)",
                 "inset 0 0 40px color-mix(in oklab, var(--primary) 30%, transparent)",
                 "0 0 24px color-mix(in oklab, var(--primary) 28%, transparent)",
               ].join(", "),

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -3112,7 +3112,7 @@ export function PreviewPanel({
             data-testid="preview-webview-surface"
             style={
               rendererOccludedLeft > 0
-                ? { clipPath: `inset(0px 0px 0px ${rendererOccludedLeft}px)` }
+                ? { left: rendererOccludedLeft }
                 : undefined
             }
             className={cn(

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1560,6 +1560,8 @@ export interface PreviewPanelProps {
   readonly workspaceId?: string | null;
   /** Mount only renderer-owned automation webviews, without native preview events. */
   readonly automationOnly?: boolean;
+  /** Left edge hidden beneath floating renderer chrome while the remaining guest stays interactive. */
+  readonly rendererOccludedLeft?: number;
 }
 
 function useLiveViewportCoordinatorState(
@@ -1811,7 +1813,12 @@ function WebRuntimePreview({
  * would hide in-surface overlays. In web-only builds without
  * `desktopBridge.preview`, renders an explanatory empty state.
  */
-export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: PreviewPanelProps) {
+export function PreviewPanel({
+  threadId,
+  workspaceId,
+  automationOnly = false,
+  rendererOccludedLeft = 0,
+}: PreviewPanelProps) {
   const surfaceRef = useRef<HTMLDivElement>(null);
   const webviewRefs = useRef<Record<string, PreviewWebviewHandle | null>>({});
   const [viewportCanvasBounds, setViewportCanvasBounds] = useState({ width: 0, height: 0 });
@@ -3103,6 +3110,11 @@ export function PreviewPanel({ threadId, workspaceId, automationOnly = false }: 
         {hasWebviewLayer ? (
           <div
             data-testid="preview-webview-surface"
+            style={
+              rendererOccludedLeft > 0
+                ? { clipPath: `inset(0px 0px 0px ${rendererOccludedLeft}px)` }
+                : undefined
+            }
             className={cn(
               "absolute inset-0 z-0 overflow-hidden rounded-tl-md",
               !webviewLayerInteractive && "pointer-events-none",

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -125,6 +125,10 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     forwardedRef,
   ) {
   const ref = useRef<PreviewElement | null>(null);
+  const onPageStatusRef = useRef(onPageStatus);
+  const onNavigationStateChangeRef = useRef(onNavigationStateChange);
+  onPageStatusRef.current = onPageStatus;
+  onNavigationStateChangeRef.current = onNavigationStateChange;
   const domReadyRef = useRef(false);
   const pendingReloadRef = useRef(false);
   const faviconRef = useRef<string | null>(null);
@@ -213,28 +217,28 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
   const emitNavigationState = useCallback(() => {
     const el = ref.current;
     if (!domReadyRef.current || !el) {
-      onNavigationStateChange?.({ canGoBack: false, canGoForward: false });
+      onNavigationStateChangeRef.current?.({ canGoBack: false, canGoForward: false });
       return;
     }
     if (isIframeElement(el)) {
-      onNavigationStateChange?.({ canGoBack: false, canGoForward: false });
+      onNavigationStateChangeRef.current?.({ canGoBack: false, canGoForward: false });
       return;
     }
-    onNavigationStateChange?.({
+    onNavigationStateChangeRef.current?.({
       canGoBack: !!el.canGoBack?.(),
       canGoForward: !!el.canGoForward?.(),
     });
-  }, [onNavigationStateChange]);
+  }, []);
 
   const emitStatus = useCallback((phase: PreviewPageStatus["phase"]) => {
-    onPageStatus?.({
+    onPageStatusRef.current?.({
       url: readUrl(),
       title: readTitle(),
       favicon: faviconRef.current,
       phase,
     });
     emitNavigationState();
-  }, [emitNavigationState, onPageStatus, readTitle, readUrl]);
+  }, [emitNavigationState, readTitle, readUrl]);
 
   useImperativeHandle(
     forwardedRef,
@@ -244,13 +248,13 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         if (!el) return;
         if (isIframeElement(el)) {
           el.src = url;
-          onPageStatus?.({ url, title: null, favicon: null, phase: "loading" });
+          onPageStatusRef.current?.({ url, title: null, favicon: null, phase: "loading" });
           return;
         }
         if (el.loadURL) {
           void el.loadURL(url).catch((error: unknown) => {
             if (isExpectedNavigationAbort(error)) return;
-            onPageStatus?.({
+            onPageStatusRef.current?.({
               url: realUrl(url),
               title: null,
               favicon: null,
@@ -321,7 +325,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         return (await Promise.resolve(el.getZoomFactor?.())) ?? factor;
       },
     }),
-    [emitNavigationState, onPageStatus, readUrl],
+    [emitNavigationState, readUrl],
   );
 
   useEffect(() => {
@@ -405,7 +409,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     };
     const onStop = () => emitStatus("loaded");
     const onNavigate = (ev: WebviewEvent) => {
-      onPageStatus?.({
+      onPageStatusRef.current?.({
         url: realUrl(ev.url) ?? readUrl(),
         title: readTitle(),
         favicon: faviconRef.current,
@@ -414,7 +418,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       emitNavigationState();
     };
     const onTitle = (ev: WebviewEvent) => {
-      onPageStatus?.({
+      onPageStatusRef.current?.({
         url: readUrl(),
         title: ev.title && ev.title.trim().length > 0 ? ev.title : readTitle(),
         favicon: faviconRef.current,
@@ -428,7 +432,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     };
     const onFail = (ev: WebviewEvent) => {
       if (ev.errorCode === -3) return;
-      onPageStatus?.({
+      onPageStatusRef.current?.({
         url: realUrl(ev.validatedURL) ?? readUrl(),
         title: null,
         favicon: null,
@@ -469,7 +473,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       el.removeEventListener("did-fail-load", onFail);
       el.removeEventListener("ipc-message", onIpcMessage);
     };
-  }, [emitNavigationState, emitStatus, ensureViewportCoordinator, onPageStatus, readTitle, readUrl, tabId, threadId]);
+  }, [emitNavigationState, emitStatus, ensureViewportCoordinator, readTitle, readUrl, tabId, threadId]);
 
   // Use createElement via React JSX since <webview> is a custom Chromium
   // element; React 19 will pass unknown attributes through unchanged.

--- a/apps/web/src/components/panels/RightPanel.test.tsx
+++ b/apps/web/src/components/panels/RightPanel.test.tsx
@@ -25,16 +25,20 @@ const { activatePreviewPage, closePreviewPage, previewTabSet, previewTabsBridge 
 }));
 
 vi.mock("./ActivityRail", () => ({
+  ACTIVITY_RAIL_FLOATING_OVERLAP_PX: 112,
   ActivityRail: ({
     tabInstances,
     activeTabId,
     onCloseBrowserPage,
+    onExpandedChange,
   }: {
     tabInstances: Array<{ type: string }>;
     activeTabId: string | null;
     onCloseBrowserPage?: (pageId: string) => void;
+    onExpandedChange?: (expanded: boolean) => void;
   }) => (
     <div data-testid="activity-rail" data-open-tabs={tabInstances.map((instance) => instance.type).join(",")} data-active-tab-id={activeTabId}>
+      <button type="button" data-testid="expand-activity-rail" onClick={() => onExpandedChange?.(true)} />
       {tabInstances.some((instance) => instance.type === "preview") && onCloseBrowserPage && (
         <button type="button" data-testid="close-browser-page" onClick={() => onCloseBrowserPage("browser-tab-1")} />
       )}
@@ -57,7 +61,11 @@ vi.mock("./CoordinationPanel", () => ({
 }));
 vi.mock("./plan", () => ({ PlanPanel: () => <div /> }));
 vi.mock("@/components/diff", () => ({ DiffPanel: () => <div /> }));
-vi.mock("@/components/panels/PreviewPanel", () => ({ PreviewPanel: () => <div data-testid="preview-panel" /> }));
+vi.mock("@/components/panels/PreviewPanel", () => ({
+  PreviewPanel: ({ rendererOccludedLeft = 0 }: { rendererOccludedLeft?: number }) => (
+    <div data-testid="preview-panel" data-renderer-occluded-left={rendererOccludedLeft} />
+  ),
+}));
 vi.mock("@/components/terminal/TerminalPoolSlotContext", () => ({
   TerminalPoolSlot: () => <div data-testid="terminal-pool-slot" />,
 }));
@@ -221,7 +229,7 @@ describe("RightPanel", () => {
       openTabs: ["preview"],
       activeTab: "preview",
     });
-    expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "browser-tab-1");
+    expect(activatePreviewPage).not.toHaveBeenCalled();
   });
 
   it("reveals an agent-created page while its Browser bootstrap is pending", () => {
@@ -273,6 +281,78 @@ describe("RightPanel", () => {
     expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "agent-browser-tab");
   });
 
+  it("switches an already-open panel to an agent-created Browser page", () => {
+    previewTabSet.current = {
+      threadId: "workspace-1",
+      activeTabId: "existing-browser-tab",
+      tabs: [
+        {
+          id: "existing-browser-tab",
+          threadId: "workspace-1",
+          title: "Existing page",
+          url: "https://existing.example.test",
+          faviconUrl: null,
+          warm: true,
+          active: true,
+        },
+        {
+          id: "agent-browser-tab",
+          threadId: "workspace-1",
+          title: "Agent page",
+          url: "https://example.test",
+          faviconUrl: null,
+          warm: true,
+          active: false,
+        },
+      ],
+    };
+    useDiffStore.setState({
+      rightPanelFallbackByWorkspace: {
+        "workspace-1": createRightPanelState({
+          visible: true,
+          width: 400,
+          openTabs: ["tasks"],
+          activeTab: "tasks",
+        }),
+      },
+    });
+    useBrowserAutomationStore.setState({
+      pendingAgentOpens: new Map([
+        [
+          "pending-browser-open",
+          {
+            workspaceId: "workspace-1",
+            threadId: "workspace-1",
+            tabId: "agent-browser-tab",
+            url: "https://example.test",
+            startedAt: 2,
+          },
+        ],
+      ]),
+    });
+
+    const { rerender } = render(<RightPanel />);
+
+    expect(screen.getByTestId("activity-rail")).toHaveAttribute(
+      "data-open-tabs",
+      "tasks,preview",
+    );
+    expect(screen.getByTestId("activity-rail")).toHaveAttribute(
+      "data-active-tab-id",
+      "singleton:preview",
+    );
+    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+    expect(useDiffStore.getState().getRightPanel("workspace-1")).toMatchObject({
+      openTabs: ["tasks", "preview"],
+      activeTab: "preview",
+    });
+    expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "agent-browser-tab");
+
+    rerender(<RightPanel />);
+
+    expect(activatePreviewPage).toHaveBeenCalledTimes(1);
+  });
+
   it("does not re-open Browser while the final page close callback is synchronous", () => {
     previewTabSet.current = {
       threadId: "workspace-1",
@@ -314,6 +394,45 @@ describe("RightPanel", () => {
     expect(screen.queryByTestId("preview-panel")).not.toBeInTheDocument();
     expect(useDiffStore.getState().getRightPanel("workspace-1").openTabs).toEqual([]);
     expect(activatePreviewPage).not.toHaveBeenCalled();
+  });
+
+  it("passes the floating rail overlap to the visible renderer Browser", () => {
+    previewTabSet.current = {
+      threadId: "workspace-1",
+      activeTabId: "browser-tab-1",
+      tabs: [{
+        id: "browser-tab-1",
+        threadId: "workspace-1",
+        title: "Visible page",
+        url: "https://example.test",
+        faviconUrl: null,
+        warm: true,
+        active: true,
+      }],
+    };
+    useDiffStore.setState({
+      rightPanelFallbackByWorkspace: {
+        "workspace-1": createRightPanelState({
+          visible: true,
+          width: 400,
+          openTabs: ["preview"],
+          activeTab: "preview",
+        }),
+      },
+    });
+
+    render(<RightPanel />);
+    expect(screen.getByTestId("preview-panel")).toHaveAttribute(
+      "data-renderer-occluded-left",
+      "0",
+    );
+
+    fireEvent.click(screen.getByTestId("expand-activity-rail"));
+
+    expect(screen.getByTestId("preview-panel")).toHaveAttribute(
+      "data-renderer-occluded-left",
+      "112",
+    );
   });
 
   it("keeps a closed Browser scope warm while its active request settles", () => {

--- a/apps/web/src/components/panels/RightPanel.test.tsx
+++ b/apps/web/src/components/panels/RightPanel.test.tsx
@@ -1,8 +1,9 @@
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { activatePreviewPage, previewTabSet, previewTabsBridge } = vi.hoisted(() => ({
+const { activatePreviewPage, closePreviewPage, previewTabSet, previewTabsBridge } = vi.hoisted(() => ({
   activatePreviewPage: vi.fn(),
+  closePreviewPage: vi.fn(),
   previewTabSet: { current: null as {
     threadId: string;
     activeTabId: string | null;
@@ -24,8 +25,20 @@ const { activatePreviewPage, previewTabSet, previewTabsBridge } = vi.hoisted(() 
 }));
 
 vi.mock("./ActivityRail", () => ({
-  ActivityRail: ({ tabInstances, activeTabId }: { tabInstances: Array<{ type: string }>; activeTabId: string | null }) => (
-    <div data-testid="activity-rail" data-open-tabs={tabInstances.map((instance) => instance.type).join(",")} data-active-tab-id={activeTabId} />
+  ActivityRail: ({
+    tabInstances,
+    activeTabId,
+    onCloseBrowserPage,
+  }: {
+    tabInstances: Array<{ type: string }>;
+    activeTabId: string | null;
+    onCloseBrowserPage?: (pageId: string) => void;
+  }) => (
+    <div data-testid="activity-rail" data-open-tabs={tabInstances.map((instance) => instance.type).join(",")} data-active-tab-id={activeTabId}>
+      {tabInstances.some((instance) => instance.type === "preview") && onCloseBrowserPage && (
+        <button type="button" data-testid="close-browser-page" onClick={() => onCloseBrowserPage("browser-tab-1")} />
+      )}
+    </div>
   ),
 }));
 vi.mock("./PanelEmptyState", () => ({
@@ -53,7 +66,7 @@ vi.mock("@/stores/previewTabsStore", () => ({
   usePreviewTabsStore: {
     getState: () => ({
       activatePage: activatePreviewPage,
-      closePage: vi.fn(),
+      closePage: closePreviewPage,
       setTabSet: (_scopeId: string, tabSet: typeof previewTabSet.current) => {
         previewTabSet.current = tabSet;
       },
@@ -75,6 +88,7 @@ describe("RightPanel", () => {
   beforeEach(() => {
     previewTabSet.current = null;
     activatePreviewPage.mockReset();
+    closePreviewPage.mockReset();
     previewTabsBridge.list.mockReset();
     previewTabsBridge.list.mockResolvedValue({ ok: true, data: null });
     previewTabsBridge.updatedListener.current = null;
@@ -142,7 +156,7 @@ describe("RightPanel", () => {
     expect(screen.getByTestId("coordination-panel-integration")).toHaveTextContent("workspace-1:thread-1");
   });
 
-  it("reveals an existing Browser page when the user opens an empty hidden panel", () => {
+  it("keeps an idle existing Browser page behind the default panel screen", () => {
     previewTabSet.current = {
       threadId: "workspace-1",
       activeTabId: "browser-tab-1",
@@ -163,18 +177,17 @@ describe("RightPanel", () => {
 
     act(() => useDiffStore.getState().showRightPanel("workspace-1"));
 
-    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
-    expect(screen.getByTestId("activity-rail")).toHaveAttribute("data-open-tabs", "preview");
-    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-empty-state")).toBeInTheDocument();
+    expect(screen.getByTestId("activity-rail")).toHaveAttribute("data-open-tabs", "");
+    expect(screen.queryByTestId("preview-panel")).not.toBeInTheDocument();
     expect(useDiffStore.getState().getRightPanel("workspace-1")).toMatchObject({
       visible: true,
-      openTabs: ["preview"],
-      activeTab: "preview",
+      openTabs: [],
     });
-    expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "browser-tab-1");
+    expect(activatePreviewPage).not.toHaveBeenCalled();
   });
 
-  it("activates the sole Browser tab when the hidden panel retained no active instance", () => {
+  it("restores an explicitly retained Browser tab when the hidden panel had no active instance", () => {
     previewTabSet.current = {
       threadId: "workspace-1",
       activeTabId: "browser-tab-1",
@@ -198,7 +211,6 @@ describe("RightPanel", () => {
         }),
       },
     });
-
     render(<RightPanel />);
     act(() => useDiffStore.getState().showRightPanel("workspace-1"));
 
@@ -255,10 +267,112 @@ describe("RightPanel", () => {
     render(<RightPanel />);
     act(() => useDiffStore.getState().showRightPanel("workspace-1"));
 
+    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
+    expect(screen.getByTestId("activity-rail")).toHaveAttribute("data-open-tabs", "preview");
+    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
     expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "agent-browser-tab");
   });
 
-  it("reveals a Browser page that is published after the empty panel opens", () => {
+  it("does not re-open Browser while the final page close callback is synchronous", () => {
+    previewTabSet.current = {
+      threadId: "workspace-1",
+      activeTabId: "browser-tab-1",
+      tabs: [{
+        id: "browser-tab-1",
+        threadId: "workspace-1",
+        title: "Closing page",
+        url: "https://example.test",
+        faviconUrl: null,
+        warm: true,
+        active: true,
+      }],
+    };
+    useDiffStore.setState({
+      rightPanelFallbackByWorkspace: {
+        "workspace-1": createRightPanelState({
+          visible: true,
+          width: 400,
+          openTabs: ["preview"],
+          activeTab: "preview",
+        }),
+      },
+    });
+    closePreviewPage.mockImplementation((
+      _scopeId: string,
+      _tabId: string,
+      options: { onLastClose?: () => void },
+    ) => {
+      previewTabSet.current = null;
+      options.onLastClose?.();
+    });
+
+    render(<RightPanel />);
+    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("close-browser-page"));
+
+    expect(screen.getByTestId("panel-empty-state")).toBeInTheDocument();
+    expect(screen.queryByTestId("preview-panel")).not.toBeInTheDocument();
+    expect(useDiffStore.getState().getRightPanel("workspace-1").openTabs).toEqual([]);
+    expect(activatePreviewPage).not.toHaveBeenCalled();
+  });
+
+  it("keeps a closed Browser scope warm while its active request settles", () => {
+    previewTabSet.current = {
+      threadId: "workspace-1",
+      activeTabId: "browser-tab-1",
+      tabs: [{
+        id: "browser-tab-1",
+        threadId: "workspace-1",
+        title: "Busy page",
+        url: "https://example.test",
+        faviconUrl: null,
+        warm: true,
+        active: true,
+      }],
+    };
+    useDiffStore.setState({
+      rightPanelFallbackByWorkspace: {
+        "workspace-1": createRightPanelState({
+          visible: true,
+          width: 400,
+          openTabs: ["preview"],
+          activeTab: "preview",
+        }),
+      },
+    });
+    useBrowserAutomationStore.setState({
+      activeRequests: new Map([
+        [
+          "active-browser-request",
+          {
+            dispatch: { target: { threadId: "workspace-1", tabId: "browser-tab-1" } },
+            startedAt: 2,
+          } as never,
+        ],
+      ]),
+    });
+    closePreviewPage.mockImplementation((
+      _scopeId: string,
+      _tabId: string,
+      options: { onLastClose?: () => void },
+    ) => {
+      previewTabSet.current = null;
+      options.onLastClose?.();
+    });
+
+    render(<RightPanel />);
+    fireEvent.click(screen.getByTestId("close-browser-page"));
+
+    expect(screen.getByTestId("panel-empty-state")).toBeInTheDocument();
+    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("preview-panel").parentElement).toHaveClass("hidden");
+
+    act(() => useBrowserAutomationStore.setState({ activeRequests: new Map() }));
+
+    expect(screen.queryByTestId("preview-panel")).not.toBeInTheDocument();
+  });
+
+  it("keeps an ordinary host-published Browser page behind the default screen", () => {
     const { rerender } = render(<RightPanel />);
 
     act(() => useDiffStore.getState().showRightPanel("workspace-1"));
@@ -279,17 +393,16 @@ describe("RightPanel", () => {
     };
     rerender(<RightPanel />);
 
-    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
-    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-empty-state")).toBeInTheDocument();
+    expect(screen.queryByTestId("preview-panel")).not.toBeInTheDocument();
     expect(useDiffStore.getState().getRightPanel("workspace-1")).toMatchObject({
       visible: true,
-      openTabs: ["preview"],
-      activeTab: "preview",
+      openTabs: [],
     });
-    expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "browser-tab-1");
+    expect(activatePreviewPage).not.toHaveBeenCalled();
   });
 
-  it("subscribes while empty so an Electron-created Browser page replaces the default screen", async () => {
+  it("does not reveal an ordinary Electron-created Browser page from a host update", async () => {
     const { rerender } = render(<RightPanel />);
 
     act(() => useDiffStore.getState().showRightPanel("workspace-1"));
@@ -313,11 +426,12 @@ describe("RightPanel", () => {
     });
     rerender(<RightPanel />);
 
-    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
-    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-empty-state")).toBeInTheDocument();
+    expect(screen.queryByTestId("preview-panel")).not.toBeInTheDocument();
+    expect(activatePreviewPage).not.toHaveBeenCalled();
   });
 
-  it("replaces an already-visible default screen when Electron publishes a Browser page", async () => {
+  it("keeps an already-visible default screen after ordinary Electron publication", async () => {
     useDiffStore.setState({
       rightPanelFallbackByWorkspace: {
         "workspace-1": createRightPanelState({
@@ -348,8 +462,9 @@ describe("RightPanel", () => {
     });
     rerender(<RightPanel />);
 
-    expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
-    expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-empty-state")).toBeInTheDocument();
+    expect(screen.queryByTestId("preview-panel")).not.toBeInTheDocument();
+    expect(activatePreviewPage).not.toHaveBeenCalled();
   });
 
   it("does not let a background Browser page alter an existing active panel tab", () => {

--- a/apps/web/src/components/panels/RightPanel.test.tsx
+++ b/apps/web/src/components/panels/RightPanel.test.tsx
@@ -1,9 +1,16 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { activatePreviewPage, closePreviewPage, previewTabSet, previewTabsBridge } = vi.hoisted(() => ({
+const {
+  activatePreviewPage,
+  closePreviewPage,
+  previewPanelRender,
+  previewTabSet,
+  previewTabsBridge,
+} = vi.hoisted(() => ({
   activatePreviewPage: vi.fn(),
   closePreviewPage: vi.fn(),
+  previewPanelRender: vi.fn(),
   previewTabSet: { current: null as {
     threadId: string;
     activeTabId: string | null;
@@ -31,14 +38,17 @@ vi.mock("./ActivityRail", () => ({
     activeTabId,
     onCloseBrowserPage,
     onExpandedChange,
+    onTogglePanel,
   }: {
     tabInstances: Array<{ type: string }>;
     activeTabId: string | null;
     onCloseBrowserPage?: (pageId: string) => void;
     onExpandedChange?: (expanded: boolean) => void;
+    onTogglePanel?: () => void;
   }) => (
     <div data-testid="activity-rail" data-open-tabs={tabInstances.map((instance) => instance.type).join(",")} data-active-tab-id={activeTabId}>
       <button type="button" data-testid="expand-activity-rail" onClick={() => onExpandedChange?.(true)} />
+      <button type="button" data-testid="toggle-right-panel" onClick={onTogglePanel} />
       {tabInstances.some((instance) => instance.type === "preview") && onCloseBrowserPage && (
         <button type="button" data-testid="close-browser-page" onClick={() => onCloseBrowserPage("browser-tab-1")} />
       )}
@@ -49,8 +59,26 @@ vi.mock("./PanelEmptyState", () => ({
   PanelEmptyState: () => <div data-testid="panel-empty-state" />,
 }));
 vi.mock("./ResizableRightPanel", () => ({
-  ResizableRightPanel: ({ children, testId }: { children: React.ReactNode; testId?: string }) => (
-    <div data-testid={testId}>{children}</div>
+  ResizableRightPanel: ({
+    children,
+    inert,
+    testId,
+    ...props
+  }: {
+    children: React.ReactNode;
+    inert?: boolean;
+    testId?: string;
+    "aria-hidden"?: boolean;
+    "data-right-panel-root"?: string;
+  }) => (
+    <div
+      data-testid={testId}
+      aria-hidden={props["aria-hidden"]}
+      data-right-panel-root={props["data-right-panel-root"]}
+      inert={inert ? true : undefined}
+    >
+      {children}
+    </div>
   ),
 }));
 vi.mock("./SubagentsPanel", () => ({ SubagentsPanel: () => <div /> }));
@@ -62,9 +90,10 @@ vi.mock("./CoordinationPanel", () => ({
 vi.mock("./plan", () => ({ PlanPanel: () => <div /> }));
 vi.mock("@/components/diff", () => ({ DiffPanel: () => <div /> }));
 vi.mock("@/components/panels/PreviewPanel", () => ({
-  PreviewPanel: ({ rendererOccludedLeft = 0 }: { rendererOccludedLeft?: number }) => (
-    <div data-testid="preview-panel" data-renderer-occluded-left={rendererOccludedLeft} />
-  ),
+  PreviewPanel: ({ rendererOccludedLeft = 0 }: { rendererOccludedLeft?: number }) => {
+    previewPanelRender();
+    return <div data-testid="preview-panel" data-renderer-occluded-left={rendererOccludedLeft} />;
+  },
 }));
 vi.mock("@/components/terminal/TerminalPoolSlotContext", () => ({
   TerminalPoolSlot: () => <div data-testid="terminal-pool-slot" />,
@@ -85,7 +114,7 @@ vi.mock("@/lib/ensure-terminal", () => ({ createTerminalForScope: vi.fn() }));
 vi.mock("@/lib/right-panel-layout", () => ({ toggleRightPanelAdaptive: vi.fn() }));
 vi.mock("@/transport", () => ({ getTransport: () => ({ terminalKill: vi.fn() }) }));
 
-import { RightPanel } from "./RightPanel";
+import { reconcileWarmPreviewScopes, RightPanel } from "./RightPanel";
 import { createRightPanelState, useDiffStore } from "@/stores/diffStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useUiStore } from "@/stores/uiStore";
@@ -97,6 +126,7 @@ describe("RightPanel", () => {
     previewTabSet.current = null;
     activatePreviewPage.mockReset();
     closePreviewPage.mockReset();
+    previewPanelRender.mockReset();
     previewTabsBridge.list.mockReset();
     previewTabsBridge.list.mockResolvedValue({ ok: true, data: null });
     previewTabsBridge.updatedListener.current = null;
@@ -144,6 +174,30 @@ describe("RightPanel", () => {
       "The result of getSnapshot should be cached",
     );
     error.mockRestore();
+  });
+
+  it("preserves warm-scope identity when reconciliation changes nothing", () => {
+    const scopes = [{ scopeId: "workspace-1", workspaceId: "workspace-1", lastUsedAt: 1 }];
+
+    expect(reconcileWarmPreviewScopes(scopes, scopes[0]!, new Set())).toBe(scopes);
+  });
+
+  it("releases focus before making the right panel inert", () => {
+    useDiffStore.setState({
+      rightPanelFallbackByWorkspace: {
+        "workspace-1": createRightPanelState({ visible: true, width: 400 }),
+      },
+    });
+    render(<RightPanel />);
+    const toggle = screen.getByTestId("toggle-right-panel");
+    toggle.focus();
+    expect(toggle).toHaveFocus();
+
+    act(() => useDiffStore.getState().hideRightPanel("workspace-1"));
+
+    expect(toggle).not.toHaveFocus();
+    expect(screen.getByTestId("right-panel")).toHaveAttribute("inert");
+    expect(screen.getByTestId("right-panel")).not.toHaveAttribute("aria-hidden");
   });
 
   it("renders coordination content for an open active thread tab", () => {
@@ -433,6 +487,48 @@ describe("RightPanel", () => {
       "data-renderer-occluded-left",
       "112",
     );
+  });
+
+  it("does not render the active Browser surface for another scope's request", () => {
+    previewTabSet.current = {
+      threadId: "workspace-1",
+      activeTabId: "browser-tab-1",
+      tabs: [{
+        id: "browser-tab-1",
+        threadId: "workspace-1",
+        title: "Visible page",
+        url: "https://example.test",
+        faviconUrl: null,
+        warm: true,
+        active: true,
+      }],
+    };
+    useDiffStore.setState({
+      rightPanelFallbackByWorkspace: {
+        "workspace-1": createRightPanelState({
+          visible: true,
+          width: 400,
+          openTabs: ["preview"],
+          activeTab: "preview",
+        }),
+      },
+    });
+    render(<RightPanel />);
+    const renderCount = previewPanelRender.mock.calls.length;
+
+    act(() => useBrowserAutomationStore.setState({
+      activeRequests: new Map([
+        [
+          "other-scope-request",
+          {
+            dispatch: { target: { threadId: "other-scope", tabId: "other-tab" } },
+            startedAt: 2,
+          } as never,
+        ],
+      ]),
+    }));
+
+    expect(previewPanelRender).toHaveBeenCalledTimes(renderCount);
   });
 
   it("keeps a closed Browser scope warm while its active request settles", () => {

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useShallow } from "zustand/shallow";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useUiStore } from "@/stores/uiStore";
 import {
@@ -68,12 +69,53 @@ export function reconcileWarmPreviewScopes(
     if (selected.size >= BROWSER_AUTOMATION_WARM_TARGET_LIMIT) break;
     selected.set(scope.scopeId, scope);
   }
-  return [...selected.values()];
+  const result = [...selected.values()];
+  return result.length === previous.length &&
+    result.every((scope, index) => scope === previous[index])
+    ? previous
+    : result;
 }
 import { SubagentsPanel } from "./SubagentsPanel";
 import { CoordinationPanel } from "./CoordinationPanel";
 
 const EMPTY_SCOPE_TERMINALS: readonly TerminalInstance[] = [];
+
+interface WarmPreviewSurfaceProps {
+  readonly scope: WarmPreviewScope;
+  readonly visible: boolean;
+  readonly rendererOccludedLeft: number;
+}
+
+const WarmPreviewSurface = memo(function WarmPreviewSurface({
+  scope,
+  visible,
+  rendererOccludedLeft,
+}: WarmPreviewSurfaceProps) {
+  const automationHosted = useBrowserAutomationStore((state) =>
+    state.hostedScopeIds.has(scope.scopeId),
+  );
+  return (
+    <div
+      data-preview-scope={scope.scopeId}
+      className={visible ? "flex min-h-0 flex-1" : "hidden"}
+      inert={!visible ? true : undefined}
+    >
+      {automationHosted ? (
+        <div
+          data-automation-preview-dock={scope.scopeId}
+          data-visible={visible ? "true" : "false"}
+          className="min-h-0 min-w-0 flex-1"
+        />
+      ) : (
+        <PreviewPanel
+          threadId={scope.scopeId}
+          workspaceId={scope.workspaceId}
+          rendererOccludedLeft={rendererOccludedLeft}
+        />
+      )}
+    </div>
+  );
+});
 
 /**
  * Tracks whether the Changes tab has unreviewed new files for the active
@@ -160,19 +202,74 @@ export function RightPanel() {
   // workspace itself in the threadless new-thread view (where they run against
   // the local workspace root). Their stores treat this as an opaque scope key.
   const panelScopeId = activeThreadId ?? activeWorkspaceId;
-  const activeBrowserRequests = useBrowserAutomationStore((state) => state.activeRequests);
-  const pendingAgentOpens = useBrowserAutomationStore((state) => state.pendingAgentOpens);
-  const browserLifecycleTabs = useBrowserAutomationStore((state) => state.lifecycleTabs);
-  const browserLiveTargets = useBrowserAutomationStore((state) => state.liveTargets);
-  const automationHostedScopeIds = useBrowserAutomationStore((state) => state.hostedScopeIds);
-  const busyPreviewScopeIds = useMemo(
-    () => new Set(
-      [...activeBrowserRequests.values()].map(({ dispatch }) => dispatch.target.threadId),
-    ),
-    [activeBrowserRequests],
-  );
   const [warmPreviewScopes, setWarmPreviewScopes] = useState<readonly WarmPreviewScope[]>([]);
   const [activityRailExpanded, setActivityRailExpanded] = useState(false);
+  const retainedPreviewScopeIds = useMemo(
+    () => new Set([
+      ...(panelScopeId ? [panelScopeId] : []),
+      ...warmPreviewScopes.map((scope) => scope.scopeId),
+    ]),
+    [panelScopeId, warmPreviewScopes],
+  );
+  const [pendingAgentPageId, activeAgentRequestPageId, ownedAgentPageId] =
+    useBrowserAutomationStore(
+      useShallow((state) => {
+        let pendingPage: { readonly tabId: string; readonly startedAt: number } | null = null;
+        for (const pending of state.pendingAgentOpens.values()) {
+          if (
+            pending.workspaceId !== activeWorkspaceId ||
+            pending.threadId !== panelScopeId
+          ) continue;
+          if (!pendingPage || pending.startedAt > pendingPage.startedAt) {
+            pendingPage = { tabId: pending.tabId, startedAt: pending.startedAt };
+          }
+        }
+
+        let activePage: { readonly tabId: string; readonly startedAt: number } | null = null;
+        for (const { dispatch, startedAt } of state.activeRequests.values()) {
+          if (dispatch.target.threadId !== panelScopeId) continue;
+          if (!activePage || startedAt > activePage.startedAt) {
+            activePage = { tabId: dispatch.target.tabId, startedAt };
+          }
+        }
+
+        let ownedPage: { readonly tabId: string; readonly lastUsedAt: number } | null = null;
+        for (const lifecycle of state.lifecycleTabs.values()) {
+          if (
+            lifecycle.workspaceId !== activeWorkspaceId ||
+            lifecycle.threadId !== panelScopeId ||
+            lifecycle.provenance !== "agent-created" ||
+            lifecycle.ownership !== "owned"
+          ) continue;
+          const liveTarget = panelScopeId
+            ? state.liveTargets.get(browserAutomationTargetKey(panelScopeId, lifecycle.tabId))
+            : undefined;
+          const lastUsedAt = liveTarget?.lastUsedAt ?? 0;
+          if (!ownedPage || lastUsedAt > ownedPage.lastUsedAt) {
+            ownedPage = { tabId: lifecycle.tabId, lastUsedAt };
+          }
+        }
+
+        return [
+          pendingPage?.tabId ?? null,
+          activePage?.tabId ?? null,
+          ownedPage?.tabId ?? null,
+        ] as const;
+      }),
+    );
+  const busyPreviewScopeIdList = useBrowserAutomationStore(
+    useShallow((state) => [
+      ...new Set(
+        [...state.activeRequests.values()]
+          .map(({ dispatch }) => dispatch.target.threadId)
+          .filter((scopeId) => retainedPreviewScopeIds.has(scopeId)),
+      ),
+    ].sort()),
+  );
+  const busyPreviewScopeIds = useMemo(
+    () => new Set(busyPreviewScopeIdList),
+    [busyPreviewScopeIdList],
+  );
   const terminalsByScope = useTerminalStore((s) => s.terminals);
   const scopeTerminals = panelScopeId
     ? (terminalsByScope[panelScopeId] ?? EMPTY_SCOPE_TERMINALS)
@@ -202,52 +299,24 @@ export function RightPanel() {
   const requestedAgentPageActivationRef = useRef<string | null>(null);
   const agentBrowserPage = useMemo(() => {
     if (!activeWorkspaceId || !panelScopeId || !browserTabSet) return null;
-    let pendingPage: { readonly tabId: string; readonly startedAt: number } | null = null;
-    for (const pending of pendingAgentOpens.values()) {
-      if (pending.workspaceId !== activeWorkspaceId || pending.threadId !== panelScopeId) continue;
-      if (!browserTabSet.tabs.some((tab) => tab.id === pending.tabId)) continue;
-      if (!pendingPage || pending.startedAt > pendingPage.startedAt) {
-        pendingPage = { tabId: pending.tabId, startedAt: pending.startedAt };
-      }
+    const hasPage = (tabId: string | null) =>
+      tabId !== null && browserTabSet.tabs.some((tab) => tab.id === tabId);
+    if (pendingAgentPageId && hasPage(pendingAgentPageId)) {
+      return { tabId: pendingAgentPageId, presenting: true };
     }
-    if (pendingPage) return { tabId: pendingPage.tabId, presenting: true };
-
-    let selected: { readonly tabId: string; readonly startedAt: number } | null = null;
-    for (const { dispatch, startedAt } of activeBrowserRequests.values()) {
-      if (dispatch.target.threadId !== panelScopeId) continue;
-      if (!browserTabSet.tabs.some((tab) => tab.id === dispatch.target.tabId)) continue;
-      if (!selected || startedAt > selected.startedAt) {
-        selected = { tabId: dispatch.target.tabId, startedAt };
-      }
+    if (activeAgentRequestPageId && hasPage(activeAgentRequestPageId)) {
+      return { tabId: activeAgentRequestPageId, presenting: true };
     }
-    if (selected) return { tabId: selected.tabId, presenting: true };
-
-    let ownedPage: { readonly tabId: string; readonly lastUsedAt: number } | null = null;
-    for (const lifecycle of browserLifecycleTabs.values()) {
-      if (
-        lifecycle.workspaceId !== activeWorkspaceId ||
-        lifecycle.threadId !== panelScopeId ||
-        lifecycle.provenance !== "agent-created" ||
-        lifecycle.ownership !== "owned" ||
-        !browserTabSet.tabs.some((tab) => tab.id === lifecycle.tabId)
-      ) continue;
-      const liveTarget = browserLiveTargets.get(
-        browserAutomationTargetKey(panelScopeId, lifecycle.tabId),
-      );
-      const lastUsedAt = liveTarget?.lastUsedAt ?? 0;
-      if (!ownedPage || lastUsedAt > ownedPage.lastUsedAt) {
-        ownedPage = { tabId: lifecycle.tabId, lastUsedAt };
-      }
-    }
-    return ownedPage ? { tabId: ownedPage.tabId, presenting: false } : null;
+    return ownedAgentPageId && hasPage(ownedAgentPageId)
+      ? { tabId: ownedAgentPageId, presenting: false }
+      : null;
   }, [
-    activeBrowserRequests,
+    activeAgentRequestPageId,
     activeWorkspaceId,
-    browserLifecycleTabs,
-    browserLiveTargets,
     browserTabSet,
+    ownedAgentPageId,
     panelScopeId,
-    pendingAgentOpens,
+    pendingAgentPageId,
   ]);
 
   // Keep idle Browser pages background-only when the panel has no retained
@@ -318,6 +387,38 @@ export function RightPanel() {
   } =
     useDiffStore.getState();
 
+  const handlePanelWidthChange = useCallback(
+    (nextWidth: number, source: "preserve" | "user") => {
+      if (!activeWorkspaceId) return;
+      setRightPanelWidth(activeWorkspaceId, activeThreadId, nextWidth, source);
+    },
+    [activeThreadId, activeWorkspaceId, setRightPanelWidth],
+  );
+
+  const handleTogglePanel = useCallback(() => {
+    if (!activeWorkspaceId) return;
+    const activeElement = document.activeElement;
+    if (
+      panelVisible &&
+      activeElement instanceof HTMLElement &&
+      activeElement.closest("[data-right-panel-root]")
+    ) {
+      activeElement.blur();
+    }
+    toggleRightPanelAdaptive(activeWorkspaceId, activeThreadId);
+  }, [activeThreadId, activeWorkspaceId, panelVisible]);
+
+  useLayoutEffect(() => {
+    if (panelVisible) return;
+    const activeElement = document.activeElement;
+    if (
+      activeElement instanceof HTMLElement &&
+      activeElement.closest("[data-right-panel-root]")
+    ) {
+      activeElement.blur();
+    }
+  }, [panelVisible]);
+
   // Tab-strip glance status. Changes counts
   // distinct files across every turn snapshot (the cumulative working-tree diff
   // the user reviews and ships).
@@ -345,21 +446,39 @@ export function RightPanel() {
   const subagentsActive =
     renderedActiveTab === "subagents" && renderedTabInstances.some((instance) => instance.type === "subagents");
 
+  const activePreviewScopeKey = previewActive && panelScopeId && activeWorkspaceId
+    ? `${activeWorkspaceId}\u0000${panelScopeId}`
+    : null;
+  const previousActivePreviewScopeKeyRef = useRef<string | null>(null);
   useEffect(() => {
-    const next = previewActive && panelScopeId && activeWorkspaceId
-      ? { scopeId: panelScopeId, workspaceId: activeWorkspaceId, lastUsedAt: Date.now() }
-      : null;
+    if (!activePreviewScopeKey || !panelScopeId || !activeWorkspaceId) {
+      previousActivePreviewScopeKeyRef.current = null;
+      return;
+    }
+    const becameActive = previousActivePreviewScopeKeyRef.current !== activePreviewScopeKey;
+    previousActivePreviewScopeKeyRef.current = activePreviewScopeKey;
     setWarmPreviewScopes((previous) => {
-      const previousScopes =
+      const existing = previous.find((scope) => scope.scopeId === panelScopeId);
+      const next = !existing || becameActive
+        ? { scopeId: panelScopeId, workspaceId: activeWorkspaceId, lastUsedAt: Date.now() }
+        : existing;
+      return reconcileWarmPreviewScopes(previous, next, busyPreviewScopeIds);
+    });
+  }, [activePreviewScopeKey, activeWorkspaceId, busyPreviewScopeIds, panelScopeId]);
+
+  const browserScopePresent = browserTabSet !== null;
+  useEffect(() => {
+    setWarmPreviewScopes((previous) => {
+      const retained =
         !previewActive &&
-        browserTabSet === null &&
+        !browserScopePresent &&
         panelScopeId &&
         !busyPreviewScopeIds.has(panelScopeId)
         ? previous.filter((scope) => scope.scopeId !== panelScopeId)
         : previous;
-      return reconcileWarmPreviewScopes(previousScopes, next, busyPreviewScopeIds);
+      return reconcileWarmPreviewScopes(retained, null, busyPreviewScopeIds);
     });
-  }, [activeWorkspaceId, browserTabSet, busyPreviewScopeIds, panelScopeId, previewActive]);
+  }, [browserScopePresent, busyPreviewScopeIds, panelScopeId, previewActive]);
 
   const isChangesActive = panelVisible && changesActive;
   const changesFresh = useChangesFreshness(
@@ -408,14 +527,7 @@ export function RightPanel() {
       wideWidth={PANEL_WIDE_WIDTH}
       separatorLabel="Resize panel"
       resizeEnabled={panelVisible && !maximized}
-      onWidthChange={(nextWidth, source) =>
-        setRightPanelWidth(
-          activeWorkspaceId!,
-          activeThreadId,
-          nextWidth,
-          source,
-        )
-      }
+      onWidthChange={handlePanelWidthChange}
       style={
         !panelVisible
           ? {
@@ -434,12 +546,7 @@ export function RightPanel() {
         // mode is sized by the stored width above.
         panelVisible && maximized && "flex-1",
       )}
-      // Pair aria-hidden with inert: inert auto-blurs any focused descendant on
-      // apply, which avoids Chrome's "Blocked aria-hidden on an element because
-      // its descendant retained focus" warning when the user clicks the close
-      // button (focus is on the button when the panel is told to hide). Same
-      // pattern as the terminal tab below.
-      aria-hidden={!panelVisible}
+      data-right-panel-root=""
       inert={!panelVisible ? true : undefined}
     >
       {/* Rail + content. The activity rail carries close and maximize actions and,
@@ -455,9 +562,7 @@ export function RightPanel() {
           changesFresh={changesFresh}
           browserTabSet={browserTabSet}
           maximized={maximized}
-          onTogglePanel={() =>
-            toggleRightPanelAdaptive(activeWorkspaceId, activeThreadId)
-          }
+          onTogglePanel={handleTogglePanel}
           onToggleMaximized={toggleMaximized}
           onSelect={(instanceId) => {
             setRightPanelTabInstance(activeWorkspaceId!, activeThreadId, instanceId);
@@ -568,31 +673,16 @@ export function RightPanel() {
           {warmPreviewScopes.map((scope) => {
             const visible = previewActive && scope.scopeId === panelScopeId;
             return (
-              <div
+              <WarmPreviewSurface
                 key={scope.scopeId}
-                data-preview-scope={scope.scopeId}
-                className={visible ? "flex min-h-0 flex-1" : "hidden"}
-                aria-hidden={!visible}
-                inert={!visible ? true : undefined}
-              >
-                {automationHostedScopeIds.has(scope.scopeId) ? (
-                  <div
-                    data-automation-preview-dock={scope.scopeId}
-                    data-visible={visible ? "true" : "false"}
-                    className="min-h-0 min-w-0 flex-1"
-                  />
-                ) : (
-                  <PreviewPanel
-                    threadId={scope.scopeId}
-                    workspaceId={scope.workspaceId}
-                    rendererOccludedLeft={
-                      visible && activityRailExpanded
-                        ? ACTIVITY_RAIL_FLOATING_OVERLAP_PX
-                        : 0
-                    }
-                  />
-                )}
-              </div>
+                scope={scope}
+                visible={visible}
+                rendererOccludedLeft={
+                  visible && activityRailExpanded
+                    ? ACTIVITY_RAIL_FLOATING_OVERLAP_PX
+                    : 0
+                }
+              />
             );
           })}
           <div
@@ -600,7 +690,6 @@ export function RightPanel() {
               "absolute inset-0 z-0 flex min-h-0 flex-row overflow-hidden",
               !terminalActive && "pointer-events-none opacity-0",
             )}
-            aria-hidden={!terminalActive}
             inert={!terminalActive ? true : undefined}
           >
             <TerminalPoolSlot className="relative min-h-0 min-w-0 flex-1 overflow-hidden" />

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -14,7 +14,11 @@ import {
 } from "@/stores/diffStore";
 import { PlanPanel } from "./plan";
 import { PanelEmptyState } from "./PanelEmptyState";
-import { ActivityRail, type ScopeProgress } from "./ActivityRail";
+import {
+  ACTIVITY_RAIL_FLOATING_OVERLAP_PX,
+  ActivityRail,
+  type ScopeProgress,
+} from "./ActivityRail";
 import type { PanelScope } from "@/lib/panel-tabs";
 import { DiffPanel } from "@/components/diff";
 import { PreviewPanel } from "@/components/panels/PreviewPanel";
@@ -168,6 +172,7 @@ export function RightPanel() {
     [activeBrowserRequests],
   );
   const [warmPreviewScopes, setWarmPreviewScopes] = useState<readonly WarmPreviewScope[]>([]);
+  const [activityRailExpanded, setActivityRailExpanded] = useState(false);
   const terminalsByScope = useTerminalStore((s) => s.terminals);
   const scopeTerminals = panelScopeId
     ? (terminalsByScope[panelScopeId] ?? EMPTY_SCOPE_TERMINALS)
@@ -194,7 +199,8 @@ export function RightPanel() {
   // active. Null in web builds with no bridge, where the rail keeps the single
   // Browser glyph.
   const browserTabSet = usePreviewTabSet(panelScopeId);
-  const activeAgentBrowserPageId = useMemo(() => {
+  const requestedAgentPageActivationRef = useRef<string | null>(null);
+  const agentBrowserPage = useMemo(() => {
     if (!activeWorkspaceId || !panelScopeId || !browserTabSet) return null;
     let pendingPage: { readonly tabId: string; readonly startedAt: number } | null = null;
     for (const pending of pendingAgentOpens.values()) {
@@ -204,7 +210,7 @@ export function RightPanel() {
         pendingPage = { tabId: pending.tabId, startedAt: pending.startedAt };
       }
     }
-    if (pendingPage) return pendingPage.tabId;
+    if (pendingPage) return { tabId: pendingPage.tabId, presenting: true };
 
     let selected: { readonly tabId: string; readonly startedAt: number } | null = null;
     for (const { dispatch, startedAt } of activeBrowserRequests.values()) {
@@ -214,7 +220,7 @@ export function RightPanel() {
         selected = { tabId: dispatch.target.tabId, startedAt };
       }
     }
-    if (selected) return selected.tabId;
+    if (selected) return { tabId: selected.tabId, presenting: true };
 
     let ownedPage: { readonly tabId: string; readonly lastUsedAt: number } | null = null;
     for (const lifecycle of browserLifecycleTabs.values()) {
@@ -233,7 +239,7 @@ export function RightPanel() {
         ownedPage = { tabId: lifecycle.tabId, lastUsedAt };
       }
     }
-    return ownedPage?.tabId ?? null;
+    return ownedPage ? { tabId: ownedPage.tabId, presenting: false } : null;
   }, [
     activeBrowserRequests,
     activeWorkspaceId,
@@ -246,18 +252,21 @@ export function RightPanel() {
 
   // Keep idle Browser pages background-only when the panel has no retained
   // tab. An explicit retained Preview tab is restored, while an empty panel
-  // projects only the page currently controlled by an agent.
+  // projects the latest agent-owned page. A live agent request takes over an
+  // already-visible panel without discarding its other retained tools.
+  const activeAgentBrowserPageId = agentBrowserPage?.tabId ?? null;
   const previewIsOnlyOpenTab =
     tabInstances.length === 1 && tabInstances[0]?.type === "preview";
   const shouldRevealAgentPage =
-    openTabs.length === 0 && activeAgentBrowserPageId !== null;
+    activeAgentBrowserPageId !== null &&
+    (openTabs.length === 0 || (panelVisible && agentBrowserPage?.presenting === true));
   const shouldRestorePreviewTab = previewIsOnlyOpenTab && activeTab !== "preview";
   const revealExistingPreview =
     panelVisible &&
     (shouldRevealAgentPage || shouldRestorePreviewTab) &&
     (browserTabSet?.tabs.length ?? 0) > 0;
-  const renderedTabInstances = revealExistingPreview
-    ? [{ id: "singleton:preview", type: "preview" as const }]
+  const renderedTabInstances = revealExistingPreview && !openTabs.includes("preview")
+    ? [...tabInstances, { id: "singleton:preview", type: "preview" as const }]
     : tabInstances;
   const renderedOpenTabs = renderedTabInstances.map((instance) => instance.type);
   const renderedActiveTabId = revealExistingPreview ? "singleton:preview" : activeTabId;
@@ -267,17 +276,29 @@ export function RightPanel() {
     if (!revealExistingPreview || !activeWorkspaceId) return;
     const current = useDiffStore.getState().getRightPanel(activeWorkspaceId, activeThreadId);
     const hasNonPreviewTab = current.tabInstances.some((instance) => instance.type !== "preview");
-    if (!current.visible || hasNonPreviewTab) return;
-    useDiffStore.getState().setRightPanelTab(activeWorkspaceId, activeThreadId, "preview");
-    const existingPageId = activeAgentBrowserPageId ??
+    if (!current.visible || (hasNonPreviewTab && agentBrowserPage?.presenting !== true)) return;
+    if (current.activeTab !== "preview") {
+      useDiffStore.getState().setRightPanelTab(activeWorkspaceId, activeThreadId, "preview");
+    }
+    const existingPageId = agentBrowserPage?.tabId ??
       browserTabSet?.activeTabId ??
       browserTabSet?.tabs[0]?.id;
-    if (panelScopeId && existingPageId) {
+    const activationKey = panelScopeId && existingPageId
+      ? `${panelScopeId}:${existingPageId}`
+      : null;
+    if (
+      panelScopeId &&
+      existingPageId &&
+      activationKey &&
+      browserTabSet?.activeTabId !== existingPageId &&
+      requestedAgentPageActivationRef.current !== activationKey
+    ) {
+      requestedAgentPageActivationRef.current = activationKey;
       void usePreviewTabsStore.getState().activatePage(panelScopeId, existingPageId);
     }
   }, [
     activeThreadId,
-    activeAgentBrowserPageId,
+    agentBrowserPage,
     activeWorkspaceId,
     browserTabSet,
     panelScopeId,
@@ -502,6 +523,7 @@ export function RightPanel() {
                   ),
               });
           }}
+          onExpandedChange={setActivityRailExpanded}
         />
 
         {/* Tab content — DiffPanel and terminal pool stay mounted (stacked) so
@@ -563,6 +585,11 @@ export function RightPanel() {
                   <PreviewPanel
                     threadId={scope.scopeId}
                     workspaceId={scope.workspaceId}
+                    rendererOccludedLeft={
+                      visible && activityRailExpanded
+                        ? ACTIVITY_RAIL_FLOATING_OVERLAP_PX
+                        : 0
+                    }
                   />
                 )}
               </div>

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -244,14 +244,17 @@ export function RightPanel() {
     pendingAgentOpens,
   ]);
 
-  // Keep hidden agent activity background-only. Once the human can see an
-  // otherwise empty panel, project any recorded Browser page immediately,
-  // including a page published after the default screen was already visible.
+  // Keep idle Browser pages background-only when the panel has no retained
+  // tab. An explicit retained Preview tab is restored, while an empty panel
+  // projects only the page currently controlled by an agent.
   const previewIsOnlyOpenTab =
     tabInstances.length === 1 && tabInstances[0]?.type === "preview";
+  const shouldRevealAgentPage =
+    openTabs.length === 0 && activeAgentBrowserPageId !== null;
+  const shouldRestorePreviewTab = previewIsOnlyOpenTab && activeTab !== "preview";
   const revealExistingPreview =
     panelVisible &&
-    (openTabs.length === 0 || (previewIsOnlyOpenTab && activeTab !== "preview")) &&
+    (shouldRevealAgentPage || shouldRestorePreviewTab) &&
     (browserTabSet?.tabs.length ?? 0) > 0;
   const renderedTabInstances = revealExistingPreview
     ? [{ id: "singleton:preview", type: "preview" as const }]
@@ -325,10 +328,17 @@ export function RightPanel() {
     const next = previewActive && panelScopeId && activeWorkspaceId
       ? { scopeId: panelScopeId, workspaceId: activeWorkspaceId, lastUsedAt: Date.now() }
       : null;
-    setWarmPreviewScopes((previous) =>
-      reconcileWarmPreviewScopes(previous, next, busyPreviewScopeIds),
-    );
-  }, [activeWorkspaceId, busyPreviewScopeIds, panelScopeId, previewActive]);
+    setWarmPreviewScopes((previous) => {
+      const previousScopes =
+        !previewActive &&
+        browserTabSet === null &&
+        panelScopeId &&
+        !busyPreviewScopeIds.has(panelScopeId)
+        ? previous.filter((scope) => scope.scopeId !== panelScopeId)
+        : previous;
+      return reconcileWarmPreviewScopes(previousScopes, next, busyPreviewScopeIds);
+    });
+  }, [activeWorkspaceId, browserTabSet, busyPreviewScopeIds, panelScopeId, previewActive]);
 
   const isChangesActive = panelVisible && changesActive;
   const changesFresh = useChangesFreshness(

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -645,7 +645,7 @@ describe("PreviewPanel: full panel state", () => {
     expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
   });
 
-  it("uses a prominent frame and edge wash while the agent controls Browser", () => {
+  it("uses an amber shadow and edge wash while the agent controls Browser", () => {
     useBrowserAutomationStore.setState({
       controllers: new Map([
         [
@@ -665,9 +665,14 @@ describe("PreviewPanel: full panel state", () => {
     render(<PreviewPanel threadId="thread-1" />);
 
     const overlay = screen.getByTestId("browser-automation-overlay");
-    expect(overlay).toHaveClass("border-2", "border-primary");
+    expect(overlay).not.toHaveClass("border");
+    expect(overlay).not.toHaveClass("border-2");
+    expect(overlay).not.toHaveClass("border-primary");
     expect(overlay.style.backgroundImage).toContain("transparent 32px");
+    expect(overlay.style.boxShadow).not.toContain("inset 0 0 0 1px");
     expect(overlay.style.boxShadow).toContain("inset 0 0 40px");
+    expect(overlay.style.boxShadow).toContain("0 0 24px");
+    expect(overlay.style.boxShadow).toContain("var(--primary)");
   });
 
   it("shows the agent frame and cursor while the active page is still opening", () => {

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -808,7 +808,7 @@ describe("PreviewPanel: full panel state", () => {
     );
   });
 
-  it("clips only the floating rail overlap from the renderer webview", () => {
+  it("removes the floating rail overlap from the renderer webview hit area", () => {
     useSettingsStore.getState()._applyPush({
       ...getDefaultSettings(),
       preview: {
@@ -822,7 +822,8 @@ describe("PreviewPanel: full panel state", () => {
 
     render(<PreviewPanel threadId="thread-1" rendererOccludedLeft={112} />);
 
-    expect(screen.getByTestId("preview-webview-surface")).toHaveStyle({
+    expect(screen.getByTestId("preview-webview-surface")).toHaveStyle({ left: "112px" });
+    expect(screen.getByTestId("preview-webview-surface")).not.toHaveStyle({
       clipPath: "inset(0px 0px 0px 112px)",
     });
     expect(screen.getByTestId("preview-webview")).not.toHaveClass("pointer-events-none");

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -808,6 +808,26 @@ describe("PreviewPanel: full panel state", () => {
     );
   });
 
+  it("clips only the floating rail overlap from the renderer webview", () => {
+    useSettingsStore.getState()._applyPush({
+      ...getDefaultSettings(),
+      preview: {
+        ...getDefaultSettings().preview,
+        rendering: { engine: "webview" },
+      },
+    });
+    mockUsePreviewBridge.mockReturnValue(
+      mockBridgeState({ storedUrl: "https://example.com" }),
+    );
+
+    render(<PreviewPanel threadId="thread-1" rendererOccludedLeft={112} />);
+
+    expect(screen.getByTestId("preview-webview-surface")).toHaveStyle({
+      clipPath: "inset(0px 0px 0px 112px)",
+    });
+    expect(screen.getByTestId("preview-webview")).not.toHaveClass("pointer-events-none");
+  });
+
   it("keeps an about:blank live tab stable while the persisted URL is empty", async () => {
     useSettingsStore.getState()._applyPush({
       ...getDefaultSettings(),

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -171,6 +171,40 @@ describe("PreviewWebview", () => {
     }
   });
 
+  it("keeps native event subscriptions stable when parent callbacks change", () => {
+    window.desktopBridge = { preview: {} } as unknown as NonNullable<typeof window.desktopBridge>;
+    const addEventListener = vi.spyOn(HTMLElement.prototype, "addEventListener");
+    const firstStatus = vi.fn();
+    const secondStatus = vi.fn();
+    const { rerender } = render(
+      <PreviewWebview
+        threadId="thread-stable"
+        tabId="tab-stable"
+        src="https://example.com"
+        onPageStatus={firstStatus}
+      />,
+    );
+    const initialStopSubscriptions = addEventListener.mock.calls.filter(
+      ([eventName]) => eventName === "did-stop-loading",
+    ).length;
+
+    rerender(
+      <PreviewWebview
+        threadId="thread-stable"
+        tabId="tab-stable"
+        src="https://example.com"
+        onPageStatus={secondStatus}
+      />,
+    );
+    screen.getByTestId("preview-webview").dispatchEvent(new Event("did-stop-loading"));
+
+    expect(addEventListener.mock.calls.filter(
+      ([eventName]) => eventName === "did-stop-loading",
+    )).toHaveLength(initialStopSubscriptions);
+    expect(firstStatus).not.toHaveBeenCalled();
+    expect(secondStatus).toHaveBeenCalledOnce();
+  });
+
   it("applies an exact renderer-owned design viewport to the visible webview", () => {
     render(
       <PreviewWebview

--- a/apps/web/src/stores/__tests__/previewTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewTabsStore.test.ts
@@ -167,12 +167,21 @@ describe("previewTabsStore", () => {
 
   it("closePage fires onLastClose and drops the scope's set when closing the last page", async () => {
     usePreviewTabsStore.getState().setTabSet(SCOPE, set("a", [page("a")]));
-    mockBridge({});
+    const { close, closeScope } = mockBridge({});
+    usePreviewTabsStore.getState().setLiveChrome(SCOPE, { title: "A", url: null, favicon: null });
+    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "a");
     const onLastClose = vi.fn();
+    onLastClose.mockImplementation(() => {
+      expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
+      expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]).toBeNull();
+    });
     await usePreviewTabsStore.getState().closePage(SCOPE, "a", { onLastClose });
     expect(onLastClose).toHaveBeenCalledTimes(1);
-    // The host recreates a blank fallback, but the Browser tab is gone; the
-    // scope's set must clear rather than retain a phantom page.
+    expect(closeScope).toHaveBeenCalledWith(SCOPE);
+    expect(close).not.toHaveBeenCalled();
+    expect(browserTargetRegistry.get(SCOPE, "a")).toBeNull();
+    // The Browser tab is gone; the scope's set must clear rather than retain
+    // a phantom page.
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
   });
 
@@ -197,6 +206,19 @@ describe("previewTabsStore", () => {
 
     await expect(usePreviewTabsStore.getState().clearScope(SCOPE)).rejects.toThrow("scope close failed");
     expect(browserTargetRegistry.get(SCOPE, "a")).not.toBeNull();
+  });
+
+  it("retains final-page automation targets when the physical scope close fails", async () => {
+    usePreviewTabsStore.getState().setTabSet(SCOPE, set("a", [page("a")]));
+    const { close, closeScope } = mockBridge({});
+    closeScope.mockResolvedValueOnce({ ok: false, error: "scope close failed" });
+    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "a");
+
+    await usePreviewTabsStore.getState().closePage(SCOPE, "a");
+
+    expect(close).not.toHaveBeenCalled();
+    expect(browserTargetRegistry.get(SCOPE, "a")).not.toBeNull();
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
   });
 
   it("setLiveChrome keeps the same reference when the chrome is unchanged", () => {

--- a/apps/web/src/stores/__tests__/previewTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewTabsStore.test.ts
@@ -118,6 +118,20 @@ describe("previewTabsStore", () => {
     expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]?.title).toBe("T");
   });
 
+  it("setTabSet preserves state identity for a semantically identical host snapshot", () => {
+    const { setTabSet } = usePreviewTabsStore.getState();
+    setTabSet(SCOPE, set("a", [page("a")]));
+    const previousState = usePreviewTabsStore.getState();
+    const subscriber = vi.fn();
+    const unsubscribe = usePreviewTabsStore.subscribe(subscriber);
+
+    setTabSet(SCOPE, set("a", [page("a")]));
+
+    expect(usePreviewTabsStore.getState()).toBe(previousState);
+    expect(subscriber).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
   it("openPage creates a page via the bridge and focuses the omnibox", async () => {
     const created = set("new", [page("a"), page("new", { active: true })]);
     const { open } = mockBridge({ open: created });

--- a/apps/web/src/stores/__tests__/previewTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewTabsStore.test.ts
@@ -208,17 +208,26 @@ describe("previewTabsStore", () => {
     expect(browserTargetRegistry.get(SCOPE, "a")).not.toBeNull();
   });
 
-  it("retains final-page automation targets when the physical scope close fails", async () => {
-    usePreviewTabsStore.getState().setTabSet(SCOPE, set("a", [page("a")]));
+  it("retains final-page UI state and automation targets when the physical scope close fails", async () => {
+    const finalTabSet = set("a", [page("a")]);
+    usePreviewTabsStore.getState().setTabSet(SCOPE, finalTabSet);
+    usePreviewTabsStore.getState().setLiveChrome(SCOPE, { title: "A", url: "https://example.test", favicon: null });
     const { close, closeScope } = mockBridge({});
     closeScope.mockResolvedValueOnce({ ok: false, error: "scope close failed" });
     useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "a");
+    const onLastClose = vi.fn();
 
-    await usePreviewTabsStore.getState().closePage(SCOPE, "a");
+    await usePreviewTabsStore.getState().closePage(SCOPE, "a", { onLastClose });
 
     expect(close).not.toHaveBeenCalled();
+    expect(onLastClose).not.toHaveBeenCalled();
     expect(browserTargetRegistry.get(SCOPE, "a")).not.toBeNull();
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(finalTabSet);
+    expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]).toEqual({
+      title: "A",
+      url: "https://example.test",
+      favicon: null,
+    });
   });
 
   it("setLiveChrome keeps the same reference when the chrome is unchanged", () => {

--- a/apps/web/src/stores/diffStore.ts
+++ b/apps/web/src/stores/diffStore.ts
@@ -683,10 +683,13 @@ export const useDiffStore = create<DiffState>((set, get) => ({
   setRightPanelWidth: (workspaceId, threadId, width, source = "user") =>
     set((state) => {
       const current = effectiveRightPanel(state, workspaceId, threadId);
+      const nextWidth = clampWidth(width);
+      const nextWidthSource = source === "preserve" ? current.widthSource : source;
+      if (current.width === nextWidth && current.widthSource === nextWidthSource) return state;
       return writeRightPanel(state, workspaceId, threadId, {
         ...current,
-        width: clampWidth(width),
-        widthSource: source === "preserve" ? current.widthSource : source,
+        width: nextWidth,
+        widthSource: nextWidthSource,
       });
     }),
 

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -132,6 +132,25 @@ export interface ClosePageOptions {
   readonly onLastClose?: () => void;
 }
 
+function clearPreviewScopeState(
+  state: Pick<PreviewTabsState, "tabSetByScope" | "liveChromeByScope" | "persistentTabIdsByScope">,
+  scopeId: string,
+  preserveEmptyState: boolean,
+): Pick<PreviewTabsState, "tabSetByScope" | "liveChromeByScope" | "persistentTabIdsByScope"> {
+  const tabSetByScope = { ...state.tabSetByScope };
+  const liveChromeByScope = { ...state.liveChromeByScope };
+  const persistentTabIdsByScope = { ...state.persistentTabIdsByScope };
+  if (preserveEmptyState) {
+    tabSetByScope[scopeId] = null;
+    liveChromeByScope[scopeId] = null;
+  } else {
+    delete tabSetByScope[scopeId];
+    delete liveChromeByScope[scopeId];
+  }
+  delete persistentTabIdsByScope[scopeId];
+  return { tabSetByScope, liveChromeByScope, persistentTabIdsByScope };
+}
+
 /**
  * Renderer-side source of truth for the in-app browser's pages, mirroring the
  * host tab set and exposing the page add/close/switch actions the activity rail
@@ -306,20 +325,34 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
 
   closePage: async (scopeId, tabId, opts) => {
     const tabs = bridgeTabs();
+    const current = get().tabSetByScope[scopeId];
+    const isLast = !!current && current.tabs.length <= 1;
+    const clearLastScopeState = () => {
+      set((s) => clearPreviewScopeState(s, scopeId, true));
+    };
     if (!tabs) {
       if (!get().persistentTabIdsByScope[scopeId]?.has(tabId)) return;
-      const current = get().tabSetByScope[scopeId];
-      const isLast = !!current && current.tabs.length <= 1;
-      if (isLast) opts?.onLastClose?.();
+      if (isLast) {
+        clearLastScopeState();
+        opts?.onLastClose?.();
+        useBrowserAutomationStore.getState().releaseThreadTargets(scopeId);
+        return;
+      }
       get().setLiveChrome(scopeId, null);
       get().removePersistentTab(scopeId, tabId);
       useBrowserAutomationStore.getState().unregisterTarget(scopeId, tabId);
-      if (isLast) get().setTabSet(scopeId, null);
       return;
     }
-    const current = get().tabSetByScope[scopeId];
-    const isLast = !!current && current.tabs.length <= 1;
-    if (isLast) opts?.onLastClose?.();
+    if (isLast) {
+      clearLastScopeState();
+      opts?.onLastClose?.();
+      const r = tabs.closeScope
+        ? await tabs.closeScope(scopeId)
+        : await tabs.close(scopeId, tabId);
+      if (!r.ok) return;
+      useBrowserAutomationStore.getState().releaseThreadTargets(scopeId);
+      return;
+    }
     get().setLiveChrome(scopeId, null);
     const r = await tabs.close(scopeId, tabId);
     if (!r.ok) return;
@@ -336,15 +369,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     const r = await tabs?.closeScope?.(scopeId);
     if (r && !r.ok) throw new Error(r.error);
     useBrowserAutomationStore.getState().releaseThreadTargets(scopeId);
-    set((s) => {
-      const tabSetByScope = { ...s.tabSetByScope };
-      const liveChromeByScope = { ...s.liveChromeByScope };
-      const persistentTabIdsByScope = { ...s.persistentTabIdsByScope };
-      delete tabSetByScope[scopeId];
-      delete liveChromeByScope[scopeId];
-      delete persistentTabIdsByScope[scopeId];
-      return { tabSetByScope, liveChromeByScope, persistentTabIdsByScope };
-    });
+    set((s) => clearPreviewScopeState(s, scopeId, false));
   },
 }));
 

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -30,6 +30,27 @@ function sameLiveChrome(a: PreviewLiveChrome | null, b: PreviewLiveChrome | null
   return a.title === b.title && a.url === b.url && a.favicon === b.favicon;
 }
 
+function sameBrowserTab(a: BrowserTabInfo, b: BrowserTabInfo): boolean {
+  return a === b || (
+    a.id === b.id &&
+    a.threadId === b.threadId &&
+    a.title === b.title &&
+    a.url === b.url &&
+    a.faviconUrl === b.faviconUrl &&
+    a.warm === b.warm &&
+    a.active === b.active
+  );
+}
+
+function sameBrowserTabSet(a: BrowserTabSet | null, b: BrowserTabSet | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.threadId === b.threadId &&
+    a.activeTabId === b.activeTabId &&
+    a.tabs.length === b.tabs.length &&
+    a.tabs.every((tab, index) => sameBrowserTab(tab, b.tabs[index]!));
+}
+
 /** The minimal slice of the desktop bridge's tab surface this store drives. */
 interface PreviewTabsBridgeLike {
   open(
@@ -165,9 +186,13 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
   persistentTabIdsByScope: {},
 
   setTabSet: (scopeId, value) =>
-    set((s) => ({
-      tabSetByScope: { ...s.tabSetByScope, [scopeId]: value },
-    })),
+    set((s) => {
+      const previous = s.tabSetByScope[scopeId] ?? null;
+      if (sameBrowserTabSet(previous, value)) return s;
+      return {
+        tabSetByScope: { ...s.tabSetByScope, [scopeId]: value },
+      };
+    }),
 
   upsertPersistentTab: (scopeId, tab) =>
     set((s) => {

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -344,13 +344,13 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
       return;
     }
     if (isLast) {
-      clearLastScopeState();
-      opts?.onLastClose?.();
       const r = tabs.closeScope
         ? await tabs.closeScope(scopeId)
         : await tabs.close(scopeId, tabId);
       if (!r.ok) return;
+      clearLastScopeState();
       useBrowserAutomationStore.getState().releaseThreadTargets(scopeId);
+      opts?.onLastClose?.();
       return;
     }
     get().setLiveChrome(scopeId, null);

--- a/docs/agents/browser-right-panel-lifecycle-prompts.md
+++ b/docs/agents/browser-right-panel-lifecycle-prompts.md
@@ -1,0 +1,81 @@
+# Browser right-panel lifecycle test prompts
+
+Use these prompts in the seeded `fixture-repo` thread in the worktree-local Electron app. Start the app with `bun run dev:desktop` and confirm that you are using the Electron executable inside this worktree, not the installed Mcode application.
+
+## Recommended clean sequence
+
+### Scenario 1: agent starts Browser while the panel is closed
+
+Close the right panel, then send:
+
+> The right panel is closed. Use only the shared Mcode Browser. Call browser_open for https://example.com in one new agent-owned tab, inspect the page title and first heading, then keep the tab open for my observation. Do not close, finalize, or release the tab. If anything fails, report the exact Browser recovery instruction and stop.
+
+Expected result:
+
+- The agent completes while the right panel stays closed.
+- Opening the right panel shows the retained Browser page.
+- The page remains interactive and does not reload repeatedly.
+
+### Scenario 2: agent starts Browser while Plan is open
+
+Open the right panel and select Plan, then send:
+
+> The right panel is already open on Plan. Use only the shared Mcode Browser. Call browser_open for https://example.net in one new agent-owned tab, inspect the page title and first heading, then keep the tab open. Do not close, finalize, or release it. I am observing whether Mcode switches this already-open panel from Plan to Browser while retaining Plan in the activity rail. If anything fails, report the exact recovery instruction and stop.
+
+Expected result:
+
+- The visible panel switches from Plan to Browser when the agent-owned page starts.
+- Plan remains available in the activity rail.
+- Example Domain renders instead of a blank surface.
+- The agent completes without a stale host or reconnect error.
+
+### Scenario 3: agent reuses the already-visible Browser tab
+
+Leave Browser visible, then send:
+
+> The Browser panel is already open and visibly showing Example Domain. Use only the shared Mcode Browser. Call browser_inspect for the current authorized tab. Then call browser_act with exactly these argument fields: idempotencyKey, observationRef, deadlineMs, and steps. Set steps to [{ operation: "navigate", url: "https://example.org" }]. Do not include tabId, action, type, target, or url at the top level. After the document boundary, inspect again and report the tab id, title, and first heading. Keep the tab open and do not call browser_open, close, finalize, or release.
+
+Expected result:
+
+- The agent reuses the same tab id.
+- The tab navigates to `https://example.org`.
+- The page remains visible throughout the activity overlay transition.
+- No repeated reload, maximum-update-depth error, stale heartbeat, or host disconnect appears.
+
+## Prompt-shape note
+
+A prompt that only asks the agent to reuse an existing tab does not test Browser startup. If no authorized tab exists, it tests inspection recovery instead and may correctly return `reopen` or `wait`. Use an explicit `browser_open` call in Scenarios 1 and 2.
+
+For same-tab navigation, `browser_act` requires a step shaped as `{ operation: "navigate", url: "https://example.org" }`. The `url` is inside the step, not at the tool's top level. The tool call must also include a fresh `observationRef`, a fresh `idempotencyKey`, and `deadlineMs`.
+
+## Prompts used during diagnosis
+
+These are the exact unique prompts sent to the fixture agent during this investigation.
+
+1. `Scenario 1 baseline. Use only the shared Mcode Browser. Open https://example.com in one agent-owned tab, inspect the page title and first heading, then keep the tab open for my observation. Do not close, finalize, or release the tab. If anything fails, report the exact Browser recovery instruction and stop.`
+
+2. `Scenario 3 baseline. The shared Browser panel is already open on Example Domain. Use only the shared Mcode Browser. Inspect the available tabs, reuse the existing agent-owned tab if it is available, navigate that same tab to https://example.org, inspect the page title and first heading, then keep it open. Do not create a second tab. Do not close, finalize, or release anything. Report the tab id you used.`
+
+3. `Scenario 2 baseline. The right panel is already open on Plan. Use only the shared Mcode Browser. Reuse the existing agent-owned tab, navigate it to https://www.iana.org/help/example-domains, inspect the title and first heading, then keep it open. Do not create another tab. Do not close, finalize, or release anything. Report the tab id. I am specifically observing whether Mcode automatically switches the already-open right panel from Plan to Browser when your Browser action begins.`
+
+4. `Scenario 2 corrected baseline. The right panel is already open on Plan. Start a new shared Browser session by calling browser_open for https://example.net in one new agent-owned tab. Inspect the title and first heading, then keep the tab open. Do not close, finalize, or release it. I am observing whether Mcode automatically switches the already-open right panel from Plan to Browser as soon as your new Browser tab starts.`
+
+5. `Scenario 2 post-fix. The right panel is already open on Plan. Start a new shared Browser session by calling browser_open for https://example.edu in one new agent-owned tab. Inspect the title and first heading, then keep it open. Do not close, finalize, or release it. I am observing whether Mcode switches this already-open panel from Plan to Browser while retaining Plan in the activity rail.`
+
+6. `Scenario 3 post-fix. The Browser panel is already open and visibly showing Example Domain. Use only the shared Mcode Browser. Inspect the currently visible authorized tab, use browser_act to navigate that same tab to https://example.org, inspect its title and first heading, then keep it open. Do not call browser_open. Do not create, close, finalize, or release any tab. Report the tab id and any recovery instruction.`
+
+7. `Scenario 1 clean verification. The right panel is closed. Use only the shared Mcode Browser. Call browser_open for https://example.com in one new agent-owned tab, inspect the page title and first heading, then keep the tab open for my observation. Do not close, finalize, or release the tab. If anything fails, report the exact Browser recovery instruction and stop.`
+
+8. `Scenario 2 clean verification. The right panel is already open on Plan. Use only the shared Mcode Browser. Call browser_open for https://example.net in one new agent-owned tab, inspect the page title and first heading, then keep the tab open. Do not close, finalize, or release it. I am observing whether Mcode switches this already-open panel from Plan to Browser while retaining Plan in the activity rail. If anything fails, report the exact recovery instruction and stop.`
+
+9. `Scenario 1 final verification. The right panel is closed. Use only the shared Mcode Browser. Call browser_open for https://example.com in one new agent-owned tab, inspect the page title and first heading, then keep the tab open. Do not close, finalize, or release the tab. If anything fails, report the exact Browser recovery instruction and stop.`
+
+10. `Scenario 2 final verification. The right panel is already open on Plan. Use only the shared Mcode Browser. Call browser_open for https://example.net in one new agent-owned tab, inspect the page title and first heading, then keep the tab open. Do not close, finalize, or release it. I am observing whether Mcode switches this already-open panel from Plan to Browser while retaining Plan in the activity rail. If anything fails, report the exact recovery instruction and stop.`
+
+11. `Scenario 3 final verification. The Browser panel is already open on the agent-owned Example Domain tab. Use only the shared Mcode Browser. Inspect the currently authorized visible tab, use browser_act to navigate that same tab to https://example.org, inspect its title and first heading, then keep it open. Do not call browser_open. Do not create, close, finalize, or release any tab. Report the tab id and any recovery instruction.`
+
+12. `Scenario 2 stable rerun. The right panel is already open on Plan. Use only the shared Mcode Browser. Call browser_open for https://example.net in one new agent-owned tab, inspect the page title and first heading, then keep the tab open. Do not close, finalize, or release it. I am observing whether Mcode switches this already-open panel from Plan to Browser while retaining Plan in the activity rail. If anything fails, report the exact recovery instruction and stop.`
+
+13. `Scenario 3 stable rerun. The Browser panel is already open and visibly showing Example Domain. Use only the shared Mcode Browser. Call browser_inspect for the current authorized tab, then call browser_act with a navigation step on that same tab to https://example.org using the fresh observationRef and a fresh idempotency key. Inspect the resulting page title and first heading, then keep the tab open. Do not call browser_open. Do not create, close, finalize, or release any tab. Report the tab id and any recovery instruction.`
+
+14. `Scenario 3 exact-schema retry. Keep using the same authorized tab. First call browser_inspect. Then call browser_act with exactly these argument fields: idempotencyKey, observationRef, deadlineMs, and steps. Set steps to [{ operation: "navigate", url: "https://example.org" }]. Do not include tabId, action, type, target, or url at the top level. After the document boundary, inspect again and report the tab id, title, and first heading. Keep the tab open and do not call browser_open, close, finalize, or release.`

--- a/packages/thread-orchestration/src/browser-operating-guide.ts
+++ b/packages/thread-orchestration/src/browser-operating-guide.ts
@@ -1,7 +1,7 @@
 /** Provider-neutral operating guide for the visible Mcode Browser v2 contract. */
 export const MCODE_BROWSER_GUIDE = `Mcode Browser v2 Operating Guide (authenticated Mcode provider sessions only)
 
-Apply this guide automatically when the user asks to open, inspect, test, debug, or interact with the visible Mcode Browser. The user does not need to invoke /mcode-browser.
+Apply this guide automatically when the user asks to open, inspect, test, debug, or interact with the visible Browser. The user does not need to invoke $mcode-browser.
 
 - Intent: use mcode-browser for Mcode's shared Preview. Tabs may run while the Browser panel is hidden and be revealed later. Do not launch a separate browser or profile, and never compete with direct user input.
 - Target selection: browser_open creates one agent-owned background tab, makes it sticky, and returns tab metadata plus an observationRef, not a semantic page observation. Call browser_inspect before the first action unless the returned result includes sufficient current snapshot evidence. Use browser_tabs to select or claim another tab and to release, close, or finalize controlled tabs. For elements, prefer semanticId from the latest inspection, then role plus accessibleName, then CSS or coordinates only without a semantic target. Targets must come from the latest inspection; never guess ambiguous matches.


### PR DESCRIPTION
## What
Fix the Electron Browser teardown and right-panel lifecycle while preserving renderer hover behavior: the expanded rail hovers over the visible renderer `<webview>` guest without moving or hiding browser content.

## Why
The renderer guest remains mounted and should stay interactive. The expanded rail previously drew beyond its collapsed host hit-test box, so overlap events could reach guest content instead of the rail. Native `WebContentsView` content paints outside React's stacking context and therefore needs separate suppression behavior.

## Key Changes
- Tolerate invalidated preview views during hide, park, and disposal, then recreate them on the next show.
- Give the expanded activity rail a real `w-40` hit-test surface and offset it with `-mr-28`, preserving the collapsed 48px layout footprint.
- Keep the renderer `<webview>` visible at a fixed content position; the uncovered page remains interactive outside the rail overlap.
- Remove the agent-control overlay's solid amber `border-2 border-primary` frame and 1px inset ring while retaining the `var(--primary)` edge wash plus amber inset and outer shadows.
- Keep native fallback suppression for `WebContentsView` overlays separate from renderer `<webview>` behavior.
- Keep an empty right panel on the default tool picker unless it has an explicitly retained Browser tab or an active agent-controlled page.
- Clear final-page state before panel callbacks, close the whole Browser scope, and evict inactive warm guests while preserving active-agent leases.
- Add focused regressions for shutdown, hide/show recovery, overlay suppression, default selection, final-page close ordering, target cleanup, busy-scope retention, renderer guest hit-testing, and the shadow-only agent-control treatment.

## Verification
- `bun run verify` passed (typecheck, lint, and unit tests).
- The focused rail regression passed: 1 test passed, 18 skipped.
- The focused PreviewPanel overlay regression passed: 1 test passed, 80 skipped; it confirms no border classes or 1px inset shadow while the `var(--primary)` edge wash, inset shadow, and outer shadow remain.
- Ran the Electron app and confirmed the right panel opens on the default tool picker.
- Opened Browser, loaded a page, hovered its rail entry, and closed the final page. The rail entry, PreviewPanel, webview element, and guest WebContents all disappeared.
- Confirmed the panel close control remained hoverable and clickable after Browser teardown.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788536235&installation_model_id=20477&pr_number=1108&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1108&signature=27700aea67ac3739de6c4e73b8d36fa3efab4a915700870f03c6c7c100c224cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview tab recovery when views are hidden, invalidated, or destroyed.
  - Fixed Browser panel visibility, closing behavior, and preview scope cleanup.
  - Added limited navigation retry handling for recoverable failures.
  - Prevented callback and loading-event issues during preview navigation.
  - Reduced unnecessary panel and tab updates.

- **UI Improvements**
  - Improved Activity Rail expansion, sizing, interaction, and preview overlap handling.
  - Refined browser overlay styling and webview clipping.

- **Documentation**
  - Added Browser right-panel lifecycle testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
