### PR TITLE
fix(cursor): expose Browser MCP tools in fresh sessions

### DIFF
--- a/apps/server/src/__tests__/ws-server-health.test.ts
+++ b/apps/server/src/__tests__/ws-server-health.test.ts
@@ -232,6 +232,7 @@ describe("/health endpoint", () => {
           capacityRejected: 0,
           latencyTotalMs: 40,
           latencyMaxMs: 25,
+          roundTripLatency: { samples: 2, p50Ms: 20, p95Ms: 25, p99Ms: 25 },
         }),
       } as never,
     });

--- a/apps/server/src/services/browser-automation/broker.test.ts
+++ b/apps/server/src/services/browser-automation/broker.test.ts
@@ -1249,8 +1249,46 @@ describe("BrowserAutomationBroker", () => {
       capacityRejected: 1,
       latencyTotalMs: 25,
       latencyMaxMs: 25,
+      roundTripLatency: { samples: 1, p50Ms: 25, p95Ms: 25, p99Ms: 25 },
     });
     expect(JSON.stringify(broker.reliabilityStatus())).not.toContain("thread-a");
+  });
+
+  it("reports recent Browser round-trip latency percentiles without page data", async () => {
+    let now = 100;
+    let delivery: any;
+    const broker = new BrowserAutomationBroker(options({
+      now: () => now,
+      maxLatencySamples: 2,
+      send: (_socket, channel, data) => {
+        if (channel === "browserAutomation.request") delivery = data;
+        return true;
+      },
+    }));
+    const hostSocket = socket("latency");
+    const generation = register(broker, hostSocket, "latency", "workspace-a");
+    updateTargets(broker, hostSocket, "latency", generation, ["thread-a"]);
+    const scope = claims("thread-a", "workspace-a");
+    for (const [sequence, elapsed] of [[1, 10], [2, 20], [3, 30]] as const) {
+      const pending = broker.execute(scope, request(scope, sequence));
+      now += elapsed;
+      broker.respond(hostSocket, "latency", generation, {
+        contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
+        requestId: delivery.dispatch.request.requestId,
+        sequence: delivery.dispatch.request.sequence,
+        ok: true,
+        result: statusResult(),
+      });
+      await pending;
+    }
+
+    expect(broker.reliabilityStatus().roundTripLatency).toEqual({
+      samples: 2,
+      p50Ms: 20,
+      p95Ms: 30,
+      p99Ms: 30,
+    });
+    expect(JSON.stringify(broker.reliabilityStatus())).not.toMatch(/thread-a|example\.test/i);
   });
 
   it("counts truncation nested inside screenshot and snapshot results", async () => {

--- a/apps/server/src/services/browser-automation/broker.ts
+++ b/apps/server/src/services/browser-automation/broker.ts
@@ -86,6 +86,16 @@ export interface BrowserAutomationReliabilityCounters {
   capacityRejected: number;
   latencyTotalMs: number;
   latencyMaxMs: number;
+  /** Round-trip timing from broker admission through host response settlement. */
+  roundTripLatency: BrowserAutomationLatencyPercentiles;
+}
+
+/** Percentiles over the bounded Browser broker round-trip window. */
+export interface BrowserAutomationLatencyPercentiles {
+  samples: number;
+  p50Ms: number | null;
+  p95Ms: number | null;
+  p99Ms: number | null;
 }
 
 /** Function used by the broker to deliver a directed, validated push event. */
@@ -117,6 +127,7 @@ export interface BrowserAutomationBrokerOptions {
   hostHeartbeatTimeoutMs?: number;
   maxHosts?: number;
   maxTargets?: number;
+  maxLatencySamples?: number;
 }
 
 const BROWSER_V2_OPERATIONS = new Set<BrowserAutomationOperation>([
@@ -130,6 +141,8 @@ const NAVIGATION_MAX_RETRIES = 1;
 const NAVIGATION_MAX_ATTEMPTS = NAVIGATION_MAX_RETRIES + 1;
 const NAVIGATION_RETRY_WINDOW_MS = 60_000;
 const NAVIGATION_ATTEMPT_RECORD_LIMIT = 256;
+const MAX_LATENCY_SAMPLES = 256;
+const MAX_LATENCY_SAMPLE_MS = 24 * 60 * 60 * 1_000;
 
 function browserV2Recovery(code: BrowserAutomationErrorCode): "inspect" | "reopen" | "wait" | "yield_to_user" | "do_not_retry" {
   switch (code) {
@@ -320,6 +333,22 @@ function incrementBounded(value: number, amount = 1): number {
   return Math.min(Number.MAX_SAFE_INTEGER, value + Math.max(0, amount));
 }
 
+function latencyPercentile(sorted: readonly number[], quantile: number): number | null {
+  if (sorted.length === 0) return null;
+  const index = Math.max(0, Math.ceil(sorted.length * quantile) - 1);
+  return sorted[index] ?? null;
+}
+
+function summarizeLatency(values: readonly number[]): BrowserAutomationLatencyPercentiles {
+  const sorted = [...values].sort((left, right) => left - right);
+  return {
+    samples: sorted.length,
+    p50Ms: latencyPercentile(sorted, 0.5),
+    p95Ms: latencyPercentile(sorted, 0.95),
+    p99Ms: latencyPercentile(sorted, 0.99),
+  };
+}
+
 function responseWasTruncated(response: BrowserAutomationResponse): boolean {
   if (!response.ok) return false;
   const result = response.result as unknown as Record<string, unknown>;
@@ -443,6 +472,7 @@ export class BrowserAutomationBroker {
   private readonly hostHeartbeatTimeoutMs: number;
   private readonly maxHosts: number;
   private readonly maxTargets: number;
+  private readonly maxLatencySamples: number;
   private readonly openReplay = new Map<string, OpenReplayRecord>();
   private readonly actReplay = new Map<string, ActReplayRecord>();
   private readonly evaluateReplay = new Map<string, EvaluateReplayRecord>();
@@ -450,6 +480,8 @@ export class BrowserAutomationBroker {
   private readonly tabsReplay = new Map<string, TabsReplayRecord>();
   private readonly sessionHosts = new Map<string, RegisteredHost>();
   private readonly navigationAttempts = new Map<string, NavigationAttemptRecord>();
+  private readonly latencySamples: number[] = [];
+  private latencySampleCursor = 0;
   private nextGeneration = 1;
   private readonly reliability: BrowserAutomationReliabilityCounters = {
     dispatched: 0,
@@ -462,6 +494,7 @@ export class BrowserAutomationBroker {
     capacityRejected: 0,
     latencyTotalMs: 0,
     latencyMaxMs: 0,
+    roundTripLatency: { samples: 0, p50Ms: null, p95Ms: null, p99Ms: null },
   };
 
   constructor(options: BrowserAutomationBrokerOptions) {
@@ -473,6 +506,7 @@ export class BrowserAutomationBroker {
     this.hostHeartbeatTimeoutMs = options.hostHeartbeatTimeoutMs ?? 30_000;
     this.maxHosts = options.maxHosts ?? 8;
     this.maxTargets = options.maxTargets ?? 128;
+    this.maxLatencySamples = options.maxLatencySamples ?? MAX_LATENCY_SAMPLES;
     if (
       !Number.isInteger(this.maxPendingRequests) ||
       this.maxPendingRequests < 1 ||
@@ -494,6 +528,9 @@ export class BrowserAutomationBroker {
     }
     if (!Number.isInteger(this.maxTargets) || this.maxTargets < 1 || this.maxTargets > 4_096) {
       throw new Error("Browser automation target capacity is invalid");
+    }
+    if (!Number.isInteger(this.maxLatencySamples) || this.maxLatencySamples < 1 || this.maxLatencySamples > MAX_LATENCY_SAMPLES) {
+      throw new Error("Browser automation latency sample capacity is invalid");
     }
   }
 
@@ -993,7 +1030,7 @@ export class BrowserAutomationBroker {
     const startedAt = this.now();
     this.reliability.dispatched = incrementBounded(this.reliability.dispatched);
     const finishImmediately = (response: BrowserAutomationResponse): Promise<BrowserAutomationResponse> => {
-      this.recordOutcome(response, Math.max(0, this.now() - startedAt));
+      this.recordOutcome(response, Math.max(0, this.now() - startedAt), false);
       return Promise.resolve(response);
     };
     if (
@@ -1208,7 +1245,10 @@ export class BrowserAutomationBroker {
 
   /** Returns a snapshot of bounded reliability counters without page or credential data. */
   reliabilityStatus(): BrowserAutomationReliabilityCounters {
-    return { ...this.reliability };
+    return {
+      ...this.reliability,
+      roundTripLatency: summarizeLatency(this.latencySamples),
+    };
   }
 
   /** Returns the operations both the credential and its selected executor support. */
@@ -1507,7 +1547,7 @@ export class BrowserAutomationBroker {
     const key = pendingKey(host, request.requestId, request.sequence);
     if (this.pending.has(key)) {
       const response = failure(request, "INVALID_REQUEST", "Browser request correlation is already pending", false);
-      this.recordOutcome(response, 0);
+      this.recordOutcome(response, 0, false);
       return Promise.resolve(response);
     }
     return new Promise((resolve) => {
@@ -1647,9 +1687,10 @@ export class BrowserAutomationBroker {
     this.assignments.set(key, { host, targetKey: targetKey(target), lastUsedAt: this.now() });
   }
 
-  private recordOutcome(response: BrowserAutomationResponse, latencyMs: number): void {
+  private recordOutcome(response: BrowserAutomationResponse, latencyMs: number, recordLatency = true): void {
     this.reliability.latencyTotalMs = incrementBounded(this.reliability.latencyTotalMs, latencyMs);
     this.reliability.latencyMaxMs = Math.max(this.reliability.latencyMaxMs, latencyMs);
+    if (recordLatency) this.recordLatencySample(latencyMs);
     if (response.ok) {
       this.reliability.succeeded = incrementBounded(this.reliability.succeeded);
       if (responseWasTruncated(response)) {
@@ -1667,6 +1708,17 @@ export class BrowserAutomationBroker {
         this.reliability.hostLosses = incrementBounded(this.reliability.hostLosses);
       }
     }
+  }
+
+  private recordLatencySample(latencyMs: number): void {
+    if (!Number.isFinite(latencyMs)) return;
+    const bounded = Math.min(MAX_LATENCY_SAMPLE_MS, Math.max(0, latencyMs));
+    if (this.latencySamples.length < this.maxLatencySamples) {
+      this.latencySamples.push(bounded);
+      return;
+    }
+    this.latencySamples[this.latencySampleCursor] = bounded;
+    this.latencySampleCursor = (this.latencySampleCursor + 1) % this.maxLatencySamples;
   }
 
   private adoptBootstrapTarget(

--- a/apps/server/src/services/browser-automation/mcp-handler.test.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.test.ts
@@ -254,7 +254,13 @@ describe("BrowserAutomationMcpHandler", () => {
     const tool = (await listed.json() as any).result.tools[0];
     expect(tool.name).toBe("browser_tabs");
     expect(tool.annotations).toMatchObject({ readOnlyHint: false, destructiveHint: true, idempotentHint: true });
-    expect(tool.inputSchema.oneOf).toHaveLength(5);
+    expect(tool.inputSchema.oneOf).toBeUndefined();
+    expect(tool.inputSchema.required).toEqual(expect.arrayContaining(["action", "idempotencyKey", "observationRef"]));
+    expect(tool.inputSchema.properties.action.enum).toEqual(["select", "claim", "release", "close", "finalize"]);
+    expect(tool.inputSchema.properties.dispositions.items).toMatchObject({
+      required: ["tabId", "disposition"],
+      additionalProperties: false,
+    });
     const response = await post(JSON.stringify({
       jsonrpc: "2.0",
       id: 12,
@@ -269,6 +275,19 @@ describe("BrowserAutomationMcpHandler", () => {
       operation: "tabs",
       args: { action: "select", tabId: "tab-2", idempotencyKey: "tabs-key", observationRef: "obs-1" },
     }));
+
+    execute.mockClear();
+    const invalid = await post(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 13,
+      method: "tools/call",
+      params: {
+        name: "browser_tabs",
+        arguments: { action: "select", idempotencyKey: "tabs-key-2", observationRef: "obs-1" },
+      },
+    }), `Bearer ${tabs.token}`);
+    expect((await invalid.json() as any).error.code).toBe(-32602);
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("advertises only the operations allowed by the authenticated credential", async () => {

--- a/apps/server/src/services/browser-automation/mcp-handler.ts
+++ b/apps/server/src/services/browser-automation/mcp-handler.ts
@@ -160,54 +160,33 @@ const tabsMutationProperties = {
   ...commonProperties,
 } as const;
 
-const tabsMutationVariants = [
-  {
-    type: "object",
-    properties: { ...tabsMutationProperties, action: { const: "select" }, tabId: { type: "string", minLength: 1, maxLength: 256 } },
-    required: ["action", "tabId", "idempotencyKey", "observationRef"],
-    additionalProperties: false,
-  },
-  {
-    type: "object",
-    properties: { ...tabsMutationProperties, action: { const: "claim" }, tabId: { type: "string", minLength: 1, maxLength: 256 } },
-    required: ["action", "tabId", "idempotencyKey", "observationRef"],
-    additionalProperties: false,
-  },
-  {
-    type: "object",
-    properties: { ...tabsMutationProperties, action: { const: "release" }, tabId: { type: "string", minLength: 1, maxLength: 256 } },
-    required: ["action", "idempotencyKey", "observationRef"],
-    additionalProperties: false,
-  },
-  {
-    type: "object",
-    properties: { ...tabsMutationProperties, action: { const: "close" }, tabId: { type: "string", minLength: 1, maxLength: 256 } },
-    required: ["action", "idempotencyKey", "observationRef"],
-    additionalProperties: false,
-  },
-  {
-    type: "object",
-    properties: {
-      ...tabsMutationProperties,
-      action: { const: "finalize" },
-      dispositions: {
-        type: "array",
-        maxItems: 32,
-        items: {
-          type: "object",
-          properties: {
-            tabId: { type: "string", minLength: 1, maxLength: 256 },
-            disposition: { enum: ["close", "release", "handoff", "deliverable"] },
-          },
-          required: ["tabId", "disposition"],
-          additionalProperties: false,
+/** Describes Browser tab actions without a top-level JSON Schema union. */
+const tabsInputSchema = {
+  type: "object",
+  properties: {
+    ...tabsMutationProperties,
+    action: {
+      enum: ["select", "claim", "release", "close", "finalize"],
+      description: "Select or claim requires tabId; finalize requires dispositions; release and close may omit tabId.",
+    },
+    tabId: { type: "string", minLength: 1, maxLength: 256 },
+    dispositions: {
+      type: "array",
+      maxItems: 32,
+      items: {
+        type: "object",
+        properties: {
+          tabId: { type: "string", minLength: 1, maxLength: 256 },
+          disposition: { enum: ["close", "release", "handoff", "deliverable"] },
         },
+        required: ["tabId", "disposition"],
+        additionalProperties: false,
       },
     },
-    required: ["action", "dispositions", "idempotencyKey", "observationRef"],
-    additionalProperties: false,
   },
-];
+  required: ["action", "idempotencyKey", "observationRef"],
+  additionalProperties: false,
+} satisfies Record<string, unknown>;
 
 function inputSchema(operation: BrowserAutomationOperation): Record<string, unknown> {
   const schemas: Record<BrowserAutomationOperation, Record<string, unknown>> = {
@@ -246,12 +225,12 @@ function inputSchema(operation: BrowserAutomationOperation): Record<string, unkn
     },
     recordingStart: { maxDurationMs: { type: "integer", minimum: 1000, maximum: 600000 } },
     recordingStop: {},
-    tabs: { oneOf: tabsMutationVariants },
+    tabs: tabsInputSchema,
   };
   const requiredByOperation: Partial<Record<BrowserAutomationOperation, string[]>> = {
     open: ["idempotencyKey"], act: ["idempotencyKey", "observationRef", "deadlineMs", "steps"], navigate: ["url"], resize: ["width", "height"], click: ["target"], type: ["text"], press: ["key"], scroll: ["deltaY"], evaluate: ["idempotencyKey", "observationRef", "deadlineMs", "expression"],
   };
-  if (operation === "tabs") return { oneOf: tabsMutationVariants };
+  if (operation === "tabs") return tabsInputSchema;
   return {
     type: "object",
     properties: { ...commonProperties, ...schemas[operation] },

--- a/packages/browser-conformance/src/__tests__/metrics.test.ts
+++ b/packages/browser-conformance/src/__tests__/metrics.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSER_CONFORMANCE_MAX_TIMING_SAMPLES,
+  BROWSER_CONFORMANCE_TIMING_PHASES,
+  BrowserConformanceTimingMetrics,
+} from "../metrics.js";
+
+describe("Browser conformance timing metrics", () => {
+  it("reports nearest-rank p50, p95, and p99 for each explicitly measured phase", () => {
+    const metrics = new BrowserConformanceTimingMetrics();
+    metrics.record({ phase: "mcode", durationMs: 30 });
+    metrics.record({ phase: "mcode", durationMs: 10 });
+    metrics.record({ phase: "mcode", durationMs: 20 });
+    metrics.record({ phase: "network", durationMs: 7 });
+
+    expect(metrics.report()).toEqual({
+      mcode: { samples: 3, p50Ms: 20, p95Ms: 30, p99Ms: 30 },
+      application: { samples: 0, p50Ms: null, p95Ms: null, p99Ms: null },
+      network: { samples: 1, p50Ms: 7, p95Ms: 7, p99Ms: 7 },
+      wait: { samples: 0, p50Ms: null, p95Ms: null, p99Ms: null },
+      model: { samples: 0, p50Ms: null, p95Ms: null, p99Ms: null },
+    });
+  });
+
+  it("retains a bounded recent window and rejects invalid samples", () => {
+    const metrics = new BrowserConformanceTimingMetrics({ maxSamplesPerPhase: 2 });
+    metrics.record({ phase: "mcode", durationMs: 1 });
+    metrics.record({ phase: "mcode", durationMs: 2 });
+    metrics.record({ phase: "mcode", durationMs: 3 });
+
+    expect(metrics.report().mcode).toEqual({ samples: 2, p50Ms: 2, p95Ms: 3, p99Ms: 3 });
+    expect(() => metrics.record({ phase: "mcode", durationMs: -1 })).toThrow(RangeError);
+    expect(() => metrics.record({ phase: "mcode", durationMs: Number.POSITIVE_INFINITY })).toThrow(RangeError);
+    expect(() => new BrowserConformanceTimingMetrics({ maxSamplesPerPhase: BROWSER_CONFORMANCE_MAX_TIMING_SAMPLES + 1 }))
+      .toThrow(RangeError);
+  });
+
+  it("does not retain page or provider content", () => {
+    const metrics = new BrowserConformanceTimingMetrics();
+    for (const phase of BROWSER_CONFORMANCE_TIMING_PHASES) metrics.record({ phase, durationMs: 5 });
+    expect(JSON.stringify(metrics.report())).not.toMatch(/url|token|secret|thread|credential/i);
+  });
+});

--- a/packages/browser-conformance/src/index.ts
+++ b/packages/browser-conformance/src/index.ts
@@ -111,6 +111,19 @@ export type {
   BrowserConformanceFaultControl,
   BrowserConformanceFaultControlKind,
 } from "./faults.js";
+export {
+  BROWSER_CONFORMANCE_MAX_TIMING_DURATION_MS,
+  BROWSER_CONFORMANCE_MAX_TIMING_SAMPLES,
+  BROWSER_CONFORMANCE_TIMING_PHASES,
+  BrowserConformanceTimingMetrics,
+} from "./metrics.js";
+export type {
+  BrowserConformanceTimingMetricsOptions,
+  BrowserConformanceTimingPercentiles,
+  BrowserConformanceTimingPhase,
+  BrowserConformanceTimingReport,
+  BrowserConformanceTimingSample,
+} from "./metrics.js";
 export type {
   BrowserConformanceReplayBundle,
   BrowserConformanceReplayBundleInput,

--- a/packages/browser-conformance/src/metrics.ts
+++ b/packages/browser-conformance/src/metrics.ts
@@ -1,0 +1,97 @@
+/** Timing phases that a Browser tracer may measure independently. */
+export const BROWSER_CONFORMANCE_TIMING_PHASES = [
+  "mcode",
+  "application",
+  "network",
+  "wait",
+  "model",
+] as const;
+
+/** One independently measured Browser timing phase. */
+export type BrowserConformanceTimingPhase = (typeof BROWSER_CONFORMANCE_TIMING_PHASES)[number];
+
+/** Maximum number of recent samples retained for one timing phase. */
+export const BROWSER_CONFORMANCE_MAX_TIMING_SAMPLES = 256;
+
+/** Maximum duration accepted for one timing sample. */
+export const BROWSER_CONFORMANCE_MAX_TIMING_DURATION_MS = 24 * 60 * 60 * 1_000;
+
+/** One bounded, content-free timing sample from a tracer. */
+export interface BrowserConformanceTimingSample {
+  readonly phase: BrowserConformanceTimingPhase;
+  readonly durationMs: number;
+}
+
+/** Percentiles calculated from the retained samples for one phase. */
+export interface BrowserConformanceTimingPercentiles {
+  readonly samples: number;
+  readonly p50Ms: number | null;
+  readonly p95Ms: number | null;
+  readonly p99Ms: number | null;
+}
+
+/** Percentile report for all independently measured Browser timing phases. */
+export type BrowserConformanceTimingReport = Readonly<
+  Record<BrowserConformanceTimingPhase, BrowserConformanceTimingPercentiles>
+>;
+
+/** Options controlling bounded tracer timing retention. */
+export interface BrowserConformanceTimingMetricsOptions {
+  readonly maxSamplesPerPhase?: number;
+}
+
+/**
+ * Collects bounded, content-free timing samples without inferring one phase
+ * from another.
+ */
+export class BrowserConformanceTimingMetrics {
+  private readonly maxSamplesPerPhase: number;
+  private readonly samples = new Map<BrowserConformanceTimingPhase, number[]>();
+
+  constructor(options: BrowserConformanceTimingMetricsOptions = {}) {
+    this.maxSamplesPerPhase = options.maxSamplesPerPhase ?? BROWSER_CONFORMANCE_MAX_TIMING_SAMPLES;
+    if (
+      !Number.isInteger(this.maxSamplesPerPhase) ||
+      this.maxSamplesPerPhase < 1 ||
+      this.maxSamplesPerPhase > BROWSER_CONFORMANCE_MAX_TIMING_SAMPLES
+    ) {
+      throw new RangeError("Browser conformance timing sample capacity is invalid");
+    }
+    for (const phase of BROWSER_CONFORMANCE_TIMING_PHASES) this.samples.set(phase, []);
+  }
+
+  /** Records one explicitly measured phase duration. */
+  record(sample: BrowserConformanceTimingSample): void {
+    if (!sample || typeof sample !== "object") throw new RangeError("Browser conformance timing sample is invalid");
+    if (!Number.isFinite(sample.durationMs) || sample.durationMs < 0 || sample.durationMs > BROWSER_CONFORMANCE_MAX_TIMING_DURATION_MS) {
+      throw new RangeError("Browser conformance timing duration is invalid");
+    }
+    const values = this.samples.get(sample.phase);
+    if (!values) throw new RangeError("Browser conformance timing phase is invalid");
+    if (values.length >= this.maxSamplesPerPhase) values.shift();
+    values.push(sample.durationMs);
+  }
+
+  /** Returns the current bounded percentile report for every timing phase. */
+  report(): BrowserConformanceTimingReport {
+    return Object.fromEntries(
+      BROWSER_CONFORMANCE_TIMING_PHASES.map((phase) => [phase, summarize(this.samples.get(phase) ?? [])]),
+    ) as BrowserConformanceTimingReport;
+  }
+}
+
+function summarize(values: readonly number[]): BrowserConformanceTimingPercentiles {
+  if (values.length === 0) return { samples: 0, p50Ms: null, p95Ms: null, p99Ms: null };
+  const sorted = [...values].sort((left, right) => left - right);
+  return {
+    samples: sorted.length,
+    p50Ms: percentile(sorted, 0.5),
+    p95Ms: percentile(sorted, 0.95),
+    p99Ms: percentile(sorted, 0.99),
+  };
+}
+
+function percentile(sorted: readonly number[], quantile: number): number {
+  const index = Math.max(0, Math.ceil(sorted.length * quantile) - 1);
+  return sorted[index] ?? 0;
+}


### PR DESCRIPTION
## What
Make the Browser MCP catalog discoverable in fresh Cursor ACP sessions.

## Why
Cursor rejects a mixed catalog when `browser_tabs` advertises a top-level JSON Schema `oneOf`. The fresh Composer 2.5 Fast session then retries `tools/list` and exposes the Browser guide without Browser tools.

## Key Changes
- Advertise Browser tab actions with one Cursor-compatible object schema.
- Keep strict `BrowserAutomationTabsArgsSchema` validation at the request boundary.
- Add coverage for the flat catalog shape and malformed tab actions.

## Verification
- Red differential probe: the full `browser_tabs` union produced two `tools/list` requests and no MCP tool event.
- Green live probe: a fresh installed `cursor-agent acp` Composer 2.5 Fast session discovered `browser_open`, `browser_inspect`, `browser_act`, and `browser_tabs`, then attempted `browser_open`. The probe permission boundary rejected execution before navigation.
- `bun run test -- src/services/browser-automation/mcp-handler.test.ts src/providers/cursor/__tests__/cursor-browser-mcp.test.ts`: 36 tests passed.
- `bun run verify:changed`: passed. Manifest: `.dev/verification/runs/2026-08-06T14-13-35-864Z-41172-d1ffbe6b/manifest.json`.
- `bun run verify`: passed. Manifest: `.dev/verification/runs/2026-08-06T14-14-21-679Z-49584-3372a1f8/manifest.json`.

Related to #1055

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788618645&installation_model_id=20477&pr_number=1135&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1135&signature=8ace9d42183c747235762446930dbf9e37434001425650995f8d330bd9ab2050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added browser automation round-trip latency diagnostics, including sample counts and p50, p95, and p99 percentile measurements.
  - Added browser conformance timing reports across supported phases with bounded sample retention and percentile summaries.
  - Exposed timing metrics and reporting options for integrations that monitor browser performance.
  - Standardized browser tab actions under a unified input format with clearer validation for required identifiers and dispositions.

- **Bug Fixes**
  - Improved reliability reporting by excluding immediate outcomes and limiting retained timing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->