### PR TITLE
fix(runtime): install Electron before native binding

### DIFF
--- a/scripts/agent/__tests__/electron-postinstall.test.mjs
+++ b/scripts/agent/__tests__/electron-postinstall.test.mjs
@@ -1,0 +1,50 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureElectronForPrebuild } from "../../electron-postinstall.mjs";
+
+const temporaryRoots = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("ensureElectronForPrebuild", () => {
+  it("installs a missing Electron binary before resolving it", () => {
+    const root = mkdtempSync(join(tmpdir(), "mcode-electron-postinstall-"));
+    temporaryRoots.push(root);
+    const desktopRoot = join(root, "apps", "desktop");
+    const electronRoot = join(root, "node_modules", "electron");
+    const executable = join(electronRoot, "dist", "electron.exe");
+
+    mkdirSync(desktopRoot, { recursive: true });
+    mkdirSync(electronRoot, { recursive: true });
+    writeFileSync(join(desktopRoot, "package.json"), '{"private":true}');
+    writeFileSync(
+      join(electronRoot, "package.json"),
+      '{"name":"electron","version":"0.0.0","main":"index.js"}',
+    );
+    writeFileSync(
+      join(electronRoot, "index.js"),
+      "const fs=require('fs');const path=require('path');" +
+        "const executable=fs.readFileSync(path.join(__dirname,'path.txt'),'utf8').trim();" +
+        "module.exports=path.join(__dirname,'dist',executable);",
+    );
+    writeFileSync(
+      join(electronRoot, "install.js"),
+      "const fs=require('fs');const path=require('path');" +
+        "fs.mkdirSync(path.join(__dirname,'dist'),{recursive:true});" +
+        "fs.writeFileSync(path.join(__dirname,'dist','electron.exe'),'fixture');" +
+        "fs.writeFileSync(path.join(__dirname,'path.txt'),'electron.exe');",
+    );
+
+    assert.equal(existsSync(join(electronRoot, "path.txt")), false);
+    assert.equal(ensureElectronForPrebuild(desktopRoot), executable);
+    assert.equal(existsSync(join(electronRoot, "path.txt")), true);
+    assert.equal(existsSync(executable), true);
+  });
+});

--- a/scripts/electron-postinstall.mjs
+++ b/scripts/electron-postinstall.mjs
@@ -1,0 +1,18 @@
+/** Electron prerequisite used before installing ABI-specific native modules. */
+
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { ensureElectronBinary } from "./ensure-electron.mjs";
+
+/** Installs Electron when needed and returns its verified executable path. */
+export function ensureElectronForPrebuild(desktopRoot) {
+  ensureElectronBinary(desktopRoot);
+
+  const desktopRequire = createRequire(resolve(desktopRoot, "package.json"));
+  const electronPath = desktopRequire("electron");
+  if (!existsSync(electronPath)) {
+    throw new Error(`Electron binary unavailable after installation: ${electronPath}`);
+  }
+  return electronPath;
+}

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -7,9 +7,8 @@
  *
  *   build/Release/better_sqlite3.electron.node  - Electron prebuild
  *
- * Skips gracefully when:
- * - Electron binary is not installed (worktrees, CI, server-only dev)
- * - The correct prebuild is already in place (avoids re-downloading)
+ * Installs Electron first when its executable is missing. Skips only when
+ * SKIP_ELECTRON_REBUILD=1 is explicit or the correct prebuild already exists.
  *
  * Set SKIP_ELECTRON_REBUILD=1 to force skip.
  */
@@ -20,6 +19,7 @@ import { createRequire } from "module";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { tmpdir } from "os";
+import { ensureElectronForPrebuild } from "./electron-postinstall.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, "..");
@@ -53,24 +53,6 @@ const electronBinary = resolve(
 const abiMarker = resolve(betterSqliteDir, "build", "Release", ".electron-abi");
 
 /**
- * Resolve the path to the actual Electron binary from the project's
- * node_modules. Returns null if Electron is not installed or the binary
- * is missing (e.g. in worktrees before `electron install` runs).
- */
-function getElectronBinary() {
-  try {
-    const desktopRequire = createRequire(
-      resolve(desktopDir, "package.json"),
-    );
-    const electronPath = desktopRequire("electron");
-    if (!existsSync(electronPath)) return null;
-    return electronPath;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Query the actual NODE_MODULE_VERSION from the installed Electron binary.
  * Returns null if the binary can't be queried.
  */
@@ -101,14 +83,10 @@ const arch = process.arch;
 let electronABI = null;
 
 if (!skipElectron) {
-  const electronBin = getElectronBinary();
-  if (!electronBin) {
-    console.log("Skipping Electron prebuild (Electron binary not found)");
-  } else {
-    electronABI = getElectronABI(electronBin);
-    if (!electronABI) {
-      console.log("Skipping Electron prebuild (could not detect Electron ABI)");
-    }
+  const electronBin = ensureElectronForPrebuild(desktopDir);
+  electronABI = getElectronABI(electronBin);
+  if (!electronABI) {
+    throw new Error("Could not detect the installed Electron ABI");
   }
 }
 


### PR DESCRIPTION
## What
Install Electron before the postinstall script resolves its ABI and downloads the native SQLite binding.

## Why
A fresh worktree could complete `bun install` without Electron's `path.txt`. The postinstall script then skipped the SQLite binding and left `dev:desktop` unable to start.

## Key Changes
- Install and verify the Electron executable before ABI detection.
- Fail when Electron cannot report a valid ABI.
- Add a regression test for a missing `path.txt` and executable.

Related to #1055

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788637190&installation_model_id=20477&pr_number=1166&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1166&signature=8a96e3fb5181143784aed008501c5be38ef335478e05918c048e816a03818206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop installation reliability by ensuring Electron is installed and available before prebuild processing.
  - Electron setup or ABI detection failures now report clear errors instead of being silently skipped.
  - Verified that the expected Electron executable and resolution metadata are created during installation.

- **Tests**
  - Added automated coverage for Electron setup, executable creation, metadata resolution, and temporary fixture cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->