### PR TITLE
feat(browser): host web iframe surfaces

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -36,6 +36,7 @@ import type { SettingsSection } from "@/components/settings/settings-nav";
 import { TerminalPoolHost } from "@/components/terminal/TerminalPoolHost";
 import { TerminalPoolSlotProvider } from "@/components/terminal/TerminalPoolSlotContext";
 import { BrowserAutomationHost } from "@/components/panels/BrowserAutomationHost";
+import { BrowserSurfaceHostRoot } from "@/components/panels/BrowserSurfaceHostRoot";
 import { DesktopTitleBar } from "@/components/desktop/DesktopTitleBar";
 import {
   useNavigationHistoryStore,
@@ -731,6 +732,7 @@ export function App() {
           </div>
         </div>
         <TerminalPoolHost />
+        <BrowserSurfaceHostRoot />
         <BrowserAutomationHost />
         <Suspense fallback={null}>
           <LazyCommandPalette />

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -67,6 +67,10 @@ function escapeWebSelector(value: string): string {
   return escape ? escape(value) : value.replace(/[^a-zA-Z0-9_-]/g, (character) => `\\${character}`);
 }
 
+function webIframeSelector(workspaceId: string, threadId: string, tabId: string): string {
+  return `iframe[data-workspace-id="${escapeWebSelector(workspaceId)}"][data-scope-kind="thread"][data-scope-id="${escapeWebSelector(threadId)}"][data-tab-id="${escapeWebSelector(tabId)}"]`;
+}
+
 function webTargetIdentity(
   worktreeIdentity: string,
   connectionId: string,
@@ -294,10 +298,11 @@ function projectAgentControl(dispatch: BrowserAutomationHostDispatch): void {
 }
 
 function mountedWebIframe(dispatch: BrowserAutomationHostDispatch): HTMLIFrameElement | null {
-  for (const iframe of document.querySelectorAll<HTMLIFrameElement>("iframe")) {
-    if (iframe.dataset.threadId === dispatch.target.threadId && iframe.dataset.tabId === dispatch.target.tabId) return iframe;
-  }
-  return null;
+  return document.querySelector<HTMLIFrameElement>(webIframeSelector(
+    dispatch.scope.workspaceId,
+    dispatch.target.threadId,
+    dispatch.target.tabId,
+  ));
 }
 
 async function executeBrowserDispatch(
@@ -468,11 +473,12 @@ function waitForLiveTarget(
 }
 
 function webPreviewIframe(
+  workspaceId: string,
   threadId: string,
   tabId: string,
   expectedUrl: string,
 ): HTMLIFrameElement | null {
-  const selector = `iframe[data-thread-id="${escapeWebSelector(threadId)}"][data-tab-id="${escapeWebSelector(tabId)}"]`;
+  const selector = webIframeSelector(workspaceId, threadId, tabId);
   const iframe = document.querySelector<HTMLIFrameElement>(selector);
   if (!iframe || normalizeWebPreviewUrl(iframe.src) !== expectedUrl) return null;
   return resolveSameOriginFrame(iframe) ? iframe : null;
@@ -487,6 +493,7 @@ function isSameOriginWebPreviewUrl(url: string): boolean {
 }
 
 function waitForWebPreviewIframe(
+  workspaceId: string,
   threadId: string,
   tabId: string,
   expectedUrl: string,
@@ -495,7 +502,7 @@ function waitForWebPreviewIframe(
   onNavigationLoad?: (iframe: HTMLIFrameElement) => void,
 ): Promise<void> {
   if (signal.aborted) return Promise.reject(signal.reason);
-  const ready = webPreviewIframe(threadId, tabId, expectedUrl);
+  const ready = webPreviewIframe(workspaceId, threadId, tabId, expectedUrl);
   if (ready?.contentDocument?.readyState === "complete" && !onNavigationLoad) return Promise.resolve();
   return new Promise((resolve, reject) => {
     let settled = false;
@@ -508,7 +515,7 @@ function waitForWebPreviewIframe(
       resolve();
     };
     const observeReady = () => {
-      const iframe = webPreviewIframe(threadId, tabId, expectedUrl);
+      const iframe = webPreviewIframe(workspaceId, threadId, tabId, expectedUrl);
       if (!iframe) return;
       if (iframe.contentDocument?.readyState === "complete" && !onNavigationLoad) {
         finish();
@@ -548,7 +555,7 @@ function waitForWebPreviewIframe(
       subtree: true,
       childList: true,
       attributes: true,
-      attributeFilter: ["src", "data-thread-id", "data-tab-id", "class", "style", "hidden", "aria-hidden"],
+      attributeFilter: ["src", "data-workspace-id", "data-scope-kind", "data-scope-id", "data-tab-id", "class", "style", "hidden", "aria-hidden"],
     });
     signal.addEventListener("abort", onAbort, { once: true });
     if (signal.aborted) onAbort();
@@ -587,7 +594,7 @@ function acceptExpectedWebNavigationRevision(
     navigation.expectedUrl !== expectedUrl ||
     dispatch.target.targetGeneration !== navigation.initialRevision ||
     target?.revision !== navigation.initialRevision + 1 ||
-    !webPreviewIframe(dispatch.target.threadId, dispatch.target.tabId, navigation.expectedUrl)
+    !webPreviewIframe(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId, navigation.expectedUrl)
   ) return undefined;
   navigation.acceptedRevision = target.revision;
   return target.revision;
@@ -657,6 +664,9 @@ function PersistentAutomationWebTab({
     <iframe
       title="Browser automation page"
       src={tab.url}
+      data-workspace-id={tab.workspaceId}
+      data-scope-kind="thread"
+      data-scope-id={tab.threadId}
       data-thread-id={tab.threadId}
       data-tab-id={tab.tabId}
       aria-hidden={!visible}
@@ -842,7 +852,11 @@ export function BrowserAutomationHost() {
   if (!sessionDriverRef.current) {
     const webAdapter = new WebBrowserSessionAdapter({
       resolveDocument: (dispatch) => {
-        const selector = `iframe[data-thread-id="${escapeWebSelector(dispatch.target.threadId)}"][data-tab-id="${escapeWebSelector(dispatch.target.tabId)}"]`;
+        const selector = webIframeSelector(
+          dispatch.scope.workspaceId,
+          dispatch.target.threadId,
+          dispatch.target.tabId,
+        );
         for (const iframe of document.querySelectorAll<HTMLIFrameElement>(selector)) {
           const resolved = resolveSameOriginFrame(iframe);
           if (resolved) return resolved.document;
@@ -1214,7 +1228,11 @@ export function BrowserAutomationHost() {
             loadObserved: false,
           };
           webNavigationRef.current.set(key, navigation);
-          const selector = `iframe[data-thread-id="${escapeWebSelector(dispatch.target.threadId)}"][data-tab-id="${escapeWebSelector(dispatch.target.tabId)}"]`;
+          const selector = webIframeSelector(
+            dispatch.scope.workspaceId,
+            dispatch.target.threadId,
+            dispatch.target.tabId,
+          );
           const iframe = document.querySelector<HTMLIFrameElement>(selector);
           if (iframe) {
             const onLoad = () => {
@@ -1244,7 +1262,12 @@ export function BrowserAutomationHost() {
         if (!currentTarget || currentTarget.revision !== dispatch.target.targetGeneration) {
           return failureResponse(dispatch.request, "STALE_TARGET_GENERATION", "Browser operation is stale");
         }
-        const currentIframe = webPreviewIframe(dispatch.target.threadId, dispatch.target.tabId, requestedUrl);
+        const currentIframe = webPreviewIframe(
+          dispatch.scope.workspaceId,
+          dispatch.target.threadId,
+          dispatch.target.tabId,
+          requestedUrl,
+        );
         if (!currentIframe) {
           webNavigationRef.current.set(key, {
             targetKey,
@@ -1257,6 +1280,7 @@ export function BrowserAutomationHost() {
           useDiffStore.getState().setPreviewUrlForThread(dispatch.target.threadId, requestedUrl);
         }
         await waitForWebPreviewIframe(
+          dispatch.scope.workspaceId,
           dispatch.target.threadId,
           dispatch.target.tabId,
           requestedUrl,
@@ -1579,6 +1603,7 @@ export function BrowserAutomationHost() {
         }
         if (!bridge && requestedWebUrl) {
           await waitForWebPreviewIframe(
+            request.workspaceId,
             request.threadId,
             tabId,
             requestedWebUrl,

--- a/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
+++ b/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from "react";
+import {
+  BrowserSurfaceHost,
+  WebIframeBrowserSurfaceAdapter,
+} from "@/services/browser-surfaces";
+import { useBrowserAutomationStore } from "@/stores/browserAutomationStore";
+
+let surfaceRoot: HTMLDivElement | null = null;
+
+/** Renderer-window Browser surface host used by the web iframe adapter. */
+export const browserSurfaceHost = new BrowserSurfaceHost({
+  adapterFactory: (identity, generation) => new WebIframeBrowserSurfaceAdapter(
+    identity,
+    generation,
+    {
+      root: surfaceRoot ?? document.body,
+      title: "Web browser preview",
+      onLoad: (surfaceIdentity) => {
+        useBrowserAutomationStore.getState().refreshTarget(
+          surfaceIdentity.scope.id,
+          surfaceIdentity.tabId,
+        );
+      },
+    },
+  ),
+});
+
+/** Mounts the single Browser surface root for this renderer window. */
+export function BrowserSurfaceHostRoot() {
+  const setRoot = useCallback((node: HTMLDivElement | null): void => {
+    surfaceRoot = node;
+  }, []);
+
+  return (
+    <div
+      ref={setRoot}
+      data-browser-surface-host=""
+      className="pointer-events-none fixed inset-0 z-30"
+    />
+  );
+}

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -2,6 +2,7 @@ import {
   Fragment,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -102,6 +103,11 @@ import {
   getOrCreateViewportCoordinator,
   waitForViewportLayout,
 } from "@/services/browser-automation/viewportCoordinatorFactory";
+import type {
+  BrowserSurfaceIdentity,
+  BrowserSurfacePageState,
+} from "@/services/browser-surfaces";
+import { browserSurfaceHost } from "./BrowserSurfaceHostRoot";
 
 /** Human-readable label for the capture confirmation badge. */
 const CAPTURE_KIND_LABEL: Record<PreviewCaptureKind, string> = {
@@ -1604,14 +1610,29 @@ function WebRuntimePreview({
   const storedUrl = useDiffStore((state) => state.previewUrlByThread[threadId] ?? "");
   const fixtureUrl = `${window.location.origin}${WEB_AUTOMATION_FIXTURE_URL}`;
   const [inputUrl, setInputUrl] = useState(storedUrl);
-  const [src, setSrc] = useState<string | null>(() => normalizeWebPreviewUrl(storedUrl) ?? fixtureUrl);
+  const [requestedAddress, setRequestedAddress] = useState<string | null>(
+    () => normalizeWebPreviewUrl(storedUrl) ?? fixtureUrl,
+  );
+  const requestedAddressRef = useRef(requestedAddress);
+  requestedAddressRef.current = requestedAddress;
+  const [pageState, setPageState] = useState<BrowserSurfacePageState | null>(null);
   const [crossOriginObserved, setCrossOriginObserved] = useState(false);
   const [zoom, setZoom] = useState(1);
   const [canvasBounds, setCanvasBounds] = useState({ width: 0, height: 0 });
   const surfaceRef = useRef<HTMLDivElement>(null);
+  const dockRef = useRef<HTMLDivElement>(null);
+  const identity = useMemo<BrowserSurfaceIdentity>(() => ({
+    workspaceId: workspaceId ?? threadId,
+    scope: {
+      kind: "thread",
+      id: threadId,
+    },
+    tabId: WEB_RUNTIME_PREVIEW_TAB_ID,
+  }), [threadId, workspaceId]);
   const enabled = isBrowserAutomationWebRuntimeEnabled();
-  const requestedState = resolveWebPreviewState(src, enabled);
+  const requestedState = resolveWebPreviewState(requestedAddress, enabled);
   const state = crossOriginObserved ? "cross-origin" : requestedState;
+  const surfaceAvailable = enabled && requestedAddress !== null;
   const responsiveViewportSize =
     viewportState?.mode === "responsive" ? viewportState.confirmed : null;
   const responsiveViewportScale = responsiveViewportSize
@@ -1621,25 +1642,47 @@ function WebRuntimePreview({
         viewportState?.presentation ?? "fit",
       )
     : 1;
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (!surfaceAvailable) return;
     useBrowserAutomationStore.getState().registerTarget(
-      workspaceId ?? threadId,
+      identity.workspaceId,
       threadId,
       WEB_RUNTIME_PREVIEW_TAB_ID,
     );
+    const initial = browserSurfaceHost.create(identity, {
+      address: requestedAddressRef.current ?? fixtureUrl,
+    });
+    setPageState(initial);
+    const unsubscribe = browserSurfaceHost.subscribe(identity, (snapshot) => {
+      setPageState(snapshot);
+      setCrossOriginObserved(snapshot.documentAccess === "cross-origin");
+    });
     return () => {
+      unsubscribe();
+      browserSurfaceHost.dispose(identity);
       useBrowserAutomationStore.getState().detachTarget(
         threadId,
         WEB_RUNTIME_PREVIEW_TAB_ID,
       );
     };
-  }, [threadId, workspaceId]);
+  }, [fixtureUrl, identity, surfaceAvailable, threadId]);
 
   useEffect(() => {
     setInputUrl(storedUrl);
-    setSrc(normalizeWebPreviewUrl(storedUrl) ?? fixtureUrl);
+    setRequestedAddress(normalizeWebPreviewUrl(storedUrl) ?? fixtureUrl);
     setCrossOriginObserved(false);
   }, [fixtureUrl, storedUrl]);
+
+  useEffect(() => {
+    if (!requestedAddress) return;
+    const current = browserSurfaceHost.getSnapshot(identity);
+    if (!current) return;
+    if (
+      current.pendingAddress === requestedAddress ||
+      current.committedAddress === requestedAddress
+    ) return;
+    browserSurfaceHost.navigate(identity, requestedAddress);
+  }, [identity, requestedAddress]);
 
   useEffect(() => {
     const surface = surfaceRef.current;
@@ -1655,65 +1698,73 @@ function WebRuntimePreview({
     };
   }, []);
 
+  useLayoutEffect(() => {
+    const dock = dockRef.current;
+    if (!dock) {
+      browserSurfaceHost.hide(identity);
+      return;
+    }
+    const update = (): void => {
+      const bounds = dock.getBoundingClientRect();
+      if (dock.closest("[inert], [aria-hidden='true']")) {
+        browserSurfaceHost.hide(identity);
+        return;
+      }
+      const hasGeometry = bounds.width > 0 && bounds.height > 0;
+      browserSurfaceHost.present(identity, {
+        left: hasGeometry ? bounds.left : -20_000,
+        top: hasGeometry ? bounds.top : 0,
+        width: responsiveViewportSize?.width ?? (hasGeometry ? bounds.width : 1),
+        height: responsiveViewportSize?.height ?? (hasGeometry ? bounds.height : 1),
+        scale: responsiveViewportSize ? responsiveViewportScale : 1,
+        zIndex: 31,
+      });
+    };
+    const resizeObserver = typeof ResizeObserver === "function"
+      ? new ResizeObserver(update)
+      : null;
+    resizeObserver?.observe(dock);
+    window.addEventListener("resize", update);
+    update();
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", update);
+      browserSurfaceHost.hide(identity);
+    };
+  }, [identity, responsiveViewportScale, responsiveViewportSize, state]);
+
   const navigate = (candidate = inputUrl): void => {
     const next = normalizeWebPreviewUrl(candidate);
     if (!next) {
-      setSrc(null);
+      setRequestedAddress(null);
       setCrossOriginObserved(false);
       return;
     }
-    setSrc(next);
+    setRequestedAddress(next);
     setCrossOriginObserved(false);
     useDiffStore.getState().setPreviewUrlForThread(threadId, next);
-  };
-
-  const onIframeLoad = (event: React.SyntheticEvent<HTMLIFrameElement>): void => {
-    useBrowserAutomationStore.getState().refreshTarget(
-      threadId,
-      WEB_RUNTIME_PREVIEW_TAB_ID,
-    );
-    try {
-      const actualOrigin = event.currentTarget.contentWindow?.location.origin;
-      setCrossOriginObserved(actualOrigin !== window.location.origin);
-    } catch {
-      setCrossOriginObserved(true);
-    }
   };
 
   const noOp = (): void => undefined;
   const invalidateViewportObservation = (): void => {
     invalidateBrowserAutomationTargetObservation(threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
   };
-  const iframeStyle: CSSProperties | undefined = responsiveViewportSize
-    ? {
-        width: responsiveViewportSize.width,
-        height: responsiveViewportSize.height,
-      }
-    : undefined;
-  const previewContent = state === "same-origin" && src ? (
-    <iframe
-      title="Web browser preview"
-      src={src}
-      data-testid="web-runtime-preview-iframe"
-      data-thread-id={threadId}
-      data-tab-id={WEB_RUNTIME_PREVIEW_TAB_ID}
-      className={cn("border-0", responsiveViewportSize ? "absolute left-0 top-0" : "h-full w-full")}
-      style={iframeStyle}
-      referrerPolicy="no-referrer"
-      onLoad={onIframeLoad}
+  const visiblePageState = surfaceAvailable ? pageState : null;
+  const visibleAddress = visiblePageState?.phase === "error"
+    ? visiblePageState.pendingAddress ?? visiblePageState.committedAddress
+    : visiblePageState?.committedAddress ?? visiblePageState?.pendingAddress ?? requestedAddress;
+  const previewContent = state === "same-origin" && requestedAddress ? (
+    <div
+      ref={dockRef}
+      data-testid="web-runtime-preview-dock"
+      className="absolute inset-0 h-full w-full"
     />
-  ) : state === "cross-origin" && src ? (
+  ) : state === "cross-origin" && requestedAddress ? (
     <>
-      <iframe
-        title="Cross-origin web preview"
-        src={src}
-        data-testid="web-runtime-preview-iframe"
-        data-thread-id={threadId}
-        data-tab-id={WEB_RUNTIME_PREVIEW_TAB_ID}
-        className={cn("border-0", responsiveViewportSize ? "absolute left-0 top-0" : "h-full w-full")}
-        style={iframeStyle}
-        referrerPolicy="no-referrer"
-        onLoad={onIframeLoad}
+      <div
+        ref={dockRef}
+        data-testid="web-runtime-preview-dock"
+        className="absolute inset-0 h-full w-full"
       />
       <div data-testid="web-runtime-cross-origin" className="pointer-events-none absolute inset-x-3 top-3 rounded-md border border-amber-500/40 bg-background/95 px-3 py-2 text-xs text-amber-700 shadow-sm">
         Cross-origin preview is visible, but web automation and DOM access are unsupported.
@@ -1730,12 +1781,12 @@ function WebRuntimePreview({
   return (
     <div data-testid="web-runtime-preview" className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
       <BrowserHeader
-        url={src ?? ""}
-        pageTitle={null}
-        faviconUrl={null}
-        hasLoadedPage={Boolean(src)}
-        canBack={false}
-        canFwd={false}
+        url={visibleAddress ?? ""}
+        pageTitle={visiblePageState?.title || null}
+        faviconUrl={visiblePageState?.favicon ?? null}
+        hasLoadedPage={Boolean(visibleAddress)}
+        canBack={visiblePageState?.navigation?.canGoBack ?? false}
+        canFwd={visiblePageState?.navigation?.canGoForward ?? false}
         threadId=""
         designModeActive={false}
         elementPickBusy={false}
@@ -1750,7 +1801,7 @@ function WebRuntimePreview({
         onGoForward={noOp}
         onReload={() => {
           invalidateBrowserAutomationTargetObservation(threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
-          setSrc((current) => current ?? fixtureUrl);
+          browserSurfaceHost.navigate(identity, visibleAddress ?? fixtureUrl);
         }}
         onOpenExternal={noOp}
         onToggleDesign={noOp}
@@ -1758,7 +1809,7 @@ function WebRuntimePreview({
         onNewPage={noOp}
         onForceReload={() => {
           invalidateBrowserAutomationTargetObservation(threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
-          setSrc((current) => current ?? fixtureUrl);
+          browserSurfaceHost.navigate(identity, visibleAddress ?? fixtureUrl);
         }}
         onRegionCapture={noOp}
         onDumpContent={noOp}

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -184,6 +184,14 @@ function markIframeLoaded(iframe: HTMLIFrameElement): void {
   }
 }
 
+function setIframeIdentity(iframe: HTMLIFrameElement, tabId: string): void {
+  iframe.dataset.workspaceId = "workspace-1";
+  iframe.dataset.scopeKind = "thread";
+  iframe.dataset.scopeId = "thread-1";
+  iframe.dataset.threadId = "thread-1";
+  iframe.dataset.tabId = tabId;
+}
+
 describe("BrowserAutomationHost", () => {
   const execute = vi.fn();
   const beginRendererOperation = vi.fn();
@@ -563,8 +571,7 @@ describe("BrowserAutomationHost", () => {
     expect(webExecutor.executeWebBrowserDispatch).not.toHaveBeenCalled();
     const iframe = document.createElement("iframe");
     iframe.src = openRequest.args.url;
-    iframe.dataset.threadId = "thread-1";
-    iframe.dataset.tabId = "web-preview";
+    setIframeIdentity(iframe, "web-preview");
     document.body.append(iframe);
     markIframeLoaded(iframe);
     window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
@@ -595,8 +602,7 @@ describe("BrowserAutomationHost", () => {
     expect(webExecutor.executeWebBrowserDispatch).not.toHaveBeenCalled();
     const iframe = document.createElement("iframe");
     iframe.src = openRequest.args.url;
-    iframe.dataset.threadId = "thread-1";
-    iframe.dataset.tabId = "web-preview";
+    setIframeIdentity(iframe, "web-preview");
     document.body.append(iframe);
     markIframeLoaded(iframe);
     window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
@@ -793,8 +799,7 @@ describe("BrowserAutomationHost", () => {
     const normalOpenUrl = `${window.location.origin}/normal-open`;
     const existingIframe = document.createElement("iframe");
     existingIframe.src = normalOpenUrl;
-    existingIframe.dataset.threadId = "thread-1";
-    existingIframe.dataset.tabId = "tab-1";
+    setIframeIdentity(existingIframe, "tab-1");
     document.body.append(existingIframe);
     window.setTimeout(() => existingIframe.dispatchEvent(new Event("load")), 0);
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: openDispatch }));
@@ -829,8 +834,7 @@ describe("BrowserAutomationHost", () => {
     expect(webExecutor.executeWebBrowserDispatch).not.toHaveBeenCalled();
     const iframe = document.createElement("iframe");
     iframe.src = firstOpenUrl;
-    iframe.dataset.threadId = "thread-1";
-    iframe.dataset.tabId = "web-preview";
+    setIframeIdentity(iframe, "web-preview");
     document.body.append(iframe);
     window.setTimeout(() => {
       iframe.dispatchEvent(new Event("load"));
@@ -865,8 +869,7 @@ describe("BrowserAutomationHost", () => {
 
     const iframe = document.createElement("iframe");
     iframe.src = expectedUrl;
-    iframe.dataset.threadId = "thread-1";
-    iframe.dataset.tabId = "tab-1";
+    setIframeIdentity(iframe, "tab-1");
     Object.defineProperty(iframe, "contentWindow", {
       configurable: true,
       value: { location: { origin: window.location.origin } },
@@ -904,8 +907,7 @@ describe("BrowserAutomationHost", () => {
     await waitFor(() => expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(expectedUrl));
     const iframe = document.createElement("iframe");
     iframe.src = expectedUrl;
-    iframe.dataset.threadId = "thread-1";
-    iframe.dataset.tabId = "tab-1";
+    setIframeIdentity(iframe, "tab-1");
     document.body.append(iframe);
     act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
@@ -935,8 +937,7 @@ describe("BrowserAutomationHost", () => {
     } as never;
     const iframe = document.createElement("iframe");
     iframe.src = expectedUrl;
-    iframe.dataset.threadId = "thread-1";
-    iframe.dataset.tabId = "tab-1";
+    setIframeIdentity(iframe, "tab-1");
     Object.defineProperty(iframe, "contentWindow", {
       configurable: true,
       value: { location: { origin: window.location.origin } },
@@ -971,8 +972,7 @@ describe("BrowserAutomationHost", () => {
     navigateDispatch.request = { ...navigateDispatch.request, operation: "navigate", args: { url: expectedUrl } } as never;
     const iframe = document.createElement("iframe");
     iframe.src = `${window.location.origin}/before`;
-    iframe.dataset.threadId = "thread-1";
-    iframe.dataset.tabId = "tab-1";
+    setIframeIdentity(iframe, "tab-1");
     document.body.append(iframe);
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: navigateDispatch }));
     await waitFor(() => expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(navigateDispatch, expect.any(AbortSignal)));
@@ -1008,8 +1008,7 @@ describe("BrowserAutomationHost", () => {
 
     const replacement = document.createElement("iframe");
     replacement.src = `${window.location.origin}/unrelated-replacement`;
-    replacement.dataset.threadId = "thread-1";
-    replacement.dataset.tabId = "tab-1";
+    setIframeIdentity(replacement, "tab-1");
     document.body.append(replacement);
     act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
 
@@ -2200,8 +2199,7 @@ describe("BrowserAutomationHost", () => {
     delete window.desktopBridge;
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     const iframe = document.createElement("iframe");
-    iframe.dataset.threadId = "thread-1";
-    iframe.dataset.tabId = "tab-1";
+    setIframeIdentity(iframe, "tab-1");
     const targetDocument = {
       location: { href: "https://user:password@example.com/sessions/eyJabcdefghijk.abcdefghijklmnop?secret=query#fragment" },
       body: document.createElement("body"),
@@ -2231,8 +2229,7 @@ describe("BrowserAutomationHost", () => {
     delete window.desktopBridge;
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     const iframe = document.createElement("iframe");
-    iframe.dataset.threadId = "thread-1";
-    iframe.dataset.tabId = "tab-1";
+    setIframeIdentity(iframe, "tab-1");
     iframe.src = "https://evil.example/";
     Object.defineProperty(iframe, "contentWindow", { configurable: true, value: { location: { origin: "https://evil.example" } } });
     Object.defineProperty(iframe, "contentDocument", { configurable: true, value: { body: document.createElement("body") } });
@@ -2258,8 +2255,7 @@ describe("BrowserAutomationHost", () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     delete window.desktopBridge;
     const frame = document.createElement("iframe");
-    frame.dataset.threadId = "thread-1";
-    frame.dataset.tabId = "tab-1";
+    setIframeIdentity(frame, "tab-1");
     document.body.append(frame);
     Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
     const frameDocument = frame.contentDocument!;
@@ -2295,8 +2291,7 @@ describe("BrowserAutomationHost", () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     delete window.desktopBridge;
     const frame = document.createElement("iframe");
-    frame.dataset.threadId = "thread-1";
-    frame.dataset.tabId = "tab-1";
+    setIframeIdentity(frame, "tab-1");
     document.body.append(frame);
     Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
     const frameDocument = frame.contentDocument!;
@@ -2331,8 +2326,7 @@ describe("BrowserAutomationHost", () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     delete window.desktopBridge;
     const frame = document.createElement("iframe");
-    frame.dataset.threadId = "thread-1";
-    frame.dataset.tabId = "tab-1";
+    setIframeIdentity(frame, "tab-1");
     document.body.append(frame);
     Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
     const frameDocument = frame.contentDocument!;
@@ -2367,8 +2361,7 @@ describe("BrowserAutomationHost", () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     delete window.desktopBridge;
     const frame = document.createElement("iframe");
-    frame.dataset.threadId = "thread-1";
-    frame.dataset.tabId = "tab-1";
+    setIframeIdentity(frame, "tab-1");
     document.body.append(frame);
     Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
     const frameDocument = frame.contentDocument!;
@@ -2410,8 +2403,7 @@ describe("BrowserAutomationHost", () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     delete window.desktopBridge;
     const frame = document.createElement("iframe");
-    frame.dataset.threadId = "thread-1";
-    frame.dataset.tabId = "tab-1";
+    setIframeIdentity(frame, "tab-1");
     document.body.append(frame);
     Object.defineProperty(frame, "contentWindow", { configurable: true, value: { location: { origin: window.location.origin } } });
     const frameDocument = frame.contentDocument!;

--- a/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BrowserSurfaceHostRoot,
+  browserSurfaceHost,
+} from "../BrowserSurfaceHostRoot";
+import type { BrowserSurfaceIdentity } from "@/services/browser-surfaces";
+
+const IDENTITY: BrowserSurfaceIdentity = {
+  workspaceId: "workspace-1",
+  scope: { kind: "thread", id: "thread-1" },
+  tabId: "web-preview",
+};
+
+describe("BrowserSurfaceHostRoot", () => {
+  afterEach(() => browserSurfaceHost.dispose(IDENTITY));
+
+  it("mounts a hosted iframe outside the panel tree", () => {
+    render(<BrowserSurfaceHostRoot />);
+
+    browserSurfaceHost.create(IDENTITY, {
+      address: `${window.location.origin}/browser-automation-fixture.html`,
+    });
+
+    const iframe = screen.getByTestId("web-runtime-preview-iframe");
+    expect(iframe.parentElement).toHaveAttribute("data-browser-surface-host");
+    expect(iframe).toHaveAttribute("data-workspace-id", "workspace-1");
+    expect(iframe).toHaveAttribute("data-scope-kind", "thread");
+    expect(iframe).toHaveAttribute("data-scope-id", "thread-1");
+    expect(iframe).toHaveAttribute("data-tab-id", "web-preview");
+  });
+});

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -390,7 +390,7 @@ describe("PreviewPanel: unavailable state", () => {
     );
   });
 
-  it("marks a same-origin requested page unsupported after cross-origin iframe navigation", () => {
+  it("marks a same-origin requested page unsupported after cross-origin iframe navigation", async () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     useDiffStore.setState({ previewUrlByThread: { "thread-1": window.location.origin + "/fixture" } });
     render(<PreviewPanel threadId="thread-1" />);
@@ -400,9 +400,11 @@ describe("PreviewPanel: unavailable state", () => {
       value: { location: { origin: "https://example.com" } },
     });
     fireEvent.load(iframe);
-    expect(screen.getByTestId("web-runtime-cross-origin")).toHaveTextContent(
-      "automation and DOM access are unsupported",
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId("web-runtime-cross-origin")).toHaveTextContent(
+        "automation and DOM access are unsupported",
+      );
+    });
   });
 
   it("explains that web preview automation is disabled by default", () => {
@@ -411,6 +413,7 @@ describe("PreviewPanel: unavailable state", () => {
     expect(screen.getByTestId("preview-panel-unavailable")).toHaveTextContent(
       "Web preview automation is disabled",
     );
+    expect(screen.queryByTestId("web-runtime-preview-iframe")).not.toBeInTheDocument();
   });
 
   it("renders the deterministic same-origin fixture when web automation is enabled", () => {
@@ -421,6 +424,21 @@ describe("PreviewPanel: unavailable state", () => {
       "src",
       `${window.location.origin}/browser-automation-fixture.html`,
     );
+  });
+
+  it("hides the hosted iframe when navigation becomes unavailable", async () => {
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    render(<PreviewPanel threadId="thread-1" />);
+    const iframe = screen.getByTestId("web-runtime-preview-iframe");
+    const input = screen.getByLabelText("Preview URL");
+
+    fireEvent.change(input, { target: { value: "ftp://example.com" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    expect(screen.getByTestId("web-runtime-unavailable")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(iframe).not.toBeInTheDocument();
+    });
   });
 
   it("keeps the responsive toolbar available through the web Browser overflow menu", async () => {

--- a/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
+++ b/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
@@ -1,0 +1,472 @@
+import { BROWSER_TAB_INFO_STRING_MAX } from "@mcode/contracts";
+import { normalizeBrowserSurfaceAddress } from "./browserSurfaceAddress";
+
+/** Complete identity of one Browser surface in a renderer window. */
+export interface BrowserSurfaceIdentity {
+  readonly workspaceId: string;
+  readonly scope: {
+    readonly kind: "thread" | "workspace";
+    readonly id: string;
+  };
+  readonly tabId: string;
+}
+
+/** Known page phases exposed by a Browser surface. */
+export type BrowserSurfacePagePhase = "loading" | "loaded" | "error";
+
+/** Whether the web adapter can inspect the current main-frame document. */
+export type BrowserSurfaceDocumentAccess = "same-origin" | "cross-origin" | "unknown";
+
+/** History capabilities observed by an adapter, or null when history is unknown. */
+export interface BrowserSurfaceNavigationState {
+  readonly canGoBack: boolean;
+  readonly canGoForward: boolean;
+}
+
+/** Canonical, generation-bound page state for one Browser surface. */
+export interface BrowserSurfacePageState {
+  readonly identity: BrowserSurfaceIdentity;
+  readonly generation: number;
+  readonly pendingAddress: string | null;
+  readonly committedAddress: string | null;
+  readonly recoveryAddress: string | null;
+  readonly title: string;
+  readonly favicon: string | null;
+  readonly phase: BrowserSurfacePagePhase;
+  readonly mainFrameError: string | null;
+  readonly navigation: BrowserSurfaceNavigationState | null;
+  readonly documentAccess: BrowserSurfaceDocumentAccess;
+}
+
+/** Shared fields carried by every semantic adapter event. */
+export interface BrowserSurfaceAdapterEventBase {
+  readonly identity: BrowserSurfaceIdentity;
+  readonly generation: number;
+}
+
+/** Semantic events emitted by native and iframe Browser surface adapters. */
+export type BrowserSurfaceAdapterEvent = BrowserSurfaceAdapterEventBase & (
+  | { readonly type: "navigation-started"; readonly mainFrame: boolean; readonly address: string }
+  | { readonly type: "navigation-committed"; readonly mainFrame: boolean; readonly address: string }
+  | { readonly type: "load-started"; readonly mainFrame: boolean; readonly address?: string }
+  | {
+      readonly type: "load-failed";
+      readonly mainFrame: boolean;
+      readonly address?: string;
+      readonly error?: string;
+      readonly errorCode?: string | number;
+      readonly expected?: boolean;
+      readonly isExpected?: boolean;
+    }
+  | { readonly type: "load-stopped"; readonly mainFrame: boolean; readonly address?: string }
+  | { readonly type: "title-updated"; readonly title: string | null }
+  | { readonly type: "favicon-updated"; readonly favicon: string | null }
+  | { readonly type: "navigation-state"; readonly navigation: BrowserSurfaceNavigationState | null }
+  | { readonly type: "document-access"; readonly access: BrowserSurfaceDocumentAccess }
+);
+
+/** Event payload accepted by adapter test doubles before identity is attached. */
+export type BrowserSurfaceAdapterEventPayload = BrowserSurfaceAdapterEvent extends infer Event
+  ? Event extends BrowserSurfaceAdapterEvent
+    ? Omit<Event, "identity" | "generation">
+    : never
+  : never;
+
+/** Adapter owned by a BrowserSurfaceHost for one identity and generation. */
+export interface BrowserSurfaceAdapter {
+  /** Materializes the adapter's DOM/native resource. */
+  create?(): void;
+  /** Presents the resource in its host container. */
+  present(presentation?: BrowserSurfacePresentation): void;
+  /** Occludes the resource without releasing it. */
+  hide(): void;
+  /** Starts navigation to a validated address. */
+  navigate(address: string): void | Promise<void>;
+  /** Subscribes to semantic adapter events. */
+  subscribe(listener: (event: BrowserSurfaceAdapterEvent) => void): () => void;
+  /** Releases the adapter's resource and listeners. */
+  dispose(): void;
+}
+
+/** Bounded viewport placement supplied by the root host for presentation. */
+export interface BrowserSurfacePresentation {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+  readonly scale?: number;
+  readonly zIndex?: number;
+}
+
+/** Factory that creates the adapter for one complete identity and generation. */
+export type BrowserSurfaceAdapterFactory = (
+  identity: BrowserSurfaceIdentity,
+  generation: number,
+) => BrowserSurfaceAdapter;
+
+/** Deterministic scheduling hooks used by BrowserSurfaceHost publication. */
+export interface BrowserSurfaceScheduling {
+  readonly requestAnimationFrame: (callback: () => void) => number;
+  readonly cancelAnimationFrame: (handle: number) => void;
+  readonly queueTask?: (callback: () => void) => void;
+}
+
+/** Visibility hooks used to pause publication for hidden renderer documents. */
+export interface BrowserSurfaceVisibility {
+  readonly isHidden: () => boolean;
+  readonly subscribe: (listener: (hidden?: boolean) => void) => () => void;
+}
+
+/** Host dependencies. Both the adapter and publication scheduler are injected. */
+export interface BrowserSurfaceHostOptions {
+  readonly adapterFactory: BrowserSurfaceAdapterFactory;
+  readonly scheduling?: BrowserSurfaceScheduling;
+  readonly visibility?: BrowserSurfaceVisibility;
+}
+
+/** Optional creation parameters for an identity-bound Browser surface. */
+export interface BrowserSurfaceCreateOptions {
+  readonly address?: string;
+  readonly generation?: number;
+}
+
+/** Listener invoked when a generation's canonical state is published. */
+export type BrowserSurfaceListener = (snapshot: BrowserSurfacePageState) => void;
+
+const MAX_ADDRESS = BROWSER_TAB_INFO_STRING_MAX.url;
+const MAX_TITLE = BROWSER_TAB_INFO_STRING_MAX.title;
+const MAX_FAVICON = BROWSER_TAB_INFO_STRING_MAX.faviconUrl;
+
+function surfaceKey(identity: BrowserSurfaceIdentity): string {
+  return JSON.stringify([identity.workspaceId, identity.scope.kind, identity.scope.id, identity.tabId]);
+}
+
+function boundString(value: string | null | undefined, max: number): string | null {
+  if (value == null) return null;
+  return String(value).slice(0, max);
+}
+
+function sameIdentity(left: BrowserSurfaceIdentity, right: BrowserSurfaceIdentity): boolean {
+  return left.workspaceId === right.workspaceId &&
+    left.scope.kind === right.scope.kind &&
+    left.scope.id === right.scope.id &&
+    left.tabId === right.tabId;
+}
+
+function defaultScheduling(): BrowserSurfaceScheduling {
+  const requestAnimationFrame = typeof globalThis.requestAnimationFrame === "function"
+    ? globalThis.requestAnimationFrame.bind(globalThis)
+    : (callback: () => void) => Number(globalThis.setTimeout(callback, 0));
+  const cancelAnimationFrame = typeof globalThis.cancelAnimationFrame === "function"
+    ? globalThis.cancelAnimationFrame.bind(globalThis)
+    : (handle: number) => globalThis.clearTimeout(handle);
+  return { requestAnimationFrame, cancelAnimationFrame, queueTask: (callback) => { globalThis.setTimeout(callback, 0); } };
+}
+
+function defaultVisibility(): BrowserSurfaceVisibility {
+  const documentRef = typeof document === "undefined" ? null : document;
+  const listeners = new Set<(hidden?: boolean) => void>();
+  const notify = (): void => {
+    const hidden = documentRef?.visibilityState === "hidden";
+    for (const listener of listeners) listener(hidden);
+  };
+  documentRef?.addEventListener("visibilitychange", notify);
+  return {
+    isHidden: () => documentRef?.visibilityState === "hidden",
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) documentRef?.removeEventListener("visibilitychange", notify);
+      };
+    },
+  };
+}
+
+function initialPageState(identity: BrowserSurfaceIdentity, generation: number, address?: string): BrowserSurfacePageState {
+  const pendingAddress = boundString(address, MAX_ADDRESS);
+  return {
+    identity,
+    generation,
+    pendingAddress,
+    committedAddress: null,
+    recoveryAddress: null,
+    title: "",
+    favicon: null,
+    phase: "loading",
+    mainFrameError: null,
+    navigation: null,
+    documentAccess: "unknown",
+  };
+}
+
+function eventIsExpectedAbort(event: Extract<BrowserSurfaceAdapterEvent, { type: "load-failed" }>): boolean {
+  return event.expected === true || event.isExpected === true || event.errorCode === -3 || event.errorCode === "ERR_ABORTED";
+}
+
+function boundedNumber(value: number, fallback: number, minimum: number, maximum: number): number {
+  return Number.isFinite(value) ? Math.min(maximum, Math.max(minimum, value)) : fallback;
+}
+
+function boundPresentation(presentation: BrowserSurfacePresentation): BrowserSurfacePresentation {
+  return {
+    left: boundedNumber(presentation.left, 0, -100_000, 100_000),
+    top: boundedNumber(presentation.top, 0, -100_000, 100_000),
+    width: boundedNumber(presentation.width, 1, 1, 10_000),
+    height: boundedNumber(presentation.height, 1, 1, 10_000),
+    ...(presentation.scale === undefined ? {} : { scale: boundedNumber(presentation.scale, 1, 0.1, 10) }),
+    ...(presentation.zIndex === undefined ? {} : { zIndex: Math.round(boundedNumber(presentation.zIndex, 0, -2_147_483_648, 2_147_483_647)) }),
+  };
+}
+
+function sameStateValue(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (left === null || right === null || typeof left !== "object" || typeof right !== "object") return false;
+  const leftNavigation = left as BrowserSurfaceNavigationState;
+  const rightNavigation = right as BrowserSurfaceNavigationState;
+  return "canGoBack" in leftNavigation && "canGoForward" in leftNavigation &&
+    "canGoBack" in rightNavigation && "canGoForward" in rightNavigation &&
+    leftNavigation.canGoBack === rightNavigation.canGoBack &&
+    leftNavigation.canGoForward === rightNavigation.canGoForward;
+}
+
+/**
+ * Owns Browser surface adapters, generation-bound canonical state, and
+ * identity-scoped frame-batched publication.
+ */
+export class BrowserSurfaceHost {
+  private readonly records = new Map<string, SurfaceRecord>();
+  private readonly scheduling: BrowserSurfaceScheduling;
+  private readonly visibility: BrowserSurfaceVisibility;
+  private readonly stopVisibility: () => void;
+  private nextGeneration = 1;
+
+  /** Creates a host with injected adapter, scheduling, and visibility seams. */
+  public constructor(options: BrowserSurfaceHostOptions) {
+    this.scheduling = options.scheduling ?? defaultScheduling();
+    this.visibility = options.visibility ?? defaultVisibility();
+    this.stopVisibility = this.visibility.subscribe((hidden) => {
+      if (hidden ?? this.visibility.isHidden()) return;
+      this.publishVisibleRecords();
+    });
+    this.adapterFactory = options.adapterFactory;
+  }
+
+  private readonly adapterFactory: BrowserSurfaceAdapterFactory;
+
+  /** Creates or replaces the adapter for an identity and returns its snapshot. */
+  public create(identity: BrowserSurfaceIdentity, optionsOrGeneration: BrowserSurfaceCreateOptions | number = {}): BrowserSurfacePageState {
+    const options: BrowserSurfaceCreateOptions = typeof optionsOrGeneration === "number"
+      ? { generation: optionsOrGeneration }
+      : optionsOrGeneration;
+    const key = surfaceKey(identity);
+    const prior = this.records.get(key);
+    const address = options.address === undefined
+      ? undefined
+      : normalizeBrowserSurfaceAddress(options.address);
+    const generation = options.generation ?? (prior ? prior.generation + 1 : this.nextGeneration++);
+    if (prior && options.generation !== undefined && generation <= prior.generation) return prior.state;
+    if (generation >= this.nextGeneration) this.nextGeneration = generation + 1;
+    if (prior) this.disposeRecord(key, prior, false);
+    const adapter = this.adapterFactory(identity, generation);
+    const record: SurfaceRecord = {
+      identity,
+      generation,
+      adapter,
+      state: initialPageState(identity, generation, address),
+      listeners: prior?.listeners ?? new Set(),
+      stopAdapter: () => undefined,
+      frameHandle: null,
+      publicationPending: prior !== undefined,
+      disposed: false,
+    };
+    this.records.set(key, record);
+    record.stopAdapter = adapter.subscribe((event) => this.handleEvent(event));
+    adapter.create?.();
+    if (address !== undefined) void adapter.navigate(address);
+    if (record.publicationPending) this.schedulePublication(record);
+    return record.state;
+  }
+
+  /** Makes an identity's current surface visible without changing its generation. */
+  public present(identity: BrowserSurfaceIdentity, presentation: BrowserSurfacePresentation = {
+    left: 0,
+    top: 0,
+    width: 1,
+    height: 1,
+  }): void {
+    const record = this.records.get(surfaceKey(identity));
+    if (!record || !sameIdentity(record.identity, identity)) return;
+    record.adapter.present(boundPresentation(presentation));
+  }
+
+  /** Hides an identity's current surface while retaining the live adapter. */
+  public hide(identity: BrowserSurfaceIdentity): void {
+    const record = this.records.get(surfaceKey(identity));
+    if (!record || !sameIdentity(record.identity, identity)) return;
+    record.adapter.hide();
+  }
+
+  /** Requests navigation and synchronously enters the loading phase. */
+  public navigate(identity: BrowserSurfaceIdentity, address: string): void {
+    const record = this.records.get(surfaceKey(identity));
+    if (!record || !sameIdentity(record.identity, identity)) return;
+    const normalized = normalizeBrowserSurfaceAddress(address);
+    this.reduce(record, { type: "navigation-started", identity, generation: record.generation, mainFrame: true, address: normalized });
+    void record.adapter.navigate(normalized);
+  }
+
+  /** Alias for callers that name the operation as a navigation request. */
+  public requestNavigation(identity: BrowserSurfaceIdentity, address: string): void {
+    this.navigate(identity, address);
+  }
+
+  /** Applies one semantic adapter event when its identity and generation are current. */
+  public handleEvent(event: BrowserSurfaceAdapterEvent): void {
+    const record = this.records.get(surfaceKey(event.identity));
+    if (!record || record.disposed || record.generation !== event.generation || !sameIdentity(record.identity, event.identity)) return;
+    this.reduce(record, event);
+  }
+
+  /** Reads the current canonical snapshot for one identity. */
+  public getSnapshot(identity: BrowserSurfaceIdentity): BrowserSurfacePageState | null {
+    return this.records.get(surfaceKey(identity))?.state ?? null;
+  }
+
+  /** Subscribes to one identity; listeners never receive another identity's state. */
+  public subscribe(identity: BrowserSurfaceIdentity, listener: BrowserSurfaceListener): () => void {
+    const record = this.records.get(surfaceKey(identity));
+    if (!record || !sameIdentity(record.identity, identity)) return () => undefined;
+    record.listeners.add(listener);
+    return () => record.listeners.delete(listener);
+  }
+
+  /** Disposes an identity and cancels any queued publication for its generation. */
+  public dispose(identity: BrowserSurfaceIdentity): void {
+    const key = surfaceKey(identity);
+    const record = this.records.get(key);
+    if (!record || !sameIdentity(record.identity, identity)) return;
+    this.disposeRecord(key, record, true);
+  }
+
+  /** Releases host-level visibility resources. */
+  public disposeHost(): void {
+    this.stopVisibility();
+    for (const [key, record] of this.records) this.disposeRecord(key, record, true);
+  }
+
+  private disposeRecord(key: string, record: SurfaceRecord, remove: boolean): void {
+    record.disposed = true;
+    if (record.frameHandle !== null) this.scheduling.cancelAnimationFrame(record.frameHandle);
+    record.frameHandle = null;
+    record.publicationPending = false;
+    record.stopAdapter();
+    record.adapter.dispose();
+    if (remove) record.listeners.clear();
+    if (remove && this.records.get(key) === record) this.records.delete(key);
+  }
+
+  private reduce(record: SurfaceRecord, event: BrowserSurfaceAdapterEvent): void {
+    const previous = record.state;
+    const next = this.nextState(previous, event);
+    if (next === previous) return;
+    record.state = next;
+    record.publicationPending = true;
+    this.schedulePublication(record);
+  }
+
+  private nextState(state: BrowserSurfacePageState, event: BrowserSurfaceAdapterEvent): BrowserSurfacePageState {
+    if (!sameIdentity(state.identity, event.identity) || state.generation !== event.generation) return state;
+    switch (event.type) {
+      case "navigation-started":
+        if (!event.mainFrame) return state;
+        return this.mergeState(state, {
+          pendingAddress: boundString(event.address, MAX_ADDRESS),
+          phase: "loading",
+          mainFrameError: null,
+        });
+      case "navigation-committed":
+        if (!event.mainFrame) return state;
+        return this.mergeState(state, {
+          committedAddress: boundString(event.address, MAX_ADDRESS),
+          recoveryAddress: boundString(event.address, MAX_ADDRESS),
+        });
+      case "load-started":
+        if (!event.mainFrame) return state;
+        return this.mergeState(state, {
+          ...(event.address === undefined ? {} : { pendingAddress: boundString(event.address, MAX_ADDRESS) }),
+          phase: "loading",
+          mainFrameError: null,
+        });
+      case "load-failed":
+        if (!event.mainFrame || eventIsExpectedAbort(event)) return state;
+        return this.mergeState(state, {
+          ...(event.address === undefined ? {} : { pendingAddress: boundString(event.address, MAX_ADDRESS) }),
+          phase: "error",
+          mainFrameError: boundString(event.error ?? (typeof event.errorCode === "number" ? String(event.errorCode) : event.errorCode), 500),
+        });
+      case "load-stopped":
+        if (!event.mainFrame || state.phase === "error") return state;
+        return this.mergeState(state, {
+          ...(event.address === undefined ? {} : {
+            committedAddress: boundString(event.address, MAX_ADDRESS),
+            recoveryAddress: boundString(event.address, MAX_ADDRESS),
+          }),
+          pendingAddress: null,
+          phase: "loaded",
+        });
+      case "title-updated":
+        return this.mergeState(state, { title: boundString(event.title, MAX_TITLE) ?? "" });
+      case "favicon-updated":
+        return this.mergeState(state, { favicon: boundString(event.favicon, MAX_FAVICON) });
+      case "navigation-state":
+        return this.mergeState(state, { navigation: event.navigation });
+      case "document-access":
+        return this.mergeState(state, { documentAccess: event.access });
+    }
+  }
+
+  private mergeState(
+    state: BrowserSurfacePageState,
+    patch: Partial<Omit<BrowserSurfacePageState, "identity" | "generation">>,
+  ): BrowserSurfacePageState {
+    const next = { ...state, ...patch };
+    return Object.keys(next).some((key) => !sameStateValue(
+      next[key as keyof BrowserSurfacePageState],
+      state[key as keyof BrowserSurfacePageState],
+    ))
+      ? next
+      : state;
+  }
+
+  private schedulePublication(record: SurfaceRecord): void {
+    if (record.frameHandle !== null || this.visibility.isHidden()) return;
+    record.frameHandle = this.scheduling.requestAnimationFrame(() => {
+      record.frameHandle = null;
+      if (record.disposed || this.visibility.isHidden()) return;
+      if (!record.publicationPending) return;
+      record.publicationPending = false;
+      for (const listener of [...record.listeners]) listener(record.state);
+    });
+  }
+
+  private publishVisibleRecords(): void {
+    if (this.visibility.isHidden()) return;
+    for (const record of this.records.values()) {
+      if (!record.publicationPending) continue;
+      this.schedulePublication(record);
+    }
+  }
+}
+
+interface SurfaceRecord {
+  readonly identity: BrowserSurfaceIdentity;
+  readonly generation: number;
+  readonly adapter: BrowserSurfaceAdapter;
+  readonly listeners: Set<BrowserSurfaceListener>;
+  state: BrowserSurfacePageState;
+  stopAdapter: () => void;
+  frameHandle: number | null;
+  publicationPending: boolean;
+  disposed: boolean;
+}

--- a/apps/web/src/services/browser-surfaces/WebIframeBrowserSurfaceAdapter.ts
+++ b/apps/web/src/services/browser-surfaces/WebIframeBrowserSurfaceAdapter.ts
@@ -1,0 +1,206 @@
+import { BROWSER_TAB_INFO_STRING_MAX } from "@mcode/contracts";
+import type {
+  BrowserSurfaceAdapter,
+  BrowserSurfaceAdapterEvent,
+  BrowserSurfaceAdapterEventPayload,
+  BrowserSurfaceAdapterFactory,
+  BrowserSurfaceIdentity,
+  BrowserSurfacePresentation,
+} from "./BrowserSurfaceHost";
+import { normalizeBrowserSurfaceAddress } from "./browserSurfaceAddress";
+
+/** Options for the web iframe Browser surface adapter factory. */
+export interface WebIframeBrowserSurfaceAdapterFactoryOptions {
+  readonly root?: HTMLElement | null;
+  readonly document?: Document;
+  readonly title?: string;
+  readonly onLoad?: (identity: BrowserSurfaceIdentity, generation: number) => void;
+}
+
+/** Bounds observable iframe metadata without reading cross-origin documents. */
+export interface WebIframeBrowserSurfaceObservation {
+  readonly address: string | null;
+  readonly title: string | null;
+  readonly favicon: string | null;
+  readonly access: "same-origin" | "cross-origin" | "unknown";
+}
+
+const MAX_ADDRESS = BROWSER_TAB_INFO_STRING_MAX.url;
+const MAX_TITLE = BROWSER_TAB_INFO_STRING_MAX.title;
+const MAX_FAVICON = BROWSER_TAB_INFO_STRING_MAX.faviconUrl;
+
+function bound(value: string | null | undefined, max: number): string | null {
+  if (value == null) return null;
+  return String(value).slice(0, max);
+}
+
+function sameOriginObservation(frame: HTMLIFrameElement): WebIframeBrowserSurfaceObservation {
+  const fallbackAddress = bound(frame.src, MAX_ADDRESS);
+  try {
+    const sourceOrigin = fallbackAddress
+      ? new URL(fallbackAddress, frame.ownerDocument.location.href).origin
+      : null;
+    if (sourceOrigin && sourceOrigin !== frame.ownerDocument.location.origin) {
+      return { address: fallbackAddress, title: null, favicon: null, access: "cross-origin" };
+    }
+    const observedOrigin = frame.contentWindow?.location.origin;
+    if (observedOrigin && observedOrigin !== frame.ownerDocument.location.origin) {
+      return { address: fallbackAddress, title: null, favicon: null, access: "cross-origin" };
+    }
+    const frameDocument = frame.contentDocument;
+    if (!frameDocument) {
+      return { address: fallbackAddress, title: null, favicon: null, access: "unknown" };
+    }
+    const address = bound(frameDocument.location?.href || frame.src, MAX_ADDRESS);
+    const title = bound(frameDocument.title, MAX_TITLE);
+    const icon = frameDocument.querySelector<HTMLLinkElement>(
+      'link[rel~="icon"], link[rel="shortcut icon"]',
+    )?.href;
+    return {
+      address,
+      title: title || null,
+      favicon: bound(icon, MAX_FAVICON),
+      access: "same-origin",
+    };
+  } catch {
+    // A cross-origin frame is observable only through the iframe element itself.
+    return { address: fallbackAddress, title: null, favicon: null, access: "cross-origin" };
+  }
+}
+
+/** Adapter that owns one HTMLIFrameElement and reports safe semantic events. */
+export class WebIframeBrowserSurfaceAdapter implements BrowserSurfaceAdapter {
+  private readonly listeners = new Set<(event: BrowserSurfaceAdapterEvent) => void>();
+  private readonly frame: HTMLIFrameElement;
+  private readonly documentRef: Document;
+  private readonly onLoadObserved?: WebIframeBrowserSurfaceAdapterFactoryOptions["onLoad"];
+  private disposed = false;
+
+  /** Creates and mounts an iframe adapter for one identity and generation. */
+  public constructor(
+    private readonly identity: BrowserSurfaceIdentity,
+    private readonly generation: number,
+    options: WebIframeBrowserSurfaceAdapterFactoryOptions = {},
+  ) {
+    this.documentRef = options.document ?? document;
+    this.onLoadObserved = options.onLoad;
+    this.frame = this.documentRef.createElement("iframe");
+    this.frame.title = options.title ?? "Browser surface";
+    this.frame.dataset.testid = "web-runtime-preview-iframe";
+    this.frame.dataset.workspaceId = identity.workspaceId;
+    this.frame.dataset.scopeKind = identity.scope.kind;
+    this.frame.dataset.scopeId = identity.scope.id;
+    this.frame.dataset.tabId = identity.tabId;
+    this.frame.dataset.generation = String(generation);
+    if (identity.scope.kind === "thread") this.frame.dataset.threadId = identity.scope.id;
+    this.frame.referrerPolicy = "no-referrer";
+    this.frame.setAttribute("aria-hidden", "true");
+    this.frame.style.position = "fixed";
+    this.frame.style.left = "-20000px";
+    this.frame.style.top = "0";
+    this.frame.style.width = "1px";
+    this.frame.style.height = "1px";
+    this.frame.style.border = "0";
+    this.frame.style.visibility = "hidden";
+    this.frame.style.pointerEvents = "none";
+    this.frame.addEventListener("load", this.onLoad);
+    this.frame.addEventListener("error", this.onError);
+    (options.root ?? this.documentRef.body)?.appendChild(this.frame);
+  }
+
+  /** Returns the owned iframe for placement assertions and host integration. */
+  public get element(): HTMLIFrameElement {
+    return this.frame;
+  }
+
+  /** Presents the iframe at its existing placement. */
+  public present(presentation: BrowserSurfacePresentation = { left: 0, top: 0, width: 1, height: 1 }): void {
+    if (this.disposed) return;
+    this.frame.style.left = `${presentation.left}px`;
+    this.frame.style.top = `${presentation.top}px`;
+    this.frame.style.width = `${presentation.width}px`;
+    this.frame.style.height = `${presentation.height}px`;
+    this.frame.style.transformOrigin = "top left";
+    this.frame.style.transform = presentation.scale === undefined ? "" : `scale(${presentation.scale})`;
+    this.frame.style.zIndex = presentation.zIndex === undefined ? "" : String(presentation.zIndex);
+    this.frame.style.visibility = "visible";
+    this.frame.style.pointerEvents = "auto";
+    this.frame.setAttribute("aria-hidden", "false");
+  }
+
+  /** Hides the iframe without replacing its document. */
+  public hide(): void {
+    if (this.disposed) return;
+    this.frame.style.visibility = "hidden";
+    this.frame.style.pointerEvents = "none";
+    this.frame.setAttribute("aria-hidden", "true");
+  }
+
+  /** Navigates by assigning a bounded URL to the owned iframe. */
+  public navigate(address: string): void {
+    if (this.disposed) return;
+    const normalized = normalizeBrowserSurfaceAddress(address);
+    this.emit({ type: "navigation-started", mainFrame: true, address: normalized });
+    this.frame.src = normalized;
+  }
+
+  /** Subscribes to semantic adapter events. */
+  public subscribe(listener: (event: BrowserSurfaceAdapterEvent) => void): () => void {
+    if (this.disposed) return () => undefined;
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Removes DOM listeners and releases the owned iframe. */
+  public dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.frame.removeEventListener("load", this.onLoad);
+    this.frame.removeEventListener("error", this.onError);
+    this.listeners.clear();
+    this.frame.remove();
+  }
+
+  private emit(event: BrowserSurfaceAdapterEventPayload): void {
+    if (this.disposed) return;
+    const complete = { ...event, identity: this.identity, generation: this.generation } as BrowserSurfaceAdapterEvent;
+    for (const listener of [...this.listeners]) listener(complete);
+  }
+
+  private readonly onLoad = (): void => {
+    if (this.disposed) return;
+    this.onLoadObserved?.(this.identity, this.generation);
+    const observation = sameOriginObservation(this.frame);
+    if (observation.address) {
+      this.emit({ type: "navigation-committed", mainFrame: true, address: observation.address });
+    }
+    this.emit({ type: "load-stopped", mainFrame: true, address: observation.address ?? undefined });
+    this.emit({ type: "title-updated", title: observation.title });
+    this.emit({ type: "favicon-updated", favicon: observation.favicon });
+    this.emit({ type: "navigation-state", navigation: null });
+    this.emit({ type: "document-access", access: observation.access });
+  };
+
+  private readonly onError = (): void => {
+    if (this.disposed) return;
+    this.emit({
+      type: "load-failed",
+      mainFrame: true,
+      address: bound(this.frame.src, MAX_ADDRESS) ?? undefined,
+      error: "Iframe navigation failed",
+    });
+  };
+}
+
+/** Creates an adapter factory that mounts one iframe per identity and generation. */
+export function createWebIframeBrowserSurfaceAdapterFactory(
+  options: WebIframeBrowserSurfaceAdapterFactoryOptions = {},
+): BrowserSurfaceAdapterFactory {
+  return (identity, generation) => new WebIframeBrowserSurfaceAdapter(identity, generation, options);
+}
+
+/** Alias retained for callers that use the shorter iframe adapter name. */
+export const createIframeBrowserSurfaceAdapterFactory = createWebIframeBrowserSurfaceAdapterFactory;
+
+/** Alias for integrations that refer to the adapter by its surface role. */
+export const createWebIframeSurfaceAdapterFactory = createWebIframeBrowserSurfaceAdapterFactory;

--- a/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import {
+  BrowserSurfaceHost,
+  type BrowserSurfaceAdapter,
+  type BrowserSurfaceAdapterEvent,
+  type BrowserSurfaceAdapterEventPayload,
+  type BrowserSurfaceAdapterFactory,
+  type BrowserSurfaceIdentity,
+  type BrowserSurfacePresentation,
+  type BrowserSurfaceScheduling,
+  type BrowserSurfaceVisibility,
+} from "../BrowserSurfaceHost";
+
+const IDENTITY: BrowserSurfaceIdentity = {
+  workspaceId: "workspace-a",
+  scope: { kind: "thread", id: "thread-a" },
+  tabId: "tab-a",
+};
+
+class TestScheduling implements BrowserSurfaceScheduling {
+  private nextHandle = 1;
+  readonly frames = new Map<number, () => void>();
+
+  requestAnimationFrame(callback: () => void): number {
+    const handle = this.nextHandle++;
+    this.frames.set(handle, callback);
+    return handle;
+  }
+
+  cancelAnimationFrame(handle: number): void {
+    this.frames.delete(handle);
+  }
+
+  flush(): void {
+    const queued = [...this.frames.values()];
+    this.frames.clear();
+    for (const callback of queued) callback();
+  }
+}
+
+class TestVisibility implements BrowserSurfaceVisibility {
+  hidden = false;
+  private readonly listeners = new Set<(hidden?: boolean) => void>();
+
+  isHidden = (): boolean => this.hidden;
+
+  subscribe = (listener: (hidden?: boolean) => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  setHidden(hidden: boolean): void {
+    this.hidden = hidden;
+    for (const listener of this.listeners) listener(hidden);
+  }
+}
+
+class TestAdapter implements BrowserSurfaceAdapter {
+  created = 0;
+  presented = 0;
+  hidden = 0;
+  navigations: string[] = [];
+  disposed = 0;
+  readonly listeners = new Set<(event: BrowserSurfaceAdapterEvent) => void>();
+
+  create(): void {
+    this.created += 1;
+  }
+
+  present(_presentation?: BrowserSurfacePresentation): void {
+    this.presented += 1;
+  }
+
+  hide(): void {
+    this.hidden += 1;
+  }
+
+  navigate(address: string): void {
+    this.navigations.push(address);
+  }
+
+  subscribe(listener: (event: BrowserSurfaceAdapterEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  dispose(): void {
+    this.disposed += 1;
+    this.listeners.clear();
+  }
+
+  emit(event: BrowserSurfaceAdapterEventPayload, identity = IDENTITY, generation = 1): void {
+    const complete = { ...event, identity, generation } as BrowserSurfaceAdapterEvent;
+    for (const listener of [...this.listeners]) listener(complete);
+  }
+}
+
+function key(identity: BrowserSurfaceIdentity): string {
+  return JSON.stringify([identity.workspaceId, identity.scope.kind, identity.scope.id, identity.tabId]);
+}
+
+function testHost(): { host: BrowserSurfaceHost; adapter: TestAdapter; scheduling: TestScheduling; visibility: TestVisibility } {
+  const adapters = new Map<string, TestAdapter>();
+  const scheduling = new TestScheduling();
+  const visibility = new TestVisibility();
+  const adapterFactory: BrowserSurfaceAdapterFactory = (identity) => {
+    const adapter = new TestAdapter();
+    adapters.set(key(identity), adapter);
+    return adapter;
+  };
+  const host = new BrowserSurfaceHost({ adapterFactory, scheduling, visibility });
+  host.create(IDENTITY);
+  return { host, adapter: adapters.get(key(IDENTITY))!, scheduling, visibility };
+}
+
+describe("BrowserSurfaceHost", () => {
+  it("keeps canonical state synchronous and publishes once per frame", () => {
+    const { host, adapter, scheduling } = testHost();
+    const updates: string[] = [];
+    host.subscribe(IDENTITY, (snapshot) => updates.push(snapshot.title));
+    adapter.emit({ type: "title-updated", title: "A" });
+    adapter.emit({ type: "title-updated", title: "B" });
+    expect(host.getSnapshot(IDENTITY)?.title).toBe("B");
+    expect(updates).toEqual([]);
+    scheduling.flush();
+    expect(updates).toEqual(["B"]);
+  });
+
+  it("reduces pending, commit, redirect, loading, error, title, favicon, and navigation", () => {
+    const { host, adapter, scheduling } = testHost();
+    adapter.emit({ type: "navigation-started", mainFrame: true, address: "https://example.test/start" });
+    adapter.emit({ type: "navigation-committed", mainFrame: true, address: "https://example.test/redirect" });
+    adapter.emit({ type: "title-updated", title: "x".repeat(500) });
+    adapter.emit({ type: "favicon-updated", favicon: "https://example.test/icon" });
+    adapter.emit({ type: "navigation-state", navigation: { canGoBack: true, canGoForward: false } });
+    adapter.emit({ type: "document-access", access: "same-origin" });
+    expect(host.getSnapshot(IDENTITY)).toMatchObject({
+      pendingAddress: "https://example.test/start",
+      committedAddress: "https://example.test/redirect",
+      recoveryAddress: "https://example.test/redirect",
+      title: "x".repeat(240),
+      favicon: "https://example.test/icon",
+      documentAccess: "same-origin",
+      phase: "loading",
+    });
+    adapter.emit({ type: "load-stopped", mainFrame: true, address: "https://example.test/redirect" });
+    expect(host.getSnapshot(IDENTITY)).toMatchObject({ pendingAddress: null, phase: "loaded" });
+    adapter.emit({ type: "load-started", mainFrame: true, address: "https://example.test/fail" });
+    adapter.emit({ type: "load-failed", mainFrame: true, address: "https://example.test/fail", error: "offline" });
+    expect(host.getSnapshot(IDENTITY)).toMatchObject({ phase: "error", mainFrameError: "offline" });
+    adapter.emit({ type: "load-stopped", mainFrame: true });
+    expect(host.getSnapshot(IDENTITY)?.phase).toBe("error");
+    adapter.emit({ type: "load-failed", mainFrame: true, expected: true, error: "aborted" });
+    scheduling.flush();
+  });
+
+  it("ignores subframe events and semantic no-ops", () => {
+    const { host, adapter, scheduling } = testHost();
+    adapter.emit({ type: "navigation-started", mainFrame: false, address: "https://frame.test" });
+    adapter.emit({ type: "title-updated", title: "" });
+    adapter.emit({ type: "navigation-state", navigation: { canGoBack: false, canGoForward: false } });
+    const withNavigation = host.getSnapshot(IDENTITY)!;
+    adapter.emit({ type: "navigation-state", navigation: { canGoBack: false, canGoForward: false } });
+    expect(host.getSnapshot(IDENTITY)).toBe(withNavigation);
+    expect(scheduling.frames.size).toBe(1);
+    scheduling.flush();
+  });
+
+  it("pauses hidden publication and flushes latest state on visible", () => {
+    const { host, adapter, scheduling, visibility } = testHost();
+    const updates: string[] = [];
+    host.subscribe(IDENTITY, (snapshot) => updates.push(snapshot.title));
+    visibility.setHidden(true);
+    adapter.emit({ type: "title-updated", title: "hidden" });
+    expect(scheduling.frames.size).toBe(0);
+    visibility.setHidden(false);
+    expect(scheduling.frames.size).toBe(1);
+    scheduling.flush();
+    expect(updates).toEqual(["hidden"]);
+  });
+
+  it("cancels stale publication and publishes a replacement generation", () => {
+    const { host, adapter, scheduling } = testHost();
+    const generations: number[] = [];
+    host.subscribe(IDENTITY, (snapshot) => generations.push(snapshot.generation));
+    adapter.emit({ type: "title-updated", title: "old" });
+    expect(scheduling.frames.size).toBe(1);
+    const next = host.create(IDENTITY);
+    expect(next.generation).toBe(2);
+    scheduling.flush();
+    expect(generations).toEqual([2]);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "data:text/html,unsafe",
+    "https://user:password@example.test/",
+    `https://example.test/${"x".repeat(5_000)}`,
+  ])("rejects unsafe navigation addresses at the host boundary", (address) => {
+    const { host, adapter } = testHost();
+    const before = host.getSnapshot(IDENTITY);
+    expect(() => host.navigate(IDENTITY, address)).toThrow(TypeError);
+    expect(host.getSnapshot(IDENTITY)).toBe(before);
+    expect(adapter.navigations).toEqual([]);
+  });
+
+  it("does not replace a current adapter with an explicit stale generation", () => {
+    const adapters = new Map<string, TestAdapter>();
+    const host = new BrowserSurfaceHost({
+      adapterFactory: (identity) => {
+        const adapter = new TestAdapter();
+        adapters.set(key(identity), adapter);
+        return adapter;
+      },
+    });
+    const first = host.create(IDENTITY, { generation: 4 });
+    const current = adapters.get(key(IDENTITY))!;
+    expect(host.create(IDENTITY, { generation: 3 })).toBe(first);
+    expect(current.disposed).toBe(0);
+    expect(host.getSnapshot(IDENTITY)?.generation).toBe(4);
+    host.disposeHost();
+  });
+});

--- a/apps/web/src/services/browser-surfaces/__tests__/WebIframeBrowserSurfaceAdapter.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/WebIframeBrowserSurfaceAdapter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  createWebIframeBrowserSurfaceAdapterFactory,
+  WebIframeBrowserSurfaceAdapter,
+} from "../WebIframeBrowserSurfaceAdapter";
+import type { BrowserSurfaceIdentity } from "../BrowserSurfaceHost";
+import { runBrowserSurfaceContract } from "./browserSurfaceContract";
+
+const IDENTITY: BrowserSurfaceIdentity = {
+  workspaceId: "workspace-a",
+  scope: { kind: "workspace", id: "workspace-a" },
+  tabId: "tab-a",
+};
+
+runBrowserSurfaceContract(
+  "Web iframe BrowserSurfaceHost contract",
+  createWebIframeBrowserSurfaceAdapterFactory({ root: document.body }),
+);
+
+describe("WebIframeBrowserSurfaceAdapter", () => {
+  it("owns a stable, identity-bound iframe and bounded presentation", () => {
+    const adapter = new WebIframeBrowserSurfaceAdapter(IDENTITY, 7, { root: document.body, title: "Preview" });
+    expect(adapter.element.dataset).toMatchObject({
+      testid: "web-runtime-preview-iframe",
+      workspaceId: IDENTITY.workspaceId,
+      scopeKind: IDENTITY.scope.kind,
+      scopeId: IDENTITY.scope.id,
+      tabId: IDENTITY.tabId,
+      generation: "7",
+    });
+    expect(adapter.element.title).toBe("Preview");
+    adapter.present({ left: 10, top: 20, width: 640, height: 480, scale: 1.25, zIndex: 42 });
+    expect(adapter.element.style.left).toBe("10px");
+    expect(adapter.element.style.width).toBe("640px");
+    expect(adapter.element.style.zIndex).toBe("42");
+    adapter.dispose();
+    expect(document.body.contains(adapter.element)).toBe(false);
+  });
+
+  it("reports cross-origin observation as unknown and history as null", () => {
+    const adapter = new WebIframeBrowserSurfaceAdapter(IDENTITY, 1, { root: document.body });
+    const events: string[] = [];
+    adapter.subscribe((event) => {
+      if (event.type === "title-updated") events.push(`title:${event.title ?? "null"}`);
+      if (event.type === "favicon-updated") events.push(`favicon:${event.favicon ?? "null"}`);
+      if (event.type === "navigation-state") events.push(`navigation:${event.navigation === null ? "null" : "known"}`);
+      if (event.type === "document-access") events.push(`access:${event.access}`);
+    });
+    adapter.navigate("https://cross-origin.test/page");
+    adapter.element.dispatchEvent(new Event("load"));
+    expect(events).toContain("title:null");
+    expect(events).toContain("favicon:null");
+    expect(events).toContain("navigation:null");
+    expect(events).toContain("access:cross-origin");
+    adapter.dispose();
+  });
+
+  it("rejects unsafe addresses before assigning iframe src", () => {
+    const adapter = new WebIframeBrowserSurfaceAdapter(IDENTITY, 1, { root: document.body });
+    expect(() => adapter.navigate("javascript:alert(1)")).toThrow(TypeError);
+    expect(adapter.element).not.toHaveAttribute("src");
+    adapter.dispose();
+  });
+});

--- a/apps/web/src/services/browser-surfaces/__tests__/browserSurfaceContract.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/browserSurfaceContract.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  BrowserSurfaceHost,
+  type BrowserSurfaceAdapterFactory,
+  type BrowserSurfaceIdentity,
+} from "../BrowserSurfaceHost";
+
+const IDENTITY: BrowserSurfaceIdentity = {
+  workspaceId: "contract-workspace",
+  scope: { kind: "thread", id: "contract-thread" },
+  tabId: "contract-tab",
+};
+
+/** Runs the durable lifecycle contract against any Browser surface adapter. */
+export function runBrowserSurfaceContract(name: string, adapterFactory: BrowserSurfaceAdapterFactory): void {
+  describe(name, () => {
+    it("creates, presents, hides, and disposes one exact identity", () => {
+      const host = new BrowserSurfaceHost({ adapterFactory });
+      const snapshot = host.create(IDENTITY);
+      expect(snapshot.identity).toEqual(IDENTITY);
+      host.present(IDENTITY, { left: 0, top: 0, width: 640, height: 480 });
+      host.hide(IDENTITY);
+      host.dispose(IDENTITY);
+      expect(host.getSnapshot(IDENTITY)).toBeNull();
+      host.disposeHost();
+    });
+
+    it("isolates complete identity and rejects stale generation events", () => {
+      const host = new BrowserSurfaceHost({ adapterFactory });
+      const other: BrowserSurfaceIdentity = { ...IDENTITY, workspaceId: "other-workspace" };
+      host.create(IDENTITY);
+      host.create(other);
+      const before = host.getSnapshot(other);
+      host.handleEvent({ type: "title-updated", identity: IDENTITY, generation: 999, title: "stale" });
+      expect(host.getSnapshot(other)).toBe(before);
+      host.disposeHost();
+    });
+
+    it("preserves state object identity for semantic navigation no-ops", () => {
+      const host = new BrowserSurfaceHost({ adapterFactory });
+      host.create(IDENTITY);
+      host.handleEvent({ type: "navigation-state", identity: IDENTITY, generation: 1, navigation: { canGoBack: false, canGoForward: false } });
+      const snapshot = host.getSnapshot(IDENTITY);
+      host.handleEvent({ type: "navigation-state", identity: IDENTITY, generation: 1, navigation: { canGoBack: false, canGoForward: false } });
+      expect(host.getSnapshot(IDENTITY)).toBe(snapshot);
+      host.disposeHost();
+    });
+  });
+}

--- a/apps/web/src/services/browser-surfaces/browserSurfaceAddress.ts
+++ b/apps/web/src/services/browser-surfaces/browserSurfaceAddress.ts
@@ -1,0 +1,18 @@
+import { BROWSER_TAB_INFO_STRING_MAX } from "@mcode/contracts";
+
+/** Validates and normalizes an absolute HTTP(S) Browser surface address. */
+export function normalizeBrowserSurfaceAddress(address: string): string {
+  if (address.length > BROWSER_TAB_INFO_STRING_MAX.url) {
+    throw new TypeError("Browser surface address exceeds the maximum length");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(address);
+  } catch {
+    throw new TypeError("Browser surface address must be an absolute URL");
+  }
+  if ((parsed.protocol !== "http:" && parsed.protocol !== "https:") || parsed.username || parsed.password) {
+    throw new TypeError("Browser surface address must use HTTP(S) without credentials");
+  }
+  return parsed.href;
+}

--- a/apps/web/src/services/browser-surfaces/index.ts
+++ b/apps/web/src/services/browser-surfaces/index.ts
@@ -1,0 +1,3 @@
+export * from "./BrowserSurfaceHost";
+export * from "./browserSurfaceAddress";
+export * from "./WebIframeBrowserSurfaceAdapter";


### PR DESCRIPTION
## What

Host web preview iframes through a stable browser surface root with explicit surface identity and lifecycle management.

## Why

Issue #1183 requires iframe-backed Browser surfaces to remain owned by one host while panel views present, hide, and release them. This prevents React panel remounts from owning the runtime iframe lifecycle.

## Key Changes

- Add a browser surface host and web iframe adapter with bounded identity, generation, visibility, and release behavior.
- Mount one browser surface host root at the application level and make the preview panel present hosted surfaces.
- Keep focused behavior tests in the nearest `__tests__` folders.
- Verify the hosted iframe in the visible Mcode Browser, including identity attributes, parent ownership, loaded fixture content, and zero Browser console errors.

Closes #1183

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788689204&installation_model_id=20477&pr_number=1194&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1194&signature=782d0c585162a014cc98d6cc67e44a06657de7d4f6c3914f83954606bb3d2881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a browser surface system for displaying, navigating, refreshing, hiding, and disposing web previews.
  - Improved preview page state with loading, title, favicon, navigation, and document access details.
  - Added safeguards that reject unsafe or invalid navigation addresses.
  - Added workspace-aware preview identification for more reliable automation and tab handling.

- **Bug Fixes**
  - Prevented stale or mismatched preview events from affecting the active browser surface.
  - Improved unavailable-state handling for invalid navigation and disabled automation.

- **Tests**
  - Expanded coverage for browser surface lifecycle, navigation, cross-origin behavior, identity isolation, and preview rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->