### PR TITLE
feat(browser): host Electron webviews through typed adapters

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
@@ -34,7 +34,7 @@ nativeImageCreateFromBuffer.mockImplementation((buffer: Buffer) => makeFakeNativ
 const fakePreviewSession = {
   lastPreviewThreadId: "thread",
   view: null,
-  tabsByThread: new Map<string, { threadId: string; activeTabId: string; tabs: Array<{ id: string; threadId: string; view: null }> }>(),
+  tabsByThread: new Map<string, { threadId: string; activeTabId: string; tabs: Array<{ id: string; threadId: string; view: null | { webContents: FakeWebContents }; renderingHost?: "webContentsView" | "webview" }> }>(),
 };
 
 function seedFakeTab(threadId = "thread", tabId = "tab") {
@@ -417,12 +417,27 @@ describe("BrowserAutomationKernel", () => {
     fakePreviewSession.tabsByThread.set("native-thread", {
       threadId: "native-thread",
       activeTabId: "native-tab",
-      tabs: [{ id: "native-tab", threadId: "native-thread", view: { webContents: native } as never }],
+      tabs: [{ id: "native-tab", threadId: "native-thread", renderingHost: "webContentsView", view: { webContents: native } }],
     });
     adoptedWebContents.set(JSON.stringify(["native-thread", "native-tab"]), null);
     expect(kernel.describeTarget(event(), { threadId: "native-thread", tabId: "native-tab" })).toMatchObject({
       ok: true,
       target: { threadId: "native-thread", tabId: "native-tab" },
+    });
+  });
+
+  it("does not fall back to a stale native view for an unadopted webview target", () => {
+    const staleVisibleGuest = new FakeWebContents(10);
+    fakePreviewSession.tabsByThread.set("webview-thread", {
+      threadId: "webview-thread",
+      activeTabId: "webview-tab",
+      tabs: [{ id: "webview-tab", threadId: "webview-thread", renderingHost: "webview", view: { webContents: staleVisibleGuest } }],
+    });
+    adoptedWebContents.set(JSON.stringify(["webview-thread", "webview-tab"]), null);
+
+    expect(kernel.describeTarget(event(), { threadId: "webview-thread", tabId: "webview-tab" })).toEqual({
+      ok: false,
+      error: "TAB_UNAVAILABLE",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -54,6 +54,7 @@ function makeWebContentsView() {
     getURL: vi.fn().mockReturnValue(""),
     getTitle: vi.fn().mockReturnValue("Example"),
     getType: vi.fn().mockReturnValue("webview"),
+    getLastWebPreferences: vi.fn(() => ({ preload: resolvePreviewGuestPreloadPath(__dirname) })),
     hostWebContents: currentEventSender,
     loadURL: vi.fn().mockResolvedValue(undefined),
     close: vi.fn(),
@@ -137,6 +138,7 @@ vi.mock("electron", () => ({
   },
   webContents: {
     fromId: vi.fn((id: number) => mockWebContentsById.get(id) ?? null),
+    getAllWebContents: vi.fn(() => [...mockWebContentsById.values()]),
   },
   ipcMain: {
     handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
@@ -187,6 +189,8 @@ vi.mock("node:fs/promises", async () => {
 
 import { BrowserWindow } from "electron";
 import { registerPreviewBrowserHandlers, disposePreviewForWindow } from "../preview/index.js";
+import { resolvePreviewGuestPreloadPath } from "../preview/preview-webview-security.js";
+import { _resetAdoptionRegistryForTests } from "../preview/preview-webview-adopt.js";
 import {
   sessions,
   viewportBoundsForTarget,
@@ -202,6 +206,31 @@ function fakeEvent(win: ReturnType<typeof makeWindow>) {
   currentEventSender = win.webContents;
   (BrowserWindow.fromWebContents as ReturnType<typeof vi.fn>).mockReturnValue(win);
   return { sender: win.webContents } as unknown;
+}
+
+/** Adopts one renderer-owned guest through the generation-bound surface bridge. */
+async function adoptTypedGuest(
+  win: ReturnType<typeof makeWindow>,
+  threadId: string,
+  tabId: string,
+  guest: ReturnType<typeof makeWebContentsView>["webContents"],
+  token = `typed-token-${guest.id}`,
+): Promise<void> {
+  const ev = fakeEvent(win);
+  const committedUrl = guest.getURL();
+  guest.getURL.mockReturnValue(`about:blank#${token}`);
+  mockWebContentsById.set(guest.id, guest);
+  const surface = {
+    identity: {
+      workspaceId: "ws-1",
+      scope: { kind: "thread" as const, id: threadId },
+      tabId,
+    },
+    generation: 1,
+  };
+  expect(await ipcHandlers["preview.surface.prepare"]!(ev, { surface, adoptionToken: token })).toEqual({ ok: true });
+  expect(await ipcHandlers["preview.surface.adopt"]!(ev, { surface, adoptionToken: token })).toEqual({ ok: true });
+  guest.getURL.mockReturnValue(committedUrl.startsWith("http") ? committedUrl : "https://example.com/page");
 }
 
 const VALID_BOUNDS = { x: 100, y: 100, width: 800, height: 600 };
@@ -268,6 +297,7 @@ afterEach(() => {
   for (const win of testWindows) {
     disposePreviewForWindow(win as never);
   }
+  _resetAdoptionRegistryForTests();
   testWindows = [];
 });
 
@@ -1667,15 +1697,10 @@ describe("preview-browser", () => {
 
       const adopted = makeWebContentsView().webContents;
       adopted.getURL.mockReturnValue("https://example.com/page");
-      mockWebContentsById.set(47, adopted);
       const session = sessions.get(win.id)!;
       const tabId = session.tabsByThread.get("thread-webview")!.activeTabId!;
       expect(session.view).toBeNull();
-      await ipcHandlers["preview:adopt-webview"]!(ev, {
-        threadId: "thread-webview",
-        tabId,
-        webContentsId: 47,
-      });
+      await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
       const viewport = await ipcHandlers["preview:design.set-viewport"]!(ev, {
         widthOverride: 393,
@@ -1755,14 +1780,9 @@ describe("preview-browser", () => {
           layoutHeight: 768,
         }),
       );
-      mockWebContentsById.set(44, adopted);
 
-      const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId;
-      await ipcHandlers["preview:adopt-webview"]!(ev, {
-        threadId: "thread-webview",
-        tabId,
-        webContentsId: 44,
-      });
+      const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+      await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
       const result = await ipcHandlers["preview:capture-picture-reference"]!(ev) as {
         ok: true;
@@ -1806,14 +1826,9 @@ describe("preview-browser", () => {
           }),
         )
         .mockResolvedValueOnce(undefined);
-      mockWebContentsById.set(46, adopted);
 
-      const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId;
-      await ipcHandlers["preview:adopt-webview"]!(ev, {
-        threadId: "thread-webview",
-        tabId,
-        webContentsId: 46,
-      });
+      const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+      await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
       const result = await ipcHandlers["preview:capture-annotation-snapshot"]!(ev, {
         activeDisplayNumber: 2,
@@ -1874,14 +1889,9 @@ describe("preview-browser", () => {
           layoutHeight: 600,
         }),
       );
-      mockWebContentsById.set(45, adopted);
 
-      const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId;
-      await ipcHandlers["preview:adopt-webview"]!(ev, {
-        threadId: "thread-webview",
-        tabId,
-        webContentsId: 45,
-      });
+      const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+      await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
       const result = await ipcHandlers["preview:capture-context-reference"]!(ev) as {
         ok: true;
@@ -1913,13 +1923,10 @@ describe("preview-browser", () => {
         adopted.executeJavaScript
           .mockResolvedValueOnce(undefined)
           .mockResolvedValueOnce(JSON.stringify({ state: "cancelled", seq: 1 }));
-        mockWebContentsById.set(42, adopted);
 
-        const adoptedResult = await ipcHandlers["preview:adopt-webview"]!(ev, {
-          threadId: "thread-webview",
-          tabId: sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId,
-          webContentsId: 42,
-        });
+        const elementTabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+        await adoptTypedGuest(win, "thread-webview", elementTabId, adopted);
+        const adoptedResult = { ok: true };
         expect(adoptedResult).toEqual({ ok: true });
         expect(sessions.get(win.id)!.view).toBeNull();
 
@@ -1984,14 +1991,9 @@ describe("preview-browser", () => {
           )
           .mockResolvedValueOnce(undefined)
           .mockResolvedValueOnce(JSON.stringify({ visibleText: "Attach", scrollX: 0, scrollY: 0 }));
-        mockWebContentsById.set(43, adopted);
 
-        const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId;
-        await ipcHandlers["preview:adopt-webview"]!(ev, {
-          threadId: "thread-webview",
-          tabId,
-          webContentsId: 43,
-        });
+        const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+        await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
         const capturePromise = ipcHandlers["preview:capture-picture-element-pick"]!(
           ev,

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -1189,6 +1189,19 @@ describe("preview-browser", () => {
       expect(result.data.activeTabId).toBeTruthy();
     });
 
+    it("tabs.list establishes workspace ownership before renderer surface adoption", () => {
+      const win = createWindow();
+
+      const result = callTabs(win, "preview:tabs.list", {
+        threadId: "thread-A",
+        workspaceId: "workspace-A",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(sessions.get(win.id)?.workspaceId).toBe("workspace-A");
+      expect(sessions.get(win.id)?.tabsByThread.get("thread-A")?.tabs).toHaveLength(1);
+    });
+
     it("tabs.open creates a tab and activates it by default", async () => {
       const win = createWindow();
       await showPreview(win, { threadId: "thread-A" });

--- a/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
@@ -156,7 +156,7 @@ describe("preview typed surface bridge", () => {
     expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 2)).toBeNull();
   });
 
-  it("rejects hostile sender, incomplete identity, mismatched owner, type, partition, preload, and non-blank guests", () => {
+  it("rejects hostile sender, incomplete identity, mismatched owner, type, partition, and non-blank guests", () => {
     const hostile = makeWindow(2);
     expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" }, hostile.webContents)).toMatchObject({ ok: false, error: "no-window" });
     expect(invoke("preview.surface.prepare", { surface: { generation: 1 }, adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "invalid-surface" });
@@ -173,12 +173,6 @@ describe("preview typed surface bridge", () => {
       expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toMatchObject({ ok: false });
       guest.url = "about:blank#token-1234";
     }
-    _resetAdoptionRegistryForTests();
-    fakeGuests.length = 0;
-    const badPreload = makeGuest(allWindows[0]!);
-    badPreload.getLastWebPreferences = () => ({ preload: "C:/attacker/preload.cjs" });
-    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
-    expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "guest-not-found" });
   });
 
   it("fails closed for stale, duplicate, non-unique, and post-blank adoption", () => {

--- a/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolvePreviewGuestPreloadPath } from "../preview/preview-webview-security.js";
 
 const ipcHandlers: Record<string, (...args: unknown[]) => unknown> = {};
@@ -216,17 +216,30 @@ describe("preview typed surface bridge", () => {
     expect(invoke("preview.surface.prepare", { surface: otherSurface, adoptionToken: "token-5678" })).toMatchObject({ ok: false, error: "duplicate-adoption-token" });
   });
 
+  it("releases the exact adopted generation after its tab ownership record is removed", () => {
+    makeGuest(allWindows[0]!);
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    getSession(allWindows[0] as never).tabsByThread.clear();
+
+    expect(invoke("preview.surface.release", { surface: surface() })).toEqual({ ok: true });
+    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 1)).toBeNull();
+  });
+
   it("revalidates exact generation for address, history, reload, and force reload", async () => {
     const guest = makeGuest(allWindows[0]!);
     expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
     expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
     expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "initial", address: "https://example.test" } })).toEqual({ ok: true });
-    expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "address", address: "file:///etc/passwd" } })).toMatchObject({ ok: false, error: "invalid-url" });
+    expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "address", address: "file://attacker/share" } })).toMatchObject({ ok: false, error: "sensitive-file" });
+    const localUrl = pathToFileURL(fileURLToPath(import.meta.url)).href;
+    expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "restored", address: localUrl } })).toEqual({ ok: true });
     expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "back" } })).toEqual({ ok: true });
     expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "forward" } })).toEqual({ ok: true });
     expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "reload" } })).toEqual({ ok: true });
     expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "force-reload" } })).toEqual({ ok: true });
     expect(guest.loadURL).toHaveBeenCalledWith("https://example.test");
+    expect(guest.loadURL).toHaveBeenCalledWith(localUrl);
     expect(guest.reloadIgnoringCache).toHaveBeenCalledTimes(1);
     expect(await invoke("preview.surface.navigate", { surface: surface(2), navigation: { kind: "reload" } })).toMatchObject({ ok: false, error: "stale-generation" });
   });

--- a/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
@@ -1,96 +1,47 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolvePreviewGuestPreloadPath } from "../preview/preview-webview-security.js";
 
-/**
- * Tracks ipc handlers registered via the mocked electron module so tests can
- * call them directly without spinning up an actual Electron runtime.
- */
 const ipcHandlers: Record<string, (...args: unknown[]) => unknown> = {};
+const fakeGuests: FakeWebContents[] = [];
+const previewPartition = {};
+const allWindows: FakeWindow[] = [];
+const fixedPreload = resolvePreviewGuestPreloadPath(
+  dirname(fileURLToPath(import.meta.url)),
+);
+
+interface FakeWindow {
+  id: number;
+  isDestroyed: () => boolean;
+  isFocused: () => boolean;
+  webContents: { isDestroyed: () => boolean; send: ReturnType<typeof vi.fn> };
+}
 
 interface FakeWebContents {
-  id: number;
   destroyed: boolean;
   url: string;
   title: string;
-  listeners: Map<string, Set<(...args: unknown[]) => void>>;
-  isDestroyed: () => boolean;
-  getURL: () => string;
-  getTitle: () => string;
-  getType: () => string;
   hostWebContents: unknown;
   session: object;
+  getType: () => string;
+  getURL: () => string;
+  getLastWebPreferences: () => { preload: string };
+  isDestroyed: () => boolean;
   setWindowOpenHandler: ReturnType<typeof vi.fn>;
-  on: (event: string, cb: (...args: unknown[]) => void) => void;
-  once: (event: string, cb: (...args: unknown[]) => void) => void;
-  removeListener: (event: string, cb: (...args: unknown[]) => void) => void;
+  loadURL: ReturnType<typeof vi.fn>;
+  canGoBack: ReturnType<typeof vi.fn>;
+  canGoForward: ReturnType<typeof vi.fn>;
+  goBack: ReturnType<typeof vi.fn>;
+  goForward: ReturnType<typeof vi.fn>;
+  reload: ReturnType<typeof vi.fn>;
+  reloadIgnoringCache: ReturnType<typeof vi.fn>;
+  once: (event: string, listener: (...args: unknown[]) => void) => void;
+  removeListener: (event: string, listener: (...args: unknown[]) => void) => void;
   emit: (event: string, ...args: unknown[]) => void;
 }
 
-function makeFakeWebContents(
-  id: number,
-  overrides: Partial<Pick<FakeWebContents, "getType" | "hostWebContents" | "session">> = {},
-): FakeWebContents {
-  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
-  return {
-    id,
-    destroyed: false,
-    url: `https://t.test/${id}`,
-    title: `Tab ${id}`,
-    listeners,
-    isDestroyed() {
-      return this.destroyed;
-    },
-    getURL() {
-      return this.url;
-    },
-    getTitle() {
-      return this.title;
-    },
-    getType: overrides.getType ?? (() => "webview"),
-    hostWebContents: overrides.hostWebContents ?? allWindows[0]?.webContents,
-    session: overrides.session ?? previewPartition,
-    setWindowOpenHandler: vi.fn(),
-    on(event, cb) {
-      let bag = listeners.get(event);
-      if (!bag) {
-        bag = new Set();
-        listeners.set(event, bag);
-      }
-      bag.add(cb);
-    },
-    once(event, cb) {
-      let bag = listeners.get(event);
-      if (!bag) {
-        bag = new Set();
-        listeners.set(event, bag);
-      }
-      const wrapper = (...args: unknown[]) => {
-        bag!.delete(wrapper);
-        cb(...args);
-      };
-      bag.add(wrapper);
-    },
-    removeListener(event, cb) {
-      const bag = listeners.get(event);
-      if (!bag) return;
-      // Real Electron matches by reference; our once-wrapper means callers
-      // typically remove by passing the same wrapper they got. For the test
-      // it's enough to clear all listeners on that event.
-      for (const w of bag) {
-        if (w === cb) bag.delete(w);
-      }
-    },
-    emit(event, ...args) {
-      const bag = listeners.get(event);
-      if (!bag) return;
-      for (const cb of [...bag]) cb(...args);
-    },
-  };
-}
-
-const fakeWebContentsRegistry = new Map<number, FakeWebContents>();
-const previewPartition = {};
-
-function makeWindow(id: number) {
+function makeWindow(id: number): FakeWindow {
   return {
     id,
     isDestroyed: () => false,
@@ -99,57 +50,96 @@ function makeWindow(id: number) {
   };
 }
 
-const allWindows: Array<ReturnType<typeof makeWindow>> = [];
+function makeGuest(
+  host: FakeWindow,
+  overrides: Partial<Pick<FakeWebContents, "getType" | "hostWebContents" | "session">> = {},
+): FakeWebContents {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const guest: FakeWebContents = {
+    destroyed: false,
+    url: "about:blank#token-1234",
+    title: "Preview",
+    hostWebContents: overrides.hostWebContents ?? host.webContents,
+    session: overrides.session ?? previewPartition,
+    getType: overrides.getType ?? (() => "webview"),
+    getURL() { return this.url; },
+    getLastWebPreferences() { return { preload: fixedPreload }; },
+    isDestroyed() { return this.destroyed; },
+    setWindowOpenHandler: vi.fn(),
+    loadURL: vi.fn(async (url: string) => { guest.url = url; }),
+    canGoBack: vi.fn(() => true),
+    canGoForward: vi.fn(() => true),
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+    reload: vi.fn(),
+    reloadIgnoringCache: vi.fn(),
+    once(event, listener) {
+      const bag = listeners.get(event) ?? new Set();
+      listeners.set(event, bag);
+      bag.add(listener);
+    },
+    removeListener(event, listener) { listeners.get(event)?.delete(listener); },
+    emit(event, ...args) { for (const listener of [...(listeners.get(event) ?? [])]) listener(...args); },
+  };
+  fakeGuests.push(guest);
+  return guest;
+}
 
 vi.mock("electron", () => ({
   BrowserWindow: {
     fromWebContents: vi.fn((sender: unknown) => allWindows.find((window) => window.webContents === sender) ?? null),
-    getAllWindows: vi.fn(() => allWindows),
   },
   ipcMain: {
-    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
-      ipcHandlers[channel] = handler;
-    }),
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => { ipcHandlers[channel] = handler; }),
   },
   session: {
     fromPartition: vi.fn((partition: string) => partition === "persist:mcode-preview" ? previewPartition : {}),
   },
   webContents: {
-    fromId: vi.fn((id: number) => fakeWebContentsRegistry.get(id) ?? null),
+    getAllWebContents: vi.fn(() => fakeGuests),
   },
 }));
 
-vi.mock("@mcode/shared", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+vi.mock("@mcode/shared", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+vi.mock("../preview/preview-clipboard-trust.js", () => ({
+  registerPreviewClipboardGuest: vi.fn(),
+  unregisterPreviewClipboardGuest: vi.fn(),
 }));
 
 import {
   _resetAdoptionRegistryForTests,
   findAdoptedWebContentsForWindow,
-  registerWebviewAdoptHandlers,
+  registerPreviewSurfaceHandlers,
 } from "../preview/preview-webview-adopt.js";
 import { getSession, sessions } from "../preview/preview-session.js";
 
+const surface = (generation = 1) => ({
+  identity: {
+    workspaceId: "workspace-A",
+    scope: { kind: "thread" as const, id: "thread-A" },
+    tabId: "tab-1",
+  },
+  generation,
+});
+
+function invoke(channel: string, payload: unknown, sender = allWindows[0]!.webContents): unknown {
+  return ipcHandlers[channel]!({ sender } as unknown, payload);
+}
+
 beforeEach(() => {
-  fakeWebContentsRegistry.clear();
+  fakeGuests.length = 0;
   allWindows.length = 0;
   allWindows.push(makeWindow(1));
   const session = getSession(allWindows[0] as never);
+  session.workspaceId = "workspace-A";
   session.tabsByThread.clear();
   session.tabsByThread.set("thread-A", {
     threadId: "thread-A",
     activeTabId: "tab-1",
-    tabs: [{
-      id: "tab-1",
-      threadId: "thread-A",
-      view: null,
-      resumeUrl: null,
-      title: null,
-      faviconUrl: null,
-      lastActiveAt: 0,
-    }],
+    tabs: [{ id: "tab-1", threadId: "thread-A", view: null, renderingHost: "webContentsView", resumeUrl: null, title: null, faviconUrl: null, lastActiveAt: 0, viewportTargetGeneration: null, viewportOperationGeneration: null }],
   });
   _resetAdoptionRegistryForTests();
+  registerPreviewSurfaceHandlers();
 });
 
 afterEach(() => {
@@ -157,223 +147,87 @@ afterEach(() => {
   sessions.clear();
 });
 
-describe("preview-webview-adopt", () => {
-  let registered = false;
-  beforeEach(() => {
-    if (!registered) {
-      registerWebviewAdoptHandlers();
-      registered = true;
-    }
+describe("preview typed surface bridge", () => {
+  it("requires prepare, adopts the unique inert owned guest, and resolves exact generation", () => {
+    const guest = makeGuest(allWindows[0]!);
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 1)).toBe(guest);
+    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 2)).toBeNull();
   });
 
-  function fakeEvent() {
-    return { sender: allWindows[0]!.webContents } as unknown;
-  }
-
-  it("registers a WebContents under (threadId, tabId) and locates it", () => {
-    const wc = makeFakeWebContents(42);
-    fakeWebContentsRegistry.set(42, wc);
-
-    const result = ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-      webContentsId: 42,
-      threadId: "thread-A",
-      tabId: "tab-1",
-    });
-    expect(result).toEqual({ ok: true });
-
-    const located = findAdoptedWebContentsForWindow(1, "thread-A", "tab-1");
-    expect(located).toBe(wc);
-  });
-
-  it("rejects invalid webContentsId / threadId / tabId", () => {
-    expect(
-      ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-        webContentsId: 0,
-        threadId: "t",
-        tabId: "x",
-      }),
-    ).toMatchObject({ ok: false });
-    expect(
-      ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-        webContentsId: 1,
-        threadId: "",
-        tabId: "x",
-      }),
-    ).toMatchObject({ ok: false });
-    expect(
-      ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-        webContentsId: 1,
-        threadId: "t",
-        tabId: "",
-      }),
-    ).toMatchObject({ ok: false });
-    expect(
-      ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-        webContentsId: Number.MAX_SAFE_INTEGER + 1,
-        threadId: "t",
-        tabId: "x",
-      }),
-    ).toEqual({ ok: false, error: "invalid-webcontents-id" });
-    expect(
-      ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-        webContentsId: 1.5,
-        threadId: "t",
-        tabId: "x",
-      }),
-    ).toEqual({ ok: false, error: "invalid-webcontents-id" });
-    expect(
-      ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-        webContentsId: 1,
-        threadId: "t".repeat(257),
-        tabId: "x",
-      }),
-    ).toEqual({ ok: false, error: "invalid-thread-id" });
-  });
-
-  it("returns webcontents-not-found when fromId returns nothing", () => {
-    const result = ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-      webContentsId: 999,
-      threadId: "thread-A",
-      tabId: "tab-1",
-    });
-    expect(result).toMatchObject({ ok: false, error: "webcontents-not-found" });
-  });
-
-  it.each([
-    [
-      "a non-webview WebContents",
+  it("rejects hostile sender, incomplete identity, mismatched owner, type, partition, preload, and non-blank guests", () => {
+    const hostile = makeWindow(2);
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" }, hostile.webContents)).toMatchObject({ ok: false, error: "no-window" });
+    expect(invoke("preview.surface.prepare", { surface: { generation: 1 }, adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "invalid-surface" });
+    expect(invoke("preview.surface.prepare", { surface: { ...surface(), identity: { ...surface().identity, workspaceId: "workspace-other" } }, adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "surface-owner-mismatch" });
+    expect(invoke("preview.surface.prepare", { surface: { ...surface(), identity: { ...surface().identity, scope: { kind: "thread", id: "thread-other" } } }, adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "surface-owner-mismatch" });
+    for (const overrides of [
       { getType: () => "window" },
-      "invalid-webcontents-type",
-    ],
-    [
-      "a webview hosted by another sender",
-      { hostWebContents: { id: "other-window" } },
-      "webcontents-owner-mismatch",
-    ],
-    [
-      "a webview in another partition",
+      { hostWebContents: hostile.webContents },
       { session: {} },
-      "invalid-webcontents-partition",
-    ],
-  ])("rejects %s", (_label, overrides, expectedError) => {
-    const wc = makeFakeWebContents(43, overrides);
-    fakeWebContentsRegistry.set(43, wc);
-
-    const result = ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-      webContentsId: 43,
-      threadId: "thread-A",
-      tabId: "tab-1",
-    });
-
-    expect(result).toEqual({ ok: false, error: expectedError });
-    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1")).toBeNull();
+    ]) {
+      _resetAdoptionRegistryForTests();
+      const guest = makeGuest(allWindows[0]!, overrides);
+      expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+      expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toMatchObject({ ok: false });
+      guest.url = "about:blank#token-1234";
+    }
+    _resetAdoptionRegistryForTests();
+    fakeGuests.length = 0;
+    const badPreload = makeGuest(allWindows[0]!);
+    badPreload.getLastWebPreferences = () => ({ preload: "C:/attacker/preload.cjs" });
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "guest-not-found" });
   });
 
-  it.each([
-    ["wrong-thread", "tab-1"],
-    ["thread-A", "wrong-tab"],
-  ])("rejects an adoption for a missing exact slot (%s/%s)", (threadId, tabId) => {
-    const wc = makeFakeWebContents(44);
-    fakeWebContentsRegistry.set(44, wc);
-    expect(ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-      webContentsId: 44,
-      threadId,
-      tabId,
-    })).toEqual({ ok: false, error: "target-slot-not-found" });
+  it("fails closed for stale, duplicate, non-unique, and post-blank adoption", () => {
+    const guest = makeGuest(allWindows[0]!);
+    guest.url = "about:blank";
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "guest-not-found" });
+    guest.url = "about:blank#token-1234";
+    expect(invoke("preview.surface.adopt", { surface: surface(2), adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "stale-generation" });
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "duplicate-adoption" });
+    _resetAdoptionRegistryForTests();
+    fakeGuests.length = 0;
+    makeGuest(allWindows[0]!);
+    makeGuest(allWindows[0]!);
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "non-unique-adoption" });
   });
 
-  it("keeps colliding thread and tab ids isolated by BrowserWindow", () => {
-    const secondWindow = makeWindow(2);
-    allWindows.push(secondWindow);
-    const secondSession = getSession(secondWindow as never);
-    secondSession.tabsByThread.set("thread-A", {
-      threadId: "thread-A",
-      activeTabId: "tab-1",
-      tabs: [{ id: "tab-1", threadId: "thread-A", view: null, resumeUrl: null, title: null, faviconUrl: null, lastActiveAt: 0 }],
-    });
-    const first = makeFakeWebContents(45);
-    const second = makeFakeWebContents(46, { hostWebContents: secondWindow.webContents });
-    fakeWebContentsRegistry.set(45, first);
-    fakeWebContentsRegistry.set(46, second);
-    ipcHandlers["preview:adopt-webview"]!({ sender: allWindows[0]!.webContents }, { webContentsId: 45, threadId: "thread-A", tabId: "tab-1" });
-    ipcHandlers["preview:adopt-webview"]!({ sender: secondWindow.webContents }, { webContentsId: 46, threadId: "thread-A", tabId: "tab-1" });
-    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1")).toBe(first);
-    expect(findAdoptedWebContentsForWindow(2, "thread-A", "tab-1")).toBe(second);
+  it("retires the adopted guest when the owner advances to a new generation", () => {
+    const firstGuest = makeGuest(allWindows[0]!);
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+
+    firstGuest.url = "https://example.test";
+    const secondGuest = makeGuest(allWindows[0]!);
+    secondGuest.url = "about:blank#token-5678";
+    expect(invoke("preview.surface.prepare", { surface: surface(2), adoptionToken: "token-5678" })).toEqual({ ok: true });
+    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 1)).toBeNull();
+    expect(invoke("preview.surface.adopt", { surface: surface(2), adoptionToken: "token-5678" })).toEqual({ ok: true });
+    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 2)).toBe(secondGuest);
+
+    const tabSet = getSession(allWindows[0] as never).tabsByThread.get("thread-A")!;
+    tabSet.tabs.push({ ...tabSet.tabs[0]!, id: "tab-2" });
+    const otherSurface = { ...surface(), identity: { ...surface().identity, tabId: "tab-2" } };
+    expect(invoke("preview.surface.prepare", { surface: otherSurface, adoptionToken: "token-5678" })).toMatchObject({ ok: false, error: "duplicate-adoption-token" });
   });
 
-  it("keeps adversarial colon-delimited ids in distinct slots", () => {
-    const session = getSession(allWindows[0] as never);
-    session.tabsByThread.set("a:b", {
-      threadId: "a:b",
-      activeTabId: "c",
-      tabs: [{ id: "c", threadId: "a:b", view: null, resumeUrl: null, title: null, faviconUrl: null, lastActiveAt: 0 }],
-    });
-    session.tabsByThread.set("a", {
-      threadId: "a",
-      activeTabId: "b:c",
-      tabs: [{ id: "b:c", threadId: "a", view: null, resumeUrl: null, title: null, faviconUrl: null, lastActiveAt: 0 }],
-    });
-    const first = makeFakeWebContents(47);
-    const second = makeFakeWebContents(48);
-    fakeWebContentsRegistry.set(47, first);
-    fakeWebContentsRegistry.set(48, second);
-    ipcHandlers["preview:adopt-webview"]!(fakeEvent(), { webContentsId: 47, threadId: "a:b", tabId: "c" });
-    ipcHandlers["preview:adopt-webview"]!(fakeEvent(), { webContentsId: 48, threadId: "a", tabId: "b:c" });
-    expect(findAdoptedWebContentsForWindow(1, "a:b", "c")).toBe(first);
-    expect(findAdoptedWebContentsForWindow(1, "a", "b:c")).toBe(second);
-  });
-
-  it("drops the registration when the adopted WebContents emits 'destroyed'", () => {
-    const wc = makeFakeWebContents(7);
-    fakeWebContentsRegistry.set(7, wc);
-
-    ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-      webContentsId: 7,
-      threadId: "thread-A",
-      tabId: "tab-1",
-    });
-    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1")).toBe(wc);
-
-    wc.destroyed = true;
-    wc.emit("destroyed");
-    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1")).toBeNull();
-  });
-
-  it("preview:release-webview drops the slot", () => {
-    const wc = makeFakeWebContents(11);
-    fakeWebContentsRegistry.set(11, wc);
-    ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-      webContentsId: 11,
-      threadId: "thread-A",
-      tabId: "tab-1",
-    });
-    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1")).toBe(wc);
-
-    const released = ipcHandlers["preview:release-webview"]!(fakeEvent(), {
-      threadId: "thread-A",
-      tabId: "tab-1",
-    });
-    expect(released).toEqual({ ok: true });
-    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1")).toBeNull();
-  });
-
-  it("re-adopting the same slot replaces the prior registration", () => {
-    const wc1 = makeFakeWebContents(20);
-    const wc2 = makeFakeWebContents(21);
-    fakeWebContentsRegistry.set(20, wc1);
-    fakeWebContentsRegistry.set(21, wc2);
-
-    ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-      webContentsId: 20,
-      threadId: "thread-A",
-      tabId: "tab-1",
-    });
-    ipcHandlers["preview:adopt-webview"]!(fakeEvent(), {
-      webContentsId: 21,
-      threadId: "thread-A",
-      tabId: "tab-1",
-    });
-
-    expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1")).toBe(wc2);
+  it("revalidates exact generation for address, history, reload, and force reload", async () => {
+    const guest = makeGuest(allWindows[0]!);
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "initial", address: "https://example.test" } })).toEqual({ ok: true });
+    expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "address", address: "file:///etc/passwd" } })).toMatchObject({ ok: false, error: "invalid-url" });
+    expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "back" } })).toEqual({ ok: true });
+    expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "forward" } })).toEqual({ ok: true });
+    expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "reload" } })).toEqual({ ok: true });
+    expect(await invoke("preview.surface.navigate", { surface: surface(), navigation: { kind: "force-reload" } })).toEqual({ ok: true });
+    expect(guest.loadURL).toHaveBeenCalledWith("https://example.test");
+    expect(guest.reloadIgnoringCache).toHaveBeenCalledTimes(1);
+    expect(await invoke("preview.surface.navigate", { surface: surface(2), navigation: { kind: "reload" } })).toMatchObject({ ok: false, error: "stale-generation" });
   });
 });

--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -927,7 +927,9 @@ export class BrowserAutomationKernel {
     const adopted = findAdoptedWebContentsForWindow(win.id, threadId, tab.id);
     const guest = adopted?.hostWebContents === event.sender
       ? adopted
-      : tab.view?.webContents ?? (exactTargetRequested ? null : session.view?.webContents ?? null);
+      : tab.renderingHost === "webview"
+        ? null
+        : tab.view?.webContents ?? (exactTargetRequested ? null : session.view?.webContents ?? null);
     if (!guest || guest.isDestroyed()) return false;
     const state = this.targets.get(targetKey(win.id, threadId, tab.id));
     if (state) {
@@ -1029,7 +1031,7 @@ export class BrowserAutomationKernel {
     }
     let webContents = findAdoptedWebContentsForWindow(win.id, threadId, tabId);
     if (webContents?.hostWebContents !== event.sender) webContents = null;
-    if (!webContents && !adoptedOnly) {
+    if (!webContents && !adoptedOnly && tab.renderingHost !== "webview") {
       webContents = tab?.view?.webContents ?? null;
     }
     if (!webContents || webContents.isDestroyed()) throw new KernelError("TAB_UNAVAILABLE", "Exact browser tab is unavailable", true);

--- a/apps/desktop/src/main/browser-use/host-bridge.ts
+++ b/apps/desktop/src/main/browser-use/host-bridge.ts
@@ -85,6 +85,7 @@ function locateTab(threadId: string, tabId: string): {
     if (!tab) continue;
     const adopted = findAdoptedWebContentsForWindow(win.id, threadId, tabId);
     if (adopted) return { win, webContents: adopted };
+    if (tab.renderingHost === "webview") return { win, webContents: null };
     // Slice 2: every warm tab carries its own WebContentsView, so the bridge
     // can target inactive tabs too. Returns null only when the tab is cold
     // (never mounted) or its webContents has been destroyed.

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -461,8 +461,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
      * can ship tab affordances before the real per-tab backing lands.
      */
     tabs: {
-      list(threadId: string): Promise<unknown> {
-        return ipcRenderer.invoke("preview:tabs.list", { threadId });
+      list(threadId: string, workspaceId?: string): Promise<unknown> {
+        return ipcRenderer.invoke("preview:tabs.list", { threadId, workspaceId });
       },
       open(
         threadId: string,

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -328,24 +328,62 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     getPerfCounters(): Promise<unknown> {
       return ipcRenderer.invoke("preview:get-perf-counters");
     },
-    /**
-     * Phase D: adopt a renderer-hosted <webview> into the host bridge so the
-     * Codex browser-use pipe can drive it via executeCdp. The renderer reads
-     * the guest's webContentsId via `webview.getWebContentsId()` after
-     * `did-attach` fires, then forwards it here.
-     */
-    adoptWebview(payload: {
-      webContentsId: number;
-      threadId: string;
-      tabId: string;
-    }): Promise<unknown> {
-      return ipcRenderer.invoke("preview:adopt-webview", payload);
-    },
-    releaseWebview(payload: {
-      threadId: string;
-      tabId: string;
-    }): Promise<unknown> {
-      return ipcRenderer.invoke("preview:release-webview", payload);
+    /** Typed generation-bound Electron surface operations. */
+    surface: {
+      prepare(payload: {
+        surface: {
+          identity: {
+            workspaceId: string;
+            scope: { kind: "thread" | "workspace"; id: string };
+            tabId: string;
+          };
+          generation: number;
+        };
+        adoptionToken: string;
+      }): Promise<{ ok: true } | { ok: false; error: string }> {
+        return ipcRenderer.invoke("preview.surface.prepare", payload);
+      },
+      adopt(payload: {
+        surface: {
+          identity: {
+            workspaceId: string;
+            scope: { kind: "thread" | "workspace"; id: string };
+            tabId: string;
+          };
+          generation: number;
+        };
+        adoptionToken: string;
+      }): Promise<{ ok: true } | { ok: false; error: string }> {
+        return ipcRenderer.invoke("preview.surface.adopt", payload);
+      },
+      release(payload: {
+        surface: {
+          identity: {
+            workspaceId: string;
+            scope: { kind: "thread" | "workspace"; id: string };
+            tabId: string;
+          };
+          generation: number;
+        };
+      }): Promise<{ ok: true } | { ok: false; error: string }> {
+        return ipcRenderer.invoke("preview.surface.release", payload);
+      },
+      navigate(payload: {
+        surface: {
+          identity: {
+            workspaceId: string;
+            scope: { kind: "thread" | "workspace"; id: string };
+            tabId: string;
+          };
+          generation: number;
+        };
+        navigation:
+          | { kind: "initial"; address?: string }
+          | { kind: "restored" | "address"; address: string }
+          | { kind: "back" | "forward" | "reload" | "force-reload" };
+      }): Promise<{ ok: true } | { ok: false; error: string }> {
+        return ipcRenderer.invoke("preview.surface.navigate", payload);
+      },
     },
     /** Bounded provider-neutral browser operations. Raw CDP is intentionally not exposed. */
     automation: {

--- a/apps/desktop/src/main/preview/index.ts
+++ b/apps/desktop/src/main/preview/index.ts
@@ -16,7 +16,7 @@ import { registerOverlayHandlers } from "./preview-overlay.js";
 import { registerSpillHandlers } from "./preview-spill.js";
 import { registerTabHandlers } from "./preview-tabs.js";
 import { getPerfCounters } from "./preview-perf.js";
-import { registerWebviewAdoptHandlers } from "./preview-webview-adopt.js";
+import { registerPreviewSurfaceHandlers } from "./preview-webview-adopt.js";
 import { registerDesignModeHandlers } from "./preview-design-mode.js";
 import { registerBrowserAutomationHandlers } from "../browser-automation/index.js";
 import { registerPreviewClipboardPermissionHandlers } from "./preview-clipboard-trust.js";
@@ -33,7 +33,7 @@ export function registerPreviewBrowserHandlers(): void {
   registerOverlayHandlers();
   registerSpillHandlers();
   registerTabHandlers();
-  registerWebviewAdoptHandlers();
+  registerPreviewSurfaceHandlers();
   registerDesignModeHandlers();
   registerBrowserAutomationHandlers();
   ipcMain.handle("preview:get-perf-counters", () => getPerfCounters());

--- a/apps/desktop/src/main/preview/preview-active-webcontents.ts
+++ b/apps/desktop/src/main/preview/preview-active-webcontents.ts
@@ -7,14 +7,14 @@ import { findAdoptedWebContentsForWindow } from "./preview-webview-adopt.js";
  */
 export function resolveActivePreviewWebContents(s: PreviewSession): WebContents | null {
   const threadId = s.lastPreviewThreadId;
-  if (threadId) {
-    const activeTab = getActiveTab(s, threadId);
-    const windowId = [...sessions].find(([, candidate]) => candidate === s)?.[0];
-    const adopted = windowId === undefined
-      ? null
-      : findAdoptedWebContentsForWindow(windowId, threadId, activeTab.id);
-    if (adopted && !adopted.isDestroyed()) return adopted;
-  }
-  if (s.view && !s.view.webContents.isDestroyed()) return s.view.webContents;
-  return null;
+  if (!threadId) return null;
+  const activeTab = getActiveTab(s, threadId);
+  const windowId = [...sessions].find(([, candidate]) => candidate === s)?.[0];
+  const adopted = windowId === undefined
+    ? null
+    : findAdoptedWebContentsForWindow(windowId, threadId, activeTab.id);
+  if (adopted && !adopted.isDestroyed()) return adopted;
+  if (activeTab.renderingHost === "webview") return null;
+  const native = activeTab.view?.webContents ?? null;
+  return native && !native.isDestroyed() ? native : null;
 }

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -78,7 +78,7 @@ function getPreviewStorageSession(): Electron.Session {
 }
 
 /** Resolve user omnibox input to a safe preview URL without loading it. */
-async function resolvePreviewNavigationTarget(
+export async function resolvePreviewNavigationTarget(
   url: string,
   workspacePath?: string | null,
 ): Promise<PreviewResolveNavigationResult> {

--- a/apps/desktop/src/main/preview/preview-tabs.ts
+++ b/apps/desktop/src/main/preview/preview-tabs.ts
@@ -162,12 +162,17 @@ function buildTabSet(s: PreviewSession, threadId: string): BrowserTabSet {
 export function registerTabHandlers(): void {
   ipcMain.handle(
     "preview:tabs.list",
-    (_event, payload: { threadId?: unknown }): TabIpcResult<BrowserTabSet> => {
+    (_event, payload: { threadId?: unknown; workspaceId?: unknown }): TabIpcResult<BrowserTabSet> => {
       const win = BrowserWindow.fromWebContents(_event.sender);
       if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
       const tid = normaliseThreadId(payload?.threadId);
       if (!tid) return { ok: false, error: "invalid-thread-id" };
+      const workspaceId = normaliseThreadId(payload?.workspaceId);
+      if (payload?.workspaceId !== undefined && !workspaceId) {
+        return { ok: false, error: "invalid-workspace-id" };
+      }
       const s = getSession(win);
+      if (workspaceId) s.workspaceId = workspaceId;
       return { ok: true, data: buildTabSet(s, tid) };
     },
   );

--- a/apps/desktop/src/main/preview/preview-webview-adopt.ts
+++ b/apps/desktop/src/main/preview/preview-webview-adopt.ts
@@ -6,7 +6,9 @@ import {
 } from "electron";
 import type { IpcMainInvokeEvent, WebContents } from "electron";
 import { logger } from "@mcode/shared";
-import { getSession, isAllowedHttpUrl } from "./preview-session.js";
+import { getSession } from "./preview-session.js";
+import { resolvePreviewNavigationTarget } from "./preview-navigation.js";
+import { trustMainProcessFileNavigation } from "./preview-local-file.js";
 import {
   registerPreviewClipboardGuest,
   unregisterPreviewClipboardGuest,
@@ -345,9 +347,10 @@ function adoptSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSu
 
 function releaseSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSurfaceResult {
   const input = typeof inputValue === "object" && inputValue !== null ? inputValue as Partial<PreviewSurfaceReleaseInput> : {};
-  const validated = validateSenderAndSurface(event, input.surface);
-  if ("ok" in validated) return validated;
-  const { win, surface } = validated;
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win || win.isDestroyed()) return errorResult("no-window");
+  const surface = validateSurface(input.surface);
+  if (!surface) return errorResult("invalid-surface");
   const key = surfaceKey(surface.identity);
   const currentGeneration = generationByWindow.get(win.id)?.get(key);
   if (currentGeneration !== surface.generation) return errorResult("stale-generation");
@@ -379,10 +382,12 @@ async function navigateSurface(event: IpcMainInvokeEvent, inputValue: unknown): 
       case "address": {
         const address = typeof navigation.address === "string" ? navigation.address.trim() : "";
         if (navigation.kind === "initial" && !address) return { ok: true };
-        if (!address || !isAllowedHttpUrl(address)) return errorResult("invalid-url");
+        const resolved = await resolvePreviewNavigationTarget(address);
+        if (!resolved.ok) return errorResult(resolved.error);
         const current = resolveAdoptedPreviewSurfaceForWindow(win.id, surface, event.sender);
         if (!current || current.webContents !== guest) return errorResult("stale-generation");
-        await guest.loadURL(address);
+        trustMainProcessFileNavigation(getSession(win), resolved.url);
+        await guest.loadURL(resolved.url);
         return { ok: true };
       }
       case "back":

--- a/apps/desktop/src/main/preview/preview-webview-adopt.ts
+++ b/apps/desktop/src/main/preview/preview-webview-adopt.ts
@@ -13,7 +13,6 @@ import {
   registerPreviewClipboardGuest,
   unregisterPreviewClipboardGuest,
 } from "./preview-clipboard-trust.js";
-import { resolvePreviewGuestPreloadPath } from "./preview-webview-security.js";
 
 const PREVIEW_PARTITION = "persist:mcode-preview";
 const MAX_SURFACE_ID_LENGTH = 256;
@@ -168,22 +167,8 @@ function adoptedForWindow(windowId: number, surface: PreviewSurfaceRef): Adoptio
   return record;
 }
 
-function expectedGuestPreloadPath(): string {
-  return resolvePreviewGuestPreloadPath(__dirname);
-}
-
 function isInertGuestUrl(url: string, adoptionToken: string): boolean {
   return url === `about:blank#${adoptionToken}`;
-}
-
-function guestHasFixedPreload(guest: WebContents): boolean {
-  const candidate = guest as WebContents & {
-    getLastWebPreferences?: () => { preload?: string };
-  };
-  const preferences = typeof candidate.getLastWebPreferences === "function"
-    ? candidate.getLastWebPreferences()
-    : null;
-  return preferences?.preload === expectedGuestPreloadPath();
 }
 
 function guestMatchesPending(
@@ -193,8 +178,10 @@ function guestMatchesPending(
 ): boolean {
   if (guest.isDestroyed() || guest.getType() !== "webview") return false;
   if (guest.hostWebContents !== sender) return false;
+  // The main window's will-attach-webview hook replaces the preload and
+  // partition before this guest exists. Electron omits preload from
+  // getLastWebPreferences(), so the enforced partition is the runtime proof.
   if (guest.session !== electronSession.fromPartition(PREVIEW_PARTITION)) return false;
-  if (!guestHasFixedPreload(guest)) return false;
   return isInertGuestUrl(guest.getURL(), adoptionToken);
 }
 

--- a/apps/desktop/src/main/preview/preview-webview-adopt.ts
+++ b/apps/desktop/src/main/preview/preview-webview-adopt.ts
@@ -1,179 +1,442 @@
-/**
- * Adopt-by-webContentsId path for renderer-hosted `<webview>` tags.
- *
- * The renderer mounts a `<webview>` element and forwards its
- * `webContentsId` here on `did-attach`. We register the WebContents in a
- * thread/tab slot so the Codex browser-use bridge can target it via
- * `executeCdp` exactly the way it targets BrowserView-hosted tabs.
- *
- * Lifetime contract:
- *   - The renderer owns the `<webview>` element's lifetime (mount/unmount).
- *   - We listen for `destroyed` on the adopted WebContents to drop the
- *     registration. We never call `webContents.close()` ourselves.
- *
- * Mirrors dpcode's `attachWebview` / `webContents.fromId` flow.
- */
-
-import { BrowserWindow, ipcMain, session as electronSession, webContents as electronWebContents } from "electron";
-import type { WebContents } from "electron";
+import {
+  BrowserWindow,
+  ipcMain,
+  session as electronSession,
+  webContents as electronWebContents,
+} from "electron";
+import type { IpcMainInvokeEvent, WebContents } from "electron";
 import { logger } from "@mcode/shared";
-import { getSession } from "./preview-session.js";
+import { getSession, isAllowedHttpUrl } from "./preview-session.js";
 import {
   registerPreviewClipboardGuest,
   unregisterPreviewClipboardGuest,
 } from "./preview-clipboard-trust.js";
+import { resolvePreviewGuestPreloadPath } from "./preview-webview-security.js";
 
-/** Per-window registry of adopted WebContents keyed by (threadId, tabId). */
-interface AdoptedRecord {
-  threadId: string;
-  tabId: string;
-  webContents: WebContents;
-  dispose: () => void;
+const PREVIEW_PARTITION = "persist:mcode-preview";
+const MAX_SURFACE_ID_LENGTH = 256;
+const MAX_ADOPTION_TOKEN_LENGTH = 128;
+
+/** Complete identity of one renderer-owned Preview surface. */
+export interface PreviewSurfaceIdentity {
+  readonly workspaceId: string;
+  readonly scope: {
+    readonly kind: "thread" | "workspace";
+    readonly id: string;
+  };
+  readonly tabId: string;
 }
 
-/** windowId -> ("threadId:tabId" -> AdoptedRecord). */
-const adoptedByWindow = new Map<number, Map<string, AdoptedRecord>>();
-
-function key(threadId: string, tabId: string): string {
-  return JSON.stringify([threadId, tabId]);
+/** Generation-bound reference to one Preview surface. */
+export interface PreviewSurfaceRef {
+  readonly identity: PreviewSurfaceIdentity;
+  readonly generation: number;
 }
 
-/** Looks up an adopted guest inside one exact BrowserWindow identity. */
+/** Typed navigation requested by a renderer-owned Preview surface. */
+export type PreviewSurfaceNavigation =
+  | { readonly kind: "initial"; readonly address?: string }
+  | { readonly kind: "restored" | "address"; readonly address: string }
+  | { readonly kind: "back" | "forward" | "reload" | "force-reload" };
+
+/** Result returned by a typed Preview surface operation. */
+export type PreviewSurfaceResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: string };
+
+/** Pending or adopted exact Preview guest held by Electron main. */
+export interface AdoptedPreviewSurface {
+  readonly surface: PreviewSurfaceRef;
+  readonly adoptionToken: string;
+  readonly webContents: WebContents;
+}
+
+interface AdoptionRecord extends AdoptedPreviewSurface {
+  readonly dispose: () => void;
+}
+
+/** Input accepted by preview.surface.prepare. */
+export interface PreviewSurfacePrepareInput {
+  readonly surface: PreviewSurfaceRef;
+  readonly adoptionToken: string;
+}
+
+/** Input accepted by preview.surface.adopt. */
+export interface PreviewSurfaceAdoptInput extends PreviewSurfacePrepareInput {}
+
+/** Input accepted by preview.surface.release. */
+export interface PreviewSurfaceReleaseInput {
+  readonly surface: PreviewSurfaceRef;
+}
+
+/** Input accepted by preview.surface.navigate. */
+export interface PreviewSurfaceNavigateInput {
+  readonly surface: PreviewSurfaceRef;
+  readonly navigation: PreviewSurfaceNavigation;
+}
+
+/** Per-window adopted and pending Preview surfaces. */
+const adoptedByWindow = new Map<number, Map<string, AdoptionRecord>>();
+const pendingByWindow = new Map<number, Map<string, PreviewSurfacePrepareInput>>();
+const generationByWindow = new Map<number, Map<string, number>>();
+
+function surfaceKey(identity: PreviewSurfaceIdentity): string {
+  return JSON.stringify([
+    identity.workspaceId,
+    identity.scope.kind,
+    identity.scope.id,
+    identity.tabId,
+  ]);
+}
+
+function validBoundedId(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0 && value.length <= MAX_SURFACE_ID_LENGTH;
+}
+
+function validateSurface(value: unknown): PreviewSurfaceRef | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Partial<PreviewSurfaceRef>;
+  const identity = candidate.identity;
+  if (typeof candidate.generation !== "number" || !Number.isSafeInteger(candidate.generation) || candidate.generation < 1) return null;
+  if (typeof identity !== "object" || identity === null) return null;
+  const typedIdentity = identity as Partial<PreviewSurfaceIdentity>;
+  const scope = typedIdentity.scope;
+  if (
+    !validBoundedId(typedIdentity.workspaceId) ||
+    typeof scope !== "object" ||
+    scope === null ||
+    (scope.kind !== "thread" && scope.kind !== "workspace") ||
+    !validBoundedId(scope.id) ||
+    !validBoundedId(typedIdentity.tabId)
+  ) return null;
+  return {
+    identity: {
+      workspaceId: typedIdentity.workspaceId.trim(),
+      scope: { kind: scope.kind, id: scope.id.trim() },
+      tabId: typedIdentity.tabId.trim(),
+    },
+    generation: candidate.generation,
+  };
+}
+
+function validAdoptionToken(value: unknown): value is string {
+  return typeof value === "string" &&
+    value.length >= 8 &&
+    value.length <= MAX_ADOPTION_TOKEN_LENGTH &&
+    /^[A-Za-z0-9_-]+$/.test(value);
+}
+
+function windowMap<T>(maps: Map<number, Map<string, T>>, windowId: number): Map<string, T> {
+  let map = maps.get(windowId);
+  if (!map) {
+    map = new Map();
+    maps.set(windowId, map);
+  }
+  return map;
+}
+
+function findOwnedTab(
+  win: BrowserWindow,
+  identity: PreviewSurfaceIdentity,
+): { threadId: string; tabId: string } | null {
+  const session = getSession(win);
+  if (session.workspaceId !== identity.workspaceId) return null;
+  if (identity.scope.kind === "thread") {
+    const tab = session.tabsByThread.get(identity.scope.id)?.tabs.find((candidate) => candidate.id === identity.tabId);
+    return tab?.threadId === identity.scope.id ? { threadId: identity.scope.id, tabId: tab.id } : null;
+  }
+  if (identity.scope.id !== identity.workspaceId) return null;
+  let found: { threadId: string; tabId: string } | null = null;
+  for (const [threadId, tabSet] of session.tabsByThread) {
+    const tab = tabSet.tabs.find((candidate) => candidate.id === identity.tabId);
+    if (!tab) continue;
+    if (found) return null;
+    found = { threadId, tabId: tab.id };
+  }
+  return found;
+}
+
+function pendingForWindow(windowId: number, surface: PreviewSurfaceRef): PreviewSurfacePrepareInput | null {
+  return pendingByWindow.get(windowId)?.get(surfaceKey(surface.identity)) ?? null;
+}
+
+function adoptedForWindow(windowId: number, surface: PreviewSurfaceRef): AdoptionRecord | null {
+  const record = adoptedByWindow.get(windowId)?.get(surfaceKey(surface.identity));
+  if (!record || record.surface.generation !== surface.generation || record.webContents.isDestroyed()) return null;
+  return record;
+}
+
+function expectedGuestPreloadPath(): string {
+  return resolvePreviewGuestPreloadPath(__dirname);
+}
+
+function isInertGuestUrl(url: string, adoptionToken: string): boolean {
+  return url === `about:blank#${adoptionToken}`;
+}
+
+function guestHasFixedPreload(guest: WebContents): boolean {
+  const candidate = guest as WebContents & {
+    getLastWebPreferences?: () => { preload?: string };
+  };
+  const preferences = typeof candidate.getLastWebPreferences === "function"
+    ? candidate.getLastWebPreferences()
+    : null;
+  return preferences?.preload === expectedGuestPreloadPath();
+}
+
+function guestMatchesPending(
+  guest: WebContents,
+  sender: WebContents,
+  adoptionToken: string,
+): boolean {
+  if (guest.isDestroyed() || guest.getType() !== "webview") return false;
+  if (guest.hostWebContents !== sender) return false;
+  if (guest.session !== electronSession.fromPartition(PREVIEW_PARTITION)) return false;
+  if (!guestHasFixedPreload(guest)) return false;
+  return isInertGuestUrl(guest.getURL(), adoptionToken);
+}
+
+function findPendingGuest(sender: WebContents, adoptionToken: string): WebContents | null {
+  const guests = electronWebContents.getAllWebContents().filter((candidate) =>
+    guestMatchesPending(candidate, sender, adoptionToken));
+  return guests.length === 1 ? guests[0]! : null;
+}
+
+function errorResult(error: string): PreviewSurfaceResult {
+  return { ok: false, error };
+}
+
+function validateSenderAndSurface(
+  event: IpcMainInvokeEvent,
+  surfaceValue: unknown,
+): { win: BrowserWindow; surface: PreviewSurfaceRef; owner: { threadId: string; tabId: string } } | PreviewSurfaceResult {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win || win.isDestroyed()) return errorResult("no-window");
+  const surface = validateSurface(surfaceValue);
+  if (!surface) return errorResult("invalid-surface");
+  const owner = findOwnedTab(win, surface.identity);
+  if (!owner) return errorResult("surface-owner-mismatch");
+  return { win, surface, owner };
+}
+
+function dropAdoption(windowId: number, key: string): void {
+  const map = adoptedByWindow.get(windowId);
+  const record = map?.get(key);
+  if (!record) return;
+  unregisterPreviewClipboardGuest(record.webContents);
+  try {
+    record.dispose();
+  } catch {
+    // The guest may already have been destroyed.
+  }
+  map!.delete(key);
+  if (map!.size === 0) adoptedByWindow.delete(windowId);
+}
+
+function dropPending(windowId: number, key: string): void {
+  const map = pendingByWindow.get(windowId);
+  map?.delete(key);
+  if (map && map.size === 0) pendingByWindow.delete(windowId);
+}
+
+/** Resolves the adopted guest for an exact identity and generation. */
+export function resolveAdoptedPreviewSurfaceForWindow(
+  windowId: number,
+  surface: PreviewSurfaceRef,
+  sender?: WebContents,
+): AdoptedPreviewSurface | null {
+  const record = adoptedForWindow(windowId, surface);
+  if (!record) return null;
+  if (sender && record.webContents.hostWebContents !== sender) return null;
+  return record;
+}
+
+/** Legacy resolver retained for existing main-process automation call sites. */
 export function findAdoptedWebContentsForWindow(
   windowId: number,
   threadId: string,
   tabId: string,
+  generation?: number,
 ): WebContents | null {
-  const record = adoptedByWindow.get(windowId)?.get(key(threadId, tabId));
-  return record && !record.webContents.isDestroyed() ? record.webContents : null;
-}
-
-function dropAdoption(windowId: number, threadId: string, tabId: string): void {
-  const inner = adoptedByWindow.get(windowId);
-  if (!inner) return;
-  const rec = inner.get(key(threadId, tabId));
-  if (!rec) return;
-  unregisterPreviewClipboardGuest(rec.webContents);
-  try {
-    rec.dispose();
-  } catch {
-    /* listener may already be gone */
+  const records = adoptedByWindow.get(windowId);
+  for (const record of records?.values() ?? []) {
+    if (
+      record.surface.identity.scope.kind === "thread" &&
+      record.surface.identity.scope.id === threadId &&
+      record.surface.identity.tabId === tabId &&
+      (generation === undefined || record.surface.generation === generation) &&
+      !record.webContents.isDestroyed()
+    ) return record.webContents;
   }
-  inner.delete(key(threadId, tabId));
-  if (inner.size === 0) adoptedByWindow.delete(windowId);
+  return null;
 }
 
-export interface AdoptInput {
-  webContentsId: number;
-  threadId: string;
-  tabId: string;
+function prepareSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSurfaceResult {
+  const input = typeof inputValue === "object" && inputValue !== null ? inputValue as Partial<PreviewSurfacePrepareInput> : {};
+  if (!validAdoptionToken(input.adoptionToken)) return errorResult("invalid-adoption-token");
+  const validated = validateSenderAndSurface(event, input.surface);
+  if ("ok" in validated) return validated;
+  const { win, surface } = validated;
+  const key = surfaceKey(surface.identity);
+  const adopted = adoptedByWindow.get(win.id)?.get(key);
+  if (adopted?.surface.generation === surface.generation) return errorResult("duplicate-adoption");
+  if (adopted && surface.generation < adopted.surface.generation) return errorResult("stale-generation");
+  const pending = pendingByWindow.get(win.id)?.get(key);
+  if (pending?.surface.generation === surface.generation) return errorResult("duplicate-adoption");
+  if (pending && surface.generation < pending.surface.generation) return errorResult("stale-generation");
+  const generations = generationByWindow.get(win.id)?.get(key);
+  if (generations !== undefined && surface.generation <= generations) return errorResult("stale-generation");
+  for (const records of pendingByWindow.values()) {
+    for (const candidate of records.values()) {
+      if (candidate.adoptionToken === input.adoptionToken) return errorResult("duplicate-adoption-token");
+    }
+  }
+  for (const records of adoptedByWindow.values()) {
+    for (const candidate of records.values()) {
+      if (candidate.adoptionToken === input.adoptionToken) return errorResult("duplicate-adoption-token");
+    }
+  }
+  if (adopted) dropAdoption(win.id, key);
+  if (pending) dropPending(win.id, key);
+  windowMap(generationByWindow, win.id).set(key, surface.generation);
+  windowMap(pendingByWindow, win.id).set(key, { surface, adoptionToken: input.adoptionToken });
+  return { ok: true };
 }
 
-export type AdoptResult =
-  | { ok: true }
-  | { ok: false; error: string };
-
-/** Registers the renderer-owned webview adopt and release IPC channels. */
-export function registerWebviewAdoptHandlers(): void {
-  ipcMain.handle(
-    "preview:adopt-webview",
-    (event, payload: AdoptInput): AdoptResult => {
-      const win = BrowserWindow.fromWebContents(event.sender);
-      if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
-
-      const wcId = payload?.webContentsId;
-      const tid = typeof payload?.threadId === "string" ? payload.threadId.trim() : "";
-      const tabId = typeof payload?.tabId === "string" ? payload.tabId.trim() : "";
-      if (!Number.isSafeInteger(wcId) || wcId <= 0)
-        return { ok: false, error: "invalid-webcontents-id" };
-      if (!tid || tid.length > 256) return { ok: false, error: "invalid-thread-id" };
-      if (!tabId || tabId.length > 256) return { ok: false, error: "invalid-tab-id" };
-
-      const wc = electronWebContents.fromId(wcId);
-      if (!wc || wc.isDestroyed()) {
-        return { ok: false, error: "webcontents-not-found" };
-      }
-      if (wc.getType() !== "webview") {
-        return { ok: false, error: "invalid-webcontents-type" };
-      }
-      if (wc.hostWebContents !== event.sender) {
-        return { ok: false, error: "webcontents-owner-mismatch" };
-      }
-      if (wc.session !== electronSession.fromPartition("persist:mcode-preview")) {
-        return { ok: false, error: "invalid-webcontents-partition" };
-      }
-      wc.setWindowOpenHandler(() => ({ action: "deny" }));
-
-      const s = getSession(win);
-      const tab = s.tabsByThread.get(tid)?.tabs.find((candidate) => candidate.id === tabId);
-      if (!tab || tab.threadId !== tid) return { ok: false, error: "target-slot-not-found" };
-
-      // Drop a prior adoption for the same slot first; this may delete the
-      // inner Map from `adoptedByWindow` if it leaves it empty, so we
-      // re-fetch/create it after.
-      dropAdoption(win.id, tid, tabId);
-
-      let inner = adoptedByWindow.get(win.id);
-      if (!inner) {
-        inner = new Map();
-        adoptedByWindow.set(win.id, inner);
-      }
-
-      const onDestroyed = () => dropAdoption(win.id, tid, tabId);
-      wc.once("destroyed", onDestroyed);
-      registerPreviewClipboardGuest(wc, () => {
-        if (win.isDestroyed() || !win.isFocused()) return false;
-        const current = getSession(win);
-        return (
-          current.lastPreviewThreadId === tid &&
-          current.tabsByThread.get(tid)?.activeTabId === tabId &&
-          adoptedByWindow.get(win.id)?.get(key(tid, tabId))?.webContents === wc
-        );
-      });
-      const dispose = () => {
-        try {
-          wc.removeListener("destroyed", onDestroyed);
-        } catch {
-          /* webContents already gone */
-        }
-      };
-      inner.set(key(tid, tabId), {
-        threadId: tid,
-        tabId,
-        webContents: wc,
-        dispose,
-      });
-
-      logger.info("Preview: adopted webview", { threadId: tid, tabId, wcId });
-      return { ok: true };
-    },
-  );
-
-  ipcMain.handle(
-    "preview:release-webview",
-    (event, payload: { threadId?: string; tabId?: string }): AdoptResult => {
-      const win = BrowserWindow.fromWebContents(event.sender);
-      if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
-      const tid = typeof payload?.threadId === "string" ? payload.threadId.trim() : "";
-      const tabId = typeof payload?.tabId === "string" ? payload.tabId.trim() : "";
-      if (!tid || tid.length > 256) return { ok: false, error: "invalid-thread-id" };
-      if (!tabId || tabId.length > 256) return { ok: false, error: "invalid-tab-id" };
-      dropAdoption(win.id, tid, tabId);
-      return { ok: true };
-    },
-  );
+function adoptSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSurfaceResult {
+  const input = typeof inputValue === "object" && inputValue !== null ? inputValue as Partial<PreviewSurfaceAdoptInput> : {};
+  if (!validAdoptionToken(input.adoptionToken)) return errorResult("invalid-adoption-token");
+  const validated = validateSenderAndSurface(event, input.surface);
+  if ("ok" in validated) return validated;
+  const { win, surface } = validated;
+  const key = surfaceKey(surface.identity);
+  const currentGeneration = generationByWindow.get(win.id)?.get(key);
+  if (currentGeneration !== surface.generation) return errorResult("stale-generation");
+  const pending = pendingForWindow(win.id, surface);
+  if (!pending || pending.adoptionToken !== input.adoptionToken) return errorResult("adoption-not-prepared");
+  if (adoptedByWindow.get(win.id)?.has(key)) return errorResult("duplicate-adoption");
+  const guest = findPendingGuest(event.sender, input.adoptionToken);
+  if (!guest) {
+    const matches = electronWebContents.getAllWebContents().filter((candidate) =>
+      candidate.getURL() === `about:blank#${input.adoptionToken}` && candidate.hostWebContents === event.sender);
+    return errorResult(matches.length > 1 ? "non-unique-adoption" : "guest-not-found");
+  }
+  guest.setWindowOpenHandler(() => ({ action: "deny" }));
+  const onDestroyed = () => dropAdoption(win.id, key);
+  guest.once("destroyed", onDestroyed);
+  registerPreviewClipboardGuest(guest, () => {
+    if (win.isDestroyed() || !win.isFocused()) return false;
+    const record = adoptedByWindow.get(win.id)?.get(key);
+    return record?.webContents === guest && record?.surface.generation === surface.generation;
+  });
+  const dispose = () => {
+    guest.removeListener("destroyed", onDestroyed);
+  };
+  windowMap(adoptedByWindow, win.id).set(key, { surface, adoptionToken: input.adoptionToken, webContents: guest, dispose });
+  dropPending(win.id, key);
+  logger.info("Preview: adopted typed webview surface", {
+    workspaceId: surface.identity.workspaceId,
+    scope: surface.identity.scope,
+    tabId: surface.identity.tabId,
+    generation: surface.generation,
+  });
+  return { ok: true };
 }
 
-/** Test/internal helper: drop every adopted record. Tests call this in afterEach. */
+function releaseSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSurfaceResult {
+  const input = typeof inputValue === "object" && inputValue !== null ? inputValue as Partial<PreviewSurfaceReleaseInput> : {};
+  const validated = validateSenderAndSurface(event, input.surface);
+  if ("ok" in validated) return validated;
+  const { win, surface } = validated;
+  const key = surfaceKey(surface.identity);
+  const currentGeneration = generationByWindow.get(win.id)?.get(key);
+  if (currentGeneration !== surface.generation) return errorResult("stale-generation");
+  const record = adoptedByWindow.get(win.id)?.get(key);
+  if (record) {
+    if (record.webContents.hostWebContents !== event.sender) return errorResult("webcontents-owner-mismatch");
+    dropAdoption(win.id, key);
+  }
+  dropPending(win.id, key);
+  return { ok: true };
+}
+
+async function navigateSurface(event: IpcMainInvokeEvent, inputValue: unknown): Promise<PreviewSurfaceResult> {
+  const input = typeof inputValue === "object" && inputValue !== null ? inputValue as Partial<PreviewSurfaceNavigateInput> : {};
+  const validated = validateSenderAndSurface(event, input.surface);
+  if ("ok" in validated) return validated;
+  const { win, surface } = validated;
+  const navigation = input.navigation;
+  if (typeof navigation !== "object" || navigation === null || typeof navigation.kind !== "string") return errorResult("invalid-navigation");
+  // Resolve immediately before the side effect. A replacement or release that
+  // raced validation must not inherit the prior guest's authority.
+  const record = resolveAdoptedPreviewSurfaceForWindow(win.id, surface, event.sender);
+  if (!record) return errorResult("stale-generation");
+  const guest = record.webContents;
+  try {
+    switch (navigation.kind) {
+      case "initial":
+      case "restored":
+      case "address": {
+        const address = typeof navigation.address === "string" ? navigation.address.trim() : "";
+        if (navigation.kind === "initial" && !address) return { ok: true };
+        if (!address || !isAllowedHttpUrl(address)) return errorResult("invalid-url");
+        const current = resolveAdoptedPreviewSurfaceForWindow(win.id, surface, event.sender);
+        if (!current || current.webContents !== guest) return errorResult("stale-generation");
+        await guest.loadURL(address);
+        return { ok: true };
+      }
+      case "back":
+        if (!guest.canGoBack()) return errorResult("history-unavailable");
+        if (!resolveAdoptedPreviewSurfaceForWindow(win.id, surface, event.sender)) return errorResult("stale-generation");
+        guest.goBack();
+        return { ok: true };
+      case "forward":
+        if (!guest.canGoForward()) return errorResult("history-unavailable");
+        if (!resolveAdoptedPreviewSurfaceForWindow(win.id, surface, event.sender)) return errorResult("stale-generation");
+        guest.goForward();
+        return { ok: true };
+      case "reload":
+        if (!resolveAdoptedPreviewSurfaceForWindow(win.id, surface, event.sender)) return errorResult("stale-generation");
+        guest.reload();
+        return { ok: true };
+      case "force-reload":
+        if (!resolveAdoptedPreviewSurfaceForWindow(win.id, surface, event.sender)) return errorResult("stale-generation");
+        guest.reloadIgnoringCache();
+        return { ok: true };
+      default:
+        return errorResult("invalid-navigation");
+    }
+  } catch {
+    return errorResult("navigation-failed");
+  }
+}
+
+/** Registers the generation-bound Preview surface IPC channels. */
+let surfaceHandlersRegistered = false;
+export function registerPreviewSurfaceHandlers(): void {
+  if (surfaceHandlersRegistered) return;
+  surfaceHandlersRegistered = true;
+  ipcMain.handle("preview.surface.prepare", (event, input: unknown) => prepareSurface(event, input));
+  ipcMain.handle("preview.surface.adopt", (event, input: unknown) => adoptSurface(event, input));
+  ipcMain.handle("preview.surface.release", (event, input: unknown) => releaseSurface(event, input));
+  ipcMain.handle("preview.surface.navigate", (event, input: unknown) => navigateSurface(event, input));
+}
+
+/** Backward-compatible registration name for the preview subsystem index. */
+export const registerWebviewAdoptHandlers = registerPreviewSurfaceHandlers;
+
+/** Test/internal helper that drops every pending and adopted surface. */
 export function _resetAdoptionRegistryForTests(): void {
-  for (const inner of adoptedByWindow.values()) {
-    for (const rec of inner.values()) {
+  for (const records of adoptedByWindow.values()) {
+    for (const record of records.values()) {
       try {
-        rec.dispose();
+        record.dispose();
       } catch {
-        /* ignore */
+        // Ignore already-destroyed guests during test cleanup.
       }
     }
   }
   adoptedByWindow.clear();
+  pendingByWindow.clear();
+  generationByWindow.clear();
 }

--- a/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
+++ b/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
@@ -1,19 +1,35 @@
 import { useCallback } from "react";
 import {
   BrowserSurfaceHost,
+  ElectronWebviewBrowserSurfaceAdapter,
   WebIframeBrowserSurfaceAdapter,
 } from "@/services/browser-surfaces";
-import { useBrowserAutomationStore } from "@/stores/browserAutomationStore";
+import {
+  invalidateBrowserAutomationTargetObservation,
+  useBrowserAutomationStore,
+} from "@/stores/browserAutomationStore";
 
 let surfaceRoot: HTMLDivElement | null = null;
 
 /** Renderer-window Browser surface host used by the web iframe adapter. */
 export const browserSurfaceHost = new BrowserSurfaceHost({
-  adapterFactory: (identity, generation) => new WebIframeBrowserSurfaceAdapter(
-    identity,
-    generation,
-    {
-      root: surfaceRoot ?? document.body,
+  adapterFactory: (identity, generation) => {
+    const root = surfaceRoot ?? document.body;
+    if (window.desktopBridge?.preview?.surface) {
+      return new ElectronWebviewBrowserSurfaceAdapter(identity, generation, {
+        root,
+        title: "Electron browser preview",
+        onHumanInput: (surfaceIdentity) => {
+          if (surfaceIdentity.scope.kind !== "thread") return;
+          invalidateBrowserAutomationTargetObservation(
+            surfaceIdentity.scope.id,
+            surfaceIdentity.tabId,
+          );
+        },
+      });
+    }
+    return new WebIframeBrowserSurfaceAdapter(identity, generation, {
+      root,
       title: "Web browser preview",
       onLoad: (surfaceIdentity) => {
         useBrowserAutomationStore.getState().refreshTarget(
@@ -21,8 +37,8 @@ export const browserSurfaceHost = new BrowserSurfaceHost({
           surfaceIdentity.tabId,
         );
       },
-    },
-  ),
+    });
+  },
 });
 
 /** Mounts the single Browser surface root for this renderer window. */

--- a/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
+++ b/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import {
   BrowserSurfaceHost,
   ElectronWebviewBrowserSurfaceAdapter,
+  normalizeElectronWebviewSurfaceAddress,
   WebIframeBrowserSurfaceAdapter,
 } from "@/services/browser-surfaces";
 import {
@@ -13,6 +14,9 @@ let surfaceRoot: HTMLDivElement | null = null;
 
 /** Renderer-window Browser surface host used by the web iframe adapter. */
 export const browserSurfaceHost = new BrowserSurfaceHost({
+  normalizeAddress: window.desktopBridge?.preview?.surface
+    ? normalizeElectronWebviewSurfaceAddress
+    : undefined,
   adapterFactory: (identity, generation) => {
     const root = surfaceRoot ?? document.body;
     if (window.desktopBridge?.preview?.surface) {

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -2022,7 +2022,7 @@ export function PreviewPanel({
   // Subscribes the scope's tab set into usePreviewTabsStore and exposes the
   // "New page" action for the header. Page switching/closing is driven from the
   // activity rail (the page switcher), so this panel no longer renders a strip.
-  const tabs = usePreviewTabs(threadId);
+  const tabs = usePreviewTabs(threadId, workspaceId);
   const automationControllers = useBrowserAutomationStore((state) => state.controllers);
   const pendingAgentOpens = useBrowserAutomationStore((state) => state.pendingAgentOpens);
   const automationActiveRequests = useBrowserAutomationStore((state) => state.activeRequests);
@@ -2240,9 +2240,8 @@ export function PreviewPanel({
       .filter((tab) => warmIds.has(tab.id))
       .map((tab) => ({
         id: tab.id,
-        src: webviewRequestedUrlByTab[tab.id] ?? tab.url ?? null,
-      }))
-      .filter((tab): tab is { id: string; src: string } => !!tab.src);
+        src: webviewRequestedUrlByTab[tab.id] ?? tab.url ?? "about:blank",
+      }));
   }, [
     activeWebviewSrc,
     activeWebviewTabId,

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -3,37 +3,28 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
   useRef,
 } from "react";
 import type { PreviewPageStatus } from "@mcode/contracts";
+import type {
+  BrowserSurfaceIdentity,
+  BrowserSurfacePageState,
+} from "@/services/browser-surfaces";
 import {
   browserAutomationTargetKey,
-  invalidateBrowserAutomationTargetObservation,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
-import {
-  DEFAULT_VIEWPORT_SIZE,
-} from "@/services/browser-automation/viewportCoordinator";
+import { browserSurfaceHost } from "./BrowserSurfaceHostRoot";
+import { DEFAULT_VIEWPORT_SIZE } from "@/services/browser-automation/viewportCoordinator";
 import {
   getOrCreateViewportCoordinator,
   waitForViewportLayout,
 } from "@/services/browser-automation/viewportCoordinatorFactory";
 
-const PREVIEW_GUEST_HUMAN_INPUT_CHANNEL = "mcode:browser-human-input";
-const HUMAN_INPUT_KINDS = new Set(["keyboard", "pointer", "touch", "wheel"]);
-
-/**
- * Renderer-hosted Electron `<webview>` that the host process can adopt by
- * `webContentsId`. Mirrors dpcode's renderer-attach flow: the renderer owns
- * the element lifetime; the host owns the WebContents lifecycle (debugger
- * attach, CDP routing) once the id is registered.
- *
- * Phase D scope: provide the adopt path so the Codex browser-use bridge can
- * drive a renderer-embedded tab via executeCdp. The component is opt-in -
- * tabs that don't request a webview keep the BrowserView path unchanged.
- */
+/** Properties for one hosted renderer Browser surface. */
 export interface PreviewWebviewProps {
-  /** Workspace that authorizes this visible target. Defaults to the threadless scope id. */
   readonly workspaceId?: string;
   readonly threadId: string;
   readonly tabId: string;
@@ -47,32 +38,7 @@ export interface PreviewWebviewProps {
   }) => void;
 }
 
-/** Subset of Electron's WebviewTag API we actually call. */
-interface ElectronWebviewElement {
-  src: string;
-  getWebContentsId(): number;
-  getURL?(): string;
-  getTitle?(): string;
-  loadURL?(url: string): Promise<void>;
-  reload?(): void;
-  reloadIgnoringCache?(): void;
-  canGoBack?(): boolean;
-  canGoForward?(): boolean;
-  goBack?(): void;
-  goForward?(): void;
-  getZoomFactor?(): number | Promise<number>;
-  setZoomFactor?(factor: number): void | Promise<void>;
-  addEventListener(type: string, listener: (ev: Event) => void): void;
-  removeEventListener(type: string, listener: (ev: Event) => void): void;
-}
-
-type PreviewElement = ElectronWebviewElement | HTMLIFrameElement;
-
-function isIframeElement(element: PreviewElement | null): element is HTMLIFrameElement {
-  return typeof HTMLIFrameElement !== "undefined" && element instanceof HTMLIFrameElement;
-}
-
-/** Imperative controls for a live renderer-hosted preview webview. */
+/** Imperative controls for one hosted renderer Browser surface. */
 export interface PreviewWebviewHandle {
   navigate(url: string): void;
   reload(): void;
@@ -86,30 +52,37 @@ export interface PreviewWebviewHandle {
   setZoom(factor: number): Promise<number>;
 }
 
-type WebviewEvent = Event & {
-  readonly url?: string;
-  readonly title?: string;
-  readonly favicons?: readonly string[];
-  readonly validatedURL?: string;
-  readonly errorCode?: number;
-  readonly errorDescription?: string;
-  readonly channel?: string;
-  readonly args?: readonly unknown[];
-};
-
-function realUrl(url: string | null | undefined): string | null {
-  if (!url || url.startsWith("about:") || url.startsWith("chrome-error://")) {
-    return null;
-  }
-  return url;
+function visibleAddress(state: BrowserSurfacePageState): string | null {
+  const address = state.committedAddress ?? state.pendingAddress;
+  return !address || address.startsWith("about:") || address.startsWith("chrome-error:")
+    ? null
+    : address;
 }
 
-function isExpectedNavigationAbort(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
-  const candidate = error as { code?: unknown; errno?: unknown };
-  return candidate.code === "ERR_ABORTED" || candidate.errno === -3;
+function previewStatus(state: BrowserSurfacePageState): PreviewPageStatus {
+  const committedBlank = state.committedAddress?.startsWith("about:") === true;
+  return {
+    url: visibleAddress(state),
+    title: state.title || null,
+    favicon: state.favicon,
+    phase: committedBlank ? "loaded" : state.phase,
+    ...(state.mainFrameError
+      ? {
+          error: {
+            kind: "network" as const,
+            code: "ERR_FAILED",
+            message: state.mainFrameError,
+          },
+        }
+      : {}),
+  };
 }
 
+function supportedInitialAddress(address: string): string | undefined {
+  return /^https?:\/\//i.test(address) ? address : undefined;
+}
+
+/** Placement controller for a surface owned by the renderer-window BrowserSurfaceHost. */
 export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewProps>(
   function PreviewWebview(
     {
@@ -124,379 +97,205 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     },
     forwardedRef,
   ) {
-  const ref = useRef<PreviewElement | null>(null);
-  const onPageStatusRef = useRef(onPageStatus);
-  const onNavigationStateChangeRef = useRef(onNavigationStateChange);
-  onPageStatusRef.current = onPageStatus;
-  onNavigationStateChangeRef.current = onNavigationStateChange;
-  const domReadyRef = useRef(false);
-  const pendingReloadRef = useRef(false);
-  const faviconRef = useRef<string | null>(null);
-  const initialViewportRef = useRef(viewport ?? DEFAULT_VIEWPORT_SIZE);
-  const ensureViewportCoordinator = useCallback((targetGeneration: number) => {
-    const key = browserAutomationTargetKey(threadId, tabId);
-    const store = useBrowserAutomationStore.getState();
-    const existing = store.viewportCoordinators.get(key);
-    const coordinator = getOrCreateViewportCoordinator({
-      existing,
-      target: { threadId, tabId },
-      initial: store.viewportStateByTarget.get(key)?.confirmed ??
-        store.viewportByTarget.get(key) ?? initialViewportRef.current,
-      mode: store.viewportStateByTarget.get(key)?.mode,
-      presentation: store.viewportStateByTarget.get(key)?.presentation,
-      targetGeneration,
-      nativeHost: () => window.desktopBridge?.preview?.design,
-      rendererHost: {
-        setViewport: (size, operation, coordinator) => useBrowserAutomationStore.getState().applyViewportIfCurrent(
-          threadId,
-          tabId,
-          coordinator,
-          operation.targetGeneration,
-          size,
-        ),
-        resetViewport: (operation, coordinator) =>
-          useBrowserAutomationStore.getState().resetViewportIfCurrent(
+    const placementRef = useRef<HTMLDivElement | null>(null);
+    const stateRef = useRef<BrowserSurfacePageState | null>(null);
+    const initialAddressRef = useRef(supportedInitialAddress(src));
+    const callbacksRef = useRef({ onPageStatus, onNavigationStateChange });
+    callbacksRef.current = { onPageStatus, onNavigationStateChange };
+    const identity = useMemo<BrowserSurfaceIdentity>(() => ({
+      workspaceId,
+      scope: { kind: "thread", id: threadId },
+      tabId,
+    }), [tabId, threadId, workspaceId]);
+    const initialViewportRef = useRef(viewport ?? DEFAULT_VIEWPORT_SIZE);
+
+    const ensureViewportCoordinator = useCallback((targetGeneration: number) => {
+      const key = browserAutomationTargetKey(threadId, tabId);
+      const store = useBrowserAutomationStore.getState();
+      const existing = store.viewportCoordinators.get(key);
+      return getOrCreateViewportCoordinator({
+        existing,
+        target: { threadId, tabId },
+        initial: store.viewportStateByTarget.get(key)?.confirmed ??
+          store.viewportByTarget.get(key) ?? initialViewportRef.current,
+        mode: store.viewportStateByTarget.get(key)?.mode,
+        presentation: store.viewportStateByTarget.get(key)?.presentation,
+        targetGeneration,
+        nativeHost: () => window.desktopBridge?.preview?.design,
+        rendererHost: {
+          setViewport: (size, operation, coordinator) => useBrowserAutomationStore.getState().applyViewportIfCurrent(
+            threadId,
+            tabId,
+            coordinator,
+            operation.targetGeneration,
+            size,
+          ),
+          resetViewport: (operation, coordinator) => useBrowserAutomationStore.getState().resetViewportIfCurrent(
             threadId,
             tabId,
             coordinator,
             operation.targetGeneration,
           ),
-        readViewport: () => useBrowserAutomationStore.getState().viewportByTarget.get(key) ?? null,
-        waitForLayout: waitForViewportLayout,
-        isCurrent: (operation, coordinator) => {
-          const current = useBrowserAutomationStore.getState();
-          return current.viewportCoordinators.get(key) === coordinator &&
-            current.liveTargets.get(key)?.revision === operation.targetGeneration;
+          readViewport: () => useBrowserAutomationStore.getState().viewportByTarget.get(key) ?? null,
+          waitForLayout: waitForViewportLayout,
+          isCurrent: (operation, coordinator) => {
+            const current = useBrowserAutomationStore.getState();
+            return current.viewportCoordinators.get(key) === coordinator &&
+              current.liveTargets.get(key)?.revision === operation.targetGeneration;
+          },
         },
-      },
-      readConfirmed: () =>
-        useBrowserAutomationStore.getState().viewportStateByTarget.get(key)?.confirmed ??
-        useBrowserAutomationStore.getState().viewportByTarget.get(key) ?? null,
-      onStateChange: (state, coordinator) => useBrowserAutomationStore.getState().setViewportState(
-        threadId,
-        tabId,
-        state,
-        coordinator,
-      ),
-      onCreated: (created) => useBrowserAutomationStore.getState().setViewportCoordinator(
-        threadId,
-        tabId,
-        created,
-      ),
-    });
-    return coordinator;
-  }, [tabId, threadId]);
+        readConfirmed: () =>
+          useBrowserAutomationStore.getState().viewportStateByTarget.get(key)?.confirmed ??
+          useBrowserAutomationStore.getState().viewportByTarget.get(key) ?? null,
+        onStateChange: (state, coordinator) => useBrowserAutomationStore.getState().setViewportState(
+          threadId,
+          tabId,
+          state,
+          coordinator,
+        ),
+        onCreated: (created) => useBrowserAutomationStore.getState().setViewportCoordinator(
+          threadId,
+          tabId,
+          created,
+        ),
+      });
+    }, [tabId, threadId]);
 
-  const readUrl = useCallback((): string | null => {
-    const el = ref.current;
-    if (el && isIframeElement(el)) return realUrl(el.src);
-    try {
-      return realUrl(el?.getURL?.() ?? el?.src ?? null);
-    } catch {
-      return realUrl(el?.src ?? null);
-    }
-  }, []);
+    const currentSurface = useCallback(() => {
+      const state = browserSurfaceHost.getSnapshot(identity);
+      stateRef.current = state;
+      return state;
+    }, [identity]);
 
-  const readTitle = useCallback((): string | null => {
-    if (ref.current && isIframeElement(ref.current)) {
-      try {
-        const title = ref.current.contentDocument?.title ?? null;
-        return title && title.trim().length > 0 ? title : null;
-      } catch {
-        return null;
-      }
-    }
-    try {
-      const title = ref.current?.getTitle?.() ?? null;
-      return title && title.trim().length > 0 ? title : null;
-    } catch {
-      return null;
-    }
-  }, []);
+    const navigateMain = useCallback((kind: "back" | "forward" | "reload" | "force-reload"): void => {
+      const surface = currentSurface();
+      if (!surface) return;
+      void window.desktopBridge?.preview?.surface.navigate({
+        surface: { identity, generation: surface.generation },
+        navigation: { kind },
+      });
+    }, [currentSurface, identity]);
 
-  const emitNavigationState = useCallback(() => {
-    const el = ref.current;
-    if (!domReadyRef.current || !el) {
-      onNavigationStateChangeRef.current?.({ canGoBack: false, canGoForward: false });
-      return;
-    }
-    if (isIframeElement(el)) {
-      onNavigationStateChangeRef.current?.({ canGoBack: false, canGoForward: false });
-      return;
-    }
-    onNavigationStateChangeRef.current?.({
-      canGoBack: !!el.canGoBack?.(),
-      canGoForward: !!el.canGoForward?.(),
-    });
-  }, []);
-
-  const emitStatus = useCallback((phase: PreviewPageStatus["phase"]) => {
-    onPageStatusRef.current?.({
-      url: readUrl(),
-      title: readTitle(),
-      favicon: faviconRef.current,
-      phase,
-    });
-    emitNavigationState();
-  }, [emitNavigationState, readTitle, readUrl]);
-
-  useImperativeHandle(
-    forwardedRef,
-    () => ({
+    useImperativeHandle(forwardedRef, () => ({
       navigate(url: string) {
-        const el = ref.current;
-        if (!el) return;
-        if (isIframeElement(el)) {
-          el.src = url;
-          onPageStatusRef.current?.({ url, title: null, favicon: null, phase: "loading" });
-          return;
-        }
-        if (el.loadURL) {
-          void el.loadURL(url).catch((error: unknown) => {
-            if (isExpectedNavigationAbort(error)) return;
-            onPageStatusRef.current?.({
-              url: realUrl(url),
-              title: null,
-              favicon: null,
-              phase: "error",
-              error: {
-                kind: "network",
-                code: "ERR_FAILED",
-                message: "Navigation failed.",
-              },
-            });
-            emitNavigationState();
-          });
-        } else {
-          el.src = url;
-        }
+        browserSurfaceHost.navigate(identity, url);
       },
       reload() {
-        if (!domReadyRef.current) {
-          pendingReloadRef.current = true;
-          return;
-        }
-        pendingReloadRef.current = false;
-        if (ref.current && isIframeElement(ref.current)) {
-          ref.current.contentWindow?.location.reload();
-        } else ref.current?.reload?.();
+        navigateMain("reload");
       },
       forceReload() {
-        if (!domReadyRef.current) return;
-        const el = ref.current;
-        if (isIframeElement(el)) {
-          el.contentWindow?.location.reload();
-        } else if (el?.reloadIgnoringCache) {
-          el.reloadIgnoringCache();
-        } else {
-          el?.reload?.();
-        }
+        navigateMain("force-reload");
       },
       goBack() {
-        if (!domReadyRef.current || !ref.current) return;
-        if (isIframeElement(ref.current)) ref.current.contentWindow?.history.back();
-        else if (ref.current.canGoBack?.()) ref.current.goBack?.();
+        navigateMain("back");
       },
       goForward() {
-        if (!domReadyRef.current || !ref.current) return;
-        if (isIframeElement(ref.current)) ref.current.contentWindow?.history.forward();
-        else if (ref.current.canGoForward?.()) ref.current.goForward?.();
+        navigateMain("forward");
       },
       canGoBack() {
-        if (!domReadyRef.current) return false;
-        return isIframeElement(ref.current) ? false : !!ref.current?.canGoBack?.();
+        return currentSurface()?.navigation?.canGoBack ?? false;
       },
       canGoForward() {
-        if (!domReadyRef.current) return false;
-        return isIframeElement(ref.current) ? false : !!ref.current?.canGoForward?.();
+        return currentSurface()?.navigation?.canGoForward ?? false;
       },
       getUrl() {
-        return readUrl() ?? "";
+        const state = currentSurface();
+        return state ? visibleAddress(state) ?? "" : "";
       },
       async getZoom() {
-        const el = ref.current;
-        if (!domReadyRef.current || !el || isIframeElement(el)) return 1;
-        return (await Promise.resolve(el.getZoomFactor?.())) ?? 1;
+        return window.desktopBridge?.preview?.getZoom?.() ?? 1;
       },
       async setZoom(factor: number) {
-        const el = ref.current;
-        if (!domReadyRef.current || !el || isIframeElement(el)) return factor;
-        await Promise.resolve(el.setZoomFactor?.(factor));
-        return (await Promise.resolve(el.getZoomFactor?.())) ?? factor;
+        return window.desktopBridge?.preview?.setZoom?.(factor) ?? factor;
       },
-    }),
-    [emitNavigationState, readUrl],
-  );
+    }), [currentSurface, identity, navigateMain]);
 
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    if (isIframeElement(el)) {
-      domReadyRef.current = true;
+    useLayoutEffect(() => {
       useBrowserAutomationStore.getState().registerTarget(workspaceId, threadId, tabId);
-      const revision = useBrowserAutomationStore.getState().liveTargets.get(
+      const targetGeneration = useBrowserAutomationStore.getState().liveTargets.get(
         browserAutomationTargetKey(threadId, tabId),
       )?.revision ?? 1;
-      ensureViewportCoordinator(revision);
-      const onLoad = () => {
-        emitStatus("loaded");
-      };
-      el.addEventListener("load", onLoad);
+      ensureViewportCoordinator(targetGeneration);
+      const initial = browserSurfaceHost.create(identity, {
+        address: initialAddressRef.current,
+        generation: targetGeneration,
+      });
+      stateRef.current = initial;
+      callbacksRef.current.onPageStatus?.(previewStatus(initial));
+      const unsubscribe = browserSurfaceHost.subscribe(identity, (state) => {
+        stateRef.current = state;
+        callbacksRef.current.onPageStatus?.(previewStatus(state));
+        callbacksRef.current.onNavigationStateChange?.(state.navigation ?? {
+          canGoBack: false,
+          canGoForward: false,
+        });
+      });
       return () => {
-        el.removeEventListener("load", onLoad);
+        unsubscribe();
+        browserSurfaceHost.dispose(identity);
         useBrowserAutomationStore.getState().detachTarget(threadId, tabId);
       };
-    }
-    if (!window.desktopBridge?.preview?.adoptWebview) return;
+    }, [ensureViewportCoordinator, identity, tabId, threadId, workspaceId]);
 
-    let cancelled = false;
-    const onAttached = (_ev: Event) => {
-      if (cancelled) return;
-      try {
-        const wcId = el.getWebContentsId();
-        if (Number.isFinite(wcId) && wcId > 0) {
-          void window.desktopBridge!.preview!.adoptWebview!({
-            webContentsId: wcId,
-            threadId,
-            tabId,
-          }).then((result) => {
-            if (cancelled || !result.ok) return;
-            useBrowserAutomationStore.getState().registerTarget(workspaceId, threadId, tabId);
-            const revision = useBrowserAutomationStore.getState().liveTargets.get(
-              browserAutomationTargetKey(threadId, tabId),
-            )?.revision ?? 1;
-            ensureViewportCoordinator(revision);
-          });
+    useEffect(() => {
+      const address = supportedInitialAddress(src);
+      if (!address) return;
+      const current = currentSurface();
+      if (current?.pendingAddress === address || current?.committedAddress === address) return;
+      browserSurfaceHost.navigate(identity, address);
+    }, [currentSurface, identity, src]);
+
+    useLayoutEffect(() => {
+      const placement = placementRef.current;
+      if (!placement) return;
+      const update = (): void => {
+        const bounds = placement.getBoundingClientRect();
+        if (
+          bounds.width <= 0 ||
+          bounds.height <= 0 ||
+          placement.closest("[inert], [aria-hidden='true']")
+        ) {
+          browserSurfaceHost.hide(identity);
+          return;
         }
-      } catch {
-        /* webview not yet ready */
-      }
-    };
-    el.addEventListener("did-attach", onAttached);
-    onAttached(new Event("did-attach"));
-    return () => {
-      cancelled = true;
-      try {
-        el.removeEventListener("did-attach", onAttached);
-      } catch {
-        /* webview gone */
-      }
-      useBrowserAutomationStore.getState().detachTarget(threadId, tabId);
-      void window.desktopBridge?.preview?.releaseWebview?.({ threadId, tabId });
-    };
-  }, [ensureViewportCoordinator, threadId, tabId, workspaceId]);
+        const intrinsicWidth = viewport?.width ?? bounds.width;
+        const intrinsicHeight = viewport?.height ?? bounds.height;
+        browserSurfaceHost.present(identity, {
+          left: bounds.left,
+          top: bounds.top,
+          width: intrinsicWidth,
+          height: intrinsicHeight,
+          scale: viewport ? Math.min(bounds.width / intrinsicWidth, bounds.height / intrinsicHeight) : 1,
+          zIndex: 31,
+        });
+      };
+      const observer = typeof ResizeObserver === "function" ? new ResizeObserver(update) : null;
+      observer?.observe(placement);
+      window.addEventListener("resize", update);
+      update();
+      return () => {
+        observer?.disconnect();
+        window.removeEventListener("resize", update);
+        browserSurfaceHost.hide(identity);
+      };
+    }, [identity, viewport]);
 
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-
-    if (isIframeElement(el)) return;
-
-    const onStart = () => emitStatus("loading");
-    const onDomReady = () => {
-      domReadyRef.current = true;
-      const store = useBrowserAutomationStore.getState();
-      store.refreshTarget(threadId, tabId);
-      const revision = useBrowserAutomationStore.getState().liveTargets.get(
-        browserAutomationTargetKey(threadId, tabId),
-      )?.revision;
-      if (revision !== undefined) ensureViewportCoordinator(revision);
-      if (pendingReloadRef.current) {
-        pendingReloadRef.current = false;
-        el.reload?.();
-      }
-      emitNavigationState();
-    };
-    const onStop = () => emitStatus("loaded");
-    const onNavigate = (ev: WebviewEvent) => {
-      onPageStatusRef.current?.({
-        url: realUrl(ev.url) ?? readUrl(),
-        title: readTitle(),
-        favicon: faviconRef.current,
-        phase: "loaded",
-      });
-      emitNavigationState();
-    };
-    const onTitle = (ev: WebviewEvent) => {
-      onPageStatusRef.current?.({
-        url: readUrl(),
-        title: ev.title && ev.title.trim().length > 0 ? ev.title : readTitle(),
-        favicon: faviconRef.current,
-        phase: "loaded",
-      });
-      emitNavigationState();
-    };
-    const onFavicon = (ev: WebviewEvent) => {
-      faviconRef.current = ev.favicons?.[0] ?? null;
-      emitStatus("loaded");
-    };
-    const onFail = (ev: WebviewEvent) => {
-      if (ev.errorCode === -3) return;
-      onPageStatusRef.current?.({
-        url: realUrl(ev.validatedURL) ?? readUrl(),
-        title: null,
-        favicon: null,
-        phase: "error",
-        error: {
-          kind: "network",
-          code: String(ev.errorCode ?? "ERR_FAILED"),
-          message: ev.errorDescription ?? "Navigation failed.",
-        },
-      });
-      emitNavigationState();
-    };
-    const onIpcMessage = (ev: WebviewEvent) => {
-      if (ev.channel !== PREVIEW_GUEST_HUMAN_INPUT_CHANNEL) return;
-      const message = ev.args?.[0];
-      if (!message || typeof message !== "object" || Array.isArray(message)) return;
-      const kind = (message as { kind?: unknown }).kind;
-      if (typeof kind !== "string" || !HUMAN_INPUT_KINDS.has(kind)) return;
-      invalidateBrowserAutomationTargetObservation(threadId, tabId);
-    };
-    el.addEventListener("did-start-loading", onStart);
-    el.addEventListener("dom-ready", onDomReady);
-    el.addEventListener("did-stop-loading", onStop);
-    el.addEventListener("did-navigate", onNavigate);
-    el.addEventListener("did-navigate-in-page", onNavigate);
-    el.addEventListener("page-title-updated", onTitle);
-    el.addEventListener("page-favicon-updated", onFavicon);
-    el.addEventListener("did-fail-load", onFail);
-    el.addEventListener("ipc-message", onIpcMessage);
-    return () => {
-      el.removeEventListener("did-start-loading", onStart);
-      el.removeEventListener("dom-ready", onDomReady);
-      el.removeEventListener("did-stop-loading", onStop);
-      el.removeEventListener("did-navigate", onNavigate);
-      el.removeEventListener("did-navigate-in-page", onNavigate);
-      el.removeEventListener("page-title-updated", onTitle);
-      el.removeEventListener("page-favicon-updated", onFavicon);
-      el.removeEventListener("did-fail-load", onFail);
-      el.removeEventListener("ipc-message", onIpcMessage);
-    };
-  }, [emitNavigationState, emitStatus, ensureViewportCoordinator, readTitle, readUrl, tabId, threadId]);
-
-  // Use createElement via React JSX since <webview> is a custom Chromium
-  // element; React 19 will pass unknown attributes through unchanged.
-  // We cast to any here only because @types/react does not know about <webview>.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const Tag = (!window.desktopBridge?.preview ? "iframe" : "webview") as any;
-  return (
-    <Tag
-      ref={ref}
-      src={src}
-      data-testid="preview-webview"
-      data-thread-id={threadId}
-      data-tab-id={tabId}
-      partition="persist:mcode-preview"
-      title="Preview"
-      className={className}
-      style={{
-        display: "inline-flex",
-        width: viewport?.width ?? "100%",
-        height: viewport?.height ?? "100%",
-        minWidth: 0,
-        minHeight: 0,
-      }}
-    />
-  );
-});
+    return (
+      <div
+        {...({ src } as Record<string, string>)}
+        ref={placementRef}
+        data-testid="preview-webview"
+        data-workspace-id={workspaceId}
+        data-thread-id={threadId}
+        data-tab-id={tabId}
+        className={className}
+        style={{
+          width: viewport?.width ?? "100%",
+          height: viewport?.height ?? "100%",
+          minWidth: 0,
+          minHeight: 0,
+        }}
+      />
+    );
+  },
+);

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -218,7 +218,6 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       ensureViewportCoordinator(targetGeneration);
       const initial = browserSurfaceHost.create(identity, {
         address: initialAddressRef.current,
-        generation: targetGeneration,
       });
       stateRef.current = initial;
       callbacksRef.current.onPageStatus?.(previewStatus(initial));

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -79,7 +79,7 @@ function previewStatus(state: BrowserSurfacePageState): PreviewPageStatus {
 }
 
 function supportedInitialAddress(address: string): string | undefined {
-  return /^https?:\/\//i.test(address) ? address : undefined;
+  return /^(https?|file):\/\//i.test(address) ? address : undefined;
 }
 
 /** Placement controller for a surface owned by the renderer-window BrowserSurfaceHost. */

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -295,7 +295,7 @@ export function RightPanel() {
   // page entries (and the active-page favicon glyph) even while another tab is
   // active. Null in web builds with no bridge, where the rail keeps the single
   // Browser glyph.
-  const browserTabSet = usePreviewTabSet(panelScopeId);
+  const browserTabSet = usePreviewTabSet(panelScopeId, activeWorkspaceId);
   const requestedAgentPageActivationRef = useRef<string | null>(null);
   const agentBrowserPage = useMemo(() => {
     if (!activeWorkspaceId || !panelScopeId || !browserTabSet) return null;

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -806,6 +806,40 @@ describe("PreviewPanel: full panel state", () => {
     );
   });
 
+  it("mounts a blank Electron surface for a new page", () => {
+    mockUsePreviewTabs.mockReturnValue({
+      tabSet: {
+        threadId: "thread-1",
+        activeTabId: "blank-tab",
+        tabs: [
+          {
+            id: "blank-tab",
+            threadId: "thread-1",
+            title: "New page",
+            url: null,
+            faviconUrl: null,
+            warm: true,
+            active: true,
+          },
+        ],
+      },
+      newTab: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+    });
+
+    render(<PreviewPanel threadId="thread-1" />);
+
+    expect(screen.getByTestId("preview-webview")).toHaveAttribute(
+      "data-tab-id",
+      "blank-tab",
+    );
+    expect(
+      screen.getByTestId("electron-browser-surface-webview").getAttribute("src"),
+    ).toMatch(/^about:blank/);
+    expect(screen.getByTestId("browser-local-ports")).toBeInTheDocument();
+  });
+
   it("renders the active URL in a live webview when the effective engine is webview", () => {
     useSettingsStore.getState()._applyPush({
       ...getDefaultSettings(),

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -600,8 +600,12 @@ describe("PreviewPanel: full panel state", () => {
           .mockResolvedValue({ canGoBack: false, canGoForward: false }),
         onPageStatus: vi.fn().mockReturnValue(() => {}),
         cancelCapture: vi.fn().mockResolvedValue(undefined),
-        adoptWebview: vi.fn().mockResolvedValue({ ok: true }),
-        releaseWebview: vi.fn().mockResolvedValue(undefined),
+        surface: {
+          prepare: vi.fn().mockResolvedValue({ ok: true }),
+          adopt: vi.fn().mockResolvedValue({ ok: true }),
+          release: vi.fn().mockResolvedValue({ ok: true }),
+          navigate: vi.fn().mockResolvedValue({ ok: true }),
+        },
         design: {
           setAnnotationGuard: vi.fn().mockResolvedValue({ ok: true }),
         },
@@ -915,22 +919,23 @@ describe("PreviewPanel: full panel state", () => {
 
     try {
       render(<PreviewPanel threadId="thread-1" />);
-      const webview = await screen.findByTestId("preview-webview");
-      fireEvent(webview, new Event("did-start-loading"));
+      await screen.findByTestId("preview-webview");
+      const hostedWebview = screen.getByTestId("electron-browser-surface-webview");
+      fireEvent(hostedWebview, new Event("did-start-loading"));
       expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(
-        "https://example.com",
+        "https://example.com/",
       );
 
       const titleEvent = new Event("page-title-updated") as Event & { title?: string };
       Object.defineProperty(titleEvent, "title", { value: "Example" });
-      fireEvent(webview, titleEvent);
+      fireEvent(hostedWebview, titleEvent);
       expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe(
-        "https://example.com",
+        "https://example.com/",
       );
 
       const blankEvent = new Event("did-navigate") as Event & { url?: string };
       Object.defineProperty(blankEvent, "url", { value: "about:blank" });
-      fireEvent(webview, blankEvent);
+      fireEvent(hostedWebview, blankEvent);
       await waitFor(() => {
         expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe("");
       });
@@ -1016,7 +1021,7 @@ describe("PreviewPanel: full panel state", () => {
     ]);
   });
 
-  it("persists favicon updates from inactive warm webview pages", () => {
+  it("persists favicon updates from inactive warm webview pages", async () => {
     const tabSet = {
       threadId: "thread-1",
       activeTabId: "tab-a",
@@ -1052,7 +1057,7 @@ describe("PreviewPanel: full panel state", () => {
     render(<PreviewPanel threadId="thread-1" />);
 
     const inactiveWebview = screen
-      .getAllByTestId("preview-webview")
+      .getAllByTestId("electron-browser-surface-webview")
       .find((node) => node.getAttribute("data-tab-id") === "tab-b")!;
     fireEvent(
       inactiveWebview,
@@ -1061,10 +1066,12 @@ describe("PreviewPanel: full panel state", () => {
       }),
     );
 
-    const updatedTabSet = usePreviewTabsStore.getState().tabSetByScope["thread-1"]!;
-    expect(updatedTabSet.tabs.find((tab) => tab.id === "tab-b")?.faviconUrl).toBe(
-      "https://b.example/favicon.ico",
-    );
+    await waitFor(() => {
+      const updatedTabSet = usePreviewTabsStore.getState().tabSetByScope["thread-1"]!;
+      expect(updatedTabSet.tabs.find((tab) => tab.id === "tab-b")?.faviconUrl).toBe(
+        "https://b.example/favicon.ico",
+      );
+    });
   });
 
   it("does not loop when equivalent active webview tab data is republished", () => {
@@ -1193,6 +1200,10 @@ describe("PreviewPanel: full panel state", () => {
       expect(webview).toHaveAttribute("src", "https://google.com/");
 
       liveUrl = "https://about.google/";
+      fireEvent(
+        screen.getByTestId("electron-browser-surface-webview"),
+        Object.assign(new Event("did-navigate"), { url: liveUrl }),
+      );
       mockUsePreviewBridge.mockReturnValue(
         mockBridgeState({ storedUrl: "https://about.google/" }),
       );
@@ -1208,7 +1219,7 @@ describe("PreviewPanel: full panel state", () => {
     }
   });
 
-  it("keeps one webview mounted while its viewport coordinator registers", async () => {
+  it("keeps one hosted placement mounted while its viewport coordinator registers", async () => {
     const threadId = "thread-adoption-stability";
     const tabId = "tab-adoption-stability";
     mockUsePreviewTabs.mockReturnValue({
@@ -1234,29 +1245,20 @@ describe("PreviewPanel: full panel state", () => {
     mockUsePreviewBridge.mockReturnValue(
       mockBridgeState({ storedUrl: "https://example.com" }),
     );
-    let nextWebContentsId = 70;
-    const restoreWebviewMethods = installMockWebviewMethods({
-      getURL: () => "https://example.com",
-      getWebContentsId: () => ++nextWebContentsId,
+    const prepare = vi.mocked(window.desktopBridge!.preview!.surface.prepare);
+    const release = vi.mocked(window.desktopBridge!.preview!.surface.release);
+
+    render(<PreviewPanel threadId={threadId} workspaceId="workspace-1" />);
+    const initialPlacement = screen.getByTestId("preview-webview");
+
+    await waitFor(() => expect(prepare).toHaveBeenCalled());
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
     });
-    const adoptWebview = vi.mocked(window.desktopBridge!.preview!.adoptWebview!);
-    const releaseWebview = vi.mocked(window.desktopBridge!.preview!.releaseWebview!);
 
-    try {
-      render(<PreviewPanel threadId={threadId} workspaceId="workspace-1" />);
-      const initialWebview = screen.getByTestId("preview-webview");
-
-      await waitFor(() => expect(adoptWebview).toHaveBeenCalled());
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      });
-
-      expect(adoptWebview).toHaveBeenCalledTimes(1);
-      expect(releaseWebview).not.toHaveBeenCalled();
-      expect(screen.getByTestId("preview-webview")).toBe(initialWebview);
-    } finally {
-      restoreWebviewMethods();
-    }
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+    expect(screen.getByTestId("preview-webview")).toBe(initialPlacement);
   });
 
   it("does not feed an agent navigation redirect back into the webview src", async () => {
@@ -1303,6 +1305,10 @@ describe("PreviewPanel: full panel state", () => {
       expect(webview).toHaveAttribute("src", requestedUrl);
 
       liveUrl = redirectedUrl;
+      fireEvent(
+        screen.getByTestId("electron-browser-surface-webview"),
+        Object.assign(new Event("did-navigate"), { url: liveUrl }),
+      );
       mockUsePreviewBridge.mockReturnValue(
         mockBridgeState({ storedUrl: redirectedUrl }),
       );
@@ -1339,10 +1345,9 @@ describe("PreviewPanel: full panel state", () => {
     );
 
     const loadURL = vi.fn().mockResolvedValue(undefined);
-    const reload = vi.fn();
+    const navigateSurface = vi.mocked(window.desktopBridge!.preview!.surface.navigate);
     const restoreWebviewMethods = installMockWebviewMethods({
       loadURL,
-      reload,
       getURL: () => "https://google.com/",
     });
 
@@ -1357,9 +1362,10 @@ describe("PreviewPanel: full panel state", () => {
       await waitFor(() => {
         expect(resolveNavigation).toHaveBeenCalledWith("https://google.com/");
       });
-      fireEvent(screen.getByTestId("preview-webview"), new Event("dom-ready"));
       await waitFor(() => {
-        expect(reload).toHaveBeenCalledTimes(1);
+        expect(navigateSurface).toHaveBeenCalledWith(expect.objectContaining({
+          navigation: { kind: "reload" },
+        }));
       });
       expect(loadURL).not.toHaveBeenCalled();
     } finally {

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -139,6 +139,30 @@ describe("PreviewWebview", () => {
     }
   });
 
+  it("advances the Electron surface generation when the same target remounts", () => {
+    const prepare = vi.fn().mockResolvedValue({ ok: true });
+    window.desktopBridge = { preview: { surface: {
+      prepare,
+      adopt: vi.fn().mockResolvedValue({ ok: true }),
+      navigate: vi.fn().mockResolvedValue({ ok: true }),
+      release: vi.fn().mockResolvedValue({ ok: true }),
+    } } } as unknown as NonNullable<typeof window.desktopBridge>;
+    const props = {
+      workspaceId: "workspace-remount",
+      threadId: "thread-remount",
+      tabId: "tab-remount",
+      src: "about:blank",
+    };
+
+    const first = render(<PreviewWebview {...props} />);
+    const firstGeneration = prepare.mock.calls[0]?.[0].surface.generation as number;
+    first.unmount();
+    render(<PreviewWebview {...props} />);
+    const secondGeneration = prepare.mock.calls[1]?.[0].surface.generation as number;
+
+    expect(secondGeneration).toBeGreaterThan(firstGeneration);
+  });
+
   it("keeps native event subscriptions stable when parent callbacks change", async () => {
     window.desktopBridge = { preview: {} } as unknown as NonNullable<typeof window.desktopBridge>;
     const addEventListener = vi.spyOn(HTMLElement.prototype, "addEventListener");

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -1,7 +1,6 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { useEffect, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Mock } from "vitest";
 
 import {
   browserAutomationTargetKey,
@@ -12,48 +11,26 @@ import {
 import { PreviewWebview, type PreviewWebviewHandle } from "../PreviewWebview";
 
 describe("PreviewWebview", () => {
-  let canGoBack: Mock<() => boolean>;
-  let canGoForward: Mock<() => boolean>;
-  let domReady = false;
-  const prototype = HTMLElement.prototype as HTMLElement & {
-    canGoBack?: () => boolean;
-    canGoForward?: () => boolean;
-  };
-  const originalCanGoBack = prototype.canGoBack;
-  const originalCanGoForward = prototype.canGoForward;
-
   beforeEach(() => {
-    domReady = false;
-    canGoBack = vi.fn(() => {
-      if (!domReady) {
-        throw new Error(
-          "The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.",
-        );
-      }
-      return true;
-    });
-    canGoForward = vi.fn(() => {
-      if (!domReady) {
-        throw new Error(
-          "The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.",
-        );
-      }
-      return false;
-    });
-    prototype.canGoBack = canGoBack;
-    prototype.canGoForward = canGoForward;
+    document.querySelectorAll("[data-testid='electron-browser-surface-webview'], [data-testid='web-runtime-preview-iframe']")
+      .forEach((element) => element.remove());
   });
 
   afterEach(() => {
-    prototype.canGoBack = originalCanGoBack;
-    prototype.canGoForward = originalCanGoForward;
     delete window.desktopBridge;
   });
 
   it("invalidates exact tab observations only for the trusted guest input channel", () => {
     const invalidate = vi.fn();
     window.desktopBridge = {
-      preview: {},
+      preview: {
+        surface: {
+          prepare: vi.fn().mockResolvedValue({ ok: true }),
+          adopt: vi.fn().mockResolvedValue({ ok: true }),
+          navigate: vi.fn().mockResolvedValue({ ok: true }),
+          release: vi.fn().mockResolvedValue({ ok: true }),
+        },
+      },
     } as unknown as NonNullable<typeof window.desktopBridge>;
     const unsubscribe = onBrowserAutomationObservationInvalidation(invalidate);
     render(
@@ -64,7 +41,7 @@ describe("PreviewWebview", () => {
         src="https://example.com"
       />,
     );
-    const webview = screen.getByTestId("preview-webview");
+    const webview = screen.getByTestId("electron-browser-surface-webview");
     webview.dispatchEvent(Object.assign(new Event("ipc-message"), {
       channel: "mcode:browser-human-input",
       args: [{ kind: "pointer" }],
@@ -86,16 +63,21 @@ describe("PreviewWebview", () => {
     expect(invalidate).toHaveBeenCalledWith("thread-1", "tab-1");
   });
 
-  it("does not call Electron navigation methods before dom-ready", async () => {
+  it("routes history through the exact generation-bound main bridge", async () => {
     const observed: { handle: PreviewWebviewHandle | null } = { handle: null };
-    window.desktopBridge = { preview: {} } as unknown as NonNullable<typeof window.desktopBridge>;
+    const navigate = vi.fn().mockResolvedValue({ ok: true });
+    window.desktopBridge = { preview: { surface: {
+      prepare: vi.fn().mockResolvedValue({ ok: true }),
+      adopt: vi.fn().mockResolvedValue({ ok: true }),
+      navigate,
+      release: vi.fn().mockResolvedValue({ ok: true }),
+    } } } as unknown as NonNullable<typeof window.desktopBridge>;
 
     function Probe() {
       const ref = useRef<PreviewWebviewHandle>(null);
       useEffect(() => {
         observed.handle = ref.current;
-        ref.current?.canGoBack();
-        ref.current?.canGoForward();
+        ref.current?.goBack();
       }, []);
       return (
         <PreviewWebview
@@ -110,35 +92,26 @@ describe("PreviewWebview", () => {
     render(<Probe />);
 
     await waitFor(() => expect(observed.handle).not.toBeNull());
-    expect(observed.handle?.canGoBack()).toBe(false);
-    expect(observed.handle?.canGoForward()).toBe(false);
-    expect(canGoBack).not.toHaveBeenCalled();
-    expect(canGoForward).not.toHaveBeenCalled();
-
-    domReady = true;
-    screen.getByTestId("preview-webview").dispatchEvent(new Event("dom-ready"));
-
-    expect(observed.handle?.canGoBack()).toBe(true);
-    expect(observed.handle?.canGoForward()).toBe(false);
-    expect(canGoBack).toHaveBeenCalled();
-    expect(canGoForward).toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith({
+      surface: {
+        identity: {
+          workspaceId: "thread-1",
+          scope: { kind: "thread", id: "thread-1" },
+          tabId: "tab-1",
+        },
+        generation: expect.any(Number),
+      },
+      navigation: { kind: "back" },
+    });
   });
 
-  it("advances the viewport coordinator when dom-ready refreshes the target", async () => {
-    const getWebContentsId = vi.fn(() => 42);
-    const originalGetWebContentsId = (
-      HTMLElement.prototype as HTMLElement & { getWebContentsId?: () => number }
-    ).getWebContentsId;
-    (
-      HTMLElement.prototype as HTMLElement & { getWebContentsId?: () => number }
-    ).getWebContentsId = getWebContentsId;
-    window.desktopBridge = {
-      preview: {
-        adoptWebview: vi.fn().mockResolvedValue({ ok: true }),
-        releaseWebview: vi.fn().mockResolvedValue(undefined),
-        design: {},
-      },
-    } as unknown as NonNullable<typeof window.desktopBridge>;
+  it("binds the viewport coordinator to the hosted target generation", async () => {
+    window.desktopBridge = { preview: { surface: {
+      prepare: vi.fn().mockResolvedValue({ ok: true }),
+      adopt: vi.fn().mockResolvedValue({ ok: true }),
+      navigate: vi.fn().mockResolvedValue({ ok: true }),
+      release: vi.fn().mockResolvedValue({ ok: true }),
+    }, design: {} } } as unknown as NonNullable<typeof window.desktopBridge>;
 
     try {
       render(
@@ -154,24 +127,19 @@ describe("PreviewWebview", () => {
         expect(useBrowserAutomationStore.getState().viewportCoordinators.get(key)).toBeDefined();
       });
 
-      fireEvent(screen.getByTestId("preview-webview"), new Event("dom-ready"));
-
       await waitFor(() => {
         const store = useBrowserAutomationStore.getState();
         expect(store.viewportCoordinators.get(key)?.snapshot().targetGeneration).toBe(
           store.liveTargets.get(key)?.revision,
         );
-        expect(store.liveTargets.get(key)?.revision).toBe(2);
+        expect(store.liveTargets.get(key)?.revision).toBe(1);
       });
     } finally {
       releaseBrowserAutomationThreadScope("thread-generation");
-      (
-        HTMLElement.prototype as HTMLElement & { getWebContentsId?: () => number }
-      ).getWebContentsId = originalGetWebContentsId;
     }
   });
 
-  it("keeps native event subscriptions stable when parent callbacks change", () => {
+  it("keeps native event subscriptions stable when parent callbacks change", async () => {
     window.desktopBridge = { preview: {} } as unknown as NonNullable<typeof window.desktopBridge>;
     const addEventListener = vi.spyOn(HTMLElement.prototype, "addEventListener");
     const firstStatus = vi.fn();
@@ -196,13 +164,14 @@ describe("PreviewWebview", () => {
         onPageStatus={secondStatus}
       />,
     );
-    screen.getByTestId("preview-webview").dispatchEvent(new Event("did-stop-loading"));
+    firstStatus.mockClear();
+    screen.getByTestId("web-runtime-preview-iframe").dispatchEvent(new Event("load"));
 
     expect(addEventListener.mock.calls.filter(
       ([eventName]) => eventName === "did-stop-loading",
     )).toHaveLength(initialStopSubscriptions);
     expect(firstStatus).not.toHaveBeenCalled();
-    expect(secondStatus).toHaveBeenCalledOnce();
+    await waitFor(() => expect(secondStatus).toHaveBeenCalled());
   });
 
   it("applies an exact renderer-owned design viewport to the visible webview", () => {

--- a/apps/web/src/components/panels/hooks/usePreviewTabs.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewTabs.ts
@@ -18,8 +18,8 @@ import {
  *
  * A no-op in non-desktop builds (the bridge is absent, so `tabSet` stays null).
  */
-export function usePreviewTabs(scopeId: string) {
-  const tabSet = usePreviewTabSet(scopeId);
+export function usePreviewTabs(scopeId: string, workspaceId?: string | null) {
+  const tabSet = usePreviewTabSet(scopeId, workspaceId);
   const newTab = useCallback(
     () => usePreviewTabsStore.getState().openPage(scopeId),
     [scopeId],
@@ -38,7 +38,10 @@ export function usePreviewTabs(scopeId: string) {
 }
 
 /** Keeps Electron Browser tab membership synchronized for an optional panel scope. */
-export function usePreviewTabSet(scopeId: string | null): BrowserTabSet | null {
+export function usePreviewTabSet(
+  scopeId: string | null,
+  workspaceId?: string | null,
+): BrowserTabSet | null {
   const tabSet = usePreviewDisplayTabSet(scopeId);
   const bridge = window.desktopBridge?.preview?.tabs;
 
@@ -46,7 +49,7 @@ export function usePreviewTabSet(scopeId: string | null): BrowserTabSet | null {
     if (!bridge || !scopeId) return;
     let cancelled = false;
     const { setTabSet } = usePreviewTabsStore.getState();
-    void bridge.list(scopeId).then((r) => {
+    void bridge.list(scopeId, workspaceId ?? undefined).then((r) => {
       if (cancelled) return;
       if (r.ok) setTabSet(scopeId, r.data);
     });
@@ -58,6 +61,6 @@ export function usePreviewTabSet(scopeId: string | null): BrowserTabSet | null {
       cancelled = true;
       off();
     };
-  }, [bridge, scopeId]);
+  }, [bridge, scopeId, workspaceId]);
   return tabSet;
 }

--- a/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
+++ b/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
@@ -120,6 +120,7 @@ export interface BrowserSurfaceVisibility {
 /** Host dependencies. Both the adapter and publication scheduler are injected. */
 export interface BrowserSurfaceHostOptions {
   readonly adapterFactory: BrowserSurfaceAdapterFactory;
+  readonly normalizeAddress?: (address: string) => string;
   readonly scheduling?: BrowserSurfaceScheduling;
   readonly visibility?: BrowserSurfaceVisibility;
 }
@@ -238,6 +239,7 @@ export class BrowserSurfaceHost {
   private readonly records = new Map<string, SurfaceRecord>();
   private readonly scheduling: BrowserSurfaceScheduling;
   private readonly visibility: BrowserSurfaceVisibility;
+  private readonly normalizeAddress: (address: string) => string;
   private readonly stopVisibility: () => void;
   private nextGeneration = 1;
 
@@ -245,6 +247,7 @@ export class BrowserSurfaceHost {
   public constructor(options: BrowserSurfaceHostOptions) {
     this.scheduling = options.scheduling ?? defaultScheduling();
     this.visibility = options.visibility ?? defaultVisibility();
+    this.normalizeAddress = options.normalizeAddress ?? normalizeBrowserSurfaceAddress;
     this.stopVisibility = this.visibility.subscribe((hidden) => {
       if (hidden ?? this.visibility.isHidden()) return;
       this.publishVisibleRecords();
@@ -263,7 +266,7 @@ export class BrowserSurfaceHost {
     const prior = this.records.get(key);
     const address = options.address === undefined
       ? undefined
-      : normalizeBrowserSurfaceAddress(options.address);
+      : this.normalizeAddress(options.address);
     const generation = options.generation ?? (prior ? prior.generation + 1 : this.nextGeneration++);
     if (prior && options.generation !== undefined && generation <= prior.generation) return prior.state;
     if (generation >= this.nextGeneration) this.nextGeneration = generation + 1;
@@ -311,7 +314,7 @@ export class BrowserSurfaceHost {
   public navigate(identity: BrowserSurfaceIdentity, address: string): void {
     const record = this.records.get(surfaceKey(identity));
     if (!record || !sameIdentity(record.identity, identity)) return;
-    const normalized = normalizeBrowserSurfaceAddress(address);
+    const normalized = this.normalizeAddress(address);
     this.reduce(record, { type: "navigation-started", identity, generation: record.generation, mainFrame: true, address: normalized });
     void record.adapter.navigate(normalized);
   }

--- a/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
+++ b/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
@@ -47,6 +47,8 @@ type WebviewEvent = Event & {
 
 const PREVIEW_GUEST_HUMAN_INPUT_CHANNEL = "mcode:browser-human-input";
 const HUMAN_INPUT_KINDS = new Set(["keyboard", "pointer", "touch", "wheel"]);
+const ADOPTION_DISCOVERY_ATTEMPTS = 40;
+const ADOPTION_DISCOVERY_RETRY_MS = 50;
 
 /** Validates an absolute address that Electron main will authorize again before loading. */
 export function normalizeElectronWebviewSurfaceAddress(address: string): string {
@@ -258,10 +260,18 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
       this.resolveAdoptionWaiters(false);
       return false;
     }
-    const result = await Promise.resolve(this.bridge.adopt({
-      surface: this.surface,
-      adoptionToken: this.adoptionToken,
-    })).catch(() => ({ ok: false as const, error: "Surface adoption failed" }));
+    let result: PreviewSurfaceBridgeResult = {
+      ok: false,
+      error: "Surface adoption failed",
+    };
+    for (let attempt = 0; attempt < ADOPTION_DISCOVERY_ATTEMPTS; attempt += 1) {
+      result = await Promise.resolve(this.bridge.adopt({
+        surface: this.surface,
+        adoptionToken: this.adoptionToken,
+      })).catch(() => ({ ok: false as const, error: "Surface adoption failed" }));
+      if (result.ok || result.error !== "guest-not-found" || this.disposed) break;
+      await new Promise((resolve) => window.setTimeout(resolve, ADOPTION_DISCOVERY_RETRY_MS));
+    }
     if (!asResult(result) || this.disposed) {
       this.resolveAdoptionWaiters(false);
       return false;

--- a/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
+++ b/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
@@ -13,7 +13,6 @@ import type {
   BrowserSurfaceIdentity,
   BrowserSurfacePresentation,
 } from "./BrowserSurfaceHost";
-import { normalizeBrowserSurfaceAddress } from "./browserSurfaceAddress";
 
 const MAX_ADDRESS = BROWSER_TAB_INFO_STRING_MAX.url;
 const MAX_TITLE = BROWSER_TAB_INFO_STRING_MAX.title;
@@ -48,6 +47,21 @@ type WebviewEvent = Event & {
 
 const PREVIEW_GUEST_HUMAN_INPUT_CHANNEL = "mcode:browser-human-input";
 const HUMAN_INPUT_KINDS = new Set(["keyboard", "pointer", "touch", "wheel"]);
+
+/** Validates an absolute address that Electron main will authorize again before loading. */
+export function normalizeElectronWebviewSurfaceAddress(address: string): string {
+  if (address.length > MAX_ADDRESS) throw new TypeError("Browser surface address exceeds the maximum length");
+  let parsed: URL;
+  try {
+    parsed = new URL(address);
+  } catch {
+    throw new TypeError("Browser surface address must be an absolute URL");
+  }
+  if (!["http:", "https:", "file:"].includes(parsed.protocol) || parsed.username || parsed.password) {
+    throw new TypeError("Electron Browser surface address must use HTTP(S) or file without credentials");
+  }
+  return parsed.href;
+}
 
 function opaqueToken(): string {
   const cryptoRef = globalThis.crypto;
@@ -187,7 +201,7 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
   /** Requests main-process navigation after trusted adoption. */
   public async navigate(address: string): Promise<void> {
     if (this.disposed) return;
-    const normalized = normalizeBrowserSurfaceAddress(address);
+    const normalized = normalizeElectronWebviewSurfaceAddress(address);
     this.emit({ type: "navigation-started", mainFrame: true, address: normalized });
     if (!this.adopted) {
       this.pendingAddress = normalized;

--- a/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
+++ b/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
@@ -1,0 +1,359 @@
+import { BROWSER_TAB_INFO_STRING_MAX } from "@mcode/contracts";
+import type {
+  PreviewSurfaceBridge,
+  PreviewSurfaceBridgeResult,
+  PreviewSurfaceNavigation,
+  PreviewSurfaceRef,
+} from "@/transport/desktop-bridge";
+import type {
+  BrowserSurfaceAdapter,
+  BrowserSurfaceAdapterEvent,
+  BrowserSurfaceAdapterEventPayload,
+  BrowserSurfaceAdapterFactory,
+  BrowserSurfaceIdentity,
+  BrowserSurfacePresentation,
+} from "./BrowserSurfaceHost";
+import { normalizeBrowserSurfaceAddress } from "./browserSurfaceAddress";
+
+const MAX_ADDRESS = BROWSER_TAB_INFO_STRING_MAX.url;
+const MAX_TITLE = BROWSER_TAB_INFO_STRING_MAX.title;
+const MAX_FAVICON = BROWSER_TAB_INFO_STRING_MAX.faviconUrl;
+const INERT_URL_PREFIX = "about:blank#";
+
+/** Options for the renderer-owned Electron webview Browser surface adapter. */
+export interface ElectronWebviewBrowserSurfaceAdapterOptions {
+  readonly root?: HTMLElement | null;
+  readonly document?: Document;
+  readonly bridge?: PreviewSurfaceBridge;
+  readonly title?: string;
+  readonly onHumanInput?: (identity: BrowserSurfaceIdentity, generation: number) => void;
+}
+
+interface ElectronWebviewElement extends HTMLElement {
+  src: string;
+  referrerPolicy: string;
+}
+
+type WebviewEvent = Event & {
+  readonly isMainFrame?: boolean;
+  readonly url?: unknown;
+  readonly validatedURL?: unknown;
+  readonly title?: unknown;
+  readonly favicons?: unknown;
+  readonly errorCode?: unknown;
+  readonly errorDescription?: unknown;
+  readonly channel?: unknown;
+  readonly args?: readonly unknown[];
+};
+
+const PREVIEW_GUEST_HUMAN_INPUT_CHANNEL = "mcode:browser-human-input";
+const HUMAN_INPUT_KINDS = new Set(["keyboard", "pointer", "touch", "wheel"]);
+
+function opaqueToken(): string {
+  const cryptoRef = globalThis.crypto;
+  if (typeof cryptoRef?.randomUUID === "function") return cryptoRef.randomUUID();
+  if (typeof cryptoRef?.getRandomValues !== "function") {
+    throw new Error("Secure randomness is required for Browser surface adoption");
+  }
+  const bytes = cryptoRef.getRandomValues(new Uint8Array(16));
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function surfaceRef(identity: BrowserSurfaceIdentity, generation: number): PreviewSurfaceRef {
+  return { identity, generation };
+}
+
+function bounded(value: unknown, max: number): string | null {
+  return typeof value === "string" && value.length > 0 ? value.slice(0, max) : null;
+}
+
+function eventAddress(event: WebviewEvent): string | null {
+  return bounded(event.url, MAX_ADDRESS) ?? bounded(event.validatedURL, MAX_ADDRESS);
+}
+
+function mainFrame(event: WebviewEvent): boolean {
+  return event.isMainFrame !== false;
+}
+
+function bridgeFromWindow(): PreviewSurfaceBridge | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.desktopBridge?.preview?.surface;
+}
+
+function asResult(result: PreviewSurfaceBridgeResult | undefined): boolean {
+  return result?.ok === true;
+}
+
+/** Adapter that owns one Electron `<webview>` and emits generation-bound semantic events. */
+export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapter {
+  private readonly listeners = new Set<(event: BrowserSurfaceAdapterEvent) => void>();
+  private readonly documentRef: Document;
+  private readonly bridge: PreviewSurfaceBridge;
+  private readonly surface: PreviewSurfaceRef;
+  private readonly adoptionToken: string;
+  private readonly preparePromise: Promise<boolean>;
+  private adoptionPromise: Promise<boolean> | null = null;
+  private readonly adoptionWaiters = new Set<(adopted: boolean) => void>();
+  private pendingAddress: string | null = null;
+  private adopted = false;
+  private disposed = false;
+  private readonly frame: ElectronWebviewElement;
+  private readonly onHumanInput?: ElectronWebviewBrowserSurfaceAdapterOptions["onHumanInput"];
+
+  /** Creates and mounts a blank Electron webview for one identity and generation. */
+  public constructor(
+    private readonly identity: BrowserSurfaceIdentity,
+    private readonly generation: number,
+    options: ElectronWebviewBrowserSurfaceAdapterOptions = {},
+  ) {
+    this.documentRef = options.document ?? document;
+    this.bridge = options.bridge ?? bridgeFromWindow() ?? (() => {
+      throw new Error("Electron Browser surface bridge is unavailable");
+    })();
+    this.onHumanInput = options.onHumanInput;
+    this.surface = surfaceRef(identity, generation);
+    this.adoptionToken = opaqueToken();
+    this.frame = this.documentRef.createElement("webview") as ElectronWebviewElement;
+    this.frame.src = `${INERT_URL_PREFIX}${this.adoptionToken}`;
+    this.frame.setAttribute("src", this.frame.src);
+    this.frame.title = options.title ?? "Browser surface";
+    this.frame.setAttribute("partition", "persist:mcode-preview");
+    this.frame.setAttribute("aria-hidden", "true");
+    this.frame.dataset.testid = "electron-browser-surface-webview";
+    this.frame.dataset.workspaceId = identity.workspaceId;
+    this.frame.dataset.scopeKind = identity.scope.kind;
+    this.frame.dataset.scopeId = identity.scope.id;
+    this.frame.dataset.tabId = identity.tabId;
+    this.frame.dataset.generation = String(generation);
+    this.frame.referrerPolicy = "no-referrer";
+    this.frame.style.position = "fixed";
+    this.frame.style.left = "-20000px";
+    this.frame.style.top = "0";
+    this.frame.style.width = "1px";
+    this.frame.style.height = "1px";
+    this.frame.style.border = "0";
+    this.frame.style.visibility = "hidden";
+    this.frame.style.pointerEvents = "none";
+    this.frame.addEventListener("did-attach", this.onDidAttach);
+    this.frame.addEventListener("did-start-loading", this.onLoadStarted);
+    this.frame.addEventListener("did-stop-loading", this.onLoadStopped);
+    this.frame.addEventListener("did-navigate", this.onNavigated);
+    this.frame.addEventListener("did-navigate-in-page", this.onNavigated);
+    this.frame.addEventListener("did-fail-load", this.onLoadFailed);
+    this.frame.addEventListener("page-title-updated", this.onTitleUpdated);
+    this.frame.addEventListener("page-favicon-updated", this.onFaviconUpdated);
+    this.frame.addEventListener("dom-ready", this.onDomReady);
+    this.frame.addEventListener("ipc-message", this.onIpcMessage);
+    this.preparePromise = Promise.resolve(this.bridge.prepare({
+      surface: this.surface,
+      adoptionToken: this.adoptionToken,
+    })).then(asResult, () => false);
+    (options.root ?? this.documentRef.body)?.appendChild(this.frame);
+  }
+
+  /** Returns the owned webview for host placement and lifecycle integration. */
+  public get element(): ElectronWebviewElement {
+    return this.frame;
+  }
+
+  /** Materializes this adapter; construction already owns and attaches its webview. */
+  public create(): void {
+    if (this.disposed) return;
+  }
+
+  /** Presents the webview at bounded host coordinates. */
+  public present(presentation: BrowserSurfacePresentation = { left: 0, top: 0, width: 1, height: 1 }): void {
+    if (this.disposed) return;
+    this.frame.style.left = `${presentation.left}px`;
+    this.frame.style.top = `${presentation.top}px`;
+    this.frame.style.width = `${presentation.width}px`;
+    this.frame.style.height = `${presentation.height}px`;
+    this.frame.style.transformOrigin = "top left";
+    this.frame.style.transform = presentation.scale === undefined ? "" : `scale(${presentation.scale})`;
+    this.frame.style.zIndex = presentation.zIndex === undefined ? "" : String(presentation.zIndex);
+    this.frame.style.visibility = "visible";
+    this.frame.style.pointerEvents = "auto";
+    this.frame.setAttribute("aria-hidden", "false");
+  }
+
+  /** Hides the webview without changing its guest document. */
+  public hide(): void {
+    if (this.disposed) return;
+    this.frame.style.visibility = "hidden";
+    this.frame.style.pointerEvents = "none";
+    this.frame.setAttribute("aria-hidden", "true");
+  }
+
+  /** Requests main-process navigation after trusted adoption. */
+  public async navigate(address: string): Promise<void> {
+    if (this.disposed) return;
+    const normalized = normalizeBrowserSurfaceAddress(address);
+    this.emit({ type: "navigation-started", mainFrame: true, address: normalized });
+    if (!this.adopted) {
+      this.pendingAddress = normalized;
+      await this.waitForAdoption();
+      return;
+    }
+    await this.sendNavigation(normalized);
+  }
+
+  /** Subscribes to semantic adapter events. */
+  public subscribe(listener: (event: BrowserSurfaceAdapterEvent) => void): () => void {
+    if (this.disposed) return () => undefined;
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Removes native listeners, releases the exact surface generation, and detaches the webview. */
+  public dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.resolveAdoptionWaiters(false);
+    this.frame.removeEventListener("did-attach", this.onDidAttach);
+    this.frame.removeEventListener("did-start-loading", this.onLoadStarted);
+    this.frame.removeEventListener("did-stop-loading", this.onLoadStopped);
+    this.frame.removeEventListener("did-navigate", this.onNavigated);
+    this.frame.removeEventListener("did-navigate-in-page", this.onNavigated);
+    this.frame.removeEventListener("did-fail-load", this.onLoadFailed);
+    this.frame.removeEventListener("page-title-updated", this.onTitleUpdated);
+    this.frame.removeEventListener("page-favicon-updated", this.onFaviconUpdated);
+    this.frame.removeEventListener("dom-ready", this.onDomReady);
+    this.frame.removeEventListener("ipc-message", this.onIpcMessage);
+    this.listeners.clear();
+    void Promise.resolve(this.bridge.release({ surface: this.surface })).catch(() => undefined);
+    this.frame.remove();
+  }
+
+  private waitForAdoption(): Promise<boolean> {
+    if (this.adopted) return Promise.resolve(true);
+    return new Promise((resolve) => this.adoptionWaiters.add(resolve));
+  }
+
+  private resolveAdoptionWaiters(adopted: boolean): void {
+    for (const resolve of this.adoptionWaiters) resolve(adopted);
+    this.adoptionWaiters.clear();
+  }
+
+  private readonly onDidAttach = (): void => {
+    if (this.disposed || this.adoptionPromise) return;
+    this.adoptionPromise = this.adoptAfterPreparation();
+  };
+
+  private async adoptAfterPreparation(): Promise<boolean> {
+    if (!(await this.preparePromise) || this.disposed) {
+      this.resolveAdoptionWaiters(false);
+      return false;
+    }
+    const result = await Promise.resolve(this.bridge.adopt({
+      surface: this.surface,
+      adoptionToken: this.adoptionToken,
+    })).catch(() => ({ ok: false as const, error: "Surface adoption failed" }));
+    if (!asResult(result) || this.disposed) {
+      this.resolveAdoptionWaiters(false);
+      return false;
+    }
+    this.adopted = true;
+    const pendingAddress = this.pendingAddress;
+    this.pendingAddress = null;
+    if (pendingAddress) await this.sendNavigation(pendingAddress);
+    this.resolveAdoptionWaiters(true);
+    return true;
+  }
+
+  private async sendNavigation(address: string): Promise<void> {
+    const navigation: PreviewSurfaceNavigation = { kind: "address", address };
+    const result = await Promise.resolve(this.bridge.navigate({
+      surface: this.surface,
+      navigation,
+    })).catch(() => ({ ok: false as const, error: "Navigation failed" }));
+    if (!asResult(result)) {
+      this.emit({
+        type: "load-failed",
+        mainFrame: true,
+        address,
+        error: result.ok ? undefined : result.error,
+      });
+    }
+  }
+
+  private emit(event: BrowserSurfaceAdapterEventPayload): void {
+    if (this.disposed) return;
+    const complete = { ...event, identity: this.identity, generation: this.generation } as BrowserSurfaceAdapterEvent;
+    for (const listener of [...this.listeners]) listener(complete);
+  }
+
+  private readonly onLoadStarted = (event: Event): void => {
+    const typed = event as WebviewEvent;
+    this.emit({ type: "load-started", mainFrame: mainFrame(typed), address: eventAddress(typed) ?? undefined });
+  };
+
+  private readonly onLoadStopped = (event: Event): void => {
+    const typed = event as WebviewEvent;
+    this.emit({ type: "load-stopped", mainFrame: mainFrame(typed), address: eventAddress(typed) ?? undefined });
+  };
+
+  private readonly onNavigated = (event: Event): void => {
+    const typed = event as WebviewEvent;
+    const address = eventAddress(typed);
+    if (!address) return;
+    this.emit({ type: "navigation-committed", mainFrame: mainFrame(typed), address });
+    if (address.startsWith("about:") || address.startsWith("chrome-error:")) {
+      this.emit({ type: "title-updated", title: null });
+      this.emit({ type: "favicon-updated", favicon: null });
+    }
+  };
+
+  private readonly onLoadFailed = (event: Event): void => {
+    const typed = event as WebviewEvent;
+    const errorCode = typeof typed.errorCode === "string" || typeof typed.errorCode === "number"
+      ? typed.errorCode
+      : undefined;
+    this.emit({
+      type: "load-failed",
+      mainFrame: mainFrame(typed),
+      address: eventAddress(typed) ?? undefined,
+      error: bounded(typed.errorDescription, 500) ?? undefined,
+      ...(errorCode === undefined ? {} : { errorCode }),
+      expected: errorCode === -3 || errorCode === "ERR_ABORTED",
+    });
+  };
+
+  private readonly onTitleUpdated = (event: Event): void => {
+    const title = bounded((event as WebviewEvent).title, MAX_TITLE);
+    this.emit({ type: "title-updated", title });
+  };
+
+  private readonly onFaviconUpdated = (event: Event): void => {
+    const favicons = (event as WebviewEvent).favicons;
+    const favicon = Array.isArray(favicons) ? bounded(favicons[0], MAX_FAVICON) : null;
+    this.emit({ type: "favicon-updated", favicon });
+  };
+
+  private readonly onDomReady = (): void => {
+    this.emit({ type: "document-access", access: "unknown" });
+    this.emit({ type: "navigation-state", navigation: null });
+  };
+
+  private readonly onIpcMessage = (event: Event): void => {
+    const typed = event as WebviewEvent;
+    if (typed.channel !== PREVIEW_GUEST_HUMAN_INPUT_CHANNEL) return;
+    const message = typed.args?.[0];
+    if (!message || typeof message !== "object" || Array.isArray(message)) return;
+    const kind = (message as { readonly kind?: unknown }).kind;
+    if (typeof kind !== "string" || !HUMAN_INPUT_KINDS.has(kind)) return;
+    this.onHumanInput?.(this.identity, this.generation);
+  };
+}
+
+/** Options that create one Electron webview adapter per complete identity and generation. */
+export type ElectronWebviewBrowserSurfaceAdapterFactoryOptions = ElectronWebviewBrowserSurfaceAdapterOptions;
+
+/** Creates an Electron webview adapter factory for a renderer surface root. */
+export function createElectronWebviewBrowserSurfaceAdapterFactory(
+  options: ElectronWebviewBrowserSurfaceAdapterFactoryOptions = {},
+): BrowserSurfaceAdapterFactory {
+  return (identity, generation) => new ElectronWebviewBrowserSurfaceAdapter(identity, generation, options);
+}
+
+/** Alias for integrations that use the shorter Electron surface adapter name. */
+export const createElectronWebviewSurfaceAdapterFactory = createElectronWebviewBrowserSurfaceAdapterFactory;

--- a/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createElectronWebviewBrowserSurfaceAdapterFactory,
+  ElectronWebviewBrowserSurfaceAdapter,
+} from "../ElectronWebviewBrowserSurfaceAdapter";
+import type {
+  BrowserSurfaceIdentity,
+  BrowserSurfaceAdapterEvent,
+} from "../BrowserSurfaceHost";
+import type { PreviewSurfaceBridge } from "@/transport/desktop-bridge";
+import { runBrowserSurfaceContract } from "./browserSurfaceContract";
+
+const IDENTITY: BrowserSurfaceIdentity = {
+  workspaceId: "workspace-electron",
+  scope: { kind: "thread", id: "thread-electron" },
+  tabId: "tab-electron",
+};
+
+function bridge(): PreviewSurfaceBridge & {
+  prepare: ReturnType<typeof vi.fn>;
+  adopt: ReturnType<typeof vi.fn>;
+  navigate: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+} {
+  return {
+    prepare: vi.fn().mockResolvedValue({ ok: true }),
+    adopt: vi.fn().mockResolvedValue({ ok: true }),
+    navigate: vi.fn().mockResolvedValue({ ok: true }),
+    release: vi.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+runBrowserSurfaceContract(
+  "Electron webview BrowserSurfaceHost contract",
+  createElectronWebviewBrowserSurfaceAdapterFactory({ root: document.body, bridge: bridge() }),
+);
+
+describe("ElectronWebviewBrowserSurfaceAdapter", () => {
+  it("starts inert, adopts with an opaque complete identity, and navigates through the typed bridge", async () => {
+    const surfaceBridge = bridge();
+    const adapter = new ElectronWebviewBrowserSurfaceAdapter(IDENTITY, 7, {
+      root: document.body,
+      bridge: surfaceBridge,
+    });
+    const element = adapter.element;
+    const inertSource = element.getAttribute("src");
+
+    expect(element.tagName).toBe("WEBVIEW");
+    expect(element.getAttribute("src")).toMatch(/^about:blank#[A-Za-z0-9_-]+$/);
+    expect(surfaceBridge.prepare).toHaveBeenCalledWith(expect.objectContaining({
+      surface: { identity: IDENTITY, generation: 7 },
+      adoptionToken: expect.any(String),
+    }));
+    expect(surfaceBridge.prepare.mock.calls[0]?.[0]).not.toHaveProperty("webContentsId");
+
+    const pending = adapter.navigate("https://example.test/next");
+    expect(surfaceBridge.navigate).not.toHaveBeenCalled();
+    element.dispatchEvent(new Event("did-attach"));
+    await pending;
+    await vi.waitFor(() => expect(surfaceBridge.adopt).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(surfaceBridge.navigate).toHaveBeenCalledTimes(1));
+    expect(surfaceBridge.adopt).toHaveBeenCalledWith(expect.objectContaining({
+      surface: { identity: IDENTITY, generation: 7 },
+      adoptionToken: surfaceBridge.prepare.mock.calls[0]?.[0].adoptionToken,
+    }));
+    expect(surfaceBridge.navigate).toHaveBeenCalledWith({
+      surface: { identity: IDENTITY, generation: 7 },
+      navigation: { kind: "address", address: "https://example.test/next" },
+    });
+    expect(surfaceBridge.navigate.mock.calls[0]?.[0]).not.toHaveProperty("webContentsId");
+    expect(element.getAttribute("src")).toBe(inertSource);
+    adapter.dispose();
+  });
+
+  it("emits generation-bound semantic events and owns presentation and disposal", () => {
+    const surfaceBridge = bridge();
+    const adapter = new ElectronWebviewBrowserSurfaceAdapter(IDENTITY, 3, {
+      root: document.body,
+      bridge: surfaceBridge,
+    });
+    const events: BrowserSurfaceAdapterEvent[] = [];
+    adapter.subscribe((event) => events.push(event));
+    adapter.present({ left: 10, top: 20, width: 640, height: 480, scale: 1.25, zIndex: 42 });
+    expect(adapter.element.style.left).toBe("10px");
+    expect(adapter.element.style.width).toBe("640px");
+    expect(adapter.element.style.zIndex).toBe("42");
+    adapter.hide();
+    expect(adapter.element.style.visibility).toBe("hidden");
+
+    adapter.element.dispatchEvent(Object.assign(new Event("did-start-loading"), {
+      url: "https://example.test/loading",
+      isMainFrame: true,
+    }));
+    adapter.element.dispatchEvent(Object.assign(new Event("did-navigate"), {
+      url: "https://example.test/loaded",
+      isMainFrame: true,
+    }));
+    adapter.element.dispatchEvent(Object.assign(new Event("page-title-updated"), { title: "Example" }));
+    adapter.element.dispatchEvent(Object.assign(new Event("page-favicon-updated"), { favicons: ["https://example.test/icon.png"] }));
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "load-started", identity: IDENTITY, generation: 3 }),
+      expect.objectContaining({ type: "navigation-committed", address: "https://example.test/loaded", identity: IDENTITY, generation: 3 }),
+      expect.objectContaining({ type: "title-updated", title: "Example", identity: IDENTITY, generation: 3 }),
+      expect.objectContaining({ type: "favicon-updated", favicon: "https://example.test/icon.png", identity: IDENTITY, generation: 3 }),
+    ]));
+    adapter.dispose();
+    expect(surfaceBridge.release).toHaveBeenCalledWith({ surface: { identity: IDENTITY, generation: 3 } });
+    expect(document.body.contains(adapter.element)).toBe(false);
+    expect(() => adapter.element.dispatchEvent(new Event("did-navigate"))).not.toThrow();
+  });
+});

--- a/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
@@ -108,4 +108,20 @@ describe("ElectronWebviewBrowserSurfaceAdapter", () => {
     expect(document.body.contains(adapter.element)).toBe(false);
     expect(() => adapter.element.dispatchEvent(new Event("did-navigate"))).not.toThrow();
   });
+
+  it("retries the bounded guest discovery race after did-attach", async () => {
+    const surfaceBridge = bridge();
+    surfaceBridge.adopt
+      .mockResolvedValueOnce({ ok: false, error: "guest-not-found" })
+      .mockResolvedValueOnce({ ok: true });
+    const adapter = new ElectronWebviewBrowserSurfaceAdapter(IDENTITY, 5, {
+      root: document.body,
+      bridge: surfaceBridge,
+    });
+
+    adapter.element.dispatchEvent(new Event("did-attach"));
+
+    await vi.waitFor(() => expect(surfaceBridge.adopt).toHaveBeenCalledTimes(2));
+    adapter.dispose();
+  });
 });

--- a/apps/web/src/services/browser-surfaces/index.ts
+++ b/apps/web/src/services/browser-surfaces/index.ts
@@ -1,3 +1,4 @@
 export * from "./BrowserSurfaceHost";
 export * from "./browserSurfaceAddress";
 export * from "./WebIframeBrowserSurfaceAdapter";
+export * from "./ElectronWebviewBrowserSurfaceAdapter";

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -107,6 +107,56 @@ export type PreviewContextReferenceResult =
   | { readonly ok: true; readonly capture: McodeBrowserCapture }
   | { readonly ok: false; readonly error: string };
 
+/** Complete identity and generation for one renderer-hosted Electron surface. */
+export interface PreviewSurfaceRef {
+  readonly identity: {
+    readonly workspaceId: string;
+    readonly scope: {
+      readonly kind: "thread" | "workspace";
+      readonly id: string;
+    };
+    readonly tabId: string;
+  };
+  readonly generation: number;
+}
+
+/** Typed navigation operation executed by Electron main for one exact surface. */
+export type PreviewSurfaceNavigation =
+  | { readonly kind: "initial"; readonly address?: string }
+  | { readonly kind: "restored"; readonly address: string }
+  | { readonly kind: "address"; readonly address: string }
+  | { readonly kind: "back" }
+  | { readonly kind: "forward" }
+  | { readonly kind: "reload" }
+  | { readonly kind: "force-reload" };
+
+/** Result returned by a typed Electron Browser surface operation. */
+export type PreviewSurfaceBridgeResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: string };
+
+/** Opaque Electron surface operations exposed to the renderer. */
+export interface PreviewSurfaceBridge {
+  /** Registers an inert webview token before the guest can be adopted. */
+  prepare(payload: {
+    readonly surface: PreviewSurfaceRef;
+    readonly adoptionToken: string;
+  }): Promise<PreviewSurfaceBridgeResult>;
+  /** Adopts the prepared webview without exposing a guest handle to the renderer. */
+  adopt(payload: {
+    readonly surface: PreviewSurfaceRef;
+    readonly adoptionToken: string;
+    readonly initialAddress?: string;
+  }): Promise<PreviewSurfaceBridgeResult>;
+  /** Releases one exact surface generation. */
+  release(payload: { readonly surface: PreviewSurfaceRef }): Promise<PreviewSurfaceBridgeResult>;
+  /** Executes one validated navigation operation against one exact surface generation. */
+  navigate(payload: {
+    readonly surface: PreviewSurfaceRef;
+    readonly navigation: PreviewSurfaceNavigation;
+  }): Promise<PreviewSurfaceBridgeResult>;
+}
+
 /**
  * A localhost port detected as bound by a process on the machine, surfaced in
  * the empty browser as a one-click card. `name` is a best-effort label for the
@@ -202,16 +252,8 @@ interface PreviewBridge {
   tabs: PreviewTabsBridge;
   /** Live preview perf counters; dev HUD only. */
   getPerfCounters(): Promise<BrowserPerfCounters>;
-  /** Phase D: adopt a renderer-hosted <webview>'s WebContents into the host bridge. */
-  adoptWebview(payload: {
-    webContentsId: number;
-    threadId: string;
-    tabId: string;
-  }): Promise<{ ok: true } | { ok: false; error: string }>;
-  releaseWebview(payload: {
-    threadId: string;
-    tabId: string;
-  }): Promise<{ ok: true } | { ok: false; error: string }>;
+  /** Generation-bound Electron surface operations for renderer-hosted webviews. */
+  surface: PreviewSurfaceBridge;
   /** Bounded provider-neutral operations for adopted visible Browser tabs. */
   automation: PreviewAutomationBridge;
   /** Phase G: design-mode surface. */

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -337,7 +337,10 @@ export interface PreviewTabOpenData {
 
 /** Tab control surface mounted under `desktopBridge.preview.tabs`. */
 interface PreviewTabsBridge {
-  list(threadId: string): Promise<PreviewTabIpcResult<BrowserTabSet>>;
+  list(
+    threadId: string,
+    workspaceId?: string,
+  ): Promise<PreviewTabIpcResult<BrowserTabSet>>;
   open(
     threadId: string,
     options?: {


### PR DESCRIPTION
## What
Add typed Electron webview adapters for Browser surfaces and connect them to the desktop host.

## Why
Issue #1184 requires Electron Browser tabs to use the same surface contract as web iframe tabs. The desktop host must also preserve exact ownership, generation, and navigation authority.

## Key Changes
- Add an `ElectronWebviewBrowserSurfaceAdapter` and expose the typed desktop bridge operations it needs.
- Adopt Electron webview guests with bounded retries and exact workspace, tab, owner, and generation checks.
- Keep blank new-page surfaces alive so Browser automation can open and navigate them.
- Add focused desktop and web tests for adoption, lifecycle, navigation, and stale-authority rejection.

## Verification
- Live Electron and Playwright check: opened a Browser tab, navigated it to a local fixture, and observed `Electron webview navigation works` in the guest.
- `bun run verify`: typecheck, lint, and unit tests passed.

Closes #1184

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788743776&installation_model_id=20477&pr_number=1195&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1195&signature=53d7c36c32f5f0d38f43c2fd4316b313e1e281ff0364bea4d77356a1139ee3b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-scoped preview tabs for more consistent tab state.
  * Introduced a unified browser-surface experience supporting Electron webviews and iframe previews.
  * Added safer preview navigation, lifecycle handling, and surface recovery.

* **Bug Fixes**
  * Prevented browser automation and DevTools from using stale or unavailable tab content.
  * Improved handling of blank previews, navigation errors, reloads, and surface remounts.
  * Added validation to prevent unauthorized or outdated preview surfaces from being adopted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->