### PR TITLE
feat(browser): mediate popups through shared session

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
@@ -202,6 +202,7 @@ vi.mock("../preview/preview-session.js", () => ({
 }));
 
 import { BrowserAutomationKernel, selectAllModifierMask } from "../browser-automation/kernel.js";
+import { isBrowserAutomationAgentOperationActive } from "../browser-automation/active-operation.js";
 
 function request(
   operation: BrowserAutomationRequest["operation"],
@@ -384,6 +385,21 @@ describe("BrowserAutomationKernel", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(kernel.finishRendererOperation(event(), { leaseId: second.leaseId, succeeded: true })).toBe(false);
     expect(kernel.getCounters()).toMatchObject({ active: 0, queued: 0, cancellations: 0 });
+  });
+
+  it("classifies only the exact guest while its automation operation is active", async () => {
+    let finishNavigation!: () => void;
+    currentWebContents!.loadURL.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      finishNavigation = resolve;
+    }));
+    const otherGuest = new FakeWebContents(99);
+    const pending = kernel.execute(event(), payload(request("open", { url: "https://example.test" }, { requestId: "popup-source" })));
+    await Promise.resolve();
+    expect(isBrowserAutomationAgentOperationActive(currentWebContents! as never)).toBe(true);
+    expect(isBrowserAutomationAgentOperationActive(otherGuest as never)).toBe(false);
+    finishNavigation();
+    await pending;
+    expect(isBrowserAutomationAgentOperationActive(currentWebContents! as never)).toBe(false);
   });
 
   it("rejects stale target generations after a webview replacement", async () => {

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -1218,6 +1218,49 @@ describe("preview-browser", () => {
       expect(created.data.tabs.activeTabId).toBe(created.data.tabId);
     });
 
+    it("tabs.open stores a validated popup address and preserves background selection", () => {
+      const win = createWindow();
+      const listed = callTabs<{ activeTabId: string; tabs: unknown[] }>(
+        win,
+        "preview:tabs.list",
+        { threadId: "thread-A" },
+      );
+      expect(listed.ok).toBe(true);
+      if (!listed.ok) return;
+
+      const opened = callTabs<{
+        tabId: string;
+        tabs: { activeTabId: string; tabs: Array<{ id: string; url: string | null }> };
+      }>(win, "preview:tabs.open", {
+        threadId: "thread-A",
+        activate: false,
+        renderingHost: "webview",
+        initialAddress: "https://popup.example.test/next",
+      });
+
+      expect(opened.ok).toBe(true);
+      if (!opened.ok) return;
+      expect(opened.data.tabs.activeTabId).toBe(listed.data.activeTabId);
+      expect(opened.data.tabs.tabs).toContainEqual(expect.objectContaining({
+        id: opened.data.tabId,
+        url: "https://popup.example.test/next",
+      }));
+      expect(sessions.get(win.id)?.tabsByThread.get("thread-A")?.tabs).toContainEqual(
+        expect.objectContaining({
+          id: opened.data.tabId,
+          resumeUrl: "https://popup.example.test/next",
+          userCreatedBlank: false,
+        }),
+      );
+
+      const rejected = callTabs(win, "preview:tabs.open", {
+        threadId: "thread-A",
+        initialAddress: "data:text/html,blocked",
+      });
+      expect(rejected).toEqual({ ok: false, error: "invalid-initial-address" });
+      expect(sessions.get(win.id)?.tabsByThread.get("thread-A")?.tabs).toHaveLength(2);
+    });
+
     it("tabs.open continues an exact existing page for a hidden agent open", async () => {
       const win = createWindow();
       const initial = callTabs<{ tabs: { id: string }[] }>(win, "preview:tabs.list", {

--- a/apps/desktop/src/main/__tests__/preview-session-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-session-adapter.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+const previewSession = {
+  on: vi.fn(),
+  clearStorageData: vi.fn(async () => undefined),
+  clearCache: vi.fn(async () => undefined),
+};
+
+vi.mock("electron", () => ({
+  ipcMain: { on: vi.fn() },
+  session: {
+    fromPartition: vi.fn((partition: string) => {
+      if (partition !== "persist:mcode-preview") throw new Error(`unexpected partition ${partition}`);
+      return previewSession;
+    }),
+  },
+}));
+
+vi.mock("../preview/preview-clipboard-trust.js", () => ({
+  registerPreviewClipboardPermissionHandlers: vi.fn(),
+}));
+
+import { session } from "electron";
+import { PreviewSessionAdapter } from "../preview/preview-session-adapter.js";
+
+describe("PreviewSessionAdapter", () => {
+  const surface = {
+    sourceSurface: {
+      identity: {
+        workspaceId: "workspace",
+        scope: { kind: "thread" as const, id: "thread" },
+        tabId: "tab",
+      },
+      generation: 1,
+    },
+  };
+
+  it("uses one fixed partition and denies guest popup creation", () => {
+    const adapter = new PreviewSessionAdapter();
+    const guest = {
+      setWindowOpenHandler: vi.fn(),
+      once: vi.fn(),
+      removeListener: vi.fn(),
+      isDestroyed: () => false,
+    };
+
+    expect(adapter.session).toBe(previewSession);
+    expect(session.fromPartition).toHaveBeenCalledWith("persist:mcode-preview");
+
+    adapter.bindGuestPopup(guest as never, {
+      ...surface,
+      emitPopup: vi.fn(),
+      isAgentOperationActive: () => false,
+    });
+
+    const handler = guest.setWindowOpenHandler.mock.calls[0]?.[0] as ((details: { url: string }) => unknown) | undefined;
+    expect(handler?.({ url: "https://example.test" })).toEqual({ action: "deny" });
+  });
+
+  it("owns cookies, cache, clipboard policy, and denied downloads", async () => {
+    const adapter = new PreviewSessionAdapter({ previewSession: previewSession as never });
+    adapter.registerPolicy();
+    adapter.registerPolicy();
+    expect(previewSession.on).toHaveBeenCalledTimes(1);
+    const downloadEvent = { preventDefault: vi.fn() };
+    const downloadHandler = previewSession.on.mock.calls[0]?.[1] as ((event: typeof downloadEvent) => void);
+    downloadHandler(downloadEvent);
+    expect(downloadEvent.preventDefault).toHaveBeenCalledTimes(1);
+    await adapter.clearCookies();
+    await adapter.clearCache();
+    expect(previewSession.clearStorageData).toHaveBeenCalledWith({ storages: ["cookies"] });
+    expect(previewSession.clearCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits only bounded credential-free HTTP(S) popups and unbinds stale guests", () => {
+    let destroyed: (() => void) | undefined;
+    const setWindowOpenHandler = vi.fn();
+    const guest = {
+      setWindowOpenHandler,
+      once: vi.fn((_event: string, listener: () => void) => { destroyed = listener; }),
+      removeListener: vi.fn(),
+      isDestroyed: () => false,
+    };
+    const emitPopup = vi.fn();
+    let agent = false;
+    const adapter = new PreviewSessionAdapter({ previewSession: previewSession as never });
+    const unbind = adapter.bindGuestPopup(guest as never, {
+      ...surface,
+      emitPopup,
+      isAgentOperationActive: () => agent,
+    });
+    const handler = setWindowOpenHandler.mock.calls[0]?.[0] as ((details: { url: string }) => unknown);
+    for (const address of ["file:///tmp/x", "javascript:alert(1)", "data:text/html,hello", "custom:test", "https://user:pass@example.test", "not a url", `https://example.test/${"x".repeat(4096)}`]) {
+      expect(handler({ url: address })).toEqual({ action: "deny" });
+    }
+    expect(emitPopup).not.toHaveBeenCalled();
+    agent = true;
+    expect(handler({ url: "https://example.test/agent" })).toEqual({ action: "deny" });
+    expect(emitPopup).toHaveBeenCalledWith({ ...surface, address: "https://example.test/agent", initiator: "agent" });
+    agent = false;
+    expect(handler({ url: "http://example.test/human" })).toEqual({ action: "deny" });
+    expect(emitPopup).toHaveBeenLastCalledWith({ ...surface, address: "http://example.test/human", initiator: "human" });
+    emitPopup.mockImplementationOnce(() => { throw new Error("renderer unavailable"); });
+    expect(handler({ url: "https://example.test/delivery-failure" })).toEqual({ action: "deny" });
+    destroyed?.();
+    expect(handler({ url: "https://example.test/stale" })).toEqual({ action: "deny" });
+    expect(emitPopup).toHaveBeenCalledTimes(3);
+    unbind();
+    expect(setWindowOpenHandler).toHaveBeenLastCalledWith(expect.any(Function));
+  });
+});

--- a/apps/desktop/src/main/browser-automation/active-operation.ts
+++ b/apps/desktop/src/main/browser-automation/active-operation.ts
@@ -1,0 +1,18 @@
+import type { WebContents } from "electron";
+
+const activeDepthByGuest = new WeakMap<object, number>();
+
+/** Returns true only while an exact main-process automation operation runs on this guest. */
+export function isBrowserAutomationAgentOperationActive(webContents: WebContents): boolean {
+  return (activeDepthByGuest.get(webContents) ?? 0) > 0;
+}
+
+/** Records one exact automation operation entering or leaving a guest. */
+export function updateBrowserAutomationAgentOperationDepth(
+  webContents: WebContents,
+  delta: 1 | -1,
+): void {
+  const next = (activeDepthByGuest.get(webContents) ?? 0) + delta;
+  if (next > 0) activeDepthByGuest.set(webContents, next);
+  else activeDepthByGuest.delete(webContents);
+}

--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -34,6 +34,7 @@ import {
 } from "./scheduler.js";
 import { OldestFirstRingBuffer } from "./ring-buffer.js";
 import { redactBrowserDiagnosticUrl, redactBrowserLocation, redactBrowserText, redactBrowserValue } from "./redaction.js";
+import { updateBrowserAutomationAgentOperationDepth } from "./active-operation.js";
 
 const EVALUATION_LIMIT = BROWSER_AUTOMATION_MAX_EXPRESSION_BYTES;
 const SCREENSHOT_BINARY_LIMIT = 360 * 1_024;
@@ -1183,6 +1184,7 @@ export class BrowserAutomationKernel {
     if (request.deadline <= Date.now()) throw new KernelError("DEADLINE_EXCEEDED", "Browser operation deadline elapsed", true);
     state.actions.push({ timestamp: Date.now(), operation: request.operation, outcome: "started" });
     if (request.operation !== "status") this.emitController(state, "agent", request);
+    updateBrowserAutomationAgentOperationDepth(webContents, 1);
     let effect: KernelErrorEffect = "none";
     const markEffect = () => {
       if (effect === "none") effect = "preserved";
@@ -1208,6 +1210,7 @@ export class BrowserAutomationKernel {
       });
       throw finalCause;
     } finally {
+      updateBrowserAutomationAgentOperationDepth(webContents, -1);
       if (state.syntheticInputDepth > 0 && state.debuggerOwned) {
         await Promise.race([
           this.releaseInput(state.webContents, state.heldKeys),

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -15,6 +15,10 @@ import type {
   BrowserAutomationViewportResetResult,
   PreviewRenderingHost,
 } from "@mcode/contracts";
+import {
+  PREVIEW_POPUP_REQUESTED_CHANNEL,
+  type PreviewPopupRequest,
+} from "./preview/preview-popup-contract.js";
 
 contextBridge.exposeInMainWorld("desktopBridge", {
   /** Platform facts and allowlisted native window actions for the custom title bar. */
@@ -384,6 +388,12 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       }): Promise<{ ok: true } | { ok: false; error: string }> {
         return ipcRenderer.invoke("preview.surface.navigate", payload);
       },
+      /** Subscribes to opener-free popup requests for exact adopted surfaces. */
+      onPopupRequested(callback: (request: PreviewPopupRequest) => void): () => void {
+        const listener = (_event: unknown, request: PreviewPopupRequest) => callback(request);
+        ipcRenderer.on(PREVIEW_POPUP_REQUESTED_CHANNEL, listener);
+        return () => ipcRenderer.removeListener(PREVIEW_POPUP_REQUESTED_CHANNEL, listener);
+      },
     },
     /** Bounded provider-neutral browser operations. Raw CDP is intentionally not exposed. */
     automation: {
@@ -470,6 +480,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
           activate?: boolean;
           tabId?: string;
           renderingHost?: PreviewRenderingHost;
+          initialAddress?: string;
         },
       ): Promise<unknown> {
         return ipcRenderer.invoke("preview:tabs.open", {
@@ -477,6 +488,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
           activate: options?.activate,
           tabId: options?.tabId,
           renderingHost: options?.renderingHost,
+          initialAddress: options?.initialAddress,
         });
       },
       activate(threadId: string, tabId: string): Promise<unknown> {

--- a/apps/desktop/src/main/preview/index.ts
+++ b/apps/desktop/src/main/preview/index.ts
@@ -9,7 +9,7 @@ export type {
   PreviewContextReferenceResult,
 } from "./preview-capture.js";
 
-import { ipcMain, session } from "electron";
+import { ipcMain } from "electron";
 import { registerNavigationHandlers } from "./preview-navigation.js";
 import { registerCaptureHandlers, registerWebRequestInterceptor } from "./preview-capture.js";
 import { registerOverlayHandlers } from "./preview-overlay.js";
@@ -19,13 +19,11 @@ import { getPerfCounters } from "./preview-perf.js";
 import { registerPreviewSurfaceHandlers } from "./preview-webview-adopt.js";
 import { registerDesignModeHandlers } from "./preview-design-mode.js";
 import { registerBrowserAutomationHandlers } from "../browser-automation/index.js";
-import { registerPreviewClipboardPermissionHandlers } from "./preview-clipboard-trust.js";
+import { registerPreviewSessionPolicy } from "./preview-session-adapter.js";
 
 /** Registers all preview:* IPC handlers. Call once at app startup. */
 export function registerPreviewBrowserHandlers(): void {
-  const previewPartition = session.fromPartition("persist:mcode-preview");
-  registerPreviewClipboardPermissionHandlers(previewPartition, ipcMain);
-  previewPartition.on("will-download", (event) => event.preventDefault());
+  const previewPartition = registerPreviewSessionPolicy();
 
   registerNavigationHandlers();
   registerCaptureHandlers();
@@ -38,3 +36,11 @@ export function registerPreviewBrowserHandlers(): void {
   registerBrowserAutomationHandlers();
   ipcMain.handle("preview:get-perf-counters", () => getPerfCounters());
 }
+
+export {
+  PREVIEW_PARTITION,
+  PreviewSessionAdapter,
+  previewSessionAdapter,
+} from "./preview-session-adapter.js";
+export { PREVIEW_POPUP_REQUESTED_CHANNEL } from "./preview-popup-contract.js";
+export type { PreviewPopupRequest } from "./preview-popup-contract.js";

--- a/apps/desktop/src/main/preview/preview-lifecycle.ts
+++ b/apps/desktop/src/main/preview/preview-lifecycle.ts
@@ -32,6 +32,7 @@ import {
   registerPreviewClipboardGuest,
   unregisterPreviewClipboardGuest,
 } from "./preview-clipboard-trust.js";
+import { PREVIEW_PARTITION } from "./preview-session-adapter.js";
 
 /**
  * Injected into every guest document so preview scrollbars match the app shell on Windows
@@ -127,7 +128,7 @@ export function ensureTabView(
       nodeIntegration: false,
       contextIsolation: true,
       sandbox: true,
-      partition: "persist:mcode-preview",
+      partition: PREVIEW_PARTITION,
       preload: resolvePreviewGuestPreloadPath(__dirname),
     },
   });

--- a/apps/desktop/src/main/preview/preview-navigation.ts
+++ b/apps/desktop/src/main/preview/preview-navigation.ts
@@ -5,7 +5,7 @@
  * overflow kebab (clear-cookies, clear-cache, get-zoom, set-zoom).
  */
 
-import { BrowserWindow, ipcMain, session as electronSession, shell } from "electron";
+import { BrowserWindow, ipcMain, shell } from "electron";
 import { logger } from "@mcode/shared";
 import {
   ensureThreadTabSet,
@@ -32,13 +32,12 @@ import {
 } from "./preview-local-file.js";
 import { isMcodeWorkspacePreviewUrl } from "@mcode/contracts";
 import { onPreviewHidden, onPreviewVisible } from "./preview-discard-scheduler.js";
+import { previewSessionAdapter } from "./preview-session-adapter.js";
 
 /** Lower bound on the preview zoom factor (25%), matching Chromium's floor. */
 const MIN_ZOOM_FACTOR = 0.25;
 /** Upper bound on the preview zoom factor (500%), matching Chromium's ceiling. */
 const MAX_ZOOM_FACTOR = 5;
-/** Shared Electron storage partition for native and renderer-hosted previews. */
-const PREVIEW_PARTITION = "persist:mcode-preview";
 
 type PreviewResolveNavigationResult =
   | { ok: true; url: string }
@@ -70,11 +69,6 @@ export function looksLikeBareDomain(input: string): boolean {
   if (!hostPart.includes(".")) return false;
   const tld = hostPart.split(":")[0]!.split(".").pop() ?? "";
   return /^[a-z][a-z0-9-]{1,}$/i.test(tld);
-}
-
-/** Returns the shared storage session used by both preview rendering hosts. */
-function getPreviewStorageSession(): Electron.Session {
-  return electronSession.fromPartition(PREVIEW_PARTITION);
 }
 
 /** Resolve user omnibox input to a safe preview URL without loading it. */
@@ -388,13 +382,13 @@ export function registerNavigationHandlers(): void {
   ipcMain.handle("preview:clear-cookies", async (_event) => {
     const win = BrowserWindow.fromWebContents(_event.sender);
     if (!win || win.isDestroyed()) return;
-    await getPreviewStorageSession().clearStorageData({ storages: ["cookies"] });
+    await previewSessionAdapter.clearCookies();
   });
 
   ipcMain.handle("preview:clear-cache", async (_event) => {
     const win = BrowserWindow.fromWebContents(_event.sender);
     if (!win || win.isDestroyed()) return;
-    await getPreviewStorageSession().clearCache();
+    await previewSessionAdapter.clearCache();
   });
 
   ipcMain.handle("preview:get-zoom", (_event): number => {

--- a/apps/desktop/src/main/preview/preview-popup-contract.ts
+++ b/apps/desktop/src/main/preview/preview-popup-contract.ts
@@ -1,0 +1,19 @@
+/** Complete identity and generation for a popup's source Browser surface. */
+export interface PreviewPopupSurfaceRef {
+  readonly identity: {
+    readonly workspaceId: string;
+    readonly scope: { readonly kind: "thread" | "workspace"; readonly id: string };
+    readonly tabId: string;
+  };
+  readonly generation: number;
+}
+
+/** Renderer channel for typed, opener-free Browser popup requests. */
+export const PREVIEW_POPUP_REQUESTED_CHANNEL = "preview.surface.popup-requested" as const;
+
+/** Typed popup request emitted after Electron denies direct popup creation. */
+export interface PreviewPopupRequest {
+  readonly sourceSurface: PreviewPopupSurfaceRef;
+  readonly address: string;
+  readonly initiator: "human" | "agent";
+}

--- a/apps/desktop/src/main/preview/preview-session-adapter.ts
+++ b/apps/desktop/src/main/preview/preview-session-adapter.ts
@@ -1,0 +1,139 @@
+import { ipcMain, session as electronSession } from "electron";
+import type { IpcMain, Session, WebContents } from "electron";
+import { BROWSER_TAB_INFO_STRING_MAX } from "@mcode/contracts";
+import { registerPreviewClipboardPermissionHandlers } from "./preview-clipboard-trust.js";
+import type { PreviewPopupRequest, PreviewPopupSurfaceRef } from "./preview-popup-contract.js";
+
+/** The single persistent Electron partition shared by every Browser guest. */
+export const PREVIEW_PARTITION = "persist:mcode-preview" as const;
+
+/** Bounded host-side popup sink used by a generation-bound guest binding. */
+export type PreviewPopupEmitter = (request: PreviewPopupRequest) => void;
+
+/** Agent-operation predicate used to classify the exact popup source guest. */
+export type PreviewAgentOperationPredicate = (webContents: WebContents) => boolean;
+
+/** Dependencies that keep the Electron session boundary deterministic in tests. */
+export interface PreviewSessionAdapterOptions {
+  readonly previewSession?: Session;
+  readonly clipboardIpc?: Pick<IpcMain, "on">;
+}
+
+/** Options for binding one exact generation-bound guest to popup mediation. */
+export interface PreviewGuestPopupBindingOptions {
+  readonly sourceSurface: PreviewPopupSurfaceRef;
+  readonly emitPopup: PreviewPopupEmitter;
+  readonly isAgentOperationActive: PreviewAgentOperationPredicate;
+}
+
+const denyPopup = () => ({ action: "deny" as const });
+
+function validPopupAddress(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0 || value.length > BROWSER_TAB_INFO_STRING_MAX.url) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  return (
+    (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+    parsed.username.length === 0 &&
+    parsed.password.length === 0
+  );
+}
+
+/** Shared Electron session boundary for Browser policy and generation-bound guest behavior. */
+export class PreviewSessionAdapter {
+  private readonly previewSessionOverride: Session | undefined;
+  private readonly clipboardIpc: Pick<IpcMain, "on">;
+  private previewSession: Session | null = null;
+  private policySession: Session | null = null;
+
+  /** Creates a session adapter, optionally with deterministic Electron test dependencies. */
+  public constructor(options: PreviewSessionAdapterOptions = {}) {
+    this.previewSessionOverride = options.previewSession;
+    this.clipboardIpc = options.clipboardIpc ?? ipcMain;
+  }
+
+  /** Returns the one fixed persistent session used by all Browser guests. */
+  public get session(): Session {
+    if (!this.previewSession) {
+      this.previewSession = this.previewSessionOverride ?? electronSession.fromPartition(PREVIEW_PARTITION);
+    }
+    return this.previewSession;
+  }
+
+  /** Installs partition-wide clipboard and download policy exactly once per session. */
+  public registerPolicy(): Session {
+    const previewSession = this.session;
+    if (this.policySession === previewSession) return previewSession;
+    registerPreviewClipboardPermissionHandlers(previewSession, this.clipboardIpc);
+    previewSession.on("will-download", (event) => event.preventDefault());
+    this.policySession = previewSession;
+    return previewSession;
+  }
+
+  /** Clears cookies from the shared Browser partition. */
+  public clearCookies(): Promise<void> {
+    return this.session.clearStorageData({ storages: ["cookies"] });
+  }
+
+  /** Clears HTTP cache from the shared Browser partition. */
+  public clearCache(): Promise<void> {
+    return this.session.clearCache();
+  }
+
+  /**
+   * Binds one exact guest generation. Electron always receives a deny action;
+   * valid HTTP(S) requests are copied into a bounded typed renderer message.
+   */
+  public bindGuestPopup(
+    guest: WebContents,
+    options: PreviewGuestPopupBindingOptions,
+  ): () => void {
+    let bound = true;
+    const unbind = () => {
+      if (!bound) return;
+      bound = false;
+      try {
+        guest.removeListener("destroyed", onDestroyed);
+        if (!guest.isDestroyed()) guest.setWindowOpenHandler(denyPopup);
+      } catch {
+        // Electron can destroy a guest before release cleanup reaches this adapter.
+      }
+    };
+    const onDestroyed = () => {
+      bound = false;
+      try {
+        guest.removeListener("destroyed", onDestroyed);
+      } catch {
+        // Guest teardown is already complete.
+      }
+    };
+    guest.setWindowOpenHandler(({ url }: { url: string }) => {
+      if (bound && validPopupAddress(url)) {
+        try {
+          options.emitPopup({
+            sourceSurface: options.sourceSurface,
+            address: url,
+            initiator: options.isAgentOperationActive(guest) ? "agent" : "human",
+          });
+        } catch {
+          // Popup delivery must not bypass Electron's direct-window denial.
+        }
+      }
+      return denyPopup();
+    });
+    guest.once("destroyed", onDestroyed);
+    return unbind;
+  }
+}
+
+/** Returns the process-wide Browser session adapter used by desktop main. */
+export const previewSessionAdapter = new PreviewSessionAdapter();
+
+/** Installs the shared Browser partition policy during desktop startup. */
+export function registerPreviewSessionPolicy(): Session {
+  return previewSessionAdapter.registerPolicy();
+}

--- a/apps/desktop/src/main/preview/preview-tabs.ts
+++ b/apps/desktop/src/main/preview/preview-tabs.ts
@@ -11,6 +11,7 @@
 import { BrowserWindow, ipcMain } from "electron";
 import { randomUUID } from "node:crypto";
 import {
+  BROWSER_TAB_INFO_STRING_MAX,
   PREVIEW_RENDERING_HOSTS,
   type BrowserTabSet,
   type PreviewRenderingHost,
@@ -66,6 +67,27 @@ function sendTabsUpdated(win: BrowserWindow, set: BrowserTabSet): void {
 function normaliseRenderingHost(value: unknown): PreviewRenderingHost | null {
   if (value === undefined) return "webContentsView";
   return PREVIEW_RENDERING_HOSTS.find((host) => host === value) ?? null;
+}
+
+function normaliseInitialAddress(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > BROWSER_TAB_INFO_STRING_MAX.url
+  ) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.username.length > 0 ||
+    parsed.password.length > 0
+  ) return null;
+  return value;
 }
 
 /**
@@ -186,6 +208,7 @@ export function registerTabHandlers(): void {
         activate?: unknown;
         tabId?: unknown;
         renderingHost?: unknown;
+        initialAddress?: unknown;
       },
     ): TabIpcResult<{ tabId: string; tabs: BrowserTabSet }> => {
       const win = BrowserWindow.fromWebContents(_event.sender);
@@ -198,6 +221,10 @@ export function registerTabHandlers(): void {
       }
       const renderingHost = normaliseRenderingHost(payload?.renderingHost);
       if (!renderingHost) return { ok: false, error: "invalid-rendering-host" };
+      const initialAddress = normaliseInitialAddress(payload?.initialAddress);
+      if (payload?.initialAddress !== undefined && initialAddress === null) {
+        return { ok: false, error: "invalid-initial-address" };
+      }
       const activate = payload?.activate !== false; // default: true
 
       const s = getSession(win);
@@ -229,6 +256,10 @@ export function registerTabHandlers(): void {
         // last URL via the per-thread resume hint on the next sync.
         userCreatedBlank: true,
       } satisfies TabState;
+      if (initialAddress !== undefined) {
+        tab.resumeUrl = initialAddress;
+        tab.userCreatedBlank = false;
+      }
       if (!existingTab) set.tabs.push(tab);
       if (existingTab && !activate) tab.backgroundOpenReserved = true;
 

--- a/apps/desktop/src/main/preview/preview-webview-adopt.ts
+++ b/apps/desktop/src/main/preview/preview-webview-adopt.ts
@@ -1,7 +1,6 @@
 import {
   BrowserWindow,
   ipcMain,
-  session as electronSession,
   webContents as electronWebContents,
 } from "electron";
 import type { IpcMainInvokeEvent, WebContents } from "electron";
@@ -13,8 +12,11 @@ import {
   registerPreviewClipboardGuest,
   unregisterPreviewClipboardGuest,
 } from "./preview-clipboard-trust.js";
+import { previewSessionAdapter } from "./preview-session-adapter.js";
+import { PREVIEW_POPUP_REQUESTED_CHANNEL } from "./preview-popup-contract.js";
+import type { PreviewPopupSurfaceRef } from "./preview-popup-contract.js";
+import { isBrowserAutomationAgentOperationActive } from "../browser-automation/active-operation.js";
 
-const PREVIEW_PARTITION = "persist:mcode-preview";
 const MAX_SURFACE_ID_LENGTH = 256;
 const MAX_ADOPTION_TOKEN_LENGTH = 128;
 
@@ -28,10 +30,9 @@ export interface PreviewSurfaceIdentity {
   readonly tabId: string;
 }
 
-/** Generation-bound reference to one Preview surface. */
-export interface PreviewSurfaceRef {
+/** Complete identity and generation for one renderer-hosted Preview surface. */
+export interface PreviewSurfaceRef extends PreviewPopupSurfaceRef {
   readonly identity: PreviewSurfaceIdentity;
-  readonly generation: number;
 }
 
 /** Typed navigation requested by a renderer-owned Preview surface. */
@@ -181,7 +182,7 @@ function guestMatchesPending(
   // The main window's will-attach-webview hook replaces the preload and
   // partition before this guest exists. Electron omits preload from
   // getLastWebPreferences(), so the enforced partition is the runtime proof.
-  if (guest.session !== electronSession.fromPartition(PREVIEW_PARTITION)) return false;
+  if (guest.session !== previewSessionAdapter.session) return false;
   return isInertGuestUrl(guest.getURL(), adoptionToken);
 }
 
@@ -310,9 +311,17 @@ function adoptSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSu
       candidate.getURL() === `about:blank#${input.adoptionToken}` && candidate.hostWebContents === event.sender);
     return errorResult(matches.length > 1 ? "non-unique-adoption" : "guest-not-found");
   }
-  guest.setWindowOpenHandler(() => ({ action: "deny" }));
   const onDestroyed = () => dropAdoption(win.id, key);
   guest.once("destroyed", onDestroyed);
+  const disposePopup = previewSessionAdapter.bindGuestPopup(guest, {
+    sourceSurface: surface,
+    emitPopup: (request) => {
+      if (!win.isDestroyed() && !event.sender.isDestroyed()) {
+        event.sender.send(PREVIEW_POPUP_REQUESTED_CHANNEL, request);
+      }
+    },
+    isAgentOperationActive: isBrowserAutomationAgentOperationActive,
+  });
   registerPreviewClipboardGuest(guest, () => {
     if (win.isDestroyed() || !win.isFocused()) return false;
     const record = adoptedByWindow.get(win.id)?.get(key);
@@ -320,6 +329,7 @@ function adoptSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSu
   });
   const dispose = () => {
     guest.removeListener("destroyed", onDestroyed);
+    disposePopup();
   };
   windowMap(adoptedByWindow, win.id).set(key, { surface, adoptionToken: input.adoptionToken, webContents: guest, dispose });
   dropPending(win.id, key);

--- a/apps/desktop/src/main/preview/preview-webview-security.ts
+++ b/apps/desktop/src/main/preview/preview-webview-security.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { PREVIEW_PARTITION } from "./preview-session-adapter.js";
 
 /** Mutable web preferences received with Electron's will-attach-webview event. */
 export interface PreviewWebviewPreferences {
@@ -33,6 +34,6 @@ export function hardenPreviewWebviewAttachment(
   webPreferences.devTools = true;
   webPreferences.preload = guestPreloadPath;
   delete webPreferences.preloadURL;
-  params.partition = "persist:mcode-preview";
+  params.partition = PREVIEW_PARTITION;
   params.preload = guestPreloadPath;
 }

--- a/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
+++ b/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import {
   BrowserSurfaceHost,
   ElectronWebviewBrowserSurfaceAdapter,
@@ -9,6 +9,7 @@ import {
   invalidateBrowserAutomationTargetObservation,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
+import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 
 let surfaceRoot: HTMLDivElement | null = null;
 
@@ -49,6 +50,21 @@ export const browserSurfaceHost = new BrowserSurfaceHost({
 export function BrowserSurfaceHostRoot() {
   const setRoot = useCallback((node: HTMLDivElement | null): void => {
     surfaceRoot = node;
+  }, []);
+
+  useEffect(() => {
+    const surfaceBridge = window.desktopBridge?.preview?.surface;
+    if (!surfaceBridge) return;
+    return surfaceBridge.onPopupRequested((request) => {
+      const source = browserSurfaceHost.getSnapshot(request.sourceSurface.identity);
+      if (!source || source.generation !== request.sourceSurface.generation) return;
+      void usePreviewTabsStore.getState().openPage(request.sourceSurface.identity.scope.id, {
+        activate: request.initiator === "human",
+        focusOmnibox: false,
+        initialAddress: request.address,
+        renderingHost: "webview",
+      });
+    });
   }, []);
 
   return (

--- a/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
@@ -1,10 +1,12 @@
-import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BrowserSurfaceHostRoot,
   browserSurfaceHost,
 } from "../BrowserSurfaceHostRoot";
 import type { BrowserSurfaceIdentity } from "@/services/browser-surfaces";
+import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import type { PreviewPopupRequest } from "@/transport/desktop-bridge";
 
 const IDENTITY: BrowserSurfaceIdentity = {
   workspaceId: "workspace-1",
@@ -13,7 +15,13 @@ const IDENTITY: BrowserSurfaceIdentity = {
 };
 
 describe("BrowserSurfaceHostRoot", () => {
-  afterEach(() => browserSurfaceHost.dispose(IDENTITY));
+  const originalOpenPage = usePreviewTabsStore.getState().openPage;
+
+  afterEach(() => {
+    browserSurfaceHost.dispose(IDENTITY);
+    usePreviewTabsStore.setState({ openPage: originalOpenPage });
+    delete window.desktopBridge;
+  });
 
   it("mounts a hosted iframe outside the panel tree", () => {
     render(<BrowserSurfaceHostRoot />);
@@ -28,5 +36,55 @@ describe("BrowserSurfaceHostRoot", () => {
     expect(iframe).toHaveAttribute("data-scope-kind", "thread");
     expect(iframe).toHaveAttribute("data-scope-id", "thread-1");
     expect(iframe).toHaveAttribute("data-tab-id", "web-preview");
+  });
+
+  it("opens current human popups in front and agent popups in the background", () => {
+    let onPopupRequested: ((request: PreviewPopupRequest) => void) | null = null;
+    const stopPopupRequests = vi.fn();
+    browserSurfaceHost.create(IDENTITY, { generation: 7 });
+    window.desktopBridge = {
+      preview: {
+        surface: {
+          onPopupRequested: vi.fn((listener: (request: PreviewPopupRequest) => void) => {
+            onPopupRequested = listener;
+            return stopPopupRequests;
+          }),
+        },
+      },
+    } as never;
+    const openPage = vi.fn(async () => "popup-tab");
+    usePreviewTabsStore.setState({ openPage });
+    const view = render(<BrowserSurfaceHostRoot />);
+
+    const request = {
+      sourceSurface: { identity: IDENTITY, generation: 7 },
+      address: "https://popup.example.test/next",
+      initiator: "human" as const,
+    };
+    act(() => onPopupRequested?.(request));
+    expect(openPage).toHaveBeenLastCalledWith("thread-1", {
+      activate: true,
+      focusOmnibox: false,
+      initialAddress: request.address,
+      renderingHost: "webview",
+    });
+
+    act(() => onPopupRequested?.({ ...request, initiator: "agent" }));
+    expect(openPage).toHaveBeenLastCalledWith("thread-1", {
+      activate: false,
+      focusOmnibox: false,
+      initialAddress: request.address,
+      renderingHost: "webview",
+    });
+
+    openPage.mockClear();
+    act(() => onPopupRequested?.({
+      ...request,
+      sourceSurface: { ...request.sourceSurface, generation: 6 },
+    }));
+    expect(openPage).not.toHaveBeenCalled();
+
+    view.unmount();
+    expect(stopPopupRequests).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
+++ b/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
@@ -134,6 +134,7 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
     this.frame.setAttribute("src", this.frame.src);
     this.frame.title = options.title ?? "Browser surface";
     this.frame.setAttribute("partition", "persist:mcode-preview");
+    this.frame.setAttribute("allowpopups", "");
     this.frame.setAttribute("aria-hidden", "true");
     this.frame.dataset.testid = "electron-browser-surface-webview";
     this.frame.dataset.workspaceId = identity.workspaceId;

--- a/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
@@ -27,6 +27,7 @@ function bridge(): PreviewSurfaceBridge & {
     adopt: vi.fn().mockResolvedValue({ ok: true }),
     navigate: vi.fn().mockResolvedValue({ ok: true }),
     release: vi.fn().mockResolvedValue({ ok: true }),
+    onPopupRequested: vi.fn(() => () => undefined),
   };
 }
 
@@ -47,6 +48,7 @@ describe("ElectronWebviewBrowserSurfaceAdapter", () => {
 
     expect(element.tagName).toBe("WEBVIEW");
     expect(element.getAttribute("src")).toMatch(/^about:blank#[A-Za-z0-9_-]+$/);
+    expect(element.hasAttribute("allowpopups")).toBe(true);
     expect(surfaceBridge.prepare).toHaveBeenCalledWith(expect.objectContaining({
       surface: { identity: IDENTITY, generation: 7 },
       adoptionToken: expect.any(String),

--- a/apps/web/src/stores/__tests__/previewTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewTabsStore.test.ts
@@ -158,6 +158,23 @@ describe("previewTabsStore", () => {
     });
   });
 
+  it("openPage passes a bounded initial address to the bridge", async () => {
+    const { open } = mockBridge({});
+
+    await usePreviewTabsStore.getState().openPage(SCOPE, {
+      activate: true,
+      focusOmnibox: false,
+      initialAddress: "https://popup.example.test/next",
+      renderingHost: "webview",
+    });
+
+    expect(open).toHaveBeenCalledWith(SCOPE, {
+      activate: true,
+      initialAddress: "https://popup.example.test/next",
+      renderingHost: "webview",
+    });
+  });
+
   it("activatePage switches the active page and clears stale live chrome", async () => {
     usePreviewTabsStore.getState().setLiveChrome(SCOPE, { title: "stale", url: null, favicon: null });
     const switched = set("b", [page("a"), page("b", { active: true })]);

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -59,6 +59,7 @@ interface PreviewTabsBridgeLike {
       readonly activate?: boolean;
       readonly tabId?: string;
       readonly renderingHost?: PreviewRenderingHost;
+      readonly initialAddress?: string;
     },
   ): Promise<{ ok: true; data: { tabId: string; tabs: BrowserTabSet } } | { ok: false; error: string }>;
   activate(
@@ -133,6 +134,7 @@ interface PreviewTabsState {
     readonly activate?: boolean;
     readonly tabId?: string;
     readonly renderingHost?: PreviewRenderingHost;
+    readonly initialAddress?: string;
   }) => Promise<string | null>;
   /** Activate (switch to) a page within the scope's browser. */
   activatePage: (scopeId: string, tabId: string) => Promise<void>;
@@ -302,6 +304,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
       activate,
       ...(options?.tabId ? { tabId: options.tabId } : {}),
       ...(options?.renderingHost ? { renderingHost: options.renderingHost } : {}),
+      ...(options?.initialAddress ? { initialAddress: options.initialAddress } : {}),
     });
     if (r.ok) {
       get().setTabSet(scopeId, r.data.tabs);

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -120,6 +120,13 @@ export interface PreviewSurfaceRef {
   readonly generation: number;
 }
 
+/** Opener-free popup request for one exact Browser surface generation. */
+export interface PreviewPopupRequest {
+  readonly sourceSurface: PreviewSurfaceRef;
+  readonly address: string;
+  readonly initiator: "human" | "agent";
+}
+
 /** Typed navigation operation executed by Electron main for one exact surface. */
 export type PreviewSurfaceNavigation =
   | { readonly kind: "initial"; readonly address?: string }
@@ -155,6 +162,8 @@ export interface PreviewSurfaceBridge {
     readonly surface: PreviewSurfaceRef;
     readonly navigation: PreviewSurfaceNavigation;
   }): Promise<PreviewSurfaceBridgeResult>;
+  /** Subscribe to popup requests that Electron main denied and mediated. */
+  onPopupRequested(callback: (request: PreviewPopupRequest) => void): () => void;
 }
 
 /**
@@ -347,6 +356,7 @@ interface PreviewTabsBridge {
       readonly activate?: boolean;
       readonly tabId?: string;
       readonly renderingHost?: PreviewRenderingHost;
+      readonly initialAddress?: string;
     },
   ): Promise<PreviewTabIpcResult<PreviewTabOpenData>>;
   activate(


### PR DESCRIPTION
## What

Mediate preview popups through the shared Electron browser session and open them as canonical Mcode tabs.

## Why

Preview webviews need one hardened session policy for cookies, cache, downloads, clipboard access, and popup routing. Electron popup windows must never open outside Mcode tab management.

## Key Changes

- Add a shared preview session adapter that owns session policy and popup binding.
- Route human-initiated popups to active tabs and agent-initiated popups to background tabs.
- Deny unsafe popup schemes, downloads, and unmanaged Electron windows.
- Add focused desktop and web regression coverage for popup routing and session policy.

Closes #1187

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788751444&installation_model_id=20477&pr_number=1196&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1196&signature=9e691c7e206e5d82b08931203622410f4e3d4fe23ddd8f9edde2c6185831619e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Preview browser popups now open as tabs, with human-initiated popups activated automatically and automation-initiated popups kept inactive.
  - Preview tabs can open directly to a validated secure web address.
- **Bug Fixes**
  - Improved popup handling prevents invalid or unsafe addresses from opening.
  - Browser automation activity is tracked accurately per preview surface.
  - Preview session cleanup and privacy controls now behave consistently across tabs and guests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->