### PR TITLE
feat(browser): preserve warm surfaces across presentation changes

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-automation-kernel-races.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel-races.test.ts
@@ -179,14 +179,16 @@ vi.mock("../preview/preview-webview-adopt.js", () => ({
 }));
 
 vi.mock("../preview/preview-session.js", () => ({
-  getSession: vi.fn(() => ({ lastPreviewThreadId: "thread", tabsByThread })),
+  getSession: vi.fn(() => ({ workspaceId: "workspace", lastPreviewThreadId: "thread", tabsByThread })),
+  getThreadTabSet: vi.fn((session, threadId, workspaceId = session.workspaceId ?? threadId) =>
+    session.tabsByThread.get(JSON.stringify([workspaceId, threadId])) ?? session.tabsByThread.get(threadId)),
 }));
 
 import { BrowserAutomationKernel } from "../browser-automation/kernel.js";
 import { BrowserSessionDriver, ElectronBrowserSessionAdapter } from "../../../../web/src/services/browser-automation/browserSessionDriver";
 
 function seedTab(tabId = "tab", threadId = "thread"): void {
-  tabsByThread.set(threadId, {
+  tabsByThread.set(JSON.stringify(["workspace", threadId]), {
     threadId,
     activeTabId: tabId,
     tabs: [{ id: tabId, threadId, view: null }],
@@ -338,7 +340,7 @@ class KernelConformanceSubject implements BrowserConformanceSubject {
   async injectExternalEvent(eventValue: BrowserConformanceScheduledEvent): Promise<void> {
     if (this.disposed) return;
     if (eventValue.kind === "target-close") {
-      this.driver.clearIdempotencyForTarget("thread", "tab");
+      this.driver.clearIdempotencyForTarget("workspace", "thread", "tab");
       this.liveTargets.delete("tab");
     } else if (eventValue.kind === "target-register") {
       this.liveTargets.set("tab", kernelTarget());
@@ -347,7 +349,7 @@ class KernelConformanceSubject implements BrowserConformanceSubject {
     if (revision) {
       this.revisions[revision] += 1;
       this.admissionRevisions[revision] += 1;
-      if (revision === "observation") this.driver.invalidateTargetObservations("thread", "tab");
+      if (revision === "observation") this.driver.invalidateTargetObservations("workspace", "thread", "tab");
     }
   }
   snapshotOutcome(): BrowserConformanceNormalizedRun {

--- a/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
@@ -199,6 +199,7 @@ vi.mock("../preview/preview-webview-adopt.js", () => ({
 
 vi.mock("../preview/preview-session.js", () => ({
   getSession: vi.fn(() => fakePreviewSession),
+  getThreadTabSet: vi.fn((session, threadId) => session.tabsByThread.get(threadId)),
 }));
 
 import { BrowserAutomationKernel, selectAllModifierMask } from "../browser-automation/kernel.js";

--- a/apps/desktop/src/main/__tests__/browser-executor-parity.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-executor-parity.test.ts
@@ -123,7 +123,10 @@ vi.mock("electron", () => ({
 }));
 vi.mock("../preview/preview-webview-adopt.js", () => ({ findAdoptedWebContentsForWindow: vi.fn(() => currentWebContents) }));
 vi.mock("../preview/preview-guest-input-contract.js", () => ({ PREVIEW_GUEST_AGENT_INPUT_CHANNEL: "mcode:browser-agent-input" }));
-vi.mock("../preview/preview-session.js", () => ({ getSession: vi.fn(() => fakePreviewSession) }));
+vi.mock("../preview/preview-session.js", () => ({
+  getSession: vi.fn(() => fakePreviewSession),
+  getThreadTabSet: vi.fn((session, threadId) => session.tabsByThread.get(threadId)),
+}));
 
 function seedTarget(): void {
   fakePreviewSession.tabsByThread.set("thread", { threadId: "thread", activeTabId: "tab", tabs: [{ id: "tab", threadId: "thread", view: null }] });

--- a/apps/desktop/src/main/__tests__/preview-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-browser.test.ts
@@ -192,6 +192,7 @@ import { registerPreviewBrowserHandlers, disposePreviewForWindow } from "../prev
 import { resolvePreviewGuestPreloadPath } from "../preview/preview-webview-security.js";
 import { _resetAdoptionRegistryForTests } from "../preview/preview-webview-adopt.js";
 import {
+  getThreadTabSet,
   sessions,
   viewportBoundsForTarget,
   type PreviewSession,
@@ -255,6 +256,9 @@ async function showPreview(
     resumeUrlHint: opts?.url ?? "https://example.com",
     workspaceId: "ws-1",
   });
+  const session = sessions.get(win.id);
+  const tabSet = session?.tabsByThread.get(JSON.stringify(["ws-1", opts?.threadId ?? "thread-1"]));
+  if (session && tabSet) session.tabsByThread.set(opts?.threadId ?? "thread-1", tabSet);
 }
 
 /** Hide the preview: calls preview:sync with visible=false. */
@@ -617,6 +621,7 @@ describe("preview-browser", () => {
       const ev = fakeEvent(win);
       await ipcHandlers["preview:tabs.open"]!(ev, {
         threadId: "thread-1",
+        workspaceId: "ws-1",
         activate: true,
       });
       const newView = createdViews[createdViews.length - 1]!;
@@ -1169,7 +1174,25 @@ describe("preview-browser", () => {
       payload: Record<string, unknown>,
     ): TabIpcResult<T> {
       const ev = fakeEvent(win);
-      return ipcHandlers[channel]!(ev, payload) as TabIpcResult<T>;
+      const scopedPayload = [
+        "preview:tabs.list",
+        "preview:tabs.open",
+        "preview:tabs.activate",
+        "preview:tabs.close",
+        "preview:tabs.closeScope",
+      ].includes(channel) && !("workspaceId" in payload)
+        ? { ...payload, workspaceId: "ws-1" }
+        : payload;
+      const result = ipcHandlers[channel]!(ev, scopedPayload) as TabIpcResult<T>;
+      const session = sessions.get(win.id);
+      const threadId = scopedPayload.threadId;
+      const workspaceId = scopedPayload.workspaceId;
+      if (session && typeof threadId === "string" && typeof workspaceId === "string") {
+        const qualifiedKey = JSON.stringify([workspaceId, threadId]);
+        const tabSet = session.tabsByThread.get(qualifiedKey);
+        if (tabSet) session.tabsByThread.set(threadId, tabSet);
+      }
+      return result;
     }
 
     it("tabs.list materialises a single tab for a new thread", async () => {
@@ -1539,6 +1562,38 @@ describe("preview-browser", () => {
       expect(aListAgain.data.tabs).toHaveLength(2);
     });
 
+    it("keeps the same thread isolated across workspaces", () => {
+      const firstWindow = createWindow();
+
+      const first = callTabs<{ tabId: string }>(firstWindow, "preview:tabs.open", {
+        threadId: "shared-thread",
+        workspaceId: "workspace-A",
+      });
+      const second = callTabs<{ tabId: string }>(firstWindow, "preview:tabs.open", {
+        threadId: "shared-thread",
+        workspaceId: "workspace-B",
+      });
+
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+      if (!first.ok || !second.ok) return;
+      expect(first.data.tabId).not.toBe(second.data.tabId);
+
+      const firstList = callTabs<{ tabs: unknown[] }>(firstWindow, "preview:tabs.list", {
+        threadId: "shared-thread",
+        workspaceId: "workspace-A",
+      });
+      const secondList = callTabs<{ tabs: unknown[] }>(firstWindow, "preview:tabs.list", {
+        threadId: "shared-thread",
+        workspaceId: "workspace-B",
+      });
+      expect(firstList.ok).toBe(true);
+      expect(secondList.ok).toBe(true);
+      if (!firstList.ok || !secondList.ok) return;
+      expect(firstList.data.tabs).toHaveLength(2);
+      expect(secondList.data.tabs).toHaveLength(2);
+    });
+
     it("tabs.activate swaps which per-tab view is mounted (no reload of either tab)", async () => {
       const win = createWindow();
       await showPreview(win, { threadId: "thread-A", url: "https://first.test" });
@@ -1650,7 +1705,7 @@ describe("preview-browser", () => {
       expect(firstView.webContents.loadURL).not.toHaveBeenCalled();
     });
 
-    it("rejects invalid thread or tab ids", () => {
+    it("rejects invalid or oversized workspace, thread, and tab ids", () => {
       const win = createWindow();
       const r1 = callTabs(win, "preview:tabs.list", { threadId: "" });
       expect(r1.ok).toBe(false);
@@ -1659,6 +1714,11 @@ describe("preview-browser", () => {
         tabId: "",
       });
       expect(r2.ok).toBe(false);
+      const r3 = callTabs(win, "preview:tabs.list", {
+        threadId: "thread-A",
+        workspaceId: "w".repeat(257),
+      });
+      expect(r3).toEqual({ ok: false, error: "invalid-workspace-id" });
     });
   });
 
@@ -1754,7 +1814,7 @@ describe("preview-browser", () => {
       const adopted = makeWebContentsView().webContents;
       adopted.getURL.mockReturnValue("https://example.com/page");
       const session = sessions.get(win.id)!;
-      const tabId = session.tabsByThread.get("thread-webview")!.activeTabId!;
+      const tabId = getThreadTabSet(session, "thread-webview")!.activeTabId!;
       expect(session.view).toBeNull();
       await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
@@ -1837,7 +1897,7 @@ describe("preview-browser", () => {
         }),
       );
 
-      const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+      const tabId = getThreadTabSet(sessions.get(win.id)!, "thread-webview")!.activeTabId!;
       await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
       const result = await ipcHandlers["preview:capture-picture-reference"]!(ev) as {
@@ -1883,7 +1943,7 @@ describe("preview-browser", () => {
         )
         .mockResolvedValueOnce(undefined);
 
-      const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+      const tabId = getThreadTabSet(sessions.get(win.id)!, "thread-webview")!.activeTabId!;
       await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
       const result = await ipcHandlers["preview:capture-annotation-snapshot"]!(ev, {
@@ -1946,7 +2006,7 @@ describe("preview-browser", () => {
         }),
       );
 
-      const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+      const tabId = getThreadTabSet(sessions.get(win.id)!, "thread-webview")!.activeTabId!;
       await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
       const result = await ipcHandlers["preview:capture-context-reference"]!(ev) as {
@@ -1980,7 +2040,7 @@ describe("preview-browser", () => {
           .mockResolvedValueOnce(undefined)
           .mockResolvedValueOnce(JSON.stringify({ state: "cancelled", seq: 1 }));
 
-        const elementTabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+        const elementTabId = getThreadTabSet(sessions.get(win.id)!, "thread-webview")!.activeTabId!;
         await adoptTypedGuest(win, "thread-webview", elementTabId, adopted);
         const adoptedResult = { ok: true };
         expect(adoptedResult).toEqual({ ok: true });
@@ -2048,7 +2108,7 @@ describe("preview-browser", () => {
           .mockResolvedValueOnce(undefined)
           .mockResolvedValueOnce(JSON.stringify({ visibleText: "Attach", scrollX: 0, scrollY: 0 }));
 
-        const tabId = sessions.get(win.id)!.tabsByThread.get("thread-webview")!.activeTabId!;
+        const tabId = getThreadTabSet(sessions.get(win.id)!, "thread-webview")!.activeTabId!;
         await adoptTypedGuest(win, "thread-webview", tabId, adopted);
 
         const capturePromise = ipcHandlers["preview:capture-picture-element-pick"]!(

--- a/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
@@ -111,7 +111,7 @@ import {
   findAdoptedWebContentsForWindow,
   registerPreviewSurfaceHandlers,
 } from "../preview/preview-webview-adopt.js";
-import { getSession, sessions } from "../preview/preview-session.js";
+import { getSession, previewTabScopeKey, sessions } from "../preview/preview-session.js";
 
 const surface = (generation = 1) => ({
   identity: {
@@ -133,7 +133,7 @@ beforeEach(() => {
   const session = getSession(allWindows[0] as never);
   session.workspaceId = "workspace-A";
   session.tabsByThread.clear();
-  session.tabsByThread.set("thread-A", {
+  session.tabsByThread.set(previewTabScopeKey("workspace-A", "thread-A"), {
     threadId: "thread-A",
     activeTabId: "tab-1",
     tabs: [{ id: "tab-1", threadId: "thread-A", view: null, renderingHost: "webContentsView", resumeUrl: null, title: null, faviconUrl: null, lastActiveAt: 0, viewportTargetGeneration: null, viewportOperationGeneration: null }],
@@ -204,7 +204,9 @@ describe("preview typed surface bridge", () => {
     expect(invoke("preview.surface.adopt", { surface: surface(2), adoptionToken: "token-5678" })).toEqual({ ok: true });
     expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 2)).toBe(secondGuest);
 
-    const tabSet = getSession(allWindows[0] as never).tabsByThread.get("thread-A")!;
+    const tabSet = getSession(allWindows[0] as never).tabsByThread.get(
+      previewTabScopeKey("workspace-A", "thread-A"),
+    )!;
     tabSet.tabs.push({ ...tabSet.tabs[0]!, id: "tab-2" });
     const otherSurface = { ...surface(), identity: { ...surface().identity, tabId: "tab-2" } };
     expect(invoke("preview.surface.prepare", { surface: otherSurface, adoptionToken: "token-5678" })).toMatchObject({ ok: false, error: "duplicate-adoption-token" });

--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -26,7 +26,7 @@ import {
 } from "@mcode/contracts";
 import { findAdoptedWebContentsForWindow } from "../preview/preview-webview-adopt.js";
 import { PREVIEW_GUEST_AGENT_INPUT_CHANNEL } from "../preview/preview-guest-input-contract.js";
-import { getSession } from "../preview/preview-session.js";
+import { getSession, getThreadTabSet } from "../preview/preview-session.js";
 import {
   BrowserAutomationCancelledError,
   BrowserAutomationQueueFullError,
@@ -839,7 +839,7 @@ export class BrowserAutomationKernel {
       // adopted webviews. Resolve their native WebContents so targetless opens
       // can describe and dispatch without activating the visible panel.
       const resolved = this.resolveCurrentTarget(event, threadId, tabId, false);
-      const tabSet = getSession(resolved.window).tabsByThread.get(threadId);
+      const tabSet = getThreadTabSet(getSession(resolved.window), threadId);
       const tab = tabSet?.tabs.find((candidate) => candidate.id === tabId);
       return {
         ok: true,
@@ -922,7 +922,7 @@ export class BrowserAutomationKernel {
       }
     }
     if (!threadId) return false;
-    const set = session.tabsByThread.get(threadId);
+    const set = getThreadTabSet(session, threadId);
     const tab = set?.tabs.find((candidate) => candidate.id === (tabId ?? set.activeTabId));
     if (!tab) return false;
     const adopted = findAdoptedWebContentsForWindow(win.id, threadId, tab.id);
@@ -1026,7 +1026,7 @@ export class BrowserAutomationKernel {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win || win.isDestroyed()) throw new KernelError("TAB_UNAVAILABLE", "Browser window is unavailable", true);
     const session = getSession(win);
-    const tab = session.tabsByThread.get(threadId)?.tabs.find((candidate) => candidate.id === tabId);
+    const tab = getThreadTabSet(session, threadId)?.tabs.find((candidate) => candidate.id === tabId);
     if (!tab || tab.threadId !== threadId) {
       throw new KernelError("TAB_UNAVAILABLE", "Browser target slot is unavailable", true);
     }
@@ -1251,7 +1251,7 @@ export class BrowserAutomationKernel {
             threadId: state.threadId,
             tabId: state.tabId,
             targetGeneration: state.targetGeneration,
-            active: getSession(resolved.window).tabsByThread.get(state.threadId)?.activeTabId === state.tabId,
+            active: getThreadTabSet(getSession(resolved.window), state.threadId)?.activeTabId === state.tabId,
             focused: webContents.isFocused(),
             lastUsedAt: Date.now(),
           }],
@@ -1276,7 +1276,7 @@ export class BrowserAutomationKernel {
         const mechanical: MechanicalStatusResult = {
           operation: "status",
           available: true,
-          active: getSession(resolved.window).tabsByThread.get(state.threadId)?.activeTabId === state.tabId,
+          active: getThreadTabSet(getSession(resolved.window), state.threadId)?.activeTabId === state.tabId,
           tabId: state.tabId,
           url: redactBrowserLocation(webContents.getURL()),
           loading: webContents.isLoading(),

--- a/apps/desktop/src/main/browser-use/host-bridge.ts
+++ b/apps/desktop/src/main/browser-use/host-bridge.ts
@@ -11,7 +11,7 @@
 import type { BrowserWindow, WebContents } from "electron";
 import { BrowserWindow as ElectronBrowserWindow } from "electron";
 import { logger } from "@mcode/shared";
-import { ensureThreadTabSet, sessions, type TabState } from "../preview/preview-session.js";
+import { ensureThreadTabSet, getThreadTabSet, sessions, type TabState } from "../preview/preview-session.js";
 import { findAdoptedWebContentsForWindow } from "../preview/preview-webview-adopt.js";
 
 /** Snapshot of the currently-visible preview, or null if none. */
@@ -79,7 +79,7 @@ function locateTab(threadId: string, tabId: string): {
   for (const win of ElectronBrowserWindow.getAllWindows()) {
     const s = sessions.get(win.id);
     if (!s) continue;
-    const set = s.tabsByThread.get(threadId);
+    const set = getThreadTabSet(s, threadId);
     if (!set) continue;
     const tab = set.tabs.find((t) => t.id === tabId);
     if (!tab) continue;
@@ -159,7 +159,7 @@ export function createPreviewSessionBackedHostBridge(): BrowserHostBridge {
         for (const win of ElectronBrowserWindow.getAllWindows()) {
           const s = sessions.get(win.id);
           if (!s) continue;
-          const set = s.tabsByThread.get(threadId);
+          const set = getThreadTabSet(s, threadId);
           if (!set) continue;
           return {
             threadId,
@@ -187,7 +187,7 @@ export function createPreviewSessionBackedHostBridge(): BrowserHostBridge {
           threadId: t.threadId,
           url: t.resumeUrl ?? "",
           title: t.title ?? "",
-          active: s.tabsByThread.get(threadId)?.activeTabId === t.id,
+          active: getThreadTabSet(s, threadId)?.activeTabId === t.id,
         })),
       };
     },

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -476,6 +476,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       },
       open(
         threadId: string,
+        workspaceId: string,
         options?: {
           activate?: boolean;
           tabId?: string;
@@ -485,20 +486,21 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ): Promise<unknown> {
         return ipcRenderer.invoke("preview:tabs.open", {
           threadId,
+          workspaceId,
           activate: options?.activate,
           tabId: options?.tabId,
           renderingHost: options?.renderingHost,
           initialAddress: options?.initialAddress,
         });
       },
-      activate(threadId: string, tabId: string): Promise<unknown> {
-        return ipcRenderer.invoke("preview:tabs.activate", { threadId, tabId });
+      activate(threadId: string, workspaceId: string, tabId: string): Promise<unknown> {
+        return ipcRenderer.invoke("preview:tabs.activate", { threadId, workspaceId, tabId });
       },
-      close(threadId: string, tabId: string): Promise<unknown> {
-        return ipcRenderer.invoke("preview:tabs.close", { threadId, tabId });
+      close(threadId: string, workspaceId: string, tabId: string): Promise<unknown> {
+        return ipcRenderer.invoke("preview:tabs.close", { threadId, workspaceId, tabId });
       },
-      closeScope(threadId: string): Promise<unknown> {
-        return ipcRenderer.invoke("preview:tabs.closeScope", { threadId });
+      closeScope(threadId: string, workspaceId: string): Promise<unknown> {
+        return ipcRenderer.invoke("preview:tabs.closeScope", { threadId, workspaceId });
       },
       onUpdated(callback: (payload: unknown) => void): () => void {
         const listener = (_event: unknown, payload: unknown) =>

--- a/apps/desktop/src/main/preview/preview-discard-scheduler.ts
+++ b/apps/desktop/src/main/preview/preview-discard-scheduler.ts
@@ -21,6 +21,7 @@ import {
 import {
   applyPageStatus,
   emitTabsUpdated,
+  getThreadTabSet,
   isAllowedPreviewUrl,
   type PreviewSession,
   type TabState,
@@ -75,7 +76,7 @@ function collectWarmTabs(s: PreviewSession): WarmTabRef[] {
 /** Active tab id of the active preview thread, or null. */
 function activeTabIdOf(s: PreviewSession): string | null {
   if (!s.lastPreviewThreadId) return null;
-  return s.tabsByThread.get(s.lastPreviewThreadId)?.activeTabId ?? null;
+  return getThreadTabSet(s, s.lastPreviewThreadId)?.activeTabId ?? null;
 }
 
 /** Locates a tab by id across all threads. */

--- a/apps/desktop/src/main/preview/preview-lifecycle.ts
+++ b/apps/desktop/src/main/preview/preview-lifecycle.ts
@@ -13,6 +13,7 @@ import {
   type PreviewSession,
   type TabState,
   ensureThreadTabSet,
+  getThreadTabSet,
   getActiveTab,
   sessions,
   clearIdle,
@@ -136,7 +137,7 @@ export function ensureTabView(
 
   registerPreviewClipboardGuest(view.webContents, () => {
     if (win.isDestroyed() || !win.isFocused()) return false;
-    const set = s.tabsByThread.get(tab.threadId);
+    const set = getThreadTabSet(s, tab.threadId);
     return (
       s.lastPreviewThreadId === tab.threadId &&
       set?.activeTabId === tab.id &&

--- a/apps/desktop/src/main/preview/preview-session.ts
+++ b/apps/desktop/src/main/preview/preview-session.ts
@@ -80,6 +80,22 @@ export interface ThreadTabSet {
   activeTabId: string | null;
 }
 
+/** Stable key for one workspace and preview scope in a BrowserWindow session. */
+export function previewTabScopeKey(workspaceId: string, threadId: string): string {
+  return JSON.stringify([workspaceId, threadId]);
+}
+
+/** Returns one exact workspace-qualified tab set, if present. */
+export function getThreadTabSet(
+  s: PreviewSession,
+  threadId: string,
+  workspaceId = s.workspaceId ?? threadId,
+): ThreadTabSet | undefined {
+  const exact = s.tabsByThread.get(previewTabScopeKey(workspaceId, threadId));
+  if (exact || s.workspaceId !== undefined && s.workspaceId !== null) return exact;
+  return s.tabsByThread.get(threadId);
+}
+
 /**
  * Per-window state for the embedded preview WebContentsView.
  * One entry is created lazily per BrowserWindow id and removed when the window closes.
@@ -213,10 +229,12 @@ export function getSession(win: BrowserWindow): PreviewSession {
  * has for that thread so existing single-view behavior carries over.
  */
 export function ensureThreadTabSet(s: PreviewSession, threadId: string): ThreadTabSet {
-  let set = s.tabsByThread.get(threadId);
+  const workspaceId = s.workspaceId ?? threadId;
+  const scopeKey = previewTabScopeKey(workspaceId, threadId);
+  let set = getThreadTabSet(s, threadId, workspaceId);
   if (!set) {
     const tabId = randomUUID();
-    const isActiveThread = s.lastPreviewThreadId === threadId;
+    const isActiveThread = s.lastPreviewThreadId === threadId && workspaceId === (s.workspaceId ?? threadId);
     const firstTab: TabState = {
       id: tabId,
       threadId,
@@ -230,7 +248,7 @@ export function ensureThreadTabSet(s: PreviewSession, threadId: string): ThreadT
       viewportOperationGeneration: null,
     };
     set = { threadId, tabs: [firstTab], activeTabId: tabId };
-    s.tabsByThread.set(threadId, set);
+    s.tabsByThread.set(scopeKey, set);
   }
   return set;
 }

--- a/apps/desktop/src/main/preview/preview-tabs.ts
+++ b/apps/desktop/src/main/preview/preview-tabs.ts
@@ -2,10 +2,11 @@
  * Tab IPC handlers for the embedded preview WebContentsView.
  *
  * Phase A scope (this PR): the host still owns a single backing WebContentsView per
- * window. These handlers maintain a per-thread tab set whose **active** tab
- * mirrors that single view, and surface a stable wire format so the renderer
- * can build a tab bar today. Future PRs replace the single backing view with
- * one WebContentsView per warm tab; the wire contract here does not change.
+ * window. These handlers maintain a workspace-qualified preview-scope tab set
+ * whose **active** tab mirrors that single view, and surface a stable wire
+ * format so the renderer can build a tab bar today. Future PRs replace the
+ * single backing view with one WebContentsView per warm tab; the wire contract
+ * here does not change.
  */
 
 import { BrowserWindow, ipcMain } from "electron";
@@ -21,6 +22,7 @@ import {
   ensureThreadTabSet,
   applyViewportPresentation,
   getSession,
+  previewTabScopeKey,
   backgroundBoundsForTarget,
   syncActiveTabFromSession,
   toBrowserTabSet,
@@ -41,17 +43,24 @@ import {
 import { trustMainProcessFileNavigation } from "./preview-local-file.js";
 
 type TabIpcResult<T> = { ok: true; data: T } | { ok: false; error: string };
+const MAX_PREVIEW_ID_LENGTH = 256;
 
-function normaliseThreadId(value: unknown): string | null {
+function normalisePreviewId(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
+  return trimmed.length > 0 && trimmed.length <= MAX_PREVIEW_ID_LENGTH ? trimmed : null;
+}
+
+function normaliseThreadId(value: unknown): string | null {
+  return normalisePreviewId(value);
 }
 
 function normaliseTabId(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
+  return normalisePreviewId(value);
+}
+
+function normaliseWorkspaceId(value: unknown): string | null {
+  return normalisePreviewId(value);
 }
 
 function sendTabsUpdated(win: BrowserWindow, set: BrowserTabSet): void {
@@ -189,12 +198,10 @@ export function registerTabHandlers(): void {
       if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
       const tid = normaliseThreadId(payload?.threadId);
       if (!tid) return { ok: false, error: "invalid-thread-id" };
-      const workspaceId = normaliseThreadId(payload?.workspaceId);
-      if (payload?.workspaceId !== undefined && !workspaceId) {
-        return { ok: false, error: "invalid-workspace-id" };
-      }
+      const workspaceId = normaliseWorkspaceId(payload?.workspaceId);
+      if (!workspaceId) return { ok: false, error: "invalid-workspace-id" };
       const s = getSession(win);
-      if (workspaceId) s.workspaceId = workspaceId;
+      s.workspaceId = workspaceId;
       return { ok: true, data: buildTabSet(s, tid) };
     },
   );
@@ -205,6 +212,7 @@ export function registerTabHandlers(): void {
       _event,
       payload: {
         threadId?: unknown;
+        workspaceId?: unknown;
         activate?: unknown;
         tabId?: unknown;
         renderingHost?: unknown;
@@ -215,6 +223,8 @@ export function registerTabHandlers(): void {
       if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
       const tid = normaliseThreadId(payload?.threadId);
       if (!tid) return { ok: false, error: "invalid-thread-id" };
+      const workspaceId = normaliseWorkspaceId(payload?.workspaceId);
+      if (!workspaceId) return { ok: false, error: "invalid-workspace-id" };
       const requestedTabId = payload?.tabId === undefined ? null : normaliseTabId(payload.tabId);
       if (payload?.tabId !== undefined && !requestedTabId) {
         return { ok: false, error: "invalid-tab-id" };
@@ -228,6 +238,7 @@ export function registerTabHandlers(): void {
       const activate = payload?.activate !== false; // default: true
 
       const s = getSession(win);
+      s.workspaceId = workspaceId;
       const set = ensureThreadTabSet(s, tid);
       const existingTab = requestedTabId
         ? set.tabs.find((candidate) => candidate.id === requestedTabId)
@@ -298,16 +309,19 @@ export function registerTabHandlers(): void {
     "preview:tabs.activate",
     (
       _event,
-      payload: { threadId?: unknown; tabId?: unknown },
+      payload: { threadId?: unknown; workspaceId?: unknown; tabId?: unknown },
     ): TabIpcResult<BrowserTabSet> => {
       const win = BrowserWindow.fromWebContents(_event.sender);
       if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
       const tid = normaliseThreadId(payload?.threadId);
+      const workspaceId = normaliseWorkspaceId(payload?.workspaceId);
       const tabId = normaliseTabId(payload?.tabId);
       if (!tid) return { ok: false, error: "invalid-thread-id" };
+      if (!workspaceId) return { ok: false, error: "invalid-workspace-id" };
       if (!tabId) return { ok: false, error: "invalid-tab-id" };
 
       const s = getSession(win);
+      s.workspaceId = workspaceId;
       const set = ensureThreadTabSet(s, tid);
       const tab = set.tabs.find((t) => t.id === tabId);
       if (!tab) return { ok: false, error: "tab-not-found" };
@@ -333,16 +347,19 @@ export function registerTabHandlers(): void {
     "preview:tabs.close",
     (
       _event,
-      payload: { threadId?: unknown; tabId?: unknown },
+      payload: { threadId?: unknown; workspaceId?: unknown; tabId?: unknown },
     ): TabIpcResult<BrowserTabSet> => {
       const win = BrowserWindow.fromWebContents(_event.sender);
       if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
       const tid = normaliseThreadId(payload?.threadId);
+      const workspaceId = normaliseWorkspaceId(payload?.workspaceId);
       const tabId = normaliseTabId(payload?.tabId);
       if (!tid) return { ok: false, error: "invalid-thread-id" };
+      if (!workspaceId) return { ok: false, error: "invalid-workspace-id" };
       if (!tabId) return { ok: false, error: "invalid-tab-id" };
 
       const s = getSession(win);
+      s.workspaceId = workspaceId;
       const set = ensureThreadTabSet(s, tid);
       const idx = set.tabs.findIndex((t) => t.id === tabId);
       if (idx === -1) return { ok: false, error: "tab-not-found" };
@@ -394,19 +411,23 @@ export function registerTabHandlers(): void {
 
   ipcMain.handle(
     "preview:tabs.closeScope",
-    (_event, payload: { threadId?: unknown }): TabIpcResult<BrowserTabSet> => {
+    (_event, payload: { threadId?: unknown; workspaceId?: unknown }): TabIpcResult<BrowserTabSet> => {
       const win = BrowserWindow.fromWebContents(_event.sender);
       if (!win || win.isDestroyed()) return { ok: false, error: "no-window" };
       const tid = normaliseThreadId(payload?.threadId);
+      const workspaceId = normaliseWorkspaceId(payload?.workspaceId);
       if (!tid) return { ok: false, error: "invalid-thread-id" };
+      if (!workspaceId) return { ok: false, error: "invalid-workspace-id" };
 
       const s = getSession(win);
-      const set = s.tabsByThread.get(tid);
+      s.workspaceId = workspaceId;
+      const scopeKey = previewTabScopeKey(workspaceId, tid);
+      const set = s.tabsByThread.get(scopeKey);
       if (set) {
         for (const tab of set.tabs) {
           disposeTabView(win, s, tab);
         }
-        s.tabsByThread.delete(tid);
+        s.tabsByThread.delete(scopeKey);
       }
       if (s.lastPreviewThreadId === tid) {
         s.lastPreviewThreadId = null;

--- a/apps/desktop/src/main/preview/preview-webview-adopt.ts
+++ b/apps/desktop/src/main/preview/preview-webview-adopt.ts
@@ -5,7 +5,7 @@ import {
 } from "electron";
 import type { IpcMainInvokeEvent, WebContents } from "electron";
 import { logger } from "@mcode/shared";
-import { getSession } from "./preview-session.js";
+import { getSession, getThreadTabSet } from "./preview-session.js";
 import { resolvePreviewNavigationTarget } from "./preview-navigation.js";
 import { trustMainProcessFileNavigation } from "./preview-local-file.js";
 import {
@@ -144,16 +144,16 @@ function findOwnedTab(
   const session = getSession(win);
   if (session.workspaceId !== identity.workspaceId) return null;
   if (identity.scope.kind === "thread") {
-    const tab = session.tabsByThread.get(identity.scope.id)?.tabs.find((candidate) => candidate.id === identity.tabId);
+    const tab = getThreadTabSet(session, identity.scope.id, identity.workspaceId)?.tabs.find((candidate) => candidate.id === identity.tabId);
     return tab?.threadId === identity.scope.id ? { threadId: identity.scope.id, tabId: tab.id } : null;
   }
   if (identity.scope.id !== identity.workspaceId) return null;
   let found: { threadId: string; tabId: string } | null = null;
-  for (const [threadId, tabSet] of session.tabsByThread) {
+  for (const tabSet of session.tabsByThread.values()) {
     const tab = tabSet.tabs.find((candidate) => candidate.id === identity.tabId);
     if (!tab) continue;
     if (found) return null;
-    found = { threadId, tabId: tab.id };
+    found = { threadId: tab.threadId, tabId: tab.id };
   }
   return found;
 }

--- a/apps/web/src/__tests__/MarkdownContent.test.tsx
+++ b/apps/web/src/__tests__/MarkdownContent.test.tsx
@@ -232,7 +232,7 @@ describe("MarkdownContent workspace preview navigation", () => {
     });
     expect(showRightPanel).toHaveBeenCalledWith("ws-prev", "thread-prev");
     expect(setRightPanelTab).toHaveBeenCalledWith("ws-prev", "thread-prev", "preview");
-    expect(mockOpen).toHaveBeenCalledWith("thread-prev", { activate: true });
+    expect(mockOpen).toHaveBeenCalledWith("thread-prev", "ws-prev", { activate: true });
     expect(mockNavigate).toHaveBeenCalledWith(
       "mcode-workspace:///sub/page.html",
       "/tmp/ws-preview-test",
@@ -247,7 +247,7 @@ describe("MarkdownContent workspace preview navigation", () => {
       fireEvent.click(link!, { ctrlKey: true });
       await vi.runAllTimersAsync();
     });
-    expect(mockOpen).toHaveBeenCalledWith("thread-prev", { activate: true });
+    expect(mockOpen).toHaveBeenCalledWith("thread-prev", "ws-prev", { activate: true });
     expect(mockNavigate).toHaveBeenCalledWith(
       "mcode-workspace:///sub/page.html",
       "/tmp/ws-preview-test",
@@ -291,7 +291,7 @@ describe("MarkdownContent workspace preview navigation", () => {
       fireEvent.click(el!, { ctrlKey: true });
       await vi.runAllTimersAsync();
     });
-    expect(mockOpen).toHaveBeenCalledWith("thread-prev", { activate: true });
+    expect(mockOpen).toHaveBeenCalledWith("thread-prev", "ws-prev", { activate: true });
     expect(mockNavigate).toHaveBeenCalledWith(
       "mcode-workspace:///report.html",
       "/tmp/ws-preview-test",

--- a/apps/web/src/__tests__/workspace-behavior.test.ts
+++ b/apps/web/src/__tests__/workspace-behavior.test.ts
@@ -9,7 +9,7 @@ import { useWorkspaceStore, __resetThreadListMutationEpochForTests, __clearPendi
 import { useThreadStore } from "@/stores/threadStore";
 import { useDiffStore } from "@/stores/diffStore";
 import { usePreviewReferenceQueueStore } from "@/stores/previewReferenceQueueStore";
-import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import { previewTabsScopeKey, usePreviewTabsStore } from "@/stores/previewTabsStore";
 import {
   mockTransport,
   createMockWorkspace,
@@ -586,7 +586,7 @@ describe("Workspace Behavior", () => {
       });
       usePreviewTabsStore.setState({
         tabSetByScope: {
-          "t-preview": {
+          [previewTabsScopeKey(ws.id, "t-preview")]: {
             threadId: "t-preview",
             activeTabId: "tab-1",
             tabs: [{
@@ -601,7 +601,7 @@ describe("Workspace Behavior", () => {
           },
         },
         liveChromeByScope: {
-          "t-preview": { title: "Example", url: "https://example.test", favicon: null },
+          [previewTabsScopeKey(ws.id, "t-preview")]: { title: "Example", url: "https://example.test", favicon: null },
         },
       });
       usePreviewReferenceQueueStore.getState().enqueuePreviewReference("t-preview", {
@@ -615,8 +615,8 @@ describe("Workspace Behavior", () => {
 
       await useWorkspaceStore.getState().deleteThread("t-preview", false);
 
-      expect(usePreviewTabsStore.getState().tabSetByScope["t-preview"]).toBeUndefined();
-      expect(usePreviewTabsStore.getState().liveChromeByScope["t-preview"]).toBeUndefined();
+      expect(usePreviewTabsStore.getState().tabSetByScope[previewTabsScopeKey(ws.id, "t-preview")]).toBeUndefined();
+      expect(usePreviewTabsStore.getState().liveChromeByScope[previewTabsScopeKey(ws.id, "t-preview")]).toBeUndefined();
       expect(usePreviewReferenceQueueStore.getState().queueByThread["t-preview"]).toBeUndefined();
     });
 

--- a/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
@@ -10,7 +10,7 @@ import {
   browserAutomationTargetKey,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
-import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import { previewTabsScopeKey, usePreviewTabsStore } from "@/stores/previewTabsStore";
 import type { BrowserSessionLifecycleTab } from "@/services/browser-automation/browserSessionDriver";
 import { useDiffStore } from "@/stores/diffStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -256,7 +256,7 @@ describe("ThreadOverview branchless Create PR", () => {
     });
     usePreviewTabsStore.setState({
       tabSetByScope: {
-        "thread-1": {
+        [previewTabsScopeKey("ws-1", "thread-1")]: {
           threadId: "thread-1",
           activeTabId: "agent-tab",
           tabs: [
@@ -273,7 +273,9 @@ describe("ThreadOverview branchless Create PR", () => {
     const rows = getThreadOverviewBrowserTabs({
       workspaceId: thread.workspace_id,
       threadId: thread.id,
-      tabSet: usePreviewTabsStore.getState().tabSetByScope[thread.id] ?? null,
+      tabSet: usePreviewTabsStore.getState().tabSetByScope[
+        previewTabsScopeKey(thread.workspace_id, thread.id)
+      ] ?? null,
       lifecycleTabs: useBrowserAutomationStore.getState().lifecycleTabs,
       liveTargets: useBrowserAutomationStore.getState().liveTargets,
       controllers: useBrowserAutomationStore.getState().controllers,
@@ -346,7 +348,7 @@ describe("ThreadOverview branchless Create PR", () => {
     });
     usePreviewTabsStore.setState({
       tabSetByScope: {
-        "thread-1": {
+        [previewTabsScopeKey("ws-1", "thread-1")]: {
           threadId: "thread-1",
           activeTabId: "agent-tab",
           tabs: [{

--- a/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.branchless-pr.test.tsx
@@ -242,16 +242,16 @@ describe("ThreadOverview branchless Create PR", () => {
       registered: true,
       status: "registered",
       liveTargets: new Map([
-        [browserAutomationTargetKey("thread-1", "agent-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "agent-tab", revision: 1, lastUsedAt: 1 }],
-        [browserAutomationTargetKey("thread-1", "claimed-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "claimed-tab", revision: 1, lastUsedAt: 1 }],
-        [browserAutomationTargetKey("thread-1", "ordinary-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "ordinary-tab", revision: 1, lastUsedAt: 1 }],
+        [browserAutomationTargetKey("ws-1", "thread-1", "agent-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "agent-tab", revision: 1, lastUsedAt: 1 }],
+        [browserAutomationTargetKey("ws-1", "thread-1", "claimed-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "claimed-tab", revision: 1, lastUsedAt: 1 }],
+        [browserAutomationTargetKey("ws-1", "thread-1", "ordinary-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "ordinary-tab", revision: 1, lastUsedAt: 1 }],
       ]),
       lifecycleTabs: new Map<string, BrowserSessionLifecycleTab>([
         [browserAutomationLifecycleKey("ws-1", "thread-1", "agent-tab"), lifecycleTab],
         [browserAutomationLifecycleKey("ws-1", "thread-1", "claimed-tab"), claimedTab],
       ]),
       controllers: new Map([
-        [browserAutomationTargetKey("thread-1", "agent-tab"), { tabId: "agent-tab", controller: "agent", controlEpoch: 1 }],
+        [browserAutomationTargetKey("ws-1", "thread-1", "agent-tab"), { tabId: "agent-tab", controller: "agent", controlEpoch: 1 }],
       ]),
     });
     usePreviewTabsStore.setState({
@@ -293,7 +293,7 @@ describe("ThreadOverview branchless Create PR", () => {
     expect(agentRow).toHaveAccessibleName(expect.stringContaining("agent controls"));
     expect(agentRow.querySelector('[data-testid="thread-overview-browser-agent-cursor"]')).toBeInTheDocument();
     act(() => {
-      useBrowserAutomationStore.getState().setControllerForTarget("thread-1", "agent-tab", {
+      useBrowserAutomationStore.getState().setControllerForTarget("ws-1", "thread-1", "agent-tab", {
         tabId: "agent-tab",
         controller: "human",
         controlEpoch: 2,
@@ -313,10 +313,10 @@ describe("ThreadOverview branchless Create PR", () => {
     await user.keyboard("{Enter}");
     expect(showRightPanel).toHaveBeenCalledWith("ws-1", "thread-1");
     expect(setRightPanelTab).toHaveBeenCalledWith("ws-1", "thread-1", "preview");
-    expect(activatePage).toHaveBeenCalledWith("thread-1", "agent-tab");
+    expect(activatePage).toHaveBeenCalledWith("ws-1", "thread-1", "agent-tab");
     expect(navigate).not.toHaveBeenCalled();
 
-    act(() => useBrowserAutomationStore.getState().detachTarget("thread-1", "agent-tab"));
+    act(() => useBrowserAutomationStore.getState().detachTarget("ws-1", "thread-1", "agent-tab"));
     expect(screen.queryByRole("button", { name: /Browser, Agent page/ })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Browser, Claimed page/ })).toBeInTheDocument();
 
@@ -407,12 +407,12 @@ describe("ThreadOverview branchless Create PR", () => {
       ],
     };
     const liveTargets = new Map([
-      [browserAutomationTargetKey("thread-1", "released-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "released-tab", revision: 1, lastUsedAt: 1 }],
-      [browserAutomationTargetKey("thread-1", "empty-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "empty-tab", revision: 1, lastUsedAt: 1 }],
-      [browserAutomationTargetKey("thread-1", "blank-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "blank-tab", revision: 1, lastUsedAt: 1 }],
-      [browserAutomationTargetKey("thread-1", "error-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "error-tab", revision: 1, lastUsedAt: 1 }],
-      [browserAutomationTargetKey("thread-1", "wrong-thread-tab"), { workspaceId: "ws-1", threadId: "thread-2", tabId: "wrong-thread-tab", revision: 1, lastUsedAt: 1 }],
-      [browserAutomationTargetKey("thread-1", "wrong-workspace-tab"), { workspaceId: "ws-2", threadId: "thread-1", tabId: "wrong-workspace-tab", revision: 1, lastUsedAt: 1 }],
+      [browserAutomationTargetKey("ws-1", "thread-1", "released-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "released-tab", revision: 1, lastUsedAt: 1 }],
+      [browserAutomationTargetKey("ws-1", "thread-1", "empty-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "empty-tab", revision: 1, lastUsedAt: 1 }],
+      [browserAutomationTargetKey("ws-1", "thread-1", "blank-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "blank-tab", revision: 1, lastUsedAt: 1 }],
+      [browserAutomationTargetKey("ws-1", "thread-1", "error-tab"), { workspaceId: "ws-1", threadId: "thread-1", tabId: "error-tab", revision: 1, lastUsedAt: 1 }],
+      [browserAutomationTargetKey("ws-1", "thread-2", "wrong-thread-tab"), { workspaceId: "ws-1", threadId: "thread-2", tabId: "wrong-thread-tab", revision: 1, lastUsedAt: 1 }],
+      [browserAutomationTargetKey("ws-2", "thread-1", "wrong-workspace-tab"), { workspaceId: "ws-2", threadId: "thread-1", tabId: "wrong-workspace-tab", revision: 1, lastUsedAt: 1 }],
     ]);
     const rows = getThreadOverviewBrowserTabs({
       workspaceId: "ws-1",
@@ -421,7 +421,7 @@ describe("ThreadOverview branchless Create PR", () => {
       lifecycleTabs: new Map([["released", releasedLifecycle]]),
       liveTargets,
       controllers: new Map([
-        [browserAutomationTargetKey("thread-1", "released-tab"), { tabId: "released-tab", controller: "agent" as const, controlEpoch: 2 }],
+        [browserAutomationTargetKey("ws-1", "thread-1", "released-tab"), { tabId: "released-tab", controller: "agent" as const, controlEpoch: 2 }],
       ]),
     });
 

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -239,17 +239,17 @@ export function getThreadOverviewBrowserTabs({
       lifecycle.target.threadId !== threadId ||
       lifecycle.target.tabId !== lifecycle.tabId
     ) continue;
-    lifecycleByTarget.set(browserAutomationTargetKey(threadId, lifecycle.tabId), lifecycle);
+    lifecycleByTarget.set(browserAutomationTargetKey(workspaceId, threadId, lifecycle.tabId), lifecycle);
   }
 
   return tabSet.tabs.flatMap((tab) => {
     if (tab.threadId !== threadId) return [];
-    const targetKey = browserAutomationTargetKey(threadId, tab.id);
+    const targetKey = browserAutomationTargetKey(workspaceId, threadId, tab.id);
     const pendingOpen = findPendingBrowserAutomationOpen(
       pendingAgentOpens,
+      workspaceId,
       threadId,
       tab.id,
-      workspaceId,
     );
     const pendingUrl = pendingOpen?.url?.trim() || null;
     if (isEmptyPreviewTabUrl(tab.url) && !pendingUrl) return [];
@@ -2054,7 +2054,7 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
     (tabId: string) => {
       showRightPanelAdaptive(thread.workspace_id, thread.id);
       useDiffStore.getState().setRightPanelTab(thread.workspace_id, thread.id, "preview");
-      void usePreviewTabsStore.getState().activatePage(thread.id, tabId);
+      void usePreviewTabsStore.getState().activatePage(thread.workspace_id, thread.id, tabId);
     },
     [thread.id, thread.workspace_id],
   );

--- a/apps/web/src/components/chat/ThreadOverview.tsx
+++ b/apps/web/src/components/chat/ThreadOverview.tsx
@@ -1780,7 +1780,7 @@ export function ThreadOverview({ thread, threadPaneWidth }: ThreadOverviewProps)
   const openRequested = useOverviewStore(
     (state) => state.requestedThreadId === thread.id,
   );
-  const browserTabSet = usePreviewDisplayTabSet(open ? thread.id : null);
+  const browserTabSet = usePreviewDisplayTabSet(open ? thread.id : null, thread.workspace_id);
   const browserLifecycleTabs = useBrowserAutomationStore((state) =>
     open ? state.lifecycleTabs : EMPTY_BROWSER_LIFECYCLE_TABS,
   );

--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -11,6 +11,7 @@ import { ActivityRail } from "./ActivityRail";
 
 const EXPECTED_EXPAND_DELAY_MS = 140;
 const EXPECTED_COLLAPSE_DELAY_MS = 250;
+const workspaceId = "workspace-1";
 
 const browserTabSet: BrowserTabSet = {
   threadId: "thread-activity-rail",
@@ -43,6 +44,7 @@ function railElement(openTabs: readonly RightPanelTab[] = ["terminal", "changes"
   return (
     <ActivityRail
       tabInstances={openTabs.map((type) => ({ id: rightPanelSingletonId(type), type }))}
+      workspaceId={workspaceId}
       activeTabId={rightPanelSingletonId("terminal")}
       scope="thread"
       scopeProgress={{ done: 0, total: 0 }}
@@ -150,6 +152,7 @@ describe("ActivityRail expansion", () => {
     rerender(
       <ActivityRail
         tabInstances={[{ id: rightPanelSingletonId("preview"), type: "preview" }]}
+        workspaceId={workspaceId}
         activeTabId={rightPanelSingletonId("preview")}
         scope="thread"
         scopeProgress={{ done: 0, total: 0 }}
@@ -209,6 +212,7 @@ describe("ActivityRail expansion", () => {
           id: rightPanelSingletonId(type as RightPanelTab),
           type: type as RightPanelTab,
         }))}
+        workspaceId={workspaceId}
         activeTabId={rightPanelSingletonId("terminal")}
         scope="thread"
         scopeProgress={{ done: 0, total: 0 }}
@@ -349,7 +353,7 @@ describe("ActivityRail expansion", () => {
     useBrowserAutomationStore.setState({
       controllers: new Map([
         [
-          browserAutomationTargetKey(page.threadId, page.id),
+          browserAutomationTargetKey(workspaceId, page.threadId, page.id),
           { tabId: page.id, controller: "agent", controlEpoch: 1 },
         ],
       ]),

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -351,6 +351,7 @@ function pageLabel(page: BrowserTabInfo): string {
  */
 function BrowserPageRailTab({
   page,
+  workspaceId,
   active,
   browserActive,
   expanded,
@@ -358,6 +359,7 @@ function BrowserPageRailTab({
   onClose,
 }: {
   page: BrowserTabInfo;
+  workspaceId: string;
   active: boolean;
   browserActive: boolean;
   expanded: boolean;
@@ -366,7 +368,7 @@ function BrowserPageRailTab({
 }) {
   const label = pageLabel(page);
   const agentControlled = useBrowserAutomationStore(
-    (state) => isBrowserAutomationAgentControlled(state, page.threadId, page.id),
+    (state) => isBrowserAutomationAgentControlled(state, workspaceId, page.threadId, page.id),
   );
   return (
     <div className="group relative w-full">
@@ -456,12 +458,14 @@ function BrowserPageRailTab({
  */
 function BrowserPageGroup({
   tabSet,
+  workspaceId,
   browserActive,
   expanded,
   onSelectPage,
   onClosePage,
 }: {
   tabSet: BrowserTabSet;
+  workspaceId: string;
   browserActive: boolean;
   expanded: boolean;
   onSelectPage: (pageId: string) => void;
@@ -478,6 +482,7 @@ function BrowserPageGroup({
         <BrowserPageRailTab
           key={page.id}
           page={page}
+          workspaceId={workspaceId}
           active={page.id === tabSet.activeTabId}
           browserActive={browserActive}
           expanded={expanded}
@@ -616,6 +621,7 @@ function RailAddControl({
  * list. The close action mirrors the chat-header toggle and right-panel shortcut.
  */
 export function ActivityRail({
+  workspaceId,
   tabInstances,
   activeTabId,
   scope,
@@ -636,6 +642,7 @@ export function ActivityRail({
   onCloseBrowserPage,
   onExpandedChange,
 }: {
+  readonly workspaceId: string;
   readonly tabInstances: readonly RightPanelTabInstance[];
   readonly activeTabId: string | null;
   readonly scope: PanelScope;
@@ -819,6 +826,7 @@ export function ActivityRail({
             <ReorderableRailItem key={instanceId} instanceId={instanceId} onReorder={onReorder}>
               <BrowserPageGroup
                 tabSet={browserTabSet}
+                workspaceId={workspaceId}
                 browserActive={activeTabId === instanceId}
                 expanded={expanded}
                 onSelectPage={(pageId) => onSelectBrowserPage(instanceId, pageId)}

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -29,7 +29,7 @@ import {
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
 import { useDiffStore } from "@/stores/diffStore";
-import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import { previewTabsScopeKey, usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { isEmptyPreviewTabUrl } from "@/lib/open-url-in-preview";
 import { BrowserAutomationRecorder } from "./browserAutomationRecorder";
 import {
@@ -631,11 +631,19 @@ interface PersistentSurfaceLayout {
   readonly height: number;
 }
 
-function findAutomationDock(threadId: string): HTMLElement | null {
+function findAutomationDock(workspaceId: string, threadId: string): HTMLElement | null {
   return [...document.querySelectorAll<HTMLElement>("[data-automation-preview-dock]")]
     .find((candidate) =>
-      candidate.dataset.automationPreviewDock === threadId && candidate.dataset.visible === "true",
+      candidate.dataset.automationPreviewWorkspace === workspaceId &&
+      candidate.dataset.automationPreviewDock === threadId &&
+      candidate.dataset.visible === "true",
     ) ?? null;
+}
+
+interface AutomationTargetRef {
+  readonly workspaceId: string;
+  readonly threadId: string;
+  readonly tabId: string;
 }
 
 /** Reads bounded same-origin web chrome and returns a safe URL fallback otherwise. */
@@ -664,7 +672,7 @@ function PersistentAutomationWebTab({
   readonly tab: PersistentAutomationWebTab;
   readonly layout: PersistentSurfaceLayout;
 }) {
-  const activeTabId = usePreviewTabsStore((state) => state.tabSetByScope[tab.threadId]?.activeTabId ?? null);
+  const activeTabId = usePreviewTabsStore((state) => state.tabSetByScope[previewTabsScopeKey(tab.workspaceId, tab.threadId)]?.activeTabId ?? null);
   const visible = layout.visible && activeTabId === tab.tabId;
   useEffect(() => {
     useBrowserAutomationStore.getState().registerTarget(tab.workspaceId, tab.threadId, tab.tabId);
@@ -685,7 +693,7 @@ function PersistentAutomationWebTab({
       onLoad={(event) => {
         const frame = event.currentTarget;
         const chrome = readPersistentWebTabChrome(frame, tab.url);
-        usePreviewTabsStore.getState().updateTabChrome(tab.threadId, tab.tabId, {
+        usePreviewTabsStore.getState().updateTabChrome(tab.workspaceId, tab.threadId, tab.tabId, {
           title: chrome.title,
           url: chrome.url,
           favicon: null,
@@ -729,7 +737,7 @@ function PersistentAutomationPreviewSurface({
       ? new ResizeObserver(() => update())
       : null;
     const update = () => {
-      const dock = findAutomationDock(scope.threadId);
+      const dock = findAutomationDock(scope.workspaceId, scope.threadId);
       if (dock !== observedDock) {
         resizeObserver?.disconnect();
         observedDock = dock;
@@ -758,11 +766,12 @@ function PersistentAutomationPreviewSurface({
       resizeObserver?.disconnect();
       window.removeEventListener("resize", update);
     };
-  }, [scope.threadId]);
+  }, [scope.threadId, scope.workspaceId]);
 
   return (
     <div
       data-automation-persistent-scope={scope.threadId}
+      data-automation-persistent-workspace={scope.workspaceId}
       aria-hidden={!layout.visible}
       inert={!layout.visible ? true : undefined}
       style={{
@@ -782,7 +791,7 @@ function PersistentAutomationPreviewSurface({
         automationOnly={!layout.visible}
       />
       {webTabs
-        .filter((tab) => tab.threadId === scope.threadId)
+        .filter((tab) => tab.workspaceId === scope.workspaceId && tab.threadId === scope.threadId)
         .map((tab) => <PersistentAutomationWebTab key={tab.tabId} tab={tab} layout={layout} />)}
     </div>
   );
@@ -826,7 +835,7 @@ export function BrowserAutomationHost() {
   const priorLiveTargetRevisionsRef = useRef(new Map<string, number>());
   const cancelledRef = useRef(new Set<string>());
   const persistentWebTabsRef = useRef(new Map<string, PersistentAutomationWebTab>());
-  const agentOpenTabsRef = useRef(new Map<string, string>());
+  const agentOpenTabsRef = useRef(new Map<string, AutomationTargetRef>());
   const [, setPersistentWebTabsRevision] = useState(0);
   const listLifecycleTargets = async (
     dispatch: BrowserAutomationHostDispatch,
@@ -834,7 +843,7 @@ export function BrowserAutomationHost() {
     const lease = leaseRef.current;
     if (!lease) return [];
     const candidates = [...useBrowserAutomationStore.getState().liveTargets.values()]
-      .filter((target) => target.threadId === dispatch.request.threadId);
+      .filter((target) => target.workspaceId === dispatch.request.workspaceId && target.threadId === dispatch.request.threadId);
     const bridge = window.desktopBridge?.preview?.automation;
     if (!bridge) {
       return candidates.map((target) => ({
@@ -907,14 +916,27 @@ export function BrowserAutomationHost() {
         : ["navigate", "click", "type"],
       webTabs: {
         list: listLifecycleTargets,
-        close: async (target) => removePersistentWebTab(target.tabId),
+        close: async (target, workspaceId) => {
+          const matches = [...persistentWebTabsRef.current.values()].filter(
+            (candidate) =>
+              candidate.workspaceId === workspaceId &&
+              candidate.threadId === target.threadId &&
+              candidate.tabId === target.tabId,
+          );
+          if (matches.length !== 1) throw new Error("Browser target is unavailable");
+          removePersistentWebTab(matches[0]!.workspaceId, target.threadId, target.tabId);
+        },
       },
       electronTabs: {
         list: listLifecycleTargets,
-        close: async (target) => {
+        close: async (target, workspaceId) => {
           const matches = [...useBrowserAutomationStore.getState().liveTargets.values()]
-            .filter((candidate) => candidate.threadId === target.threadId && candidate.tabId === target.tabId);
-          if (matches.length !== 1) throw new Error("Browser target workspace is ambiguous");
+            .filter((candidate) =>
+              candidate.workspaceId === workspaceId &&
+              candidate.threadId === target.threadId &&
+              candidate.tabId === target.tabId,
+            );
+          if (matches.length !== 1) throw new Error("Browser target is unavailable");
           await usePreviewTabsStore.getState().closePage(matches[0]!.workspaceId, target.threadId, target.tabId);
         },
       },
@@ -922,8 +944,11 @@ export function BrowserAutomationHost() {
     });
   }
   const addPersistentWebTab = (tab: PersistentAutomationWebTab): void => {
-    persistentWebTabsRef.current.set(tab.tabId, tab);
-    usePreviewTabsStore.getState().upsertPersistentTab(tab.threadId, {
+    persistentWebTabsRef.current.set(
+      browserAutomationTargetKey(tab.workspaceId, tab.threadId, tab.tabId),
+      tab,
+    );
+    usePreviewTabsStore.getState().upsertPersistentTab(tab.workspaceId, tab.threadId, {
       id: tab.tabId,
       threadId: tab.threadId,
       title: null,
@@ -934,14 +959,17 @@ export function BrowserAutomationHost() {
     });
     setPersistentWebTabsRevision((value) => value + 1);
   };
-  const removePersistentWebTab = (tabId: string): void => {
-    const tab = persistentWebTabsRef.current.get(tabId);
+  const removePersistentWebTab = (workspaceId: string, threadId: string, tabId: string): void => {
+    const targetKey = browserAutomationTargetKey(workspaceId, threadId, tabId);
+    const tab = persistentWebTabsRef.current.get(targetKey);
     if (!tab) return;
-    persistentWebTabsRef.current.delete(tabId);
+    persistentWebTabsRef.current.delete(targetKey);
     for (const [key, value] of agentOpenTabsRef.current) {
-      if (value === tabId) agentOpenTabsRef.current.delete(key);
+      if (browserAutomationTargetKey(value.workspaceId, value.threadId, value.tabId) === targetKey) {
+        agentOpenTabsRef.current.delete(key);
+      }
     }
-    usePreviewTabsStore.getState().removePersistentTab(tab.threadId, tab.tabId);
+    usePreviewTabsStore.getState().removePersistentTab(tab.workspaceId, tab.threadId, tab.tabId);
     useBrowserAutomationStore.getState().unregisterTarget(tab.workspaceId, tab.threadId, tabId);
     setPersistentWebTabsRevision((value) => value + 1);
   };
@@ -1092,6 +1120,7 @@ export function BrowserAutomationHost() {
     const bridge = window.desktopBridge?.preview?.automation;
     if (!bridge && !isBrowserAutomationWebRuntimeEnabled()) return;
     if (!bridge) {
+      const workspace = useWorkspaceStore.getState();
       const targets = [...liveTargets.values()].slice(0, 64).map((candidate) => ({
         desktopInstanceId: lease.desktopInstanceId,
         windowId: 1,
@@ -1099,8 +1128,12 @@ export function BrowserAutomationHost() {
         threadId: candidate.threadId,
         tabId: candidate.tabId,
         targetGeneration: Math.max(1, candidate.revision),
-        active: candidate.threadId === useWorkspaceStore.getState().activeThreadId,
-        focused: candidate.threadId === useWorkspaceStore.getState().activeThreadId,
+        active:
+          candidate.workspaceId === workspace.activeWorkspaceId &&
+          candidate.threadId === workspace.activeThreadId,
+        focused:
+          candidate.workspaceId === workspace.activeWorkspaceId &&
+          candidate.threadId === workspace.activeThreadId,
         lastUsedAt: candidate.lastUsedAt,
         controller: useBrowserAutomationStore.getState().controllers.get(browserAutomationTargetKey(candidate.workspaceId, candidate.threadId, candidate.tabId)),
       } satisfies BrowserAutomationHostDispatchTarget));
@@ -1163,9 +1196,15 @@ export function BrowserAutomationHost() {
     for (const removed of priorLiveTargetKeysRef.current) {
       if (next.has(removed)) continue;
       const [workspaceId, threadId, tabId] = JSON.parse(removed) as [string, string, string];
-      sessionDriverRef.current?.clearIdempotencyForTarget(threadId, tabId);
-      for (const [openKey, mappedTabId] of agentOpenTabsRef.current) {
-        if (mappedTabId === tabId) agentOpenTabsRef.current.delete(openKey);
+      sessionDriverRef.current?.clearIdempotencyForTarget(workspaceId, threadId, tabId);
+      for (const [openKey, mappedTarget] of agentOpenTabsRef.current) {
+        if (
+          browserAutomationTargetKey(
+            mappedTarget.workspaceId,
+            mappedTarget.threadId,
+            mappedTarget.tabId,
+          ) === removed
+        ) agentOpenTabsRef.current.delete(openKey);
       }
       recorderRef.current.disposeTarget(workspaceId, threadId, tabId);
       for (const [key, dispatch] of inFlightRef.current) {
@@ -1449,7 +1488,7 @@ export function BrowserAutomationHost() {
         () => controller.abort(new Error("Browser bootstrap deadline elapsed")),
         Math.max(1, request.deadline - Date.now()),
       );
-      const previousTabId = usePreviewTabsStore.getState().tabSetByScope[request.threadId]?.activeTabId ?? null;
+      const previousTabId = usePreviewTabsStore.getState().tabSetByScope[previewTabsScopeKey(request.workspaceId, request.threadId)]?.activeTabId ?? null;
       const previousPanel = useDiffStore.getState().getRightPanel(request.workspaceId, request.threadId);
       let backgroundContextRestored = false;
       let createdTabId: string | null = null;
@@ -1489,10 +1528,12 @@ export function BrowserAutomationHost() {
           workspace.activeThreadId === request.threadId;
         const diff = useDiffStore.getState();
         const currentScopes = backgroundScopesRef.current;
-        const existingScope = currentScopes.find((scope) => scope.threadId === request.threadId);
+        const existingScope = currentScopes.find(
+          (scope) => scope.workspaceId === request.workspaceId && scope.threadId === request.threadId,
+        );
         if (existingScope) {
           const nextScopes = [
-            ...currentScopes.filter((scope) => scope.threadId !== request.threadId),
+            ...currentScopes.filter((scope) => scope !== existingScope),
             existingScope,
           ];
           backgroundScopesRef.current = nextScopes;
@@ -1500,11 +1541,11 @@ export function BrowserAutomationHost() {
         } else {
           const isBusy = (scope: BackgroundBrowserScope): boolean =>
             [...bootstrapRequestRef.current.values()].some(
-              (candidate) => candidate.threadId === scope.threadId,
+              (candidate) => candidate.workspaceId === scope.workspaceId && candidate.threadId === scope.threadId,
             ) || [...inFlightRef.current.values()].some(
-              (candidate) => candidate.scope.threadId === scope.threadId,
-             ) || recorderRef.current.hasActiveThread(scope.workspaceId, scope.threadId) ||
-            findAutomationDock(scope.threadId) !== null;
+              (candidate) => candidate.scope.workspaceId === scope.workspaceId && candidate.scope.threadId === scope.threadId,
+            ) || recorderRef.current.hasActiveThread(scope.workspaceId, scope.threadId) ||
+            findAutomationDock(scope.workspaceId, scope.threadId) !== null;
           const evicted = currentScopes.length >= 5
             ? currentScopes.find((scope) => !isBusy(scope))
             : undefined;
@@ -1517,7 +1558,9 @@ export function BrowserAutomationHost() {
           ];
           if (evicted) {
             for (const tab of persistentWebTabsRef.current.values()) {
-              if (tab.threadId === evicted.threadId) removePersistentWebTab(tab.tabId);
+              if (tab.workspaceId === evicted.workspaceId && tab.threadId === evicted.threadId) {
+                removePersistentWebTab(tab.workspaceId, tab.threadId, tab.tabId);
+              }
             }
           }
           backgroundScopesRef.current = nextScopes;
@@ -1532,23 +1575,31 @@ export function BrowserAutomationHost() {
           diff.setRightPanelTab(request.workspaceId, request.threadId, "preview");
         }
         await waitForViewportLayout(2);
-        const listed = await window.desktopBridge?.preview?.tabs.list?.(request.threadId);
+        const listed = await window.desktopBridge?.preview?.tabs.list?.(request.threadId, request.workspaceId);
         if (listed?.ok && listed.data.threadId === request.threadId) {
-          usePreviewTabsStore.getState().setTabSet(request.threadId, listed.data);
+          usePreviewTabsStore.getState().setTabSet(request.workspaceId, request.threadId, listed.data);
         }
-        const existingSet = usePreviewTabsStore.getState().tabSetByScope[request.threadId];
+        const existingSet = usePreviewTabsStore.getState().tabSetByScope[previewTabsScopeKey(request.workspaceId, request.threadId)];
         const requestedWebUrl = !bridge && request.args.url
           ? normalizeWebPreviewUrl(request.args.url)
           : undefined;
         let tabId = agentOwnedOpen
-          ? (agentOpenKey ? agentOpenTabsRef.current.get(agentOpenKey) ?? null : null)
+          ? (agentOpenKey
+              ? agentOpenTabsRef.current.get(agentOpenKey)?.tabId ?? null
+              : null)
           : existingSet?.activeTabId || existingSet?.tabs[0]?.id ||
             (!bridge ? WEB_RUNTIME_PREVIEW_TAB_ID : null);
         if (!bridge && agentOwnedOpen && !tabId) {
           const webTabId = `web-agent-${globalThis.crypto.randomUUID()}`;
           const webTabUrl = requestedWebUrl ?? `${window.location.origin}/browser-automation-fixture.html`;
           createdWebTabId = webTabId;
-          if (agentOpenKey) agentOpenTabsRef.current.set(agentOpenKey, webTabId);
+          if (agentOpenKey) {
+            agentOpenTabsRef.current.set(agentOpenKey, {
+              workspaceId: request.workspaceId,
+              threadId: request.threadId,
+              tabId: webTabId,
+            });
+          }
           addPersistentWebTab({
             threadId: request.threadId,
             workspaceId: request.workspaceId,
@@ -1584,7 +1635,13 @@ export function BrowserAutomationHost() {
           }
           if (tabId) {
             createdTabId = tabId;
-            if (agentOpenKey) agentOpenTabsRef.current.set(agentOpenKey, tabId);
+            if (agentOpenKey) {
+              agentOpenTabsRef.current.set(agentOpenKey, {
+                workspaceId: request.workspaceId,
+                threadId: request.threadId,
+                tabId,
+              });
+            }
           }
         }
         if (!tabId) throw new Error("Browser tab could not be created or restored");
@@ -1607,7 +1664,7 @@ export function BrowserAutomationHost() {
           selectedTab?.url ??
           "about:blank";
         if (!selectedTab?.url || requestedWebUrl || request.args.url) {
-          usePreviewTabsStore.getState().updateTabChrome(request.threadId, tabId, {
+          usePreviewTabsStore.getState().updateTabChrome(request.workspaceId, request.threadId, tabId, {
             title: null,
             url: initialUrl,
             favicon: null,
@@ -1715,7 +1772,9 @@ export function BrowserAutomationHost() {
             // Keep finalizer cleanup settled; closePage preserves logical records on physical failure.
           }
         }
-        if (createdWebTabId && !bootstrapSucceeded) removePersistentWebTab(createdWebTabId);
+        if (createdWebTabId && !bootstrapSucceeded) {
+          removePersistentWebTab(request.workspaceId, request.threadId, createdWebTabId);
+        }
         if (!bootstrapSucceeded && agentOpenKey) agentOpenTabsRef.current.delete(agentOpenKey);
         window.clearTimeout(deadlineTimer);
         if (bootstrapAbortRef.current.get(key) === controller) bootstrapAbortRef.current.delete(key);
@@ -1732,8 +1791,8 @@ export function BrowserAutomationHost() {
     });
   }, []);
 
-  useEffect(() => onBrowserAutomationObservationInvalidation((_workspaceId, threadId, tabId) => {
-    sessionDriverRef.current?.invalidateTargetObservations(threadId, tabId);
+  useEffect(() => onBrowserAutomationObservationInvalidation((workspaceId, threadId, tabId) => {
+    sessionDriverRef.current?.invalidateTargetObservations(workspaceId, threadId, tabId);
   }), []);
 
   useEffect(() => {
@@ -1750,7 +1809,7 @@ export function BrowserAutomationHost() {
       if (!target) return;
       recorderRef.current.disposeTarget(target.workspaceId, target.threadId, target.tabId);
       for (const dispatch of inFlightRef.current.values()) {
-        if (dispatch.target.threadId !== target.threadId || dispatch.target.tabId !== target.tabId) continue;
+        if (dispatch.scope.workspaceId !== target.workspaceId || dispatch.target.threadId !== target.threadId || dispatch.target.tabId !== target.tabId) continue;
         const lease = leaseRef.current;
         if (!lease) continue;
         const key = browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence);
@@ -1813,7 +1872,9 @@ export function BrowserAutomationHost() {
       );
     }
     for (const tab of persistentWebTabsRef.current.values()) {
-      if (matches(tab.threadId, tab.workspaceId)) removePersistentWebTab(tab.tabId);
+      if (matches(tab.threadId, tab.workspaceId)) {
+        removePersistentWebTab(tab.workspaceId, tab.threadId, tab.tabId);
+      }
     }
     const lease = leaseRef.current;
     for (const [key, request] of bootstrapRequestRef.current) {
@@ -1877,7 +1938,7 @@ export function BrowserAutomationHost() {
     webAbortRef.current.clear();
     webObserverRef.current.clear();
     for (const tab of persistentWebTabsRef.current.values()) {
-      usePreviewTabsStore.getState().removePersistentTab(tab.threadId, tab.tabId);
+      usePreviewTabsStore.getState().removePersistentTab(tab.workspaceId, tab.threadId, tab.tabId);
     }
     persistentWebTabsRef.current.clear();
     sessionDriverRef.current?.clearIdempotency();
@@ -1887,7 +1948,7 @@ export function BrowserAutomationHost() {
 
   return backgroundScopes.map((scope) => (
     <PersistentAutomationPreviewSurface
-      key={scope.threadId}
+      key={browserAutomationScopeKey(scope.workspaceId, scope.threadId)}
       scope={scope}
       webTabs={[...persistentWebTabsRef.current.values()]}
     />

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -19,6 +19,7 @@ import { useThreadStore } from "@/stores/threadStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import {
   browserAutomationRequestKey,
+  browserAutomationScopeKey,
   browserAutomationTargetKey,
   invalidateBrowserAutomationTargetObservation,
   onBrowserAutomationObservationInvalidation,
@@ -155,13 +156,14 @@ async function restoreCompletedAgentViewport(
 ): Promise<BrowserAutomationResponse> {
   if (dispatch.request.operation !== "act" || !response.ok) return response;
   const coordinator = useBrowserAutomationStore.getState().viewportCoordinators.get(
-    browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+    browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId),
   );
   if (!coordinator?.snapshot().agentActive) return response;
   const result = await coordinator.completeAgent({
     targetGeneration: dispatch.target.targetGeneration,
   });
   useBrowserAutomationStore.getState().setViewportState(
+    dispatch.scope.workspaceId,
     dispatch.target.threadId,
     dispatch.target.tabId,
     coordinator.snapshot(),
@@ -191,11 +193,12 @@ async function completeViewportControlRun(
 
 function interruptViewportCoordinator(dispatch: BrowserAutomationHostDispatch): void {
   const coordinator = useBrowserAutomationStore.getState().viewportCoordinators.get(
-    browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+    browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId),
   );
   if (!coordinator) return;
   coordinator.interrupt();
   useBrowserAutomationStore.getState().setViewportState(
+    dispatch.scope.workspaceId,
     dispatch.target.threadId,
     dispatch.target.tabId,
     coordinator.snapshot(),
@@ -206,7 +209,7 @@ function interruptViewportCoordinator(dispatch: BrowserAutomationHostDispatch): 
 function ensureViewportCoordinator(
   dispatch: BrowserAutomationHostDispatch,
 ): ReturnType<typeof getOrCreateViewportCoordinator> {
-  const key = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+  const key = browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId);
   const state = useBrowserAutomationStore.getState();
   const existing = state.viewportCoordinators.get(key);
   let coordinator = existing;
@@ -220,6 +223,7 @@ function ensureViewportCoordinator(
     nativeHost: () => window.desktopBridge?.preview?.design,
     rendererHost: {
       setViewport: (size, operation, coordinator) => useBrowserAutomationStore.getState().applyViewportIfCurrent(
+        dispatch.scope.workspaceId,
         dispatch.target.threadId,
         dispatch.target.tabId,
         coordinator,
@@ -227,6 +231,7 @@ function ensureViewportCoordinator(
         size,
       ),
       resetViewport: (operation, coordinator) => useBrowserAutomationStore.getState().resetViewportIfCurrent(
+        dispatch.scope.workspaceId,
         dispatch.target.threadId,
         dispatch.target.tabId,
         coordinator,
@@ -250,12 +255,14 @@ function ensureViewportCoordinator(
       );
     },
     onStateChange: (nextState, coordinator) => useBrowserAutomationStore.getState().setViewportState(
+      dispatch.scope.workspaceId,
       dispatch.target.threadId,
       dispatch.target.tabId,
       nextState,
       coordinator,
     ),
     onCreated: (created) => useBrowserAutomationStore.getState().setViewportCoordinator(
+      dispatch.scope.workspaceId,
       dispatch.target.threadId,
       dispatch.target.tabId,
       created,
@@ -267,7 +274,7 @@ function ensureViewportCoordinator(
 
 function bindViewportCoordinatorDispatch(dispatch: BrowserAutomationHostDispatch): void {
   const coordinator = useBrowserAutomationStore.getState().viewportCoordinators.get(
-    browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+    browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId),
   );
   if (coordinator) viewportCoordinatorDispatches.set(coordinator, dispatch);
 }
@@ -279,6 +286,7 @@ function projectAgentControl(dispatch: BrowserAutomationHostDispatch): void {
     !useThreadStore.getState().runningThreadIds.has(dispatch.target.threadId)
   ) return;
   useBrowserAutomationStore.getState().setControllerForTarget(
+    dispatch.scope.workspaceId,
     dispatch.target.threadId,
     dispatch.target.tabId,
     {
@@ -331,6 +339,7 @@ async function executeBrowserDispatch(
         },
       );
       useBrowserAutomationStore.getState().setViewportState(
+        dispatch.scope.workspaceId,
         dispatch.target.threadId,
         dispatch.target.tabId,
         coordinator.snapshot(),
@@ -377,6 +386,7 @@ async function executeBrowserDispatch(
           },
         );
         useBrowserAutomationStore.getState().setViewportState(
+          dispatch.scope.workspaceId,
           dispatch.target.threadId,
           dispatch.target.tabId,
           coordinator.snapshot(),
@@ -442,12 +452,13 @@ function hostId(): string | null {
 }
 
 function waitForLiveTarget(
+  workspaceId: string,
   threadId: string,
   tabId: string,
   deadline: number,
   signal: AbortSignal,
 ): Promise<void> {
-  const key = browserAutomationTargetKey(threadId, tabId);
+  const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
   if (signal.aborted) return Promise.reject(signal.reason);
   if (useBrowserAutomationStore.getState().liveTargets.has(key)) return Promise.resolve();
   return new Promise((resolve, reject) => {
@@ -590,7 +601,7 @@ function acceptExpectedWebNavigationRevision(
   }
   const expectedUrl = normalizeWebPreviewUrl(dispatch.request.args.url ?? "");
   if (
-    navigation.targetKey !== browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId) ||
+    navigation.targetKey !== browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId) ||
     navigation.expectedUrl !== expectedUrl ||
     dispatch.target.targetGeneration !== navigation.initialRevision ||
     target?.revision !== navigation.initialRevision + 1 ||
@@ -657,7 +668,7 @@ function PersistentAutomationWebTab({
   const visible = layout.visible && activeTabId === tab.tabId;
   useEffect(() => {
     useBrowserAutomationStore.getState().registerTarget(tab.workspaceId, tab.threadId, tab.tabId);
-    return () => useBrowserAutomationStore.getState().detachTarget(tab.threadId, tab.tabId);
+    return () => useBrowserAutomationStore.getState().detachTarget(tab.workspaceId, tab.threadId, tab.tabId);
   }, [tab.tabId, tab.threadId, tab.workspaceId]);
 
   return (
@@ -679,7 +690,7 @@ function PersistentAutomationWebTab({
           url: chrome.url,
           favicon: null,
         });
-        useBrowserAutomationStore.getState().refreshTarget(tab.threadId, tab.tabId);
+        useBrowserAutomationStore.getState().refreshTarget(tab.workspaceId, tab.threadId, tab.tabId);
       }}
       style={{
         position: "fixed",
@@ -865,14 +876,14 @@ export function BrowserAutomationHost() {
       },
       resolveSignal: (dispatch, signal) => webAbortRef.current.get(browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence))?.signal ?? signal,
       getControlEpoch: (dispatch) => {
-        const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+        const targetKey = browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId);
         return useBrowserAutomationStore.getState().controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch;
       },
       getTargetGeneration: (dispatch) => {
-        const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+        const targetKey = browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId);
         return useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision ?? 0;
       },
-      onHumanInput: (dispatch) => invalidateBrowserAutomationTargetObservation(dispatch.target.threadId, dispatch.target.tabId),
+      onHumanInput: (dispatch) => invalidateBrowserAutomationTargetObservation(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId),
       onObserver: (dispatch, dispose) => webObserverRef.current.set(browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence), dispose),
       executeNonInteraction: (dispatch, signal) => executeBrowserDispatch(undefined, recorderRef.current, dispatch, signal, executorDescriptor.operations),
     });
@@ -882,11 +893,11 @@ export function BrowserAutomationHost() {
       getHostRevision: () => leaseRef.current?.generation ?? 0,
       getDocumentRevision: (dispatch) => executorDescriptor.runtime === "web"
         ? useBrowserAutomationStore.getState().liveTargets.get(
-          browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+          browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId),
         )?.revision ?? dispatch.target.targetGeneration
         : dispatch.target.targetGeneration,
       getControlRevision: (dispatch) => useBrowserAutomationStore.getState().controllers.get(
-        browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+        browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId),
       )?.controlEpoch ?? dispatch.target.controller?.controlEpoch ?? dispatch.request.expectedControlEpoch,
       electron: new ElectronBrowserSessionAdapter(
         (dispatch, signal) => executeBrowserDispatch(window.desktopBridge?.preview?.automation, recorderRef.current, dispatch, signal, executorDescriptor.operations),
@@ -900,7 +911,12 @@ export function BrowserAutomationHost() {
       },
       electronTabs: {
         list: listLifecycleTargets,
-        close: async (target) => usePreviewTabsStore.getState().closePage(target.threadId, target.tabId),
+        close: async (target) => {
+          const matches = [...useBrowserAutomationStore.getState().liveTargets.values()]
+            .filter((candidate) => candidate.threadId === target.threadId && candidate.tabId === target.tabId);
+          if (matches.length !== 1) throw new Error("Browser target workspace is ambiguous");
+          await usePreviewTabsStore.getState().closePage(matches[0]!.workspaceId, target.threadId, target.tabId);
+        },
       },
       onLifecycleChange: (tabs) => useBrowserAutomationStore.getState().setLifecycleTabs(tabs),
     });
@@ -926,7 +942,7 @@ export function BrowserAutomationHost() {
       if (value === tabId) agentOpenTabsRef.current.delete(key);
     }
     usePreviewTabsStore.getState().removePersistentTab(tab.threadId, tab.tabId);
-    useBrowserAutomationStore.getState().unregisterTarget(tab.threadId, tabId);
+    useBrowserAutomationStore.getState().unregisterTarget(tab.workspaceId, tab.threadId, tabId);
     setPersistentWebTabsRevision((value) => value + 1);
   };
   const stableHostId = useMemo(hostId, []);
@@ -947,7 +963,7 @@ export function BrowserAutomationHost() {
   ): void => {
     if (cancelledRef.current.has(key)) return;
     cancelledRef.current.add(key);
-    const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+    const targetKey = browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId);
     const viewportCoordinator = useBrowserAutomationStore.getState().viewportCoordinators.get(targetKey);
     if (viewportCoordinator?.snapshot().agentActive || dispatch.request.operation === "resize") {
       interruptViewportCoordinator(dispatch);
@@ -974,7 +990,7 @@ export function BrowserAutomationHost() {
   useEffect(() => {
     backgroundScopesRef.current = backgroundScopes;
     useBrowserAutomationStore.getState().setHostedScopeIds(
-      new Set(backgroundScopes.map((scope) => scope.threadId)),
+      new Set(backgroundScopes.map((scope) => browserAutomationScopeKey(scope.workspaceId, scope.threadId))),
     );
   }, [backgroundScopes]);
 
@@ -1086,7 +1102,7 @@ export function BrowserAutomationHost() {
         active: candidate.threadId === useWorkspaceStore.getState().activeThreadId,
         focused: candidate.threadId === useWorkspaceStore.getState().activeThreadId,
         lastUsedAt: candidate.lastUsedAt,
-        controller: useBrowserAutomationStore.getState().controllers.get(browserAutomationTargetKey(candidate.threadId, candidate.tabId)),
+        controller: useBrowserAutomationStore.getState().controllers.get(browserAutomationTargetKey(candidate.workspaceId, candidate.threadId, candidate.tabId)),
       } satisfies BrowserAutomationHostDispatchTarget));
       if (leaseRef.current === lease) {
         void getTransport().updateBrowserAutomationHostTargets(
@@ -1104,7 +1120,7 @@ export function BrowserAutomationHost() {
         tabId: candidate.tabId,
       });
       if (!described.ok) return null;
-      const controller = useBrowserAutomationStore.getState().controllers.get(browserAutomationTargetKey(candidate.threadId, candidate.tabId));
+      const controller = useBrowserAutomationStore.getState().controllers.get(browserAutomationTargetKey(candidate.workspaceId, candidate.threadId, candidate.tabId));
       return {
         ...described.target,
         desktopInstanceId: lease.desktopInstanceId,
@@ -1134,7 +1150,7 @@ export function BrowserAutomationHost() {
       const previousRevision = priorRevisions.get(key);
       if (previousRevision === undefined || previousRevision === target.revision) continue;
       for (const [requestKey, dispatch] of inFlightRef.current) {
-        if (browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId) !== key) continue;
+        if (browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId) !== key) continue;
         const navigation = webNavigationRef.current.get(requestKey);
         const expectedNavigation = acceptExpectedWebNavigationRevision(dispatch, navigation, target) !== undefined;
         if (expectedNavigation) {
@@ -1146,14 +1162,14 @@ export function BrowserAutomationHost() {
     }
     for (const removed of priorLiveTargetKeysRef.current) {
       if (next.has(removed)) continue;
-      const [threadId, tabId] = JSON.parse(removed) as [string, string];
+      const [workspaceId, threadId, tabId] = JSON.parse(removed) as [string, string, string];
       sessionDriverRef.current?.clearIdempotencyForTarget(threadId, tabId);
       for (const [openKey, mappedTabId] of agentOpenTabsRef.current) {
         if (mappedTabId === tabId) agentOpenTabsRef.current.delete(openKey);
       }
-      recorderRef.current.disposeTarget(threadId, tabId);
+      recorderRef.current.disposeTarget(workspaceId, threadId, tabId);
       for (const [key, dispatch] of inFlightRef.current) {
-        if (dispatch.target.threadId !== threadId || dispatch.target.tabId !== tabId) continue;
+        if (dispatch.scope.workspaceId !== workspaceId || dispatch.target.threadId !== threadId || dispatch.target.tabId !== tabId) continue;
         cancelHostedRequest(key, dispatch, "host-shutdown");
       }
     }
@@ -1209,7 +1225,7 @@ export function BrowserAutomationHost() {
         dispatch.request.operation === "navigate" && Boolean(dispatch.request.args.url);
       const operationAbort = webDispatch ? new AbortController() : null;
       if (operationAbort) webAbortRef.current.set(key, operationAbort);
-      const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+      const targetKey = browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId);
       const liveTarget = useBrowserAutomationStore.getState().liveTargets.get(targetKey);
       const currentEpoch = useBrowserAutomationStore.getState().controllers.get(targetKey)?.controlEpoch ?? dispatch.request.expectedControlEpoch;
       const staleAtStart = !liveTarget || liveTarget.revision !== dispatch.target.targetGeneration || currentEpoch !== dispatch.request.expectedControlEpoch;
@@ -1447,7 +1463,7 @@ export function BrowserAutomationHost() {
         if (agentOwnedOpen || request.args.activate || backgroundContextRestored) return;
         backgroundContextRestored = true;
         if (createdTabId && previousTabId && previousTabId !== createdTabId) {
-          await usePreviewTabsStore.getState().activatePage(request.threadId, previousTabId);
+          await usePreviewTabsStore.getState().activatePage(request.workspaceId, request.threadId, previousTabId);
         }
         if (!visibleContextModified) return;
         const currentDiff = useDiffStore.getState();
@@ -1487,7 +1503,7 @@ export function BrowserAutomationHost() {
               (candidate) => candidate.threadId === scope.threadId,
             ) || [...inFlightRef.current.values()].some(
               (candidate) => candidate.scope.threadId === scope.threadId,
-            ) || recorderRef.current.hasActiveThread(scope.threadId) ||
+             ) || recorderRef.current.hasActiveThread(scope.workspaceId, scope.threadId) ||
             findAutomationDock(scope.threadId) !== null;
           const evicted = currentScopes.length >= 5
             ? currentScopes.find((scope) => !isBusy(scope))
@@ -1506,7 +1522,7 @@ export function BrowserAutomationHost() {
           }
           backgroundScopesRef.current = nextScopes;
           useBrowserAutomationStore.getState().setHostedScopeIds(
-            new Set(nextScopes.map((scope) => scope.threadId)),
+             new Set(nextScopes.map((scope) => browserAutomationScopeKey(scope.workspaceId, scope.threadId))),
           );
           setBackgroundScopes(nextScopes);
         }
@@ -1553,14 +1569,14 @@ export function BrowserAutomationHost() {
               !onlyExistingTab.faviconUrl
             ? onlyExistingTab.id
             : undefined;
-          tabId = await usePreviewTabsStore.getState().openPage(request.threadId, {
+          tabId = await usePreviewTabsStore.getState().openPage(request.workspaceId, request.threadId, {
             activate: !agentOwnedOpen,
             focusOmnibox: ownsVisibleContext && request.args.activate && !agentOwnedOpen,
             ...(agentOwnedOpen ? { renderingHost: "webview" as const } : {}),
             ...(existingTabId ? { tabId: existingTabId } : {}),
           });
           if (!tabId && existingTabId) {
-            tabId = await usePreviewTabsStore.getState().openPage(request.threadId, {
+            tabId = await usePreviewTabsStore.getState().openPage(request.workspaceId, request.threadId, {
               activate: false,
               focusOmnibox: false,
               renderingHost: "webview",
@@ -1612,7 +1628,7 @@ export function BrowserAutomationHost() {
           );
           ensureActive();
         }
-        await waitForLiveTarget(request.threadId, tabId, request.deadline, controller.signal);
+        await waitForLiveTarget(request.workspaceId, request.threadId, tabId, request.deadline, controller.signal);
         ensureActive();
         const described = bridge
           ? await bridge.describeTarget({ threadId: request.threadId, tabId })
@@ -1623,7 +1639,7 @@ export function BrowserAutomationHost() {
                 threadId: request.threadId,
                 tabId,
                 targetGeneration: useBrowserAutomationStore.getState().liveTargets.get(
-                  browserAutomationTargetKey(request.threadId, tabId),
+                  browserAutomationTargetKey(request.workspaceId, request.threadId, tabId),
                 )?.revision ?? 1,
                 active: !agentOwnedOpen,
                 focused: !agentOwnedOpen,
@@ -1694,7 +1710,7 @@ export function BrowserAutomationHost() {
         }
         if (createdTabId && !bootstrapSucceeded) {
           try {
-            await usePreviewTabsStore.getState().closePage(request.threadId, createdTabId);
+            await usePreviewTabsStore.getState().closePage(request.workspaceId, request.threadId, createdTabId);
           } catch {
             // Keep finalizer cleanup settled; closePage preserves logical records on physical failure.
           }
@@ -1716,7 +1732,7 @@ export function BrowserAutomationHost() {
     });
   }, []);
 
-  useEffect(() => onBrowserAutomationObservationInvalidation((threadId, tabId) => {
+  useEffect(() => onBrowserAutomationObservationInvalidation((_workspaceId, threadId, tabId) => {
     sessionDriverRef.current?.invalidateTargetObservations(threadId, tabId);
   }), []);
 
@@ -1732,7 +1748,7 @@ export function BrowserAutomationHost() {
       store.setController(controller);
       if (controller.controller !== "human") return;
       if (!target) return;
-      recorderRef.current.disposeTarget(target.threadId, target.tabId);
+      recorderRef.current.disposeTarget(target.workspaceId, target.threadId, target.tabId);
       for (const dispatch of inFlightRef.current.values()) {
         if (dispatch.target.threadId !== target.threadId || dispatch.target.tabId !== target.tabId) continue;
         const lease = leaseRef.current;
@@ -1759,7 +1775,7 @@ export function BrowserAutomationHost() {
           providerSessionId: controller.providerSessionId,
         });
       } else {
-        store.setControllerForTarget(target.threadId, target.tabId, {
+        store.setControllerForTarget(target.workspaceId, target.threadId, target.tabId, {
           tabId: target.tabId,
           controller: "none",
           controlEpoch: controller.controlEpoch,
@@ -1768,10 +1784,10 @@ export function BrowserAutomationHost() {
     }
   }, [runningThreadIds]);
 
-  useEffect(() => onBrowserAutomationInterruption((threadId, tabId, reason) => {
-    recorderRef.current.disposeTarget(threadId, tabId);
+  useEffect(() => onBrowserAutomationInterruption((workspaceId, threadId, tabId, reason) => {
+    recorderRef.current.disposeTarget(workspaceId, threadId, tabId);
     for (const dispatch of inFlightRef.current.values()) {
-      if (dispatch.target.threadId !== threadId || dispatch.target.tabId !== tabId) continue;
+      if (dispatch.scope.workspaceId !== workspaceId || dispatch.target.threadId !== threadId || dispatch.target.tabId !== tabId) continue;
       const lease = leaseRef.current;
       if (!lease) continue;
       const key = browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence);
@@ -1781,8 +1797,10 @@ export function BrowserAutomationHost() {
 
   useEffect(() => onBrowserAutomationScopeRelease((release) => {
     const matches = (threadId: string, workspaceId: string): boolean =>
-      release.threadId !== undefined ? threadId === release.threadId : workspaceId === release.workspaceId;
-    if (release.threadId !== undefined) void sessionDriverRef.current?.releaseThread(release.threadId);
+      release.threadId !== undefined
+        ? workspaceId === release.workspaceId && threadId === release.threadId
+        : workspaceId === release.workspaceId;
+    if (release.threadId !== undefined) void sessionDriverRef.current?.releaseThread(release.workspaceId, release.threadId);
     else void sessionDriverRef.current?.releaseWorkspace(release.workspaceId);
     const nextScopes = backgroundScopesRef.current.filter(
       (scope) => !matches(scope.threadId, scope.workspaceId),
@@ -1791,7 +1809,7 @@ export function BrowserAutomationHost() {
       backgroundScopesRef.current = nextScopes;
       setBackgroundScopes(nextScopes);
       useBrowserAutomationStore.getState().setHostedScopeIds(
-        new Set(nextScopes.map((scope) => scope.threadId)),
+        new Set(nextScopes.map((scope) => browserAutomationScopeKey(scope.workspaceId, scope.threadId))),
       );
     }
     for (const tab of persistentWebTabsRef.current.values()) {

--- a/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
+++ b/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
@@ -27,6 +27,7 @@ export const browserSurfaceHost = new BrowserSurfaceHost({
         onHumanInput: (surfaceIdentity) => {
           if (surfaceIdentity.scope.kind !== "thread") return;
           invalidateBrowserAutomationTargetObservation(
+            surfaceIdentity.workspaceId,
             surfaceIdentity.scope.id,
             surfaceIdentity.tabId,
           );
@@ -38,6 +39,7 @@ export const browserSurfaceHost = new BrowserSurfaceHost({
       title: "Web browser preview",
       onLoad: (surfaceIdentity) => {
         useBrowserAutomationStore.getState().refreshTarget(
+          surfaceIdentity.workspaceId,
           surfaceIdentity.scope.id,
           surfaceIdentity.tabId,
         );

--- a/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
+++ b/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
@@ -60,12 +60,16 @@ export function BrowserSurfaceHostRoot() {
     return surfaceBridge.onPopupRequested((request) => {
       const source = browserSurfaceHost.getSnapshot(request.sourceSurface.identity);
       if (!source || source.generation !== request.sourceSurface.generation) return;
-      void usePreviewTabsStore.getState().openPage(request.sourceSurface.identity.scope.id, {
-        activate: request.initiator === "human",
-        focusOmnibox: false,
-        initialAddress: request.address,
-        renderingHost: "webview",
-      });
+      void usePreviewTabsStore.getState().openPage(
+        request.sourceSurface.identity.workspaceId,
+        request.sourceSurface.identity.scope.id,
+        {
+          activate: request.initiator === "human",
+          focusOmnibox: false,
+          initialAddress: request.address,
+          renderingHost: "webview",
+        },
+      );
     });
   }, []);
 

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -2475,17 +2475,17 @@ export function PreviewPanel({
   // every favicon tick. Clear on unmount so a backgrounded scope falls back to
   // each tab's own persisted favicon rather than a stale overlay.
   useEffect(() => {
-    usePreviewTabsStore.getState().setLiveChrome(threadId, {
+    usePreviewTabsStore.getState().setLiveChrome(browserWorkspaceId, threadId, {
       title: effectivePageStatus.title,
       url: effectivePageStatus.url,
       favicon: effectivePageStatus.favicon,
     });
-  }, [threadId, effectivePageStatus]);
+  }, [browserWorkspaceId, threadId, effectivePageStatus]);
   useEffect(() => {
     return () => {
-      usePreviewTabsStore.getState().setLiveChrome(threadId, null);
+      usePreviewTabsStore.getState().setLiveChrome(browserWorkspaceId, threadId, null);
     };
-  }, [threadId]);
+  }, [browserWorkspaceId, threadId]);
 
   useEffect(() => {
     if (!draftAnnotation) return;
@@ -2970,7 +2970,7 @@ export function PreviewPanel({
             : "pointer-events-none -z-10 opacity-0",
         )}
         onPageStatus={(status) => {
-          usePreviewTabsStore.getState().updateTabChrome(threadId, tab.id, {
+          usePreviewTabsStore.getState().updateTabChrome(browserWorkspaceId, threadId, tab.id, {
             title: status.title,
             url: status.url,
             favicon: status.favicon,

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1649,7 +1649,7 @@ function WebRuntimePreview({
       threadId,
       WEB_RUNTIME_PREVIEW_TAB_ID,
     );
-    const initial = browserSurfaceHost.create(identity, {
+    const initial = browserSurfaceHost.ensure(identity, {
       address: requestedAddressRef.current ?? fixtureUrl,
     });
     setPageState(initial);
@@ -1659,11 +1659,7 @@ function WebRuntimePreview({
     });
     return () => {
       unsubscribe();
-      browserSurfaceHost.dispose(identity);
-      useBrowserAutomationStore.getState().detachTarget(
-        threadId,
-        WEB_RUNTIME_PREVIEW_TAB_ID,
-      );
+      browserSurfaceHost.hide(identity);
     };
   }, [fixtureUrl, identity, surfaceAvailable, threadId]);
 

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1743,7 +1743,7 @@ function WebRuntimePreview({
 
   const noOp = (): void => undefined;
   const invalidateViewportObservation = (): void => {
-    invalidateBrowserAutomationTargetObservation(threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
+    invalidateBrowserAutomationTargetObservation(identity.workspaceId, threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
   };
   const visiblePageState = surfaceAvailable ? pageState : null;
   const visibleAddress = visiblePageState?.phase === "error"
@@ -1789,14 +1789,14 @@ function WebRuntimePreview({
         captureBusy={false}
         regionBusy={false}
         onNavigate={(url) => {
-          invalidateBrowserAutomationTargetObservation(threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
+          invalidateBrowserAutomationTargetObservation(identity.workspaceId, threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
           setInputUrl(url);
           navigate(url);
         }}
         onGoBack={noOp}
         onGoForward={noOp}
         onReload={() => {
-          invalidateBrowserAutomationTargetObservation(threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
+          invalidateBrowserAutomationTargetObservation(identity.workspaceId, threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
           browserSurfaceHost.navigate(identity, visibleAddress ?? fixtureUrl);
         }}
         onOpenExternal={noOp}
@@ -1804,7 +1804,7 @@ function WebRuntimePreview({
         onScreenshot={noOp}
         onNewPage={noOp}
         onForceReload={() => {
-          invalidateBrowserAutomationTargetObservation(threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
+          invalidateBrowserAutomationTargetObservation(identity.workspaceId, threadId, WEB_RUNTIME_PREVIEW_TAB_ID);
           browserSurfaceHost.navigate(identity, visibleAddress ?? fixtureUrl);
         }}
         onRegionCapture={noOp}
@@ -1821,7 +1821,7 @@ function WebRuntimePreview({
         onToggleViewportToolbar={onToggleViewportToolbar}
         viewportToolbarVisible={viewportToolbarOpen || responsiveViewportSize !== null}
         suppressPreviewForOverlays={false}
-        onHumanFocus={() => invalidateBrowserAutomationTargetObservation(threadId, WEB_RUNTIME_PREVIEW_TAB_ID)}
+        onHumanFocus={() => invalidateBrowserAutomationTargetObservation(identity.workspaceId, threadId, WEB_RUNTIME_PREVIEW_TAB_ID)}
       />
       {viewportToolbarOpen || responsiveViewportSize ? (
         viewportCoordinator && viewportState ? (
@@ -2031,7 +2031,8 @@ export function PreviewPanel({
     (window.desktopBridge?.preview
       ? PREVIEW_WEBVIEW_FALLBACK_TAB_ID
       : WEB_RUNTIME_PREVIEW_TAB_ID);
-  const activeBrowserTargetKey = browserAutomationTargetKey(threadId, activeWebviewTabId);
+  const browserWorkspaceId = workspaceId ?? threadId;
+  const activeBrowserTargetKey = browserAutomationTargetKey(browserWorkspaceId, threadId, activeWebviewTabId);
   const projectedActiveViewportState: ViewportCoordinatorState | undefined =
     automationViewportStates.get(activeBrowserTargetKey);
   const activeViewportCoordinator = automationViewportCoordinators.get(activeBrowserTargetKey);
@@ -2055,6 +2056,7 @@ export function PreviewPanel({
       nativeHost: () => window.desktopBridge?.preview?.design,
       rendererHost: {
         setViewport: (size, operation, coordinator) => useBrowserAutomationStore.getState().applyViewportIfCurrent(
+          browserWorkspaceId,
           threadId,
           activeWebviewTabId,
           coordinator,
@@ -2062,6 +2064,7 @@ export function PreviewPanel({
           size,
         ),
         resetViewport: (operation, coordinator) => useBrowserAutomationStore.getState().resetViewportIfCurrent(
+          browserWorkspaceId,
           threadId,
           activeWebviewTabId,
           coordinator,
@@ -2078,12 +2081,14 @@ export function PreviewPanel({
       readConfirmed: () => useBrowserAutomationStore.getState().viewportStateByTarget.get(activeBrowserTargetKey)?.confirmed ??
         useBrowserAutomationStore.getState().viewportByTarget.get(activeBrowserTargetKey) ?? null,
       onStateChange: (nextState, coordinator) => useBrowserAutomationStore.getState().setViewportState(
+        browserWorkspaceId,
         threadId,
         activeWebviewTabId,
         nextState,
         coordinator,
       ),
       onCreated: (coordinator) => useBrowserAutomationStore.getState().setViewportCoordinator(
+        browserWorkspaceId,
         threadId,
         activeWebviewTabId,
         coordinator,
@@ -2097,10 +2102,11 @@ export function PreviewPanel({
     automationViewportStates,
     automationViewportCoordinators,
     threadId,
+    browserWorkspaceId,
   ]);
   const invalidateActiveViewportObservation = useCallback((): void => {
-    invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
-  }, [activeWebviewTabId, threadId]);
+    invalidateBrowserAutomationTargetObservation(browserWorkspaceId, threadId, activeWebviewTabId);
+  }, [activeWebviewTabId, browserWorkspaceId, threadId]);
   useEffect(() => {
     if (!viewportToolbarOpen || !activeViewportCoordinator) return;
     let cancelled = false;
@@ -2231,7 +2237,7 @@ export function PreviewPanel({
           : webRuntime
             ? [{ id: PREVIEW_WEBVIEW_FALLBACK_TAB_ID, url: "about:blank" }]
             : [];
-    const warmIds = selectWarmBrowserTabIds(sourceTabs, threadId, activeWebviewTabId);
+    const warmIds = selectWarmBrowserTabIds(sourceTabs, browserWorkspaceId, threadId, activeWebviewTabId);
     return sourceTabs
       .filter((tab) => warmIds.has(tab.id))
       .map((tab) => ({
@@ -2244,21 +2250,23 @@ export function PreviewPanel({
     automationActiveRequests,
     tabs.tabSet,
     threadId,
+    browserWorkspaceId,
     webviewRequestedUrlByTab,
     webRuntime,
   ]);
   const activeAutomationController = automationControllers.get(
-    browserAutomationTargetKey(threadId, activeWebviewTabId),
+    browserAutomationTargetKey(browserWorkspaceId, threadId, activeWebviewTabId),
   );
   const activeAutomationRequest = [...automationActiveRequests.values()].find(
     ({ dispatch }) =>
+      dispatch.request.workspaceId === browserWorkspaceId &&
       dispatch.target.threadId === threadId && dispatch.target.tabId === activeWebviewTabId,
   );
   const agentControlsBrowser = isBrowserAutomationAgentControlled(
     { controllers: automationControllers, pendingAgentOpens },
+    browserWorkspaceId,
     threadId,
     activeWebviewTabId,
-    workspaceId,
   );
   const automationPointer = activeAutomationController?.pointer ?? null;
   const activeWebviewRef = useCallback(
@@ -2939,7 +2947,7 @@ export function PreviewPanel({
       )
     : 1;
   const warmWebviewLayer = warmWebviewTabs.map((tab) => {
-    const tabKey = browserAutomationTargetKey(threadId, tab.id);
+    const tabKey = browserAutomationTargetKey(browserWorkspaceId, threadId, tab.id);
     const tabViewport = automationViewports.get(tabKey);
     const tabViewportState = automationViewportStates.get(tabKey);
     return (
@@ -3017,30 +3025,30 @@ export function PreviewPanel({
             regionBusy={capture.regionBusy}
             focusRequest={omniboxFocusTick}
             onNavigate={(url) => {
-              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
+              invalidateBrowserAutomationTargetObservation(browserWorkspaceId, threadId, activeWebviewTabId);
               effectiveNavigate(url);
             }}
             onGoBack={() => {
-              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
+              invalidateBrowserAutomationTargetObservation(browserWorkspaceId, threadId, activeWebviewTabId);
               effectiveGoBack();
             }}
             onGoForward={() => {
-              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
+              invalidateBrowserAutomationTargetObservation(browserWorkspaceId, threadId, activeWebviewTabId);
               effectiveGoForward();
             }}
             onReload={() => {
-              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
+              invalidateBrowserAutomationTargetObservation(browserWorkspaceId, threadId, activeWebviewTabId);
               effectiveReload();
             }}
             onOpenExternal={effectiveOpenExternal}
             onToggleDesign={onToggleDesignMode}
             onScreenshot={capture.onAddPictureReference}
             onNewPage={() => {
-              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
+              invalidateBrowserAutomationTargetObservation(browserWorkspaceId, threadId, activeWebviewTabId);
               tabs.newTab();
             }}
             onForceReload={() => {
-              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
+              invalidateBrowserAutomationTargetObservation(browserWorkspaceId, threadId, activeWebviewTabId);
               effectiveForceReload();
             }}
             onRegionCapture={capture.onAddRegionPictureReference}
@@ -3062,10 +3070,11 @@ export function PreviewPanel({
             automationBusy={activeAutomationRequest !== undefined}
             onHumanFocus={() => {
               if (activeAutomationController?.controller !== "agent") return;
-              invalidateBrowserAutomationTargetObservation(threadId, activeWebviewTabId);
+              invalidateBrowserAutomationTargetObservation(browserWorkspaceId, threadId, activeWebviewTabId);
             }}
             onStopAutomation={() =>
               interruptBrowserAutomationTarget(
+                browserWorkspaceId,
                 threadId,
                 activeWebviewTabId,
                 "user-stopped",

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -110,7 +110,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     const initialViewportRef = useRef(viewport ?? DEFAULT_VIEWPORT_SIZE);
 
     const ensureViewportCoordinator = useCallback((targetGeneration: number) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
       const store = useBrowserAutomationStore.getState();
       const existing = store.viewportCoordinators.get(key);
       return getOrCreateViewportCoordinator({
@@ -124,6 +124,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         nativeHost: () => window.desktopBridge?.preview?.design,
         rendererHost: {
           setViewport: (size, operation, coordinator) => useBrowserAutomationStore.getState().applyViewportIfCurrent(
+            workspaceId,
             threadId,
             tabId,
             coordinator,
@@ -131,6 +132,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
             size,
           ),
           resetViewport: (operation, coordinator) => useBrowserAutomationStore.getState().resetViewportIfCurrent(
+            workspaceId,
             threadId,
             tabId,
             coordinator,
@@ -148,18 +150,20 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
           useBrowserAutomationStore.getState().viewportStateByTarget.get(key)?.confirmed ??
           useBrowserAutomationStore.getState().viewportByTarget.get(key) ?? null,
         onStateChange: (state, coordinator) => useBrowserAutomationStore.getState().setViewportState(
+          workspaceId,
           threadId,
           tabId,
           state,
           coordinator,
         ),
         onCreated: (created) => useBrowserAutomationStore.getState().setViewportCoordinator(
+          workspaceId,
           threadId,
           tabId,
           created,
         ),
       });
-    }, [tabId, threadId]);
+    }, [tabId, threadId, workspaceId]);
 
     const currentSurface = useCallback(() => {
       const state = browserSurfaceHost.getSnapshot(identity);
@@ -213,7 +217,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     useLayoutEffect(() => {
       useBrowserAutomationStore.getState().registerTarget(workspaceId, threadId, tabId);
       const targetGeneration = useBrowserAutomationStore.getState().liveTargets.get(
-        browserAutomationTargetKey(threadId, tabId),
+        browserAutomationTargetKey(workspaceId, threadId, tabId),
       )?.revision ?? 1;
       ensureViewportCoordinator(targetGeneration);
       const initial = browserSurfaceHost.ensure(identity, {

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -216,7 +216,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         browserAutomationTargetKey(threadId, tabId),
       )?.revision ?? 1;
       ensureViewportCoordinator(targetGeneration);
-      const initial = browserSurfaceHost.create(identity, {
+      const initial = browserSurfaceHost.ensure(identity, {
         address: initialAddressRef.current,
       });
       stateRef.current = initial;
@@ -231,8 +231,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       });
       return () => {
         unsubscribe();
-        browserSurfaceHost.dispose(identity);
-        useBrowserAutomationStore.getState().detachTarget(threadId, tabId);
+        browserSurfaceHost.hide(identity);
       };
     }, [ensureViewportCoordinator, identity, tabId, threadId, workspaceId]);
 

--- a/apps/web/src/components/panels/RightPanel.test.tsx
+++ b/apps/web/src/components/panels/RightPanel.test.tsx
@@ -182,6 +182,13 @@ describe("RightPanel", () => {
     expect(reconcileWarmPreviewScopes(scopes, scopes[0]!, new Set())).toBe(scopes);
   });
 
+  it("keeps equal scope ids from different workspaces as distinct warm surfaces", () => {
+    const first = { scopeId: "shared-scope", workspaceId: "workspace-a", lastUsedAt: 1 };
+    const second = { scopeId: "shared-scope", workspaceId: "workspace-b", lastUsedAt: 2 };
+
+    expect(reconcileWarmPreviewScopes([first], second, new Set())).toEqual([second, first]);
+  });
+
   it("releases focus before making the right panel inert", () => {
     useDiffStore.setState({
       rightPanelFallbackByWorkspace: {

--- a/apps/web/src/components/panels/RightPanel.test.tsx
+++ b/apps/web/src/components/panels/RightPanel.test.tsx
@@ -339,7 +339,11 @@ describe("RightPanel", () => {
     expect(screen.queryByTestId("panel-empty-state")).not.toBeInTheDocument();
     expect(screen.getByTestId("activity-rail")).toHaveAttribute("data-open-tabs", "preview");
     expect(screen.getByTestId("preview-panel")).toBeInTheDocument();
-    expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "agent-browser-tab");
+    expect(activatePreviewPage).toHaveBeenCalledWith(
+      "workspace-1",
+      "workspace-1",
+      "agent-browser-tab",
+    );
   });
 
   it("switches an already-open panel to an agent-created Browser page", () => {
@@ -407,7 +411,11 @@ describe("RightPanel", () => {
       openTabs: ["tasks", "preview"],
       activeTab: "preview",
     });
-    expect(activatePreviewPage).toHaveBeenCalledWith("workspace-1", "agent-browser-tab");
+    expect(activatePreviewPage).toHaveBeenCalledWith(
+      "workspace-1",
+      "workspace-1",
+      "agent-browser-tab",
+    );
 
     rerender(<RightPanel />);
 
@@ -439,6 +447,7 @@ describe("RightPanel", () => {
       },
     });
     closePreviewPage.mockImplementation((
+      _workspaceId: string,
       _scopeId: string,
       _tabId: string,
       options: { onLastClose?: () => void },
@@ -528,7 +537,10 @@ describe("RightPanel", () => {
         [
           "other-scope-request",
           {
-            dispatch: { target: { threadId: "other-scope", tabId: "other-tab" } },
+            dispatch: {
+              request: { workspaceId: "workspace-1" },
+              target: { threadId: "other-scope", tabId: "other-tab" },
+            },
             startedAt: 2,
           } as never,
         ],
@@ -567,13 +579,17 @@ describe("RightPanel", () => {
         [
           "active-browser-request",
           {
-            dispatch: { target: { threadId: "workspace-1", tabId: "browser-tab-1" } },
+            dispatch: {
+              request: { workspaceId: "workspace-1" },
+              target: { threadId: "workspace-1", tabId: "browser-tab-1" },
+            },
             startedAt: 2,
           } as never,
         ],
       ]),
     });
     closePreviewPage.mockImplementation((
+      _workspaceId: string,
       _scopeId: string,
       _tabId: string,
       options: { onLastClose?: () => void },

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -37,6 +37,7 @@ import { cn } from "@/lib/utils";
 import { ResizableRightPanel } from "./ResizableRightPanel";
 import {
   BROWSER_AUTOMATION_WARM_TARGET_LIMIT,
+  browserAutomationScopeKey,
   browserAutomationTargetKey,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
@@ -50,7 +51,7 @@ export interface WarmPreviewScope {
 }
 
 function warmPreviewScopeKey(scope: Pick<WarmPreviewScope, "scopeId" | "workspaceId">): string {
-  return JSON.stringify([scope.workspaceId, scope.scopeId]);
+  return browserAutomationScopeKey(scope.workspaceId, scope.scopeId);
 }
 
 /**
@@ -60,14 +61,14 @@ function warmPreviewScopeKey(scope: Pick<WarmPreviewScope, "scopeId" | "workspac
 export function reconcileWarmPreviewScopes(
   previous: readonly WarmPreviewScope[],
   next: WarmPreviewScope | null,
-  busyScopeIds: ReadonlySet<string>,
+  busyScopeKeys: ReadonlySet<string>,
 ): readonly WarmPreviewScope[] {
   const byId = new Map(previous.map((scope) => [warmPreviewScopeKey(scope), scope]));
   if (next) byId.set(warmPreviewScopeKey(next), next);
   const ordered = [...byId.values()].sort((left, right) => right.lastUsedAt - left.lastUsedAt);
   const leased = ordered.filter(
     (scope) => (next !== null && warmPreviewScopeKey(scope) === warmPreviewScopeKey(next)) ||
-      busyScopeIds.has(scope.scopeId),
+      busyScopeKeys.has(warmPreviewScopeKey(scope)),
   );
   const selected = new Map(leased.map((scope) => [warmPreviewScopeKey(scope), scope]));
   for (const scope of ordered) {
@@ -97,7 +98,7 @@ const WarmPreviewSurface = memo(function WarmPreviewSurface({
   rendererOccludedLeft,
 }: WarmPreviewSurfaceProps) {
   const automationHosted = useBrowserAutomationStore((state) =>
-    state.hostedScopeIds.has(scope.scopeId),
+    state.hostedScopeIds.has(warmPreviewScopeKey(scope)),
   );
   return (
     <div
@@ -209,12 +210,12 @@ export function RightPanel() {
   const panelScopeId = activeThreadId ?? activeWorkspaceId;
   const [warmPreviewScopes, setWarmPreviewScopes] = useState<readonly WarmPreviewScope[]>([]);
   const [activityRailExpanded, setActivityRailExpanded] = useState(false);
-  const retainedPreviewScopeIds = useMemo(
+  const retainedPreviewScopeKeys = useMemo(
     () => new Set([
-      ...(panelScopeId ? [panelScopeId] : []),
-      ...warmPreviewScopes.map((scope) => scope.scopeId),
+      ...(panelScopeId && activeWorkspaceId ? [browserAutomationScopeKey(activeWorkspaceId, panelScopeId)] : []),
+      ...warmPreviewScopes.map(warmPreviewScopeKey),
     ]),
-    [panelScopeId, warmPreviewScopes],
+    [activeWorkspaceId, panelScopeId, warmPreviewScopes],
   );
   const [pendingAgentPageId, activeAgentRequestPageId, ownedAgentPageId] =
     useBrowserAutomationStore(
@@ -232,7 +233,7 @@ export function RightPanel() {
 
         let activePage: { readonly tabId: string; readonly startedAt: number } | null = null;
         for (const { dispatch, startedAt } of state.activeRequests.values()) {
-          if (dispatch.target.threadId !== panelScopeId) continue;
+          if (dispatch.request.workspaceId !== activeWorkspaceId || dispatch.target.threadId !== panelScopeId) continue;
           if (!activePage || startedAt > activePage.startedAt) {
             activePage = { tabId: dispatch.target.tabId, startedAt };
           }
@@ -247,7 +248,7 @@ export function RightPanel() {
             lifecycle.ownership !== "owned"
           ) continue;
           const liveTarget = panelScopeId
-            ? state.liveTargets.get(browserAutomationTargetKey(panelScopeId, lifecycle.tabId))
+             ? state.liveTargets.get(browserAutomationTargetKey(activeWorkspaceId, panelScopeId, lifecycle.tabId))
             : undefined;
           const lastUsedAt = liveTarget?.lastUsedAt ?? 0;
           if (!ownedPage || lastUsedAt > ownedPage.lastUsedAt) {
@@ -266,8 +267,8 @@ export function RightPanel() {
     useShallow((state) => [
       ...new Set(
         [...state.activeRequests.values()]
-          .map(({ dispatch }) => dispatch.target.threadId)
-          .filter((scopeId) => retainedPreviewScopeIds.has(scopeId)),
+          .map(({ dispatch }) => browserAutomationScopeKey(dispatch.request.workspaceId, dispatch.target.threadId))
+          .filter((scopeKey) => retainedPreviewScopeKeys.has(scopeKey)),
       ),
     ].sort()),
   );
@@ -368,7 +369,7 @@ export function RightPanel() {
       requestedAgentPageActivationRef.current !== activationKey
     ) {
       requestedAgentPageActivationRef.current = activationKey;
-      void usePreviewTabsStore.getState().activatePage(panelScopeId, existingPageId);
+      void usePreviewTabsStore.getState().activatePage(activeWorkspaceId!, panelScopeId, existingPageId);
     }
   }, [
     activeThreadId,
@@ -480,14 +481,15 @@ export function RightPanel() {
         !previewActive &&
         !browserScopePresent &&
         panelScopeId &&
-        !busyPreviewScopeIds.has(panelScopeId)
+        activeWorkspaceId &&
+        !busyPreviewScopeIds.has(browserAutomationScopeKey(activeWorkspaceId, panelScopeId))
         ? previous.filter((scope) =>
             scope.scopeId !== panelScopeId || scope.workspaceId !== activeWorkspaceId
           )
         : previous;
       return reconcileWarmPreviewScopes(retained, null, busyPreviewScopeIds);
     });
-  }, [browserScopePresent, busyPreviewScopeIds, panelScopeId, previewActive]);
+  }, [activeWorkspaceId, browserScopePresent, busyPreviewScopeIds, panelScopeId, previewActive]);
 
   const isChangesActive = panelVisible && changesActive;
   const changesFresh = useChangesFreshness(
@@ -563,6 +565,7 @@ export function RightPanel() {
           keeps those panel actions beside the empty-state create list. */}
       <div className="flex min-h-0 flex-1 flex-row overflow-hidden">
         <ActivityRail
+          workspaceId={activeWorkspaceId!}
           tabInstances={renderedTabInstances}
           activeTabId={renderedActiveTabId}
           scope={panelScope}
@@ -619,7 +622,7 @@ export function RightPanel() {
             if (panelScopeId) {
               void usePreviewTabsStore
                 .getState()
-                .activatePage(panelScopeId, pageId);
+                .activatePage(activeWorkspaceId!, panelScopeId, pageId);
             }
           }}
           onCloseBrowserPage={(pageId) => {
@@ -628,7 +631,7 @@ export function RightPanel() {
             // the page switcher, so an empty browser has nothing to show).
             void usePreviewTabsStore
               .getState()
-              .closePage(panelScopeId, pageId, {
+              .closePage(activeWorkspaceId!, panelScopeId, pageId, {
                 onLastClose: () =>
                   closeRightPanelTab(
                     activeWorkspaceId!,

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -109,6 +109,7 @@ const WarmPreviewSurface = memo(function WarmPreviewSurface({
       {automationHosted ? (
         <div
           data-automation-preview-dock={scope.scopeId}
+          data-automation-preview-workspace={scope.workspaceId}
           data-visible={visible ? "true" : "false"}
           className="min-h-0 min-w-0 flex-1"
         />

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -49,6 +49,10 @@ export interface WarmPreviewScope {
   readonly lastUsedAt: number;
 }
 
+function warmPreviewScopeKey(scope: Pick<WarmPreviewScope, "scopeId" | "workspaceId">): string {
+  return JSON.stringify([scope.workspaceId, scope.scopeId]);
+}
+
 /**
  * Retain active and agent-busy Browser scopes, then fill the warm budget by
  * recency. Busy scopes are leased until their operation settles.
@@ -58,16 +62,17 @@ export function reconcileWarmPreviewScopes(
   next: WarmPreviewScope | null,
   busyScopeIds: ReadonlySet<string>,
 ): readonly WarmPreviewScope[] {
-  const byId = new Map(previous.map((scope) => [scope.scopeId, scope]));
-  if (next) byId.set(next.scopeId, next);
+  const byId = new Map(previous.map((scope) => [warmPreviewScopeKey(scope), scope]));
+  if (next) byId.set(warmPreviewScopeKey(next), next);
   const ordered = [...byId.values()].sort((left, right) => right.lastUsedAt - left.lastUsedAt);
   const leased = ordered.filter(
-    (scope) => scope.scopeId === next?.scopeId || busyScopeIds.has(scope.scopeId),
+    (scope) => (next !== null && warmPreviewScopeKey(scope) === warmPreviewScopeKey(next)) ||
+      busyScopeIds.has(scope.scopeId),
   );
-  const selected = new Map(leased.map((scope) => [scope.scopeId, scope]));
+  const selected = new Map(leased.map((scope) => [warmPreviewScopeKey(scope), scope]));
   for (const scope of ordered) {
     if (selected.size >= BROWSER_AUTOMATION_WARM_TARGET_LIMIT) break;
-    selected.set(scope.scopeId, scope);
+    selected.set(warmPreviewScopeKey(scope), scope);
   }
   const result = [...selected.values()];
   return result.length === previous.length &&
@@ -458,7 +463,9 @@ export function RightPanel() {
     const becameActive = previousActivePreviewScopeKeyRef.current !== activePreviewScopeKey;
     previousActivePreviewScopeKeyRef.current = activePreviewScopeKey;
     setWarmPreviewScopes((previous) => {
-      const existing = previous.find((scope) => scope.scopeId === panelScopeId);
+      const existing = previous.find((scope) =>
+        scope.scopeId === panelScopeId && scope.workspaceId === activeWorkspaceId
+      );
       const next = !existing || becameActive
         ? { scopeId: panelScopeId, workspaceId: activeWorkspaceId, lastUsedAt: Date.now() }
         : existing;
@@ -474,7 +481,9 @@ export function RightPanel() {
         !browserScopePresent &&
         panelScopeId &&
         !busyPreviewScopeIds.has(panelScopeId)
-        ? previous.filter((scope) => scope.scopeId !== panelScopeId)
+        ? previous.filter((scope) =>
+            scope.scopeId !== panelScopeId || scope.workspaceId !== activeWorkspaceId
+          )
         : previous;
       return reconcileWarmPreviewScopes(retained, null, busyPreviewScopeIds);
     });
@@ -671,10 +680,12 @@ export function RightPanel() {
             <DiffPanel />
           </div>
           {warmPreviewScopes.map((scope) => {
-            const visible = previewActive && scope.scopeId === panelScopeId;
+            const visible = previewActive &&
+              scope.scopeId === panelScopeId &&
+              scope.workspaceId === activeWorkspaceId;
             return (
               <WarmPreviewSurface
-                key={scope.scopeId}
+                key={warmPreviewScopeKey(scope)}
                 scope={scope}
                 visible={visible}
                 rendererOccludedLeft={

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/stores/browserAutomationStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useDiffStore } from "@/stores/diffStore";
-import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import { previewTabsScopeKey, usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { browserTargetRegistry } from "@/services/browser-automation/browserTargetRegistry";
 
 const harness = vi.hoisted(() => {
@@ -519,6 +519,26 @@ describe("BrowserAutomationHost", () => {
     webExecutor.executeWebBrowserDispatch.mockReset();
   });
 
+  it("publishes web targets as active only in the active workspace and thread", async () => {
+    delete window.desktopBridge;
+    vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
+    useBrowserAutomationStore.getState().registerTarget(
+      "workspace-2",
+      "thread-1",
+      "tab-2",
+    );
+
+    const view = render(<BrowserAutomationHost />);
+    await waitFor(() => expect(harness.transport.updateBrowserAutomationHostTargets).toHaveBeenCalled());
+    const targets = harness.transport.updateBrowserAutomationHostTargets.mock.calls.at(-1)?.[2];
+
+    expect(targets).toEqual(expect.arrayContaining([
+      expect.objectContaining({ tabId: "tab-1", active: true, focused: true }),
+      expect.objectContaining({ tabId: "tab-2", active: false, focused: false }),
+    ]));
+    view.unmount();
+  });
+
   it("keeps evaluate out of the pure web descriptor, registration, and status capabilities", async () => {
     delete window.desktopBridge;
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
@@ -760,7 +780,7 @@ describe("BrowserAutomationHost", () => {
     });
     const tabId = iframe.dataset.tabId!;
     await waitFor(() => expect(
-      usePreviewTabsStore.getState().tabSetByScope["thread-1"]?.tabs.some((tab) => tab.id === tabId),
+      usePreviewTabsStore.getState().tabSetByScope[previewTabsScopeKey("workspace-1", "thread-1")]?.tabs.some((tab) => tab.id === tabId),
     ).toBe(true));
     markIframeLoaded(iframe);
     window.setTimeout(() => iframe.dispatchEvent(new Event("load")), 0);
@@ -768,6 +788,7 @@ describe("BrowserAutomationHost", () => {
 
     const dock = document.createElement("div");
     dock.dataset.automationPreviewDock = "thread-1";
+    dock.dataset.automationPreviewWorkspace = "workspace-1";
     dock.dataset.visible = "true";
     Object.defineProperty(dock, "getBoundingClientRect", {
       configurable: true,
@@ -775,7 +796,7 @@ describe("BrowserAutomationHost", () => {
     });
     document.body.append(dock);
     await act(async () => usePreviewTabsStore.getState().activatePage("workspace-1", "thread-1", tabId));
-    await waitFor(() => expect(usePreviewTabsStore.getState().tabSetByScope["thread-1"]?.activeTabId).toBe(tabId));
+    await waitFor(() => expect(usePreviewTabsStore.getState().tabSetByScope[previewTabsScopeKey("workspace-1", "thread-1")]?.activeTabId).toBe(tabId));
     await waitFor(() => expect(iframe.style.pointerEvents).toBe("auto"));
     expect(document.querySelector('[data-automation-persistent-scope="thread-1"]')).toHaveAttribute("aria-hidden", "false");
 
@@ -1277,7 +1298,7 @@ describe("BrowserAutomationHost", () => {
 
     act(() => useBrowserAutomationStore.getState().unregisterTarget("workspace-1", "thread-1", "tab-1"));
     await waitFor(() => expect(cancel).toHaveBeenCalledWith(activeDispatch.request.requestId));
-    expect(clearTargetReplay).toHaveBeenCalledWith("thread-1", "tab-1");
+    expect(clearTargetReplay).toHaveBeenCalledWith("workspace-1", "thread-1", "tab-1");
     expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(
       hostId,
       1,
@@ -1434,7 +1455,7 @@ describe("BrowserAutomationHost", () => {
     execute.mockImplementation(async (value: BrowserAutomationHostDispatch) => {
       expect(useDiffStore.getState().previewUrlByThread["thread-1"]).toBe("about:blank");
       expect(
-        usePreviewTabsStore.getState().tabSetByScope["thread-1"]?.tabs[0]?.url,
+        usePreviewTabsStore.getState().tabSetByScope[previewTabsScopeKey("workspace-1", "thread-1")]?.tabs[0]?.url,
       ).toBe("about:blank");
       controllerChanged?.({
         tabId: "created-tab",
@@ -1462,8 +1483,8 @@ describe("BrowserAutomationHost", () => {
     });
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalled());
     expect(createTab).toHaveBeenCalledOnce();
-    expect(createTab).toHaveBeenCalledWith("thread-1", { activate: true });
-    expect(usePreviewTabsStore.getState().tabSetByScope["thread-1"]?.tabs[0]?.url).toBe(
+    expect(createTab).toHaveBeenCalledWith("thread-1", "workspace-1", { activate: true });
+    expect(usePreviewTabsStore.getState().tabSetByScope[previewTabsScopeKey("workspace-1", "thread-1")]?.tabs[0]?.url).toBe(
       "about:blank",
     );
     expect(useWorkspaceStore.getState().activeThreadId).toBe("thread-1");
@@ -1577,7 +1598,7 @@ describe("BrowserAutomationHost", () => {
         await Promise.resolve();
       });
       expect(execute).toHaveBeenCalledOnce();
-      expect(createTab).toHaveBeenCalledWith("thread-1", {
+      expect(createTab).toHaveBeenCalledWith("thread-1", "workspace-1", {
         activate: false,
         renderingHost: "webview",
         tabId: "cold-tab",
@@ -1589,7 +1610,7 @@ describe("BrowserAutomationHost", () => {
         expect.objectContaining({ tabId: "cold-tab" }),
       );
       expect(useBrowserAutomationStore.getState().pendingAgentOpens).toHaveLength(0);
-      expect(usePreviewTabsStore.getState().tabSetByScope["thread-1"]?.tabs).toEqual([
+      expect(usePreviewTabsStore.getState().tabSetByScope[previewTabsScopeKey("workspace-1", "thread-1")]?.tabs).toEqual([
         expect.objectContaining({ id: "cold-tab", url: "https://example.com/" }),
       ]);
       view.unmount();
@@ -1772,6 +1793,7 @@ describe("BrowserAutomationHost", () => {
         );
         oldestDock = document.createElement("div");
         oldestDock.dataset.automationPreviewDock = "sequential-0";
+        oldestDock.dataset.automationPreviewWorkspace = "workspace-1";
         oldestDock.dataset.visible = "true";
         vi.spyOn(oldestDock, "getBoundingClientRect").mockReturnValue({
           left: 5, top: 10, width: 700, height: 500, right: 705, bottom: 510, x: 5, y: 10, toJSON: () => undefined,
@@ -1811,9 +1833,11 @@ describe("BrowserAutomationHost", () => {
     );
     const fourthDock = document.createElement("div");
     fourthDock.dataset.automationPreviewDock = "sequential-4";
+    fourthDock.dataset.automationPreviewWorkspace = "workspace-1";
     fourthDock.dataset.visible = "false";
     const fifthDock = document.createElement("div");
     fifthDock.dataset.automationPreviewDock = "sequential-5";
+    fifthDock.dataset.automationPreviewWorkspace = "workspace-1";
     fifthDock.dataset.visible = "true";
     vi.spyOn(fourthDock, "getBoundingClientRect").mockReturnValue({
       left: 10, top: 20, width: 800, height: 600, right: 810, bottom: 620, x: 10, y: 20, toJSON: () => undefined,
@@ -1996,7 +2020,7 @@ describe("BrowserAutomationHost", () => {
     executing.resolve(response(openRequest));
     await act(async () => executing.promise);
     expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
-    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "created-tab"));
+    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "workspace-1", "created-tab"));
     expect(browserTargetRegistry.get("workspace-1", "thread-1", "created-tab")).toBeNull();
     view.unmount();
   });
@@ -2024,7 +2048,7 @@ describe("BrowserAutomationHost", () => {
     const request = dispatch(1, 13).request;
     const openRequest = { ...request, operation: "open" as const, args: { url: "https://example.com/", activate: true } };
     act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
-    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "failed-tab"));
+    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "workspace-1", "failed-tab"));
     expect(browserTargetRegistry.get("workspace-1", "thread-1", "failed-tab")).toBeNull();
     view.unmount();
   });
@@ -2033,7 +2057,7 @@ describe("BrowserAutomationHost", () => {
     useBrowserAutomationStore.setState({ liveTargets: new Map() });
     usePreviewTabsStore.setState({
       tabSetByScope: {
-        "thread-1": {
+        [previewTabsScopeKey("workspace-1", "thread-1")]: {
           threadId: "thread-1",
           activeTabId: "previous-tab",
           tabs: [{ id: "previous-tab", threadId: "thread-1", url: null, title: null, faviconUrl: null, warm: true, active: true }],
@@ -2063,7 +2087,7 @@ describe("BrowserAutomationHost", () => {
     const request = dispatch(1, 15).request;
     const openRequest = { ...request, operation: "open" as const, args: { url: "https://example.com/", activate: false } };
     act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
-    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "restore-failure-tab"));
+    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "workspace-1", "restore-failure-tab"));
     expect(activatePage).toHaveBeenCalledWith("workspace-1", "thread-1", "previous-tab");
     expect(browserTargetRegistry.get("workspace-1", "thread-1", "restore-failure-tab")).toBeNull();
     view.unmount();
@@ -2092,7 +2116,7 @@ describe("BrowserAutomationHost", () => {
     const request = dispatch(1, 17).request;
     const openRequest = { ...request, operation: "open" as const, args: { url: "https://example.com/", activate: true } };
     act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
-    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "close-failure-tab"));
+    await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "workspace-1", "close-failure-tab"));
     expect(browserTargetRegistry.get("workspace-1", "thread-1", "close-failure-tab")).not.toBeNull();
     view.unmount();
   });

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useThreadStore } from "@/stores/threadStore";
 import {
+  browserAutomationScopeKey,
   browserAutomationTargetKey,
   interruptBrowserAutomationTarget,
   releaseBrowserAutomationThreadScope,
@@ -103,7 +104,7 @@ function dispatch(
   const threadId = options.threadId ?? "thread-1";
   const tabId = options.tabId ?? "tab-1";
   const targetGeneration = options.targetGeneration ??
-    useBrowserAutomationStore.getState().liveTargets.get(browserAutomationTargetKey(threadId, tabId))?.revision ?? 1;
+    useBrowserAutomationStore.getState().liveTargets.get(browserAutomationTargetKey("workspace-1", threadId, tabId))?.revision ?? 1;
   return {
     scope: {
       workspaceId: "workspace-1",
@@ -384,8 +385,9 @@ describe("BrowserAutomationHost", () => {
       targetGeneration: 1,
     });
     await coordinator.requestAgentResize({ width: 1_200, height: 800 });
-    useBrowserAutomationStore.getState().setViewportCoordinator("thread-1", "tab-1", coordinator);
+    useBrowserAutomationStore.getState().setViewportCoordinator("workspace-1", "thread-1", "tab-1", coordinator);
     useBrowserAutomationStore.getState().setViewportState(
+      "workspace-1",
       "thread-1",
       "tab-1",
       coordinator.snapshot(),
@@ -469,12 +471,12 @@ describe("BrowserAutomationHost", () => {
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
 
     expect(useBrowserAutomationStore.getState().controllers.get(
-      JSON.stringify(["thread-1", "tab-1"]),
+      browserAutomationTargetKey("workspace-1", "thread-1", "tab-1"),
     )).toMatchObject({ controller: "agent", controlEpoch: 0 });
 
     act(() => useThreadStore.setState({ runningThreadIds: new Set() }));
     await waitFor(() => expect(useBrowserAutomationStore.getState().controllers.get(
-      JSON.stringify(["thread-1", "tab-1"]),
+      browserAutomationTargetKey("workspace-1", "thread-1", "tab-1"),
     )).toMatchObject({ controller: "none", controlEpoch: 0 }));
     expect(releaseAgentControl).toHaveBeenCalledWith({
       threadId: "thread-1",
@@ -644,7 +646,9 @@ describe("BrowserAutomationHost", () => {
       },
     };
     act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
-    await waitFor(() => expect(useBrowserAutomationStore.getState().hostedScopeIds.has("thread-1")).toBe(true));
+    await waitFor(() => expect(useBrowserAutomationStore.getState().hostedScopeIds.has(
+      browserAutomationScopeKey("workspace-1", "thread-1"),
+    )).toBe(true));
     const surface = document.querySelector<HTMLElement>('[data-automation-persistent-scope="thread-1"]');
     expect(surface).not.toBeNull();
     let iframe!: HTMLIFrameElement;
@@ -770,7 +774,7 @@ describe("BrowserAutomationHost", () => {
       value: () => ({ left: 40, top: 20, width: 640, height: 480, right: 680, bottom: 500, x: 40, y: 20, toJSON: () => ({}) }),
     });
     document.body.append(dock);
-    await act(async () => usePreviewTabsStore.getState().activatePage("thread-1", tabId));
+    await act(async () => usePreviewTabsStore.getState().activatePage("workspace-1", "thread-1", tabId));
     await waitFor(() => expect(usePreviewTabsStore.getState().tabSetByScope["thread-1"]?.activeTabId).toBe(tabId));
     await waitFor(() => expect(iframe.style.pointerEvents).toBe("auto"));
     expect(document.querySelector('[data-automation-persistent-scope="thread-1"]')).toHaveAttribute("aria-hidden", "false");
@@ -838,7 +842,7 @@ describe("BrowserAutomationHost", () => {
     document.body.append(iframe);
     window.setTimeout(() => {
       iframe.dispatchEvent(new Event("load"));
-      useBrowserAutomationStore.getState().refreshTarget("thread-1", "web-preview");
+      useBrowserAutomationStore.getState().refreshTarget("workspace-1", "thread-1", "web-preview");
     }, 0);
     await waitFor(() => expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(
       expect.objectContaining({ request: expect.objectContaining({ args: { activate: true } }) }),
@@ -876,7 +880,7 @@ describe("BrowserAutomationHost", () => {
     });
     document.body.append(iframe);
     window.setTimeout(() => {
-      useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1");
+      useBrowserAutomationStore.getState().refreshTarget("workspace-1", "thread-1", "tab-1");
       iframe.dispatchEvent(new Event("load"));
     }, 0);
 
@@ -909,7 +913,7 @@ describe("BrowserAutomationHost", () => {
     iframe.src = expectedUrl;
     setIframeIdentity(iframe, "tab-1");
     document.body.append(iframe);
-    act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
+    act(() => useBrowserAutomationStore.getState().refreshTarget("workspace-1", "thread-1", "tab-1"));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
     expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
       hostId,
@@ -946,7 +950,7 @@ describe("BrowserAutomationHost", () => {
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: navigateDispatch }));
     await waitFor(() => expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(navigateDispatch, expect.any(AbortSignal)));
     act(() => iframe.dispatchEvent(new Event("load")));
-    act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
+    act(() => useBrowserAutomationStore.getState().refreshTarget("workspace-1", "thread-1", "tab-1"));
     executing.resolve(successResponse(navigateDispatch.request));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
     expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
@@ -976,7 +980,7 @@ describe("BrowserAutomationHost", () => {
     document.body.append(iframe);
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: navigateDispatch }));
     await waitFor(() => expect(webExecutor.executeWebBrowserDispatch).toHaveBeenCalledWith(navigateDispatch, expect.any(AbortSignal)));
-    act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
+    act(() => useBrowserAutomationStore.getState().refreshTarget("workspace-1", "thread-1", "tab-1"));
     executing.resolve(successResponse(navigateDispatch.request));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
     expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
@@ -1010,7 +1014,7 @@ describe("BrowserAutomationHost", () => {
     replacement.src = `${window.location.origin}/unrelated-replacement`;
     setIframeIdentity(replacement, "tab-1");
     document.body.append(replacement);
-    act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
+    act(() => useBrowserAutomationStore.getState().refreshTarget("workspace-1", "thread-1", "tab-1"));
 
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
     expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
@@ -1212,7 +1216,7 @@ describe("BrowserAutomationHost", () => {
       ok: true,
       target: { windowId: 8, threadId: "thread-1", tabId: "tab-1", targetGeneration: 4, active: true, focused: true, lastUsedAt: 20 },
     });
-    act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
+    act(() => useBrowserAutomationStore.getState().refreshTarget("workspace-1", "thread-1", "tab-1"));
     await waitFor(() => expect(harness.transport.updateBrowserAutomationHostTargets).toHaveBeenCalledTimes(2));
     expect(harness.transport.updateBrowserAutomationHostTargets.mock.calls[1]?.[2]).toEqual([
       expect.objectContaining({ windowId: 8, targetGeneration: 4, connectionGeneration: 1 }),
@@ -1271,7 +1275,7 @@ describe("BrowserAutomationHost", () => {
     }));
     await waitFor(() => expect(useBrowserAutomationStore.getState().activeRequests).toHaveLength(1));
 
-    act(() => useBrowserAutomationStore.getState().unregisterTarget("thread-1", "tab-1"));
+    act(() => useBrowserAutomationStore.getState().unregisterTarget("workspace-1", "thread-1", "tab-1"));
     await waitFor(() => expect(cancel).toHaveBeenCalledWith(activeDispatch.request.requestId));
     expect(clearTargetReplay).toHaveBeenCalledWith("thread-1", "tab-1");
     expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(
@@ -1303,7 +1307,7 @@ describe("BrowserAutomationHost", () => {
     await act(async () => {
       harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: firstDispatch });
       harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: secondDispatch });
-      interruptBrowserAutomationTarget("thread-2", "tab-1", "human-interrupted");
+      interruptBrowserAutomationTarget("workspace-1", "thread-2", "tab-1", "human-interrupted");
       await Promise.resolve();
     });
     expect(interrupt).toHaveBeenCalledWith({ threadId: "thread-2", tabId: "tab-1" });
@@ -1371,7 +1375,9 @@ describe("BrowserAutomationHost", () => {
       request: openRequest,
     }));
     await waitFor(() => expect(createTab).toHaveBeenCalledOnce());
-    await waitFor(() => expect(useBrowserAutomationStore.getState().hostedScopeIds.has("thread-1")).toBe(true));
+    await waitFor(() => expect(useBrowserAutomationStore.getState().hostedScopeIds.has(
+      browserAutomationScopeKey("workspace-1", "thread-1"),
+    )).toBe(true));
 
     view.unmount();
     expect(harness.transport.cancelBrowserAutomationRequest).toHaveBeenCalledWith(
@@ -1466,7 +1472,9 @@ describe("BrowserAutomationHost", () => {
       activeTab: "preview",
     });
     expect(document.querySelector('[data-automation-persistent-scope="thread-1"]')).not.toBeNull();
-    expect(useBrowserAutomationStore.getState().hostedScopeIds.has("thread-1")).toBe(true);
+    expect(useBrowserAutomationStore.getState().hostedScopeIds.has(
+      browserAutomationScopeKey("workspace-1", "thread-1"),
+    )).toBe(true);
     expect(execute).toHaveBeenCalledWith(expect.objectContaining({
       request: openRequest,
       target: expect.objectContaining({ tabId: "created-tab" }),
@@ -1480,7 +1488,7 @@ describe("BrowserAutomationHost", () => {
       expect.objectContaining({ tabId: "created-tab", targetGeneration: 1 }),
     );
     expect(useBrowserAutomationStore.getState().controllers.get(
-      JSON.stringify(["thread-1", "created-tab"]),
+      browserAutomationTargetKey("workspace-1", "thread-1", "created-tab"),
     )).toMatchObject({ controller: "agent", operation: "open" });
     view.unmount();
   });
@@ -1700,9 +1708,11 @@ describe("BrowserAutomationHost", () => {
     await waitFor(() => expect(execute).toHaveBeenCalledOnce());
     const surface = document.querySelector('[data-automation-persistent-scope="thread-1"]');
     expect(surface).not.toBeNull();
-    expect(useBrowserAutomationStore.getState().hostedScopeIds.has("thread-1")).toBe(true);
+    expect(useBrowserAutomationStore.getState().hostedScopeIds.has(
+      browserAutomationScopeKey("workspace-1", "thread-1"),
+    )).toBe(true);
 
-    act(() => releaseBrowserAutomationThreadScope("thread-1"));
+    act(() => releaseBrowserAutomationThreadScope("workspace-1", "thread-1"));
     await waitFor(() => expect(document.querySelector(
       '[data-automation-persistent-scope="thread-1"]',
     )).toBeNull());
@@ -1714,7 +1724,9 @@ describe("BrowserAutomationHost", () => {
       openRequest.sequence,
       "host-shutdown",
     );
-    expect(useBrowserAutomationStore.getState().hostedScopeIds.has("thread-1")).toBe(false);
+    expect(useBrowserAutomationStore.getState().hostedScopeIds.has(
+      browserAutomationScopeKey("workspace-1", "thread-1"),
+    )).toBe(false);
 
     pending.resolve(response(openRequest));
     await act(async () => pending.promise);
@@ -1936,7 +1948,7 @@ describe("BrowserAutomationHost", () => {
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: resizeDispatch }));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalled());
     expect(useBrowserAutomationStore.getState().viewportByTarget.get(
-      JSON.stringify(["thread-1", "tab-1"]),
+      browserAutomationTargetKey("workspace-1", "thread-1", "tab-1"),
     )).toEqual({ width: 1024, height: 768 });
     expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledWith(
       hostId,
@@ -1985,7 +1997,7 @@ describe("BrowserAutomationHost", () => {
     await act(async () => executing.promise);
     expect(harness.transport.respondToBrowserAutomationRequest).not.toHaveBeenCalled();
     await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "created-tab"));
-    expect(browserTargetRegistry.get("thread-1", "created-tab")).toBeNull();
+    expect(browserTargetRegistry.get("workspace-1", "thread-1", "created-tab")).toBeNull();
     view.unmount();
   });
 
@@ -2013,7 +2025,7 @@ describe("BrowserAutomationHost", () => {
     const openRequest = { ...request, operation: "open" as const, args: { url: "https://example.com/", activate: true } };
     act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
     await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "failed-tab"));
-    expect(browserTargetRegistry.get("thread-1", "failed-tab")).toBeNull();
+    expect(browserTargetRegistry.get("workspace-1", "thread-1", "failed-tab")).toBeNull();
     view.unmount();
   });
 
@@ -2052,8 +2064,8 @@ describe("BrowserAutomationHost", () => {
     const openRequest = { ...request, operation: "open" as const, args: { url: "https://example.com/", activate: false } };
     act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
     await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "restore-failure-tab"));
-    expect(activatePage).toHaveBeenCalledWith("thread-1", "previous-tab");
-    expect(browserTargetRegistry.get("thread-1", "restore-failure-tab")).toBeNull();
+    expect(activatePage).toHaveBeenCalledWith("workspace-1", "thread-1", "previous-tab");
+    expect(browserTargetRegistry.get("workspace-1", "thread-1", "restore-failure-tab")).toBeNull();
     view.unmount();
   });
 
@@ -2081,7 +2093,7 @@ describe("BrowserAutomationHost", () => {
     const openRequest = { ...request, operation: "open" as const, args: { url: "https://example.com/", activate: true } };
     act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
     await waitFor(() => expect(closeTab).toHaveBeenCalledWith("thread-1", "close-failure-tab"));
-    expect(browserTargetRegistry.get("thread-1", "close-failure-tab")).not.toBeNull();
+    expect(browserTargetRegistry.get("workspace-1", "thread-1", "close-failure-tab")).not.toBeNull();
     view.unmount();
   });
 
@@ -2107,7 +2119,7 @@ describe("BrowserAutomationHost", () => {
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: resizeDispatch }));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalled());
     expect(useBrowserAutomationStore.getState().viewportByTarget.has(
-      JSON.stringify(["thread-1", "tab-1"]),
+      browserAutomationTargetKey("workspace-1", "thread-1", "tab-1"),
     )).toBe(false);
     expect(finishRendererOperation).not.toHaveBeenCalled();
     view.unmount();
@@ -2337,7 +2349,7 @@ describe("BrowserAutomationHost", () => {
     vi.spyOn(input, "getBoundingClientRect").mockReturnValue({ width: 120, height: 20 } as DOMRect);
     const clicked = vi.fn();
     button.addEventListener("click", clicked);
-    useBrowserAutomationStore.getState().setControllerForTarget("thread-1", "tab-1", { tabId: "tab-1", controller: "agent", controlEpoch: 2 });
+    useBrowserAutomationStore.getState().setControllerForTarget("workspace-1", "thread-1", "tab-1", { tabId: "tab-1", controller: "agent", controlEpoch: 2 });
     const view = render(<BrowserAutomationHost />);
     await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
     const hostId = sessionStorage.getItem("mcode.browserAutomation.hostId");
@@ -2384,7 +2396,7 @@ describe("BrowserAutomationHost", () => {
     typeDispatch.request = { ...typeDispatch.request, operation: "type", args: { target: { cssSelector: "#name" }, text: "typed", clear: true, submit: false, timeoutMs: 1000 } } as never;
     act(() => harness.emit("browserAutomation.request", { hostId, generation: 1, dispatch: typeDispatch }));
     await waitFor(() => expect(useBrowserAutomationStore.getState().activeRequests.size).toBe(1));
-    act(() => useBrowserAutomationStore.getState().refreshTarget("thread-1", "tab-1"));
+    act(() => useBrowserAutomationStore.getState().refreshTarget("workspace-1", "thread-1", "tab-1"));
     pending.shift()?.(performance.now());
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
     expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenLastCalledWith(
@@ -2431,10 +2443,10 @@ describe("BrowserAutomationHost", () => {
     const view = render(<BrowserAutomationHost />);
     await waitFor(() => expect(harness.transport.registerBrowserAutomationHost).toHaveBeenCalledOnce());
     await act(async () => {
-      interruptBrowserAutomationTarget("thread-1", "tab-1", "human-interrupted");
+      interruptBrowserAutomationTarget("workspace-1", "thread-1", "tab-1", "human-interrupted");
       await Promise.resolve();
     });
-    expect(disposeTarget).toHaveBeenCalledWith("thread-1", "tab-1");
+    expect(disposeTarget).toHaveBeenCalledWith("workspace-1", "thread-1", "tab-1");
     view.unmount();
     disposeTarget.mockRestore();
   });

--- a/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
@@ -62,7 +62,7 @@ describe("BrowserSurfaceHostRoot", () => {
       initiator: "human" as const,
     };
     act(() => onPopupRequested?.(request));
-    expect(openPage).toHaveBeenLastCalledWith("thread-1", {
+    expect(openPage).toHaveBeenLastCalledWith("workspace-1", "thread-1", {
       activate: true,
       focusOmnibox: false,
       initialAddress: request.address,
@@ -70,7 +70,7 @@ describe("BrowserSurfaceHostRoot", () => {
     });
 
     act(() => onPopupRequested?.({ ...request, initiator: "agent" }));
-    expect(openPage).toHaveBeenLastCalledWith("thread-1", {
+    expect(openPage).toHaveBeenLastCalledWith("workspace-1", "thread-1", {
       activate: false,
       focusOmnibox: false,
       initialAddress: request.address,

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -312,14 +312,14 @@ describe("PreviewPanel: unavailable state", () => {
     expect(iframe).toHaveAttribute("data-thread-id", "thread-1");
     expect(iframe).toHaveAttribute("data-tab-id", "web-preview");
     expect(useBrowserAutomationStore.getState().liveTargets.get(
-      JSON.stringify(["thread-1", "web-preview"]),
+      JSON.stringify(["workspace-1", "thread-1", "web-preview"]),
     )).toMatchObject({ workspaceId: "workspace-1", threadId: "thread-1", tabId: "web-preview" });
     const initialRevision = useBrowserAutomationStore.getState().liveTargets.get(
-      JSON.stringify(["thread-1", "web-preview"]),
+      JSON.stringify(["workspace-1", "thread-1", "web-preview"]),
     )!.revision;
     fireEvent.load(iframe);
     expect(useBrowserAutomationStore.getState().liveTargets.get(
-      JSON.stringify(["thread-1", "web-preview"]),
+      JSON.stringify(["workspace-1", "thread-1", "web-preview"]),
     )!.revision).toBe(initialRevision + 1);
     const page = document.implementation.createHTMLDocument("Fixture");
     page.body.innerHTML = "<main>Visible fixture</main>";
@@ -471,7 +471,7 @@ describe("PreviewPanel: unavailable state", () => {
     await waitFor(() => {
       expect(
         useBrowserAutomationStore.getState().viewportStateByTarget.get(
-          JSON.stringify(["thread-1", "web-preview"]),
+          JSON.stringify(["workspace-1", "thread-1", "web-preview"]),
         ),
       ).toMatchObject({ mode: "responsive" });
     });
@@ -481,7 +481,7 @@ describe("PreviewPanel: unavailable state", () => {
     await waitFor(() => {
       expect(
         useBrowserAutomationStore.getState().viewportStateByTarget.get(
-          JSON.stringify(["thread-1", "web-preview"]),
+          JSON.stringify(["workspace-1", "thread-1", "web-preview"]),
         ),
       ).toMatchObject({ mode: "regular" });
     });
@@ -508,7 +508,7 @@ describe("PreviewPanel: unavailable state", () => {
     await waitFor(() => {
       expect(
         useBrowserAutomationStore.getState().viewportStateByTarget.get(
-          JSON.stringify(["thread-1", "web-preview"]),
+          JSON.stringify(["workspace-1", "thread-1", "web-preview"]),
         ),
       ).toMatchObject({ presentation: "150%" });
     });
@@ -524,7 +524,7 @@ describe("PreviewPanel: unavailable state", () => {
     await waitFor(() => {
       expect(
         useBrowserAutomationStore.getState().viewportStateByTarget.get(
-          JSON.stringify(["thread-1", "web-preview"]),
+          JSON.stringify(["workspace-1", "thread-1", "web-preview"]),
         ),
       ).toMatchObject({ mode: "responsive", presentation: "fit" });
     });
@@ -539,7 +539,7 @@ describe("PreviewPanel: unavailable state", () => {
       expect(useBrowserAutomationStore.getState().viewportCoordinators.size).toBeGreaterThan(0);
     });
     const coordinator = useBrowserAutomationStore.getState().viewportCoordinators.get(
-      JSON.stringify(["thread-1", "web-preview"]),
+      JSON.stringify(["workspace-1", "thread-1", "web-preview"]),
     );
     expect(coordinator).toBeDefined();
     await coordinator!.requestAgentResize({ width: 393, height: 852 });
@@ -551,7 +551,7 @@ describe("PreviewPanel: unavailable state", () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     render(<PreviewPanel threadId="thread-1" workspaceId="workspace-1" />);
 
-    const targetKey = JSON.stringify(["thread-1", "web-preview"]);
+    const targetKey = JSON.stringify(["workspace-1", "thread-1", "web-preview"]);
     await waitFor(() => {
       expect(useBrowserAutomationStore.getState().liveTargets.has(targetKey)).toBe(true);
     });
@@ -563,6 +563,7 @@ describe("PreviewPanel: unavailable state", () => {
     });
     act(() => {
       useBrowserAutomationStore.getState().setViewportCoordinator(
+        "workspace-1",
         "thread-1",
         "web-preview",
         coordinator,
@@ -683,6 +684,7 @@ describe("PreviewPanel: full panel state", () => {
       controllers: new Map([
         [
           browserAutomationTargetKey(
+            "thread-1",
             "thread-1",
             PREVIEW_WEBVIEW_FALLBACK_TAB_ID,
           ),

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -104,6 +104,7 @@ import {
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
 import { ViewportCoordinator } from "@/services/browser-automation/viewportCoordinator";
+import { browserSurfaceHost } from "../BrowserSurfaceHostRoot";
 
 function mockBridgeState(overrides: Record<string, unknown> = {}) {
   const state = {
@@ -272,6 +273,7 @@ describe("PreviewPanel: unavailable state", () => {
   });
 
   afterEach(() => {
+    browserSurfaceHost.disposeAll();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).desktopBridge = undefined;
     mockUsePreviewBridge.mockClear();
@@ -363,7 +365,7 @@ describe("PreviewPanel: unavailable state", () => {
     expect(result).toMatchObject({ ok: true, result: { operation: "snapshot" } });
   });
 
-  it("switches thread URL and iframe synchronously without stale preview state", () => {
+  it("switches thread presentation without replacing the prior warm iframe", () => {
     vi.stubEnv("VITE_MCODE_WEB_AUTOMATION", "1");
     useDiffStore.setState({
       previewUrlByThread: {
@@ -372,12 +374,18 @@ describe("PreviewPanel: unavailable state", () => {
       },
     });
     const view = render(<PreviewPanel threadId="thread-1" />);
+    const firstIframe = screen.getByTestId("web-runtime-preview-iframe");
     view.rerender(<PreviewPanel threadId="thread-2" />);
     expect(screen.getByLabelText("Preview URL")).toHaveValue(window.location.origin + "/second");
-    expect(screen.getByTestId("web-runtime-preview-iframe")).toHaveAttribute(
+    const secondIframe = screen.getAllByTestId("web-runtime-preview-iframe").find(
+      (iframe) => iframe.getAttribute("data-thread-id") === "thread-2",
+    );
+    expect(secondIframe).toHaveAttribute(
       "src",
       window.location.origin + "/second",
     );
+    expect(firstIframe).toBeInTheDocument();
+    expect(firstIframe).toHaveAttribute("aria-hidden", "true");
   });
 
   it("keeps a cross-origin page visible while identifying DOM automation as unsupported", () => {
@@ -437,7 +445,9 @@ describe("PreviewPanel: unavailable state", () => {
 
     expect(screen.getByTestId("web-runtime-unavailable")).toBeInTheDocument();
     await waitFor(() => {
-      expect(iframe).not.toBeInTheDocument();
+      expect(iframe).toBeInTheDocument();
+      expect(iframe).toHaveAttribute("aria-hidden", "true");
+      expect(iframe).toHaveStyle({ visibility: "hidden" });
     });
   });
 
@@ -646,6 +656,7 @@ describe("PreviewPanel: full panel state", () => {
   });
 
   afterEach(() => {
+    browserSurfaceHost.disposeAll();
     vi.unstubAllGlobals();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).desktopBridge = undefined;

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -97,7 +97,7 @@ import {
 } from "@/stores/previewAnnotationStore";
 import { usePreviewDesignModeStore } from "@/stores/previewDesignModeStore";
 import { useProviderCatalogStore } from "@/stores/providerCatalogStore";
-import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import { previewTabsScopeKey, usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { useDiffStore } from "@/stores/diffStore";
 import {
   browserAutomationTargetKey,
@@ -1093,7 +1093,7 @@ describe("PreviewPanel: full panel state", () => {
         },
       ],
     };
-    usePreviewTabsStore.getState().setTabSet("thread-1", tabSet);
+    usePreviewTabsStore.getState().setTabSet("thread-1", "thread-1", tabSet);
     mockUsePreviewTabs.mockReturnValue({
       tabSet,
       newTab: vi.fn(),
@@ -1114,7 +1114,7 @@ describe("PreviewPanel: full panel state", () => {
     );
 
     await waitFor(() => {
-      const updatedTabSet = usePreviewTabsStore.getState().tabSetByScope["thread-1"]!;
+      const updatedTabSet = usePreviewTabsStore.getState().tabSetByScope[previewTabsScopeKey("thread-1", "thread-1")]!;
       expect(updatedTabSet.tabs.find((tab) => tab.id === "tab-b")?.faviconUrl).toBe(
         "https://b.example/favicon.ico",
       );

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -9,6 +9,7 @@ import {
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
 import { PreviewWebview, type PreviewWebviewHandle } from "../PreviewWebview";
+import { browserSurfaceHost } from "../BrowserSurfaceHostRoot";
 
 describe("PreviewWebview", () => {
   beforeEach(() => {
@@ -17,6 +18,7 @@ describe("PreviewWebview", () => {
   });
 
   afterEach(() => {
+    browserSurfaceHost.disposeAll();
     delete window.desktopBridge;
   });
 
@@ -139,13 +141,14 @@ describe("PreviewWebview", () => {
     }
   });
 
-  it("advances the Electron surface generation when the same target remounts", () => {
+  it("preserves the Electron guest and generation when presentation remounts", () => {
     const prepare = vi.fn().mockResolvedValue({ ok: true });
+    const release = vi.fn().mockResolvedValue({ ok: true });
     window.desktopBridge = { preview: { surface: {
       prepare,
       adopt: vi.fn().mockResolvedValue({ ok: true }),
       navigate: vi.fn().mockResolvedValue({ ok: true }),
-      release: vi.fn().mockResolvedValue({ ok: true }),
+      release,
     } } } as unknown as NonNullable<typeof window.desktopBridge>;
     const props = {
       workspaceId: "workspace-remount",
@@ -156,11 +159,27 @@ describe("PreviewWebview", () => {
 
     const first = render(<PreviewWebview {...props} />);
     const firstGeneration = prepare.mock.calls[0]?.[0].surface.generation as number;
+    const firstGuest = screen.getByTestId("electron-browser-surface-webview");
+    const targetKey = browserAutomationTargetKey(props.threadId, props.tabId);
+    const firstTargetGeneration = useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision;
     first.unmount();
+    expect(useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision).toBe(
+      firstTargetGeneration,
+    );
     render(<PreviewWebview {...props} />);
-    const secondGeneration = prepare.mock.calls[1]?.[0].surface.generation as number;
+    const snapshot = browserSurfaceHost.getSnapshot({
+      workspaceId: props.workspaceId,
+      scope: { kind: "thread", id: props.threadId },
+      tabId: props.tabId,
+    });
 
-    expect(secondGeneration).toBeGreaterThan(firstGeneration);
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+    expect(screen.getByTestId("electron-browser-surface-webview")).toBe(firstGuest);
+    expect(snapshot?.generation).toBe(firstGeneration);
+    expect(useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision).toBe(
+      firstTargetGeneration,
+    );
   });
 
   it("keeps native event subscriptions stable when parent callbacks change", async () => {

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -62,7 +62,7 @@ describe("PreviewWebview", () => {
     }));
     unsubscribe();
     expect(invalidate).toHaveBeenCalledOnce();
-    expect(invalidate).toHaveBeenCalledWith("thread-1", "tab-1");
+    expect(invalidate).toHaveBeenCalledWith("workspace-1", "thread-1", "tab-1");
   });
 
   it("routes history through the exact generation-bound main bridge", async () => {
@@ -124,7 +124,7 @@ describe("PreviewWebview", () => {
           src="https://example.com"
         />,
       );
-      const key = browserAutomationTargetKey("thread-generation", "tab-generation");
+      const key = browserAutomationTargetKey("workspace-generation", "thread-generation", "tab-generation");
       await waitFor(() => {
         expect(useBrowserAutomationStore.getState().viewportCoordinators.get(key)).toBeDefined();
       });
@@ -137,7 +137,7 @@ describe("PreviewWebview", () => {
         expect(store.liveTargets.get(key)?.revision).toBe(1);
       });
     } finally {
-      releaseBrowserAutomationThreadScope("thread-generation");
+      releaseBrowserAutomationThreadScope("workspace-generation", "thread-generation");
     }
   });
 
@@ -160,7 +160,7 @@ describe("PreviewWebview", () => {
     const first = render(<PreviewWebview {...props} />);
     const firstGeneration = prepare.mock.calls[0]?.[0].surface.generation as number;
     const firstGuest = screen.getByTestId("electron-browser-surface-webview");
-    const targetKey = browserAutomationTargetKey(props.threadId, props.tabId);
+    const targetKey = browserAutomationTargetKey(props.workspaceId, props.threadId, props.tabId);
     const firstTargetGeneration = useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision;
     first.unmount();
     expect(useBrowserAutomationStore.getState().liveTargets.get(targetKey)?.revision).toBe(

--- a/apps/web/src/components/panels/__tests__/browserVisibleConformance.test.tsx
+++ b/apps/web/src/components/panels/__tests__/browserVisibleConformance.test.tsx
@@ -28,7 +28,7 @@ import {
   releaseBrowserAutomationThreadScope,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
-import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import { previewTabsScopeKey, usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { browserTargetRegistry } from "@/services/browser-automation/browserTargetRegistry";
 import {
   ViewportCoordinator,
@@ -633,7 +633,7 @@ describe("visible Browser conformance observer", () => {
       controllers: new Map([[TARGET_KEY, { tabId: TAB_ID, controller: "agent", controlEpoch: 1 }]]),
     });
     usePreviewTabsStore.setState({
-      tabSetByScope: { [THREAD_ID]: tabSet },
+      tabSetByScope: { [previewTabsScopeKey("workspace-visible", THREAD_ID)]: tabSet },
       liveChromeByScope: {},
       persistentTabIdsByScope: {},
     });

--- a/apps/web/src/components/panels/__tests__/browserVisibleConformance.test.tsx
+++ b/apps/web/src/components/panels/__tests__/browserVisibleConformance.test.tsx
@@ -126,7 +126,8 @@ vi.mock("@/components/ui/dialog", () => ({
 
 const THREAD_ID = "thread-visible-conformance";
 const TAB_ID = "tab-visible-conformance";
-const TARGET_KEY = browserAutomationTargetKey(THREAD_ID, TAB_ID);
+const WORKSPACE_ID = "workspace-visible";
+const TARGET_KEY = browserAutomationTargetKey(WORKSPACE_ID, THREAD_ID, TAB_ID);
 
 const visibleScenario = createBrowserConformanceScenario({
   id: "visible-browser-surfaces",
@@ -411,13 +412,13 @@ describe("visible Browser conformance observer", () => {
 
   afterEach(() => {
     browserTargetRegistry.clear();
-    useBrowserAutomationStore.getState().unregisterTarget(THREAD_ID, TAB_ID);
+    useBrowserAutomationStore.getState().unregisterTarget(WORKSPACE_ID, THREAD_ID, TAB_ID);
   });
 
   it("observes agent ownership through the accessible Browser takeover control", async () => {
     const user = userEvent.setup();
-    useBrowserAutomationStore.getState().registerTarget("workspace-visible", THREAD_ID, TAB_ID);
-    useBrowserAutomationStore.getState().setControllerForTarget(THREAD_ID, TAB_ID, {
+    useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, THREAD_ID, TAB_ID);
+    useBrowserAutomationStore.getState().setControllerForTarget(WORKSPACE_ID, THREAD_ID, TAB_ID, {
       tabId: TAB_ID,
       controller: "agent",
       controlEpoch: 4,
@@ -444,7 +445,7 @@ describe("visible Browser conformance observer", () => {
     await user.click(takeover);
     expect(onStopAutomation).toHaveBeenCalledOnce();
     await act(async () => {
-      useBrowserAutomationStore.getState().setControllerForTarget(THREAD_ID, TAB_ID, {
+      useBrowserAutomationStore.getState().setControllerForTarget(WORKSPACE_ID, THREAD_ID, TAB_ID, {
         tabId: TAB_ID,
         controller: "none",
         controlEpoch: 5,
@@ -687,7 +688,7 @@ describe("visible Browser conformance observer", () => {
     expect(normalized.finalState.readiness).not.toBe("unknown");
 
     await userEvent.setup().click(row);
-    expect(activatePage).toHaveBeenCalledWith(THREAD_ID, TAB_ID);
+    expect(activatePage).toHaveBeenCalledWith(WORKSPACE_ID, THREAD_ID, TAB_ID);
   });
 
   it("observes viewport preset, orientation, and fit/actual presentation through public controls", async () => {
@@ -782,8 +783,8 @@ describe("visible Browser conformance observer", () => {
 
   it("does not resurrect visible ownership after scope cleanup and a late controller event", async () => {
     const user = userEvent.setup();
-    useBrowserAutomationStore.getState().registerTarget("workspace-visible", THREAD_ID, TAB_ID);
-    useBrowserAutomationStore.getState().setControllerForTarget(THREAD_ID, TAB_ID, {
+    useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, THREAD_ID, TAB_ID);
+    useBrowserAutomationStore.getState().setControllerForTarget(WORKSPACE_ID, THREAD_ID, TAB_ID, {
       tabId: TAB_ID,
       controller: "agent",
       controlEpoch: 7,
@@ -793,8 +794,8 @@ describe("visible Browser conformance observer", () => {
     expect(await screen.findByRole("menuitem", { name: "Take control" })).toBeInTheDocument();
 
     act(() => {
-      releaseBrowserAutomationThreadScope(THREAD_ID);
-      useBrowserAutomationStore.getState().setControllerForTarget(THREAD_ID, TAB_ID, {
+      releaseBrowserAutomationThreadScope(WORKSPACE_ID, THREAD_ID);
+      useBrowserAutomationStore.getState().setControllerForTarget(WORKSPACE_ID, THREAD_ID, TAB_ID, {
         tabId: TAB_ID,
         controller: "agent",
         controlEpoch: 8,
@@ -806,6 +807,6 @@ describe("visible Browser conformance observer", () => {
       expect(useBrowserAutomationStore.getState().controllers.size).toBe(0);
       expect(screen.queryByRole("menuitem", { name: "Take control" })).not.toBeInTheDocument();
     });
-    expect(browserTargetRegistry.get(THREAD_ID, TAB_ID)).toBeNull();
+    expect(browserTargetRegistry.get(WORKSPACE_ID, THREAD_ID, TAB_ID)).toBeNull();
   });
 });

--- a/apps/web/src/components/panels/browserAutomationRecorder.ts
+++ b/apps/web/src/components/panels/browserAutomationRecorder.ts
@@ -31,6 +31,7 @@ async function acquireBeforeDeadline<T>(
 interface RecordingSession {
   readonly id: string;
   readonly targetKey: string;
+  readonly workspaceId: string;
   readonly threadId: string;
   readonly recorder: MediaRecorder;
   readonly stream: MediaStream;
@@ -66,6 +67,7 @@ export class BrowserAutomationRecorder {
   private readonly sessions = new Map<string, RecordingSession>();
   private readonly pendingAcquisitions = new Map<string, {
     requestKey: string;
+    workspaceId: string;
     threadId: string;
     cancelled: boolean;
   }>();
@@ -76,12 +78,12 @@ export class BrowserAutomationRecorder {
     dispatch: BrowserAutomationHostDispatch,
     bridge: PreviewAutomationBridge,
   ): Promise<BrowserAutomationResponse> {
-    const key = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+    const key = browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId);
     const requestKey = browserAutomationRequestKey(dispatch.request.requestId, dispatch.request.sequence);
     if (this.sessions.has(key) || this.pendingAcquisitions.has(key)) {
       return failure(dispatch, "A recording is already active for this browser tab");
     }
-    const acquisition = { requestKey, threadId: dispatch.target.threadId, cancelled: false };
+    const acquisition = { requestKey, workspaceId: dispatch.scope.workspaceId, threadId: dispatch.target.threadId, cancelled: false };
     this.pendingAcquisitions.set(key, acquisition);
     let source: Awaited<ReturnType<PreviewAutomationBridge["getMediaSourceId"]>>;
     try {
@@ -163,6 +165,7 @@ export class BrowserAutomationRecorder {
     const session: RecordingSession = {
       id: crypto.randomUUID(),
       targetKey: key,
+      workspaceId: dispatch.scope.workspaceId,
       threadId: dispatch.target.threadId,
       recorder,
       stream,
@@ -226,14 +229,14 @@ export class BrowserAutomationRecorder {
   }
 
   /** Report whether a thread owns an active or pending recording lease. */
-  hasActiveThread(threadId: string): boolean {
-    return [...this.sessions.values()].some((session) => session.threadId === threadId) ||
-      [...this.pendingAcquisitions.values()].some((acquisition) => acquisition.threadId === threadId);
+  hasActiveThread(workspaceId: string, threadId: string): boolean {
+    return [...this.sessions.values()].some((session) => session.workspaceId === workspaceId && session.threadId === threadId) ||
+      [...this.pendingAcquisitions.values()].some((acquisition) => acquisition.workspaceId === workspaceId && acquisition.threadId === threadId);
   }
 
   /** Stop one exact recording and return a bounded base64 WebM result. */
   async stop(dispatch: BrowserAutomationHostDispatch): Promise<BrowserAutomationResponse> {
-    const key = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+    const key = browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId);
     const session = this.sessions.get(key);
     if (!session) return failure(dispatch, "No recording is active for this browser tab");
     if (session.recorder.state !== "inactive") session.recorder.stop();
@@ -276,18 +279,18 @@ export class BrowserAutomationRecorder {
 
   /** Cancel pending acquisition and release any active session for a request target. */
   cancel(dispatch: BrowserAutomationHostDispatch): void {
-    const targetKey = browserAutomationTargetKey(dispatch.target.threadId, dispatch.target.tabId);
+    const targetKey = browserAutomationTargetKey(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId);
     const acquisition = this.pendingAcquisitions.get(targetKey);
     if (acquisition?.requestKey === browserAutomationRequestKey(
       dispatch.request.requestId,
       dispatch.request.sequence,
     )) acquisition.cancelled = true;
-    this.disposeTarget(dispatch.target.threadId, dispatch.target.tabId);
+    this.disposeTarget(dispatch.scope.workspaceId, dispatch.target.threadId, dispatch.target.tabId);
   }
 
   /** Release recording resources for one exact Browser target. */
-  disposeTarget(threadId: string, tabId: string): void {
-    const key = browserAutomationTargetKey(threadId, tabId);
+  disposeTarget(workspaceId: string, threadId: string, tabId: string): void {
+    const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
     const acquisition = this.pendingAcquisitions.get(key);
     if (acquisition) acquisition.cancelled = true;
     const session = this.sessions.get(key);
@@ -302,7 +305,7 @@ export class BrowserAutomationRecorder {
   dispose(): void {
     this.disposed = true;
     for (const session of [...this.sessions.values()]) {
-      this.disposeTarget(...(JSON.parse(session.targetKey) as [string, string]));
+      this.disposeTarget(...(JSON.parse(session.targetKey) as [string, string, string]));
     }
     for (const acquisition of this.pendingAcquisitions.values()) acquisition.cancelled = true;
   }

--- a/apps/web/src/components/panels/hooks/usePreviewTabs.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewTabs.ts
@@ -19,19 +19,20 @@ import {
  * A no-op in non-desktop builds (the bridge is absent, so `tabSet` stays null).
  */
 export function usePreviewTabs(scopeId: string, workspaceId?: string | null) {
+  const exactWorkspaceId = workspaceId ?? scopeId;
   const tabSet = usePreviewTabSet(scopeId, workspaceId);
   const newTab = useCallback(
-    () => usePreviewTabsStore.getState().openPage(scopeId),
-    [scopeId],
+    () => usePreviewTabsStore.getState().openPage(exactWorkspaceId, scopeId),
+    [exactWorkspaceId, scopeId],
   );
   const activateTab = useCallback(
-    (tabId: string) => usePreviewTabsStore.getState().activatePage(scopeId, tabId),
-    [scopeId],
+    (tabId: string) => usePreviewTabsStore.getState().activatePage(exactWorkspaceId, scopeId, tabId),
+    [exactWorkspaceId, scopeId],
   );
   const closeTab = useCallback(
     (tabId: string, opts?: ClosePageOptions) =>
-      usePreviewTabsStore.getState().closePage(scopeId, tabId, opts),
-    [scopeId],
+      usePreviewTabsStore.getState().closePage(exactWorkspaceId, scopeId, tabId, opts),
+    [exactWorkspaceId, scopeId],
   );
 
   return { tabSet, newTab, activateTab, closeTab };

--- a/apps/web/src/components/panels/hooks/usePreviewTabs.ts
+++ b/apps/web/src/components/panels/hooks/usePreviewTabs.ts
@@ -43,7 +43,7 @@ export function usePreviewTabSet(
   scopeId: string | null,
   workspaceId?: string | null,
 ): BrowserTabSet | null {
-  const tabSet = usePreviewDisplayTabSet(scopeId);
+  const tabSet = usePreviewDisplayTabSet(scopeId, workspaceId);
   const bridge = window.desktopBridge?.preview?.tabs;
 
   useEffect(() => {
@@ -52,11 +52,11 @@ export function usePreviewTabSet(
     const { setTabSet } = usePreviewTabsStore.getState();
     void bridge.list(scopeId, workspaceId ?? undefined).then((r) => {
       if (cancelled) return;
-      if (r.ok) setTabSet(scopeId, r.data);
+      if (r.ok) setTabSet(workspaceId ?? scopeId, scopeId, r.data);
     });
     const off = bridge.onUpdated((payload: BrowserTabSet) => {
       if (cancelled) return;
-      if (payload.threadId === scopeId) setTabSet(scopeId, payload);
+      if (payload.threadId === scopeId) setTabSet(workspaceId ?? scopeId, scopeId, payload);
     });
     return () => {
       cancelled = true;

--- a/apps/web/src/lib/__tests__/open-url-in-preview.test.ts
+++ b/apps/web/src/lib/__tests__/open-url-in-preview.test.ts
@@ -124,7 +124,7 @@ describe("openUrlInPreview", () => {
 
     expect(showRightPanel).toHaveBeenCalledWith("ws-1", "thread-1");
     expect(setRightPanelTab).toHaveBeenCalledWith("ws-1", "thread-1", "preview");
-    expect(mockOpen).toHaveBeenCalledWith("thread-1", { activate: true });
+    expect(mockOpen).toHaveBeenCalledWith("thread-1", "ws-1", { activate: true });
     expect(mockNavigate).toHaveBeenCalledWith("https://example.com/pr/1", "/tmp/workspace");
     expect(setPreviewUrlForThread).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/open-url-in-preview.ts
+++ b/apps/web/src/lib/open-url-in-preview.ts
@@ -76,11 +76,12 @@ function findActiveTab(
  */
 async function shouldOpenInNewTab(
   threadId: string,
+  workspaceId: string,
   tabsApi: NonNullable<NonNullable<typeof window.desktopBridge>["preview"]>["tabs"],
 ): Promise<boolean> {
   if (!tabsApi?.list) return false;
 
-  const listed = await tabsApi.list(threadId);
+  const listed = await tabsApi.list(threadId, workspaceId);
   if (!listed.ok) return true;
 
   const active = findActiveTab(listed.data.tabs, listed.data.activeTabId);
@@ -124,10 +125,11 @@ export function openUrlInPreview({
   }
 
   const run = async (): Promise<void> => {
-    const openInNewTab = newTab && (await shouldOpenInNewTab(threadId, preview.tabs));
+    const exactWorkspaceId = workspaceId ?? threadId;
+    const openInNewTab = newTab && (await shouldOpenInNewTab(threadId, exactWorkspaceId, preview.tabs));
 
     if (openInNewTab && preview.tabs?.open) {
-      await preview.tabs.open(threadId, { activate: true });
+      await preview.tabs.open(threadId, exactWorkspaceId, { activate: true });
     } else if (!openInNewTab) {
       setPreviewUrlForThread(threadId, url);
     }

--- a/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.races.test.ts
@@ -370,7 +370,7 @@ class WebDriverRaceSubject implements BrowserConformanceSubject {
         this.bumpRevision("capability");
         break;
       case "observation-revision":
-        this.driver.invalidateTargetObservations("thread", "tab");
+        this.driver.invalidateTargetObservations("workspace", "thread", "tab");
         this.bumpRevision("observation");
         break;
       case "late-event":
@@ -380,7 +380,7 @@ class WebDriverRaceSubject implements BrowserConformanceSubject {
         // Late responses carry no new authority revision and disposed callbacks stay inert.
         break;
       case "target-close":
-        this.driver.clearIdempotencyForTarget("thread", "tab");
+        this.driver.clearIdempotencyForTarget("workspace", "thread", "tab");
         this.liveTargets.delete("tab");
         this.bumpRevision("document");
         break;

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -17,13 +17,13 @@ const response = {} as BrowserAutomationResponse;
 const dispatch = {} as BrowserAutomationHostDispatch;
 
 describe("BrowserSessionDriver", () => {
-  function inspectDispatch(requestId = "inspect"): BrowserAutomationHostDispatch {
+  function inspectDispatch(requestId = "inspect", workspaceId = "workspace"): BrowserAutomationHostDispatch {
     return {
       connection: { connectionGeneration: 1, targetGeneration: 1, capabilityRevision: 1 },
       target: { threadId: "thread", tabId: "tab", targetGeneration: 1, windowId: 1 },
       request: {
         contractVersion: 1,
-        workspaceId: "workspace",
+        workspaceId,
         threadId: "thread",
         providerSessionId: "session",
         providerInstanceId: "instance",
@@ -461,7 +461,7 @@ describe("BrowserSessionDriver", () => {
       if (value.request.operation === "inspect") {
         return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
       }
-      driver.invalidateTargetObservations("thread", "tab");
+      driver.invalidateTargetObservations("workspace", "thread", "tab");
       return { ok: true, result: { operation: value.request.operation } } as unknown as BrowserAutomationResponse;
     });
     const driver = new BrowserSessionDriver({
@@ -503,7 +503,7 @@ describe("BrowserSessionDriver", () => {
     });
 
     await driver.execute(inspectDispatch(), new AbortController().signal);
-    driver.invalidateTargetObservations("thread", "tab");
+    driver.invalidateTargetObservations("workspace", "thread", "tab");
     const interactionRevisions = (
       driver as unknown as { humanInteractionRevisions: Map<string, number> }
     ).humanInteractionRevisions;
@@ -512,6 +512,64 @@ describe("BrowserSessionDriver", () => {
     await driver.releaseProviderSession("session");
 
     expect(interactionRevisions.size).toBe(0);
+  });
+
+  it("isolates same thread and tab IDs across workspaces during invalidation and cleanup", async () => {
+    const execute = vi.fn(async (value: BrowserAutomationHostDispatch) => {
+      if (value.request.operation === "inspect") {
+        return { ok: true, result: { operation: "inspect" } } as unknown as BrowserAutomationResponse;
+      }
+      return { ok: true, result: { operation: value.request.operation } } as unknown as BrowserAutomationResponse;
+    });
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      supportedActOperations: ["click"],
+    });
+    const workspaceDispatch = (workspaceId: string): BrowserAutomationHostDispatch => {
+      return inspectDispatch("inspect", workspaceId);
+    };
+    const workspaceAct = (workspaceId: string, observationRef: string): BrowserAutomationHostDispatch => {
+      const base = actDispatch(observationRef, [{ operation: "click", target: { cssSelector: "#save" } }]);
+      return { ...base, request: { ...base.request, workspaceId } } as BrowserAutomationHostDispatch;
+    };
+    const inspectA = await driver.execute(workspaceDispatch("workspace-a"), new AbortController().signal);
+    const inspectB = await driver.execute(workspaceDispatch("workspace-b"), new AbortController().signal);
+    const observationA = (inspectA as { result: { observationRef: string } }).result.observationRef;
+    const observationB = (inspectB as { result: { observationRef: string } }).result.observationRef;
+
+    driver.invalidateTargetObservations("workspace-a", "thread", "tab");
+    await expect(driver.execute(workspaceAct("workspace-b", observationB), new AbortController().signal))
+      .resolves.toMatchObject({ ok: true, result: { outcome: "completed" } });
+    await expect(driver.execute(workspaceAct("workspace-a", observationA), new AbortController().signal))
+      .resolves.toMatchObject({ ok: false, error: { code: "STALE_TARGET_GENERATION" } });
+
+    const openDispatch = (workspaceId: string, requestId: string): BrowserAutomationHostDispatch => ({
+      connection: { connectionGeneration: 1, capabilityRevision: 1 },
+      target: { threadId: "thread", tabId: "tab", windowId: 1, targetGeneration: 1 },
+      request: {
+        contractVersion: 1,
+        workspaceId,
+        threadId: "thread",
+        providerSessionId: "session",
+        providerInstanceId: "instance",
+        requestId,
+        sequence: 1,
+        deadline: Date.now() + 10_000,
+        expectedControlEpoch: 0,
+        operation: "open",
+        args: { idempotencyKey: "same-open-key" },
+      },
+    } as unknown as BrowserAutomationHostDispatch);
+    await driver.execute(openDispatch("workspace-a", "open-a"), new AbortController().signal);
+    await driver.execute(openDispatch("workspace-b", "open-b"), new AbortController().signal);
+    const callsAfterInitialOpens = execute.mock.calls.length;
+    driver.clearIdempotencyForTarget("workspace-a", "thread", "tab");
+    await driver.execute(openDispatch("workspace-b", "open-b-replay"), new AbortController().signal);
+    expect(execute).toHaveBeenCalledTimes(callsAfterInitialOpens);
+    await driver.execute(openDispatch("workspace-a", "open-a-fresh"), new AbortController().signal);
+    expect(execute).toHaveBeenCalledTimes(callsAfterInitialOpens + 1);
   });
 
   it("fails before adapter execution when descriptor revision drifts", async () => {
@@ -640,7 +698,7 @@ describe("BrowserSessionDriver", () => {
     await driver.execute(makeDispatch("generation-bump", "https://example.test/", 2), new AbortController().signal);
     expect(execute).toHaveBeenCalledTimes(3);
 
-    driver.clearIdempotencyForTarget("thread", "tab");
+    driver.clearIdempotencyForTarget("workspace", "thread", "tab");
     await driver.execute(makeDispatch("fresh", "https://example.test/", 2), new AbortController().signal);
     expect(execute).toHaveBeenCalledTimes(4);
   });
@@ -1233,16 +1291,16 @@ describe("BrowserSessionDriver", () => {
       expect.objectContaining({ tabId: "user-tab", provenance: "claimed-user", ownership: "claimed" }),
     ]));
 
-    driver.invalidateTargetObservations("thread", "agent-tab");
-    driver.invalidateTargetObservations("thread", "user-tab");
+    driver.invalidateTargetObservations("workspace", "thread", "agent-tab");
+    driver.invalidateTargetObservations("workspace", "thread", "user-tab");
     const interactionRevisions = (
       driver as unknown as { humanInteractionRevisions: Map<string, number> }
     ).humanInteractionRevisions;
     expect(interactionRevisions.size).toBe(2);
 
     await driver.releaseProviderSession("session");
-    expect(close).toHaveBeenCalledWith(agent);
-    expect(close).not.toHaveBeenCalledWith(user);
+    expect(close).toHaveBeenCalledWith(agent, "workspace");
+    expect(close).not.toHaveBeenCalledWith(user, "workspace");
     expect(projections.at(-1)).toEqual([]);
     expect(interactionRevisions.size).toBe(0);
   });

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -47,8 +47,8 @@ const WEB_RUNTIME_OPERATIONS = [
   "type",
 ] as const satisfies readonly BrowserAutomationOperation[];
 
-function observationTargetKey(threadId: string, tabId: string): string {
-  return JSON.stringify([threadId, tabId]);
+function observationTargetKey(workspaceId: string, threadId: string, tabId: string): string {
+  return JSON.stringify([workspaceId, threadId, tabId]);
 }
 
 /** Options that affect the operations a runtime can truthfully advertise. */
@@ -86,7 +86,7 @@ type OpenDispatch = BrowserAutomationHostDispatch & {
 
 interface IdempotencyRecord {
   readonly fingerprint: string;
-  readonly target: { threadId: string; tabId: string; windowId: number; targetGeneration: number };
+  readonly target: { workspaceId: string; threadId: string; tabId: string; windowId: number; targetGeneration: number };
   lastUsedAt: number;
   readonly promise: Promise<BrowserAutomationResponse>;
 }
@@ -108,6 +108,7 @@ interface ObservationRecord {
 
 interface TabReplayRecord {
   readonly fingerprint: string;
+  readonly target: { workspaceId: string; threadId: string; tabId: string };
   lastUsedAt: number;
   readonly promise: Promise<BrowserAutomationResponse>;
 }
@@ -151,7 +152,7 @@ export interface BrowserSessionRuntimeAdapter {
 /** Runtime mechanics used by the driver to enumerate and physically close Preview tabs. */
 export interface BrowserSessionTabLifecycleAdapter {
   list(dispatch: BrowserAutomationHostDispatch): Promise<readonly BrowserAutomationHostDispatchTarget[]>;
-  close(target: BrowserAutomationHostDispatchTarget): Promise<void>;
+  close(target: BrowserAutomationHostDispatchTarget, workspaceId: string): Promise<void>;
 }
 
 /** Renderer-side adapter that forwards Browser v1 commands to Electron preload. */
@@ -228,7 +229,13 @@ export class BrowserSessionDriver {
     this.pruneIdempotency();
     const request = dispatch.request;
     const key = request.args.idempotencyKey;
-    const scopeKey = JSON.stringify([request.providerSessionId, request.providerInstanceId, key]);
+    const scopeKey = JSON.stringify([
+      request.workspaceId,
+      request.threadId,
+      request.providerSessionId,
+      request.providerInstanceId,
+      key,
+    ]);
     const fingerprint = JSON.stringify({
       url: request.args.url ?? null,
       workspaceId: request.workspaceId,
@@ -236,7 +243,8 @@ export class BrowserSessionDriver {
     });
     const existing = this.idempotency.get(scopeKey);
     if (existing) {
-      const sameTarget = existing.target.threadId === request.threadId &&
+      const sameTarget = existing.target.workspaceId === request.workspaceId &&
+        existing.target.threadId === request.threadId &&
         existing.target.tabId === dispatch.target.tabId &&
         existing.target.windowId === dispatch.target.windowId &&
         existing.target.targetGeneration === dispatch.target.targetGeneration;
@@ -306,6 +314,7 @@ export class BrowserSessionDriver {
     this.idempotency.set(scopeKey, {
       fingerprint,
       target: {
+        workspaceId: request.workspaceId,
         threadId: request.threadId,
         tabId: dispatch.target.tabId,
         windowId: dispatch.target.windowId,
@@ -332,15 +341,15 @@ export class BrowserSessionDriver {
   }
 
   /** Invalidates observations for one target after trusted human input. */
-  invalidateTargetObservations(threadId: string, tabId: string): void {
-    const targetKey = observationTargetKey(threadId, tabId);
+  invalidateTargetObservations(workspaceId: string, threadId: string, tabId: string): void {
+    const targetKey = observationTargetKey(workspaceId, threadId, tabId);
     this.humanInteractionRevisions.set(
       targetKey,
       (this.humanInteractionRevisions.get(targetKey) ?? 0) + 1,
     );
     for (const [observationRef, observation] of this.observations) {
       if (observation.targetKey === targetKey || [...observation.targets.values()].some(
-        (target) => observationTargetKey(target.threadId, target.tabId) === targetKey,
+        (target) => observationTargetKey(observation.workspaceId, target.threadId, target.tabId) === targetKey,
       )) {
         this.observations.delete(observationRef);
       }
@@ -353,15 +362,20 @@ export class BrowserSessionDriver {
   }
 
   /** Clears replay state bound to one browser target after that target closes or is replaced. */
-  clearIdempotencyForTarget(threadId: string, tabId: string): void {
-    this.invalidateTargetObservations(threadId, tabId);
-    this.clearHumanInteractionTarget(observationTargetKey(threadId, tabId));
+  clearIdempotencyForTarget(workspaceId: string, threadId: string, tabId: string): void {
+    this.invalidateTargetObservations(workspaceId, threadId, tabId);
+    this.clearHumanInteractionTarget(observationTargetKey(workspaceId, threadId, tabId));
     for (const [key, record] of this.idempotency) {
-      if (record.target.threadId === threadId && record.target.tabId === tabId) this.idempotency.delete(key);
+      if (record.target.workspaceId === workspaceId && record.target.threadId === threadId && record.target.tabId === tabId) this.idempotency.delete(key);
+    }
+    for (const [key, record] of this.tabIdempotency) {
+      if (record.target.workspaceId === workspaceId && record.target.threadId === threadId && record.target.tabId === tabId) this.tabIdempotency.delete(key);
     }
     for (const session of this.tabSessions.values()) {
+      if (session.workspaceId !== workspaceId) continue;
       if (session.current?.threadId === threadId && session.current.tabId === tabId) session.current = null;
-      session.tabs.delete(tabId);
+      const target = session.tabs.get(tabId)?.target;
+      if (target?.threadId === threadId) session.tabs.delete(tabId);
     }
     this.publishLifecycleProjectionInternal();
   }
@@ -441,7 +455,7 @@ export class BrowserSessionDriver {
       ...currentBinding,
       capabilityRevision,
       humanInteractionRevision: this.currentHumanInteractionRevision(dispatch),
-      targetKey: observationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+      targetKey: observationTargetKey(dispatch.request.workspaceId, dispatch.target.threadId, dispatch.target.tabId),
       workspaceId: dispatch.request.workspaceId,
       threadId: dispatch.request.threadId,
       providerSessionId: dispatch.request.providerSessionId,
@@ -755,7 +769,13 @@ export class BrowserSessionDriver {
     if (signal.aborted) {
       return Promise.resolve(this.tabCancellation(dispatch, "Browser tab mutation was interrupted before the effect"));
     }
-    const replayKey = JSON.stringify([request.providerSessionId, request.providerInstanceId, request.args.idempotencyKey]);
+    const replayKey = JSON.stringify([
+      request.workspaceId,
+      request.threadId,
+      request.providerSessionId,
+      request.providerInstanceId,
+      request.args.idempotencyKey,
+    ]);
     const fingerprint = JSON.stringify(request.args);
     const replay = this.tabIdempotency.get(replayKey);
     if (replay) {
@@ -777,7 +797,16 @@ export class BrowserSessionDriver {
     this.activeTabMutations.add(sessionKey);
     const promise = this.applyTabsMutation(dispatch, observation, capabilityRevision, signal)
       .finally(() => this.activeTabMutations.delete(sessionKey));
-    this.tabIdempotency.set(replayKey, { fingerprint, lastUsedAt: Date.now(), promise });
+    this.tabIdempotency.set(replayKey, {
+      fingerprint,
+      target: {
+        workspaceId: request.workspaceId,
+        threadId: request.threadId,
+        tabId: dispatch.target.tabId,
+      },
+      lastUsedAt: Date.now(),
+      promise,
+    });
     this.pruneIdempotency();
     return promise;
   }
@@ -875,8 +904,12 @@ export class BrowserSessionDriver {
         documentRevision: session.current.targetGeneration,
         controlRevision: dispatch.request.expectedControlEpoch,
         capabilityRevision,
-        humanInteractionRevision: this.currentHumanInteractionRevisionForTarget(session.current.threadId, session.current.tabId),
-        targetKey: observationTargetKey(session.current.threadId, session.current.tabId),
+        humanInteractionRevision: this.currentHumanInteractionRevisionForTarget(
+          session.workspaceId,
+          session.current.threadId,
+          session.current.tabId,
+        ),
+        targetKey: observationTargetKey(session.workspaceId, session.current.threadId, session.current.tabId),
         workspaceId: dispatch.request.workspaceId,
         threadId: session.current.threadId,
         providerSessionId: dispatch.request.providerSessionId,
@@ -945,7 +978,7 @@ export class BrowserSessionDriver {
     }
     let closeCause: unknown;
     try {
-      await adapter.close(controlled.target);
+      await adapter.close(controlled.target, session.workspaceId);
     } catch (cause) {
       closeCause = cause;
     }
@@ -1074,7 +1107,7 @@ export class BrowserSessionDriver {
       controlRevision: dispatch.request.expectedControlEpoch,
       capabilityRevision: dispatch.connection?.capabilityRevision ?? this.options.getCapabilityRevision?.() ?? 1,
       humanInteractionRevision: this.currentHumanInteractionRevision(dispatch),
-      targetKey: observationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+      targetKey: observationTargetKey(dispatch.request.workspaceId, dispatch.target.threadId, dispatch.target.tabId),
       workspaceId: dispatch.request.workspaceId,
       threadId: dispatch.request.threadId,
       providerSessionId: dispatch.request.providerSessionId,
@@ -1096,22 +1129,28 @@ export class BrowserSessionDriver {
 
   private currentHumanInteractionRevision(dispatch: BrowserAutomationHostDispatch): number {
     this.humanInteractionScopes.set(
-      observationTargetKey(dispatch.target.threadId, dispatch.target.tabId),
+      observationTargetKey(dispatch.request.workspaceId, dispatch.target.threadId, dispatch.target.tabId),
       {
         workspaceId: dispatch.request.workspaceId,
         threadId: dispatch.target.threadId,
         providerSessionId: dispatch.request.providerSessionId,
       },
     );
-    return this.currentHumanInteractionRevisionForTarget(dispatch.target.threadId, dispatch.target.tabId, dispatch);
+    return this.currentHumanInteractionRevisionForTarget(
+      dispatch.request.workspaceId,
+      dispatch.target.threadId,
+      dispatch.target.tabId,
+      dispatch,
+    );
   }
 
   private currentHumanInteractionRevisionForTarget(
+    workspaceId: string,
     threadId: string,
     tabId: string,
     dispatch?: BrowserAutomationHostDispatch,
   ): number {
-    const targetRevision = this.humanInteractionRevisions.get(observationTargetKey(threadId, tabId)) ?? 0;
+    const targetRevision = this.humanInteractionRevisions.get(observationTargetKey(workspaceId, threadId, tabId)) ?? 0;
     const externalRevision = dispatch ? this.options.getHumanInteractionRevision?.(dispatch) : undefined;
     return Math.max(targetRevision, externalRevision ?? 0);
   }
@@ -1173,7 +1212,11 @@ export class BrowserSessionDriver {
   }
 
   private sessionKey(dispatch: BrowserAutomationHostDispatch): string {
-    return JSON.stringify([dispatch.request.providerSessionId, dispatch.request.providerInstanceId]);
+    return JSON.stringify([
+      dispatch.request.workspaceId,
+      dispatch.request.providerSessionId,
+      dispatch.request.providerInstanceId,
+    ]);
   }
 
   private tabSession(dispatch: BrowserAutomationHostDispatch): ProviderTabSession {
@@ -1205,13 +1248,13 @@ export class BrowserSessionDriver {
       if (!predicate(session)) continue;
       if (session.current) {
         this.clearHumanInteractionTarget(
-          observationTargetKey(session.current.threadId, session.current.tabId),
+          observationTargetKey(session.workspaceId, session.current.threadId, session.current.tabId),
         );
       }
       const retained = new Map<string, ControlledTab>();
       for (const tab of session.tabs.values()) {
         this.clearHumanInteractionTarget(
-          observationTargetKey(tab.target.threadId, tab.target.tabId),
+          observationTargetKey(session.workspaceId, tab.target.threadId, tab.target.tabId),
         );
         if (tab.provenance !== "agent-created" || tab.ownership === "released") continue;
         if (!adapter) {
@@ -1219,7 +1262,7 @@ export class BrowserSessionDriver {
           continue;
         }
         try {
-          await adapter.close(tab.target);
+          await adapter.close(tab.target, session.workspaceId);
         } catch { /* Reconciliation decides whether retryable ownership remains. */ }
         const effect = await this.reconcileClosedTab(session.lastDispatch, session, adapter, tab.tabId, tab);
         if (effect === "preserved") retained.set(tab.tabId, session.tabs.get(tab.tabId) ?? tab);

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -380,10 +380,11 @@ export class BrowserSessionDriver {
   }
 
   /** Settles every tab owned or claimed by one deleted thread. */
-  async releaseThread(threadId: string): Promise<void> {
-    this.clearObservations((observation) => observation.threadId === threadId);
-    this.clearHumanInteractionScopes((scope) => scope.threadId === threadId);
-    await this.releaseSessions((session) => [...session.tabs.values()].some((tab) => tab.target.threadId === threadId));
+  async releaseThread(workspaceId: string, threadId: string): Promise<void> {
+    this.clearObservations((observation) => observation.workspaceId === workspaceId && observation.threadId === threadId);
+    this.clearHumanInteractionScopes((scope) => scope.workspaceId === workspaceId && scope.threadId === threadId);
+    await this.releaseSessions((session) => session.workspaceId === workspaceId &&
+      [...session.tabs.values()].some((tab) => tab.target.threadId === threadId));
   }
 
   /** Settles every tab owned or claimed by one deleted workspace. */

--- a/apps/web/src/services/browser-automation/browserTargetRegistry.test.ts
+++ b/apps/web/src/services/browser-automation/browserTargetRegistry.test.ts
@@ -3,31 +3,32 @@ import { BrowserTargetRegistry } from "./browserTargetRegistry";
 
 describe("BrowserTargetRegistry", () => {
   let registry: BrowserTargetRegistry;
+  const workspaceId = "workspace-1";
 
   beforeEach(() => {
     registry = new BrowserTargetRegistry();
   });
 
   it("retains the logical record across detach and reattach", () => {
-    const first = registry.register("workspace", "thread", "tab");
-    registry.detach("thread", "tab");
-    const second = registry.register("workspace", "thread", "tab");
+    const first = registry.register(workspaceId, "thread", "tab");
+    registry.detach(workspaceId, "thread", "tab");
+    const second = registry.register(workspaceId, "thread", "tab");
 
     expect(second.revision).toBe(first.revision);
-    expect(registry.get("thread", "tab")?.attached).toBe(true);
+    expect(registry.get(workspaceId, "thread", "tab")?.attached).toBe(true);
   });
 
   it("releases records only for authoritative scopes", () => {
     registry.register("workspace-a", "thread-a", "tab-a");
     registry.register("workspace-b", "thread-b", "tab-b");
-    registry.detach("thread-a", "tab-a");
-    expect(registry.get("thread-a", "tab-a")).not.toBeNull();
+    registry.detach("workspace-a", "thread-a", "tab-a");
+    expect(registry.get("workspace-a", "thread-a", "tab-a")).not.toBeNull();
 
-    registry.releaseThread("thread-a");
-    expect(registry.get("thread-a", "tab-a")).toBeNull();
-    expect(registry.get("thread-b", "tab-b")).not.toBeNull();
+    registry.releaseThread("workspace-a", "thread-a");
+    expect(registry.get("workspace-a", "thread-a", "tab-a")).toBeNull();
+    expect(registry.get("workspace-b", "thread-b", "tab-b")).not.toBeNull();
 
     registry.releaseWorkspace("workspace-b");
-    expect(registry.get("thread-b", "tab-b")).toBeNull();
+    expect(registry.get("workspace-b", "thread-b", "tab-b")).toBeNull();
   });
 });

--- a/apps/web/src/services/browser-automation/browserTargetRegistry.ts
+++ b/apps/web/src/services/browser-automation/browserTargetRegistry.ts
@@ -8,8 +8,8 @@ export interface BrowserTargetRecord {
   readonly attached: boolean;
 }
 
-function key(threadId: string, tabId: string): string {
-  return JSON.stringify([threadId, tabId]);
+function key(workspaceId: string, threadId: string, tabId: string): string {
+  return JSON.stringify([workspaceId, threadId, tabId]);
 }
 
 /**
@@ -20,7 +20,7 @@ export class BrowserTargetRegistry {
   private readonly records = new Map<string, BrowserTargetRecord>();
 
   register(workspaceId: string, threadId: string, tabId: string): BrowserTargetRecord {
-    const targetKey = key(threadId, tabId);
+    const targetKey = key(workspaceId, threadId, tabId);
     const current = this.records.get(targetKey);
     const next: BrowserTargetRecord = {
       workspaceId,
@@ -39,8 +39,8 @@ export class BrowserTargetRegistry {
     return this.register(workspaceId, threadId, tabId);
   }
 
-  refresh(threadId: string, tabId: string): BrowserTargetRecord | null {
-    const targetKey = key(threadId, tabId);
+  refresh(workspaceId: string, threadId: string, tabId: string): BrowserTargetRecord | null {
+    const targetKey = key(workspaceId, threadId, tabId);
     const current = this.records.get(targetKey);
     if (!current) return null;
     const next = { ...current, revision: current.revision + 1, lastUsedAt: Date.now(), attached: true };
@@ -48,8 +48,8 @@ export class BrowserTargetRegistry {
     return next;
   }
 
-  detach(threadId: string, tabId: string): BrowserTargetRecord | null {
-    const targetKey = key(threadId, tabId);
+  detach(workspaceId: string, threadId: string, tabId: string): BrowserTargetRecord | null {
+    const targetKey = key(workspaceId, threadId, tabId);
     const current = this.records.get(targetKey);
     if (!current) return null;
     const next = { ...current, attached: false };
@@ -57,13 +57,13 @@ export class BrowserTargetRegistry {
     return next;
   }
 
-  releaseTarget(threadId: string, tabId: string): void {
-    this.records.delete(key(threadId, tabId));
+  releaseTarget(workspaceId: string, threadId: string, tabId: string): void {
+    this.records.delete(key(workspaceId, threadId, tabId));
   }
 
-  releaseThread(threadId: string): void {
+  releaseThread(workspaceId: string, threadId: string): void {
     for (const [targetKey, target] of this.records) {
-      if (target.threadId === threadId) this.records.delete(targetKey);
+      if (target.workspaceId === workspaceId && target.threadId === threadId) this.records.delete(targetKey);
     }
   }
 
@@ -73,8 +73,8 @@ export class BrowserTargetRegistry {
     }
   }
 
-  get(threadId: string, tabId: string): BrowserTargetRecord | null {
-    return this.records.get(key(threadId, tabId)) ?? null;
+  get(workspaceId: string, threadId: string, tabId: string): BrowserTargetRecord | null {
+    return this.records.get(key(workspaceId, threadId, tabId)) ?? null;
   }
 
   attached(): BrowserTargetRecord[] {

--- a/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
+++ b/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
@@ -291,6 +291,13 @@ export class BrowserSurfaceHost {
     return record.state;
   }
 
+  /** Returns an identity's warm surface, or creates it when it does not exist. */
+  public ensure(identity: BrowserSurfaceIdentity, options: BrowserSurfaceCreateOptions = {}): BrowserSurfacePageState {
+    const current = this.records.get(surfaceKey(identity));
+    if (current && sameIdentity(current.identity, identity)) return current.state;
+    return this.create(identity, options);
+  }
+
   /** Makes an identity's current surface visible without changing its generation. */
   public present(identity: BrowserSurfaceIdentity, presentation: BrowserSurfacePresentation = {
     left: 0,
@@ -355,6 +362,11 @@ export class BrowserSurfaceHost {
   /** Releases host-level visibility resources. */
   public disposeHost(): void {
     this.stopVisibility();
+    this.disposeAll();
+  }
+
+  /** Disposes every surface while retaining host-level visibility resources. */
+  public disposeAll(): void {
     for (const [key, record] of this.records) this.disposeRecord(key, record, true);
   }
 

--- a/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
+++ b/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
@@ -359,7 +359,7 @@ export class BrowserSurfaceHost {
     this.disposeRecord(key, record, true);
   }
 
-  /** Releases host-level visibility resources. */
+  /** Stops host visibility and disposes every registered surface. */
   public disposeHost(): void {
     this.stopVisibility();
     this.disposeAll();

--- a/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
@@ -114,6 +114,30 @@ function testHost(): { host: BrowserSurfaceHost; adapter: TestAdapter; schedulin
 }
 
 describe("BrowserSurfaceHost", () => {
+  it("keeps one adapter and generation when presentation reacquires a warm surface", () => {
+    const adapters: TestAdapter[] = [];
+    const host = new BrowserSurfaceHost({
+      adapterFactory: () => {
+        const adapter = new TestAdapter();
+        adapters.push(adapter);
+        return adapter;
+      },
+    });
+
+    const first = host.ensure(IDENTITY, { address: "https://example.test/" });
+    host.hide(IDENTITY);
+    const second = host.ensure(IDENTITY, { address: "https://example.test/" });
+    host.present(IDENTITY, { left: 10, top: 20, width: 640, height: 480 });
+
+    expect(second).toBe(first);
+    expect(second.generation).toBe(first.generation);
+    expect(adapters).toHaveLength(1);
+    expect(adapters[0]?.disposed).toBe(0);
+    expect(adapters[0]?.hidden).toBe(1);
+    expect(adapters[0]?.presented).toBe(1);
+    host.disposeHost();
+  });
+
   it("keeps canonical state synchronous and publishes once per frame", () => {
     const { host, adapter, scheduling } = testHost();
     const updates: string[] = [];

--- a/apps/web/src/services/browser-surfaces/__tests__/browserSurfaceContract.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/browserSurfaceContract.ts
@@ -20,6 +20,8 @@ export function runBrowserSurfaceContract(name: string, adapterFactory: BrowserS
       expect(snapshot.identity).toEqual(IDENTITY);
       host.present(IDENTITY, { left: 0, top: 0, width: 640, height: 480 });
       host.hide(IDENTITY);
+      expect(host.ensure(IDENTITY)).toBe(snapshot);
+      expect(host.getSnapshot(IDENTITY)?.generation).toBe(snapshot.generation);
       host.dispose(IDENTITY);
       expect(host.getSnapshot(IDENTITY)).toBeNull();
       host.disposeHost();

--- a/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
+++ b/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { BROWSER_AUTOMATION_MAX_PENDING_REQUESTS } from "@mcode/contracts";
 import {
   browserAutomationRequestKey,
+  browserAutomationScopeKey,
   browserAutomationTargetKey,
   onBrowserAutomationScopeRelease,
   invalidateBrowserAutomationTargetObservation,
@@ -64,7 +65,7 @@ describe("browser automation renderer scope", () => {
       ["workspace-b", "thread-b", "tab-b"],
     ]);
 
-    useBrowserAutomationStore.getState().releaseThreadTargets("thread-a");
+    useBrowserAutomationStore.getState().releaseThreadTargets("workspace-a", "thread-a");
     expect([...useBrowserAutomationStore.getState().lifecycleTabs.values()]).toEqual([
       expect.objectContaining({ workspaceId: "workspace-b", threadId: "thread-b", tabId: "tab-b" }),
     ]);
@@ -74,8 +75,8 @@ describe("browser automation renderer scope", () => {
   });
 
   it("uses collision-proof tuple keys for adversarial external ids", () => {
-    expect(browserAutomationTargetKey("a\u0000b", "c")).not.toBe(
-      browserAutomationTargetKey("a", "b\u0000c"),
+    expect(browserAutomationTargetKey("a", "\u0000b", "c")).not.toBe(
+      browserAutomationTargetKey("a", "b", "\u0000c"),
     );
     expect(browserAutomationRequestKey("request\u00001", 2)).not.toBe(
       browserAutomationRequestKey("request", 12),
@@ -110,30 +111,71 @@ describe("browser automation renderer scope", () => {
         { scopeId: "busy", workspaceId: "ws", lastUsedAt: 0 },
       ],
       { scopeId: "active", workspaceId: "ws", lastUsedAt: 4 },
-      new Set(["busy"]),
+      new Set([browserAutomationScopeKey("ws", "busy")]),
     );
     expect(result.map((scope) => scope.scopeId)).toEqual(["active", "busy", "recent"]);
+  });
+
+  it("keeps equal thread and tab ids isolated across workspaces", () => {
+    const store = useBrowserAutomationStore.getState();
+    store.registerTarget("workspace-a", "thread", "tab");
+    store.registerTarget("workspace-b", "thread", "tab");
+    store.setControllerForTarget("workspace-a", "thread", "tab", {
+      tabId: "tab",
+      controller: "agent",
+      controlEpoch: 1,
+    });
+
+    expect(useBrowserAutomationStore.getState().liveTargets).toHaveLength(2);
+    expect(useBrowserAutomationStore.getState().controllers.get(
+      browserAutomationTargetKey("workspace-a", "thread", "tab"),
+    )).toEqual(expect.objectContaining({ controller: "agent" }));
+    expect(useBrowserAutomationStore.getState().controllers.has(
+      browserAutomationTargetKey("workspace-b", "thread", "tab"),
+    )).toBe(false);
+    expect(browserTargetRegistry.get("workspace-a", "thread", "tab")?.workspaceId).toBe("workspace-a");
+    expect(browserTargetRegistry.get("workspace-b", "thread", "tab")?.workspaceId).toBe("workspace-b");
+  });
+
+  it("leases a busy warm scope by workspace and thread", () => {
+    const result = reconcileWarmPreviewScopes(
+      [
+        { scopeId: "shared-thread", workspaceId: "workspace-a", lastUsedAt: 4 },
+        { scopeId: "shared-thread", workspaceId: "workspace-b", lastUsedAt: 1 },
+        { scopeId: "other-thread", workspaceId: "workspace-a", lastUsedAt: 3 },
+        { scopeId: "other-thread", workspaceId: "workspace-b", lastUsedAt: 2 },
+      ],
+      null,
+      new Set([browserAutomationScopeKey("workspace-b", "shared-thread")]),
+    );
+
+    expect(result.map((scope) => [scope.workspaceId, scope.scopeId])).toEqual([
+      ["workspace-b", "shared-thread"],
+      ["workspace-a", "shared-thread"],
+      ["workspace-a", "other-thread"],
+    ]);
   });
 
   it("bounds a 20-tab pool while preserving active and busy leases exactly", () => {
     const tabs = Array.from({ length: 20 }, (_, index) => ({ id: `tab-${index}` }));
     useBrowserAutomationStore.setState({
       liveTargets: new Map(tabs.map((tab, index) => [
-        browserAutomationTargetKey("thread-a", tab.id),
+        browserAutomationTargetKey("ws-a", "thread-a", tab.id),
         target("ws-a", "thread-a", tab.id, index),
       ])),
       activeRequests: new Map([1, 2, 3, 4].map((index) => {
         const activeDispatch = {
+          request: { workspaceId: "ws-a" },
           target: { threadId: "thread-a", tabId: `tab-${index}` },
         } as never;
         return [`request-${index}`, { dispatch: activeDispatch, startedAt: index }];
       })),
     });
-    const leased = selectWarmBrowserTabIds(tabs, "thread-a", "tab-0");
+    const leased = selectWarmBrowserTabIds(tabs, "ws-a", "thread-a", "tab-0");
     expect(leased).toEqual(new Set(["tab-0", "tab-1", "tab-2", "tab-3", "tab-4"]));
 
     useBrowserAutomationStore.setState({ activeRequests: new Map() });
-    const settled = selectWarmBrowserTabIds(tabs, "thread-a", "tab-0");
+    const settled = selectWarmBrowserTabIds(tabs, "ws-a", "thread-a", "tab-0");
     expect(settled.size).toBe(3);
     expect(settled.has("tab-0")).toBe(true);
   });
@@ -142,7 +184,7 @@ describe("browser automation renderer scope", () => {
     useBrowserAutomationStore.setState({ activeRequests: new Map() });
     const requests = Array.from({ length: BROWSER_AUTOMATION_MAX_PENDING_REQUESTS + 1 }, (_, index) => {
       const activeDispatch = {
-        request: { requestId: `request-${index}`, sequence: index },
+        request: { workspaceId: "ws-a", requestId: `request-${index}`, sequence: index },
         target: { threadId: "thread-a", tabId: `tab-${index}` },
       } as BrowserAutomationActiveRequest["dispatch"];
       return {
@@ -164,6 +206,7 @@ describe("browser automation renderer scope", () => {
     ))).toBe(true);
     expect(selectWarmBrowserTabIds(
       requests.map((request) => ({ id: request.dispatch.target.tabId })),
+      "ws-a",
       "thread-a",
       "tab-0",
     )).toContain("tab-32");
@@ -181,35 +224,35 @@ describe("browser automation renderer scope", () => {
     const workspaceId = "workspace-late-refresh";
     const threadId = "thread-late-refresh";
     const tabId = "tab-late-refresh";
-    const key = browserAutomationTargetKey(threadId, tabId);
+    const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
     const store = useBrowserAutomationStore.getState();
 
-    store.unregisterTarget(threadId, tabId);
+    store.unregisterTarget(workspaceId, threadId, tabId);
     store.registerTarget(workspaceId, threadId, tabId);
     const attachedRevision = useBrowserAutomationStore.getState().liveTargets.get(key)?.revision;
     expect(attachedRevision).toBeDefined();
 
-    store.refreshTarget(threadId, tabId);
+    store.refreshTarget(workspaceId, threadId, tabId);
     expect(useBrowserAutomationStore.getState().liveTargets.get(key)?.revision).toBe(
       attachedRevision! + 1,
     );
 
-    store.detachTarget(threadId, tabId);
-    store.refreshTarget(threadId, tabId);
+    store.detachTarget(workspaceId, threadId, tabId);
+    store.refreshTarget(workspaceId, threadId, tabId);
 
     expect(useBrowserAutomationStore.getState().liveTargets.has(key)).toBe(false);
-    expect(browserTargetRegistry.get(threadId, tabId)?.attached).toBe(false);
+    expect(browserTargetRegistry.get(workspaceId, threadId, tabId)?.attached).toBe(false);
 
-    store.unregisterTarget(threadId, tabId);
+    store.unregisterTarget(workspaceId, threadId, tabId);
   });
 
   it("interrupts a detached viewport host without creating a Regular-mode viewport on remount", async () => {
     const workspaceId = "workspace-viewport-remount";
     const threadId = "thread-viewport-remount";
     const tabId = "tab-viewport-remount";
-    const key = browserAutomationTargetKey(threadId, tabId);
+    const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
     const store = useBrowserAutomationStore.getState();
-    store.unregisterTarget(threadId, tabId);
+    store.unregisterTarget(workspaceId, threadId, tabId);
     store.registerTarget(workspaceId, threadId, tabId);
     const target = useBrowserAutomationStore.getState().liveTargets.get(key)!;
     let resolveHost!: (result: { status: "applied"; applied: { width: number; height: number } }) => void;
@@ -218,10 +261,10 @@ describe("browser automation renderer scope", () => {
       targetGeneration: target.revision,
       apply: () => new Promise((resolve) => { resolveHost = resolve; }),
     });
-    store.setViewportCoordinator(threadId, tabId, coordinator);
+    store.setViewportCoordinator(workspaceId, threadId, tabId, coordinator);
 
     const pending = coordinator.requestUserResize({ width: 900, height: 700 });
-    store.detachTarget(threadId, tabId);
+    store.detachTarget(workspaceId, threadId, tabId);
     expect(await pending).toMatchObject({ status: "stale", applied: { width: 1280, height: 800 } });
     expect(useBrowserAutomationStore.getState().viewportByTarget.get(key)).toBeUndefined();
     expect(useBrowserAutomationStore.getState().viewportStateByTarget.get(key)?.confirmed).toEqual({ width: 1280, height: 800 });
@@ -235,16 +278,16 @@ describe("browser automation renderer scope", () => {
     await Promise.resolve();
     expect(useBrowserAutomationStore.getState().viewportByTarget.get(key)).toBeUndefined();
 
-    store.unregisterTarget(threadId, tabId);
+    store.unregisterTarget(workspaceId, threadId, tabId);
   });
 
   it("does not let a late renderer write update a remounted target", async () => {
     const workspaceId = "workspace-viewport-late-renderer";
     const threadId = "thread-viewport-late-renderer";
     const tabId = "tab-viewport-late-renderer";
-    const key = browserAutomationTargetKey(threadId, tabId);
+    const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
     const store = useBrowserAutomationStore.getState();
-    store.unregisterTarget(threadId, tabId);
+    store.unregisterTarget(workspaceId, threadId, tabId);
     store.registerTarget(workspaceId, threadId, tabId);
     const target = useBrowserAutomationStore.getState().liveTargets.get(key)!;
     let releaseLayout!: () => void;
@@ -256,6 +299,7 @@ describe("browser automation renderer scope", () => {
       rendererHost: {
         setViewport: (size, operation, currentCoordinator) => {
           lateWrite = () => store.applyViewportIfCurrent(
+            workspaceId,
             threadId,
             tabId,
             currentCoordinator,
@@ -268,17 +312,18 @@ describe("browser automation renderer scope", () => {
         waitForLayout: () => new Promise<void>((resolve) => { releaseLayout = resolve; }),
       },
       onStateChange: (state, currentCoordinator) => store.setViewportState(
+        workspaceId,
         threadId,
         tabId,
         state,
         currentCoordinator,
       ),
     });
-    store.setViewportCoordinator(threadId, tabId, coordinator);
+    store.setViewportCoordinator(workspaceId, threadId, tabId, coordinator);
 
     const pending = coordinator.requestUserResize({ width: 900, height: 700 });
     await Promise.resolve();
-    store.detachTarget(threadId, tabId);
+    store.detachTarget(workspaceId, threadId, tabId);
     store.registerTarget(workspaceId, threadId, tabId);
     lateWrite();
     expect(useBrowserAutomationStore.getState().viewportByTarget.get(key)).toBeUndefined();
@@ -287,16 +332,16 @@ describe("browser automation renderer scope", () => {
     await pending;
     expect(useBrowserAutomationStore.getState().viewportByTarget.get(key)).toBeUndefined();
 
-    store.unregisterTarget(threadId, tabId);
+    store.unregisterTarget(workspaceId, threadId, tabId);
   });
 
   it("clears a current renderer viewport when Regular mode resets the host", () => {
     const workspaceId = "workspace-viewport-reset";
     const threadId = "thread-viewport-reset";
     const tabId = "tab-viewport-reset";
-    const key = browserAutomationTargetKey(threadId, tabId);
+    const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
     const store = useBrowserAutomationStore.getState();
-    store.unregisterTarget(threadId, tabId);
+    store.unregisterTarget(workspaceId, threadId, tabId);
     store.registerTarget(workspaceId, threadId, tabId);
     const target = useBrowserAutomationStore.getState().liveTargets.get(key)!;
     const coordinator = new ViewportCoordinator({
@@ -304,8 +349,8 @@ describe("browser automation renderer scope", () => {
       targetGeneration: target.revision,
       apply: async (operation) => ({ status: "applied", applied: operation.requested }),
     });
-    store.setViewportCoordinator(threadId, tabId, coordinator);
-    store.applyViewportIfCurrent(threadId, tabId, coordinator, target.revision, {
+    store.setViewportCoordinator(workspaceId, threadId, tabId, coordinator);
+    store.applyViewportIfCurrent(workspaceId, threadId, tabId, coordinator, target.revision, {
       width: 960,
       height: 640,
     });
@@ -314,33 +359,33 @@ describe("browser automation renderer scope", () => {
       width: 960,
       height: 640,
     });
-    expect(store.resetViewportIfCurrent(threadId, tabId, coordinator, target.revision)).toBe(true);
-    store.setViewportState(threadId, tabId, {
+    expect(store.resetViewportIfCurrent(workspaceId, threadId, tabId, coordinator, target.revision)).toBe(true);
+    store.setViewportState(workspaceId, threadId, tabId, {
       ...coordinator.snapshot(),
       mode: "regular",
     }, coordinator);
     expect(useBrowserAutomationStore.getState().viewportByTarget.has(key)).toBe(false);
 
-    store.unregisterTarget(threadId, tabId);
+    store.unregisterTarget(workspaceId, threadId, tabId);
   });
 
   it("routes authoritative thread and workspace cleanup to exact host scopes", () => {
     const listener = vi.fn();
     const unsubscribe = onBrowserAutomationScopeRelease(listener);
-    releaseBrowserAutomationThreadScope("thread-a");
+    releaseBrowserAutomationThreadScope("workspace-a", "thread-a");
     releaseBrowserAutomationWorkspaceScopes("workspace-a");
     expect(listener.mock.calls).toEqual([
-      [{ threadId: "thread-a" }],
+      [{ workspaceId: "workspace-a", threadId: "thread-a" }],
       [{ workspaceId: "workspace-a" }],
     ]);
     unsubscribe();
-    releaseBrowserAutomationThreadScope("thread-b");
+    releaseBrowserAutomationThreadScope("workspace-b", "thread-b");
     expect(listener).toHaveBeenCalledTimes(2);
   });
 
   it("notifies exact human-input listeners without changing controller state", () => {
     useBrowserAutomationStore.getState().registerTarget("workspace-a", "thread-a", "tab-a");
-    useBrowserAutomationStore.getState().setControllerForTarget("thread-a", "tab-a", {
+    useBrowserAutomationStore.getState().setControllerForTarget("workspace-a", "thread-a", "tab-a", {
       tabId: "tab-a",
       controller: "agent",
       controlEpoch: 3,
@@ -348,12 +393,12 @@ describe("browser automation renderer scope", () => {
     const listener = vi.fn();
     const unsubscribe = onBrowserAutomationObservationInvalidation(listener);
 
-    invalidateBrowserAutomationTargetObservation("thread-a", "tab-a");
+    invalidateBrowserAutomationTargetObservation("workspace-a", "thread-a", "tab-a");
 
     expect(listener).toHaveBeenCalledOnce();
-    expect(listener).toHaveBeenCalledWith("thread-a", "tab-a");
+    expect(listener).toHaveBeenCalledWith("workspace-a", "thread-a", "tab-a");
     expect(useBrowserAutomationStore.getState().controllers.get(
-      browserAutomationTargetKey("thread-a", "tab-a"),
+      browserAutomationTargetKey("workspace-a", "thread-a", "tab-a"),
     )).toEqual({ tabId: "tab-a", controller: "agent", controlEpoch: 3 });
     unsubscribe();
   });
@@ -362,24 +407,24 @@ describe("browser automation renderer scope", () => {
     const store = useBrowserAutomationStore.getState();
     store.registerTarget("workspace-agent", "thread-agent", "tab-first");
     store.registerTarget("workspace-agent", "thread-agent", "tab-second");
-    store.setControllerForTarget("thread-agent", "tab-first", {
+    store.setControllerForTarget("workspace-agent", "thread-agent", "tab-first", {
       tabId: "tab-first",
       controller: "agent",
       controlEpoch: 1,
     });
-    store.setControllerForTarget("thread-agent", "tab-second", {
+    store.setControllerForTarget("workspace-agent", "thread-agent", "tab-second", {
       tabId: "tab-second",
       controller: "agent",
       controlEpoch: 2,
     });
 
     expect(useBrowserAutomationStore.getState().controllers.get(
-      browserAutomationTargetKey("thread-agent", "tab-first"),
+      browserAutomationTargetKey("workspace-agent", "thread-agent", "tab-first"),
     )).toEqual({ tabId: "tab-first", controller: "none", controlEpoch: 1 });
     expect(useBrowserAutomationStore.getState().controllers.get(
-      browserAutomationTargetKey("thread-agent", "tab-second"),
+      browserAutomationTargetKey("workspace-agent", "thread-agent", "tab-second"),
     )).toEqual({ tabId: "tab-second", controller: "agent", controlEpoch: 2 });
 
-    store.releaseThreadTargets("thread-agent");
+    store.releaseThreadTargets("workspace-agent", "thread-agent");
   });
 });

--- a/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
+++ b/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { BROWSER_AUTOMATION_MAX_PENDING_REQUESTS } from "@mcode/contracts";
 import {
+  browserAutomationLifecycleKey,
   browserAutomationRequestKey,
   browserAutomationScopeKey,
   browserAutomationTargetKey,
@@ -29,6 +30,33 @@ function target(
   lastUsedAt = 1,
 ): BrowserAutomationLiveTarget {
   return { workspaceId, threadId, tabId, lastUsedAt, revision: 1 };
+}
+
+function lifecycleTab(
+  workspaceId: string,
+  threadId: string,
+  tabId: string,
+): BrowserSessionLifecycleTab {
+  return {
+    workspaceId,
+    threadId,
+    tabId,
+    providerSessionId: "session",
+    providerInstanceId: "instance",
+    provenance: "claimed-user",
+    ownership: "claimed",
+    target: {
+      desktopInstanceId: "desktop",
+      windowId: 1,
+      connectionGeneration: 1,
+      threadId,
+      tabId,
+      targetGeneration: 1,
+      active: false,
+      focused: false,
+      lastUsedAt: 1,
+    },
+  };
 }
 
 describe("browser automation renderer scope", () => {
@@ -135,6 +163,25 @@ describe("browser automation renderer scope", () => {
     )).toBe(false);
     expect(browserTargetRegistry.get("workspace-a", "thread", "tab")?.workspaceId).toBe("workspace-a");
     expect(browserTargetRegistry.get("workspace-b", "thread", "tab")?.workspaceId).toBe("workspace-b");
+  });
+
+  it("unregisters lifecycle state only for the exact workspace target", () => {
+    const store = useBrowserAutomationStore.getState();
+    store.registerTarget("workspace-a", "thread", "tab");
+    store.registerTarget("workspace-b", "thread", "tab");
+    store.setLifecycleTabs([
+      lifecycleTab("workspace-a", "thread", "tab"),
+      lifecycleTab("workspace-b", "thread", "tab"),
+    ]);
+
+    store.unregisterTarget("workspace-a", "thread", "tab");
+
+    expect(useBrowserAutomationStore.getState().lifecycleTabs.has(
+      browserAutomationLifecycleKey("workspace-a", "thread", "tab"),
+    )).toBe(false);
+    expect(useBrowserAutomationStore.getState().lifecycleTabs.has(
+      browserAutomationLifecycleKey("workspace-b", "thread", "tab"),
+    )).toBe(true);
   });
 
   it("leases a busy warm scope by workspace and thread", () => {

--- a/apps/web/src/stores/__tests__/previewTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewTabsStore.test.ts
@@ -10,6 +10,7 @@ import { useBrowserAutomationStore } from "../browserAutomationStore";
 import { browserTargetRegistry } from "@/services/browser-automation/browserTargetRegistry";
 
 const SCOPE = "thread-1";
+const WORKSPACE_ID = "workspace-1";
 
 function page(id: string, over: Partial<BrowserTabInfo> = {}): BrowserTabInfo {
   return {
@@ -135,7 +136,7 @@ describe("previewTabsStore", () => {
   it("openPage creates a page via the bridge and focuses the omnibox", async () => {
     const created = set("new", [page("a"), page("new", { active: true })]);
     const { open } = mockBridge({ open: created });
-    await usePreviewTabsStore.getState().openPage(SCOPE);
+    await usePreviewTabsStore.getState().openPage(WORKSPACE_ID, SCOPE);
     expect(open).toHaveBeenCalledWith(SCOPE, { activate: true });
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(created);
     expect(usePreviewFocusStore.getState().omniboxFocusTick).toBe(1);
@@ -144,7 +145,7 @@ describe("previewTabsStore", () => {
   it("openPage passes an exact existing page id to the bridge", async () => {
     const { open } = mockBridge({});
 
-    await usePreviewTabsStore.getState().openPage(SCOPE, {
+    await usePreviewTabsStore.getState().openPage(WORKSPACE_ID, SCOPE, {
       activate: false,
       focusOmnibox: false,
       tabId: "blank",
@@ -179,7 +180,7 @@ describe("previewTabsStore", () => {
     usePreviewTabsStore.getState().setLiveChrome(SCOPE, { title: "stale", url: null, favicon: null });
     const switched = set("b", [page("a"), page("b", { active: true })]);
     const { activate } = mockBridge({ activate: switched });
-    await usePreviewTabsStore.getState().activatePage(SCOPE, "b");
+    await usePreviewTabsStore.getState().activatePage(WORKSPACE_ID, SCOPE, "b");
     expect(activate).toHaveBeenCalledWith(SCOPE, "b");
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(switched);
     expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]).toBeNull();
@@ -190,7 +191,7 @@ describe("previewTabsStore", () => {
     const remaining = set("a", [page("a")]);
     const { close } = mockBridge({ close: remaining });
     const onLastClose = vi.fn();
-    await usePreviewTabsStore.getState().closePage(SCOPE, "b", { onLastClose });
+    await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, "b", { onLastClose });
     expect(close).toHaveBeenCalledWith(SCOPE, "b");
     expect(onLastClose).not.toHaveBeenCalled();
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(remaining);
@@ -200,43 +201,43 @@ describe("previewTabsStore", () => {
     usePreviewTabsStore.getState().setTabSet(SCOPE, set("a", [page("a")]));
     const { close, closeScope } = mockBridge({});
     usePreviewTabsStore.getState().setLiveChrome(SCOPE, { title: "A", url: null, favicon: null });
-    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "a");
+    useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, SCOPE, "a");
     const onLastClose = vi.fn();
     onLastClose.mockImplementation(() => {
       expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
       expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]).toBeNull();
     });
-    await usePreviewTabsStore.getState().closePage(SCOPE, "a", { onLastClose });
+    await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, "a", { onLastClose });
     expect(onLastClose).toHaveBeenCalledTimes(1);
     expect(closeScope).toHaveBeenCalledWith(SCOPE);
     expect(close).not.toHaveBeenCalled();
-    expect(browserTargetRegistry.get(SCOPE, "a")).toBeNull();
+    expect(browserTargetRegistry.get(WORKSPACE_ID, SCOPE, "a")).toBeNull();
     // The Browser tab is gone; the scope's set must clear rather than retain
     // a phantom page.
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
   });
 
   it("clearScope releases every target after a successful scope close", async () => {
-    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "a");
-    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "b");
-    useBrowserAutomationStore.getState().registerTarget("workspace-1", "thread-2", "other");
+    useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, SCOPE, "a");
+    useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, SCOPE, "b");
+    useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, "thread-2", "other");
     const { closeScope } = mockBridge({});
 
-    await usePreviewTabsStore.getState().clearScope(SCOPE);
+    await usePreviewTabsStore.getState().clearScope(WORKSPACE_ID, SCOPE);
 
     expect(closeScope).toHaveBeenCalledWith(SCOPE);
-    expect(browserTargetRegistry.get(SCOPE, "a")).toBeNull();
-    expect(browserTargetRegistry.get(SCOPE, "b")).toBeNull();
-    expect(browserTargetRegistry.get("thread-2", "other")).not.toBeNull();
+    expect(browserTargetRegistry.get(WORKSPACE_ID, SCOPE, "a")).toBeNull();
+    expect(browserTargetRegistry.get(WORKSPACE_ID, SCOPE, "b")).toBeNull();
+    expect(browserTargetRegistry.get(WORKSPACE_ID, "thread-2", "other")).not.toBeNull();
   });
 
   it("clearScope retains targets when the physical scope close fails", async () => {
-    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "a");
+    useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, SCOPE, "a");
     const { closeScope } = mockBridge({});
     closeScope.mockResolvedValueOnce({ ok: false, error: "scope close failed" });
 
-    await expect(usePreviewTabsStore.getState().clearScope(SCOPE)).rejects.toThrow("scope close failed");
-    expect(browserTargetRegistry.get(SCOPE, "a")).not.toBeNull();
+    await expect(usePreviewTabsStore.getState().clearScope(WORKSPACE_ID, SCOPE)).rejects.toThrow("scope close failed");
+    expect(browserTargetRegistry.get(WORKSPACE_ID, SCOPE, "a")).not.toBeNull();
   });
 
   it("retains final-page UI state and automation targets when the physical scope close fails", async () => {
@@ -245,14 +246,14 @@ describe("previewTabsStore", () => {
     usePreviewTabsStore.getState().setLiveChrome(SCOPE, { title: "A", url: "https://example.test", favicon: null });
     const { close, closeScope } = mockBridge({});
     closeScope.mockResolvedValueOnce({ ok: false, error: "scope close failed" });
-    useBrowserAutomationStore.getState().registerTarget("workspace-1", SCOPE, "a");
+    useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, SCOPE, "a");
     const onLastClose = vi.fn();
 
-    await usePreviewTabsStore.getState().closePage(SCOPE, "a", { onLastClose });
+    await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, "a", { onLastClose });
 
     expect(close).not.toHaveBeenCalled();
     expect(onLastClose).not.toHaveBeenCalled();
-    expect(browserTargetRegistry.get(SCOPE, "a")).not.toBeNull();
+    expect(browserTargetRegistry.get(WORKSPACE_ID, SCOPE, "a")).not.toBeNull();
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(finalTabSet);
     expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]).toEqual({
       title: "A",
@@ -321,9 +322,9 @@ describe("previewTabsStore", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).desktopBridge = undefined;
     const onLastClose = vi.fn();
-    await usePreviewTabsStore.getState().openPage(SCOPE);
-    await usePreviewTabsStore.getState().activatePage(SCOPE, "a");
-    await usePreviewTabsStore.getState().closePage(SCOPE, "a", { onLastClose });
+    await usePreviewTabsStore.getState().openPage(WORKSPACE_ID, SCOPE);
+    await usePreviewTabsStore.getState().activatePage(WORKSPACE_ID, SCOPE, "a");
+    await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, "a", { onLastClose });
     expect(onLastClose).not.toHaveBeenCalled();
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeUndefined();
   });
@@ -340,19 +341,19 @@ describe("previewTabsStore", () => {
     usePreviewTabsStore.getState().upsertPersistentTab(SCOPE, persistent);
     usePreviewTabsStore.getState().upsertPersistentTab(SCOPE, second);
 
-    await usePreviewTabsStore.getState().activatePage(SCOPE, persistent.id);
+    await usePreviewTabsStore.getState().activatePage(WORKSPACE_ID, SCOPE, persistent.id);
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]?.activeTabId).toBe(persistent.id);
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]?.tabs[0]?.active).toBe(true);
 
     const onLastClose = vi.fn();
-    await usePreviewTabsStore.getState().closePage(SCOPE, second.id, { onLastClose });
+    await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, second.id, { onLastClose });
     expect(onLastClose).not.toHaveBeenCalled();
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toMatchObject({
       activeTabId: persistent.id,
       tabs: [{ ...persistent, active: true }],
     });
 
-    await usePreviewTabsStore.getState().closePage(SCOPE, persistent.id, { onLastClose });
+    await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, persistent.id, { onLastClose });
     expect(onLastClose).toHaveBeenCalledOnce();
     expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
     expect(usePreviewTabsStore.getState().persistentTabIdsByScope[SCOPE]).toBeUndefined();

--- a/apps/web/src/stores/__tests__/previewTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewTabsStore.test.ts
@@ -195,14 +195,14 @@ describe("previewTabsStore", () => {
   it("openPage passes a bounded initial address to the bridge", async () => {
     const { open } = mockBridge({});
 
-    await usePreviewTabsStore.getState().openPage(SCOPE, {
+    await usePreviewTabsStore.getState().openPage(WORKSPACE_ID, SCOPE, {
       activate: true,
       focusOmnibox: false,
       initialAddress: "https://popup.example.test/next",
       renderingHost: "webview",
     });
 
-    expect(open).toHaveBeenCalledWith(SCOPE, {
+    expect(open).toHaveBeenCalledWith(SCOPE, WORKSPACE_ID, {
       activate: true,
       initialAddress: "https://popup.example.test/next",
       renderingHost: "webview",

--- a/apps/web/src/stores/__tests__/previewTabsStore.test.ts
+++ b/apps/web/src/stores/__tests__/previewTabsStore.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import type { BrowserTabInfo, BrowserTabSet } from "@mcode/contracts";
 import {
   overlayDisplaySet,
+  previewTabsScopeKey,
   usePreviewTabsStore,
   type PreviewLiveChrome,
 } from "../previewTabsStore";
@@ -11,6 +12,7 @@ import { browserTargetRegistry } from "@/services/browser-automation/browserTarg
 
 const SCOPE = "thread-1";
 const WORKSPACE_ID = "workspace-1";
+const SCOPE_KEY = previewTabsScopeKey(WORKSPACE_ID, SCOPE);
 
 function page(id: string, over: Partial<BrowserTabInfo> = {}): BrowserTabInfo {
   return {
@@ -113,32 +115,63 @@ describe("previewTabsStore", () => {
   it("setTabSet / setLiveChrome reconcile per scope", () => {
     const { setTabSet, setLiveChrome } = usePreviewTabsStore.getState();
     const ts = set("a", [page("a")]);
-    setTabSet(SCOPE, ts);
-    setLiveChrome(SCOPE, { title: "T", url: null, favicon: null });
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(ts);
-    expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]?.title).toBe("T");
+    setTabSet(WORKSPACE_ID, SCOPE, ts);
+    setLiveChrome(WORKSPACE_ID, SCOPE, { title: "T", url: null, favicon: null });
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBe(ts);
+    expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE_KEY]?.title).toBe("T");
   });
 
   it("setTabSet preserves state identity for a semantically identical host snapshot", () => {
     const { setTabSet } = usePreviewTabsStore.getState();
-    setTabSet(SCOPE, set("a", [page("a")]));
+    setTabSet(WORKSPACE_ID, SCOPE, set("a", [page("a")]));
     const previousState = usePreviewTabsStore.getState();
     const subscriber = vi.fn();
     const unsubscribe = usePreviewTabsStore.subscribe(subscriber);
 
-    setTabSet(SCOPE, set("a", [page("a")]));
+    setTabSet(WORKSPACE_ID, SCOPE, set("a", [page("a")]));
 
     expect(usePreviewTabsStore.getState()).toBe(previousState);
     expect(subscriber).not.toHaveBeenCalled();
     unsubscribe();
   });
 
+  it("keeps equal scope ids isolated by workspace", () => {
+    const otherWorkspaceId = "workspace-2";
+    const firstKey = previewTabsScopeKey(WORKSPACE_ID, SCOPE);
+    const secondKey = previewTabsScopeKey(otherWorkspaceId, SCOPE);
+    const firstSet = set("first", [page("first")]);
+    const secondSet = set("second", [page("second")]);
+
+    usePreviewTabsStore.getState().setTabSet(WORKSPACE_ID, SCOPE, firstSet);
+    usePreviewTabsStore.getState().setTabSet(otherWorkspaceId, SCOPE, secondSet);
+    usePreviewTabsStore.getState().setLiveChrome(WORKSPACE_ID, SCOPE, {
+      title: "First",
+      url: "https://first.test",
+      favicon: null,
+    });
+    usePreviewTabsStore.getState().setLiveChrome(otherWorkspaceId, SCOPE, {
+      title: "Second",
+      url: "https://second.test",
+      favicon: null,
+    });
+    usePreviewTabsStore.getState().upsertPersistentTab(WORKSPACE_ID, SCOPE, page("persistent"));
+    usePreviewTabsStore.getState().upsertPersistentTab(otherWorkspaceId, SCOPE, page("persistent"));
+
+    const state = usePreviewTabsStore.getState();
+    expect(state.tabSetByScope[firstKey]?.tabs.map((tab) => tab.id)).toEqual(["first", "persistent"]);
+    expect(state.tabSetByScope[secondKey]?.tabs.map((tab) => tab.id)).toEqual(["second", "persistent"]);
+    expect(state.liveChromeByScope[firstKey]?.title).toBe("First");
+    expect(state.liveChromeByScope[secondKey]?.title).toBe("Second");
+    expect(state.persistentTabIdsByScope[firstKey]).toEqual(new Set(["persistent"]));
+    expect(state.persistentTabIdsByScope[secondKey]).toEqual(new Set(["persistent"]));
+  });
+
   it("openPage creates a page via the bridge and focuses the omnibox", async () => {
     const created = set("new", [page("a"), page("new", { active: true })]);
     const { open } = mockBridge({ open: created });
     await usePreviewTabsStore.getState().openPage(WORKSPACE_ID, SCOPE);
-    expect(open).toHaveBeenCalledWith(SCOPE, { activate: true });
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(created);
+    expect(open).toHaveBeenCalledWith(SCOPE, WORKSPACE_ID, { activate: true });
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBe(created);
     expect(usePreviewFocusStore.getState().omniboxFocusTick).toBe(1);
   });
 
@@ -152,7 +185,7 @@ describe("previewTabsStore", () => {
       renderingHost: "webview",
     });
 
-    expect(open).toHaveBeenCalledWith(SCOPE, {
+    expect(open).toHaveBeenCalledWith(SCOPE, WORKSPACE_ID, {
       activate: false,
       renderingHost: "webview",
       tabId: "blank",
@@ -177,44 +210,44 @@ describe("previewTabsStore", () => {
   });
 
   it("activatePage switches the active page and clears stale live chrome", async () => {
-    usePreviewTabsStore.getState().setLiveChrome(SCOPE, { title: "stale", url: null, favicon: null });
+    usePreviewTabsStore.getState().setLiveChrome(WORKSPACE_ID, SCOPE, { title: "stale", url: null, favicon: null });
     const switched = set("b", [page("a"), page("b", { active: true })]);
     const { activate } = mockBridge({ activate: switched });
     await usePreviewTabsStore.getState().activatePage(WORKSPACE_ID, SCOPE, "b");
-    expect(activate).toHaveBeenCalledWith(SCOPE, "b");
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(switched);
-    expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]).toBeNull();
+    expect(activate).toHaveBeenCalledWith(SCOPE, WORKSPACE_ID, "b");
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBe(switched);
+    expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE_KEY]).toBeNull();
   });
 
   it("closePage closes a non-last page without firing onLastClose", async () => {
-    usePreviewTabsStore.getState().setTabSet(SCOPE, set("a", [page("a"), page("b")]));
+    usePreviewTabsStore.getState().setTabSet(WORKSPACE_ID, SCOPE, set("a", [page("a"), page("b")]));
     const remaining = set("a", [page("a")]);
     const { close } = mockBridge({ close: remaining });
     const onLastClose = vi.fn();
     await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, "b", { onLastClose });
-    expect(close).toHaveBeenCalledWith(SCOPE, "b");
+    expect(close).toHaveBeenCalledWith(SCOPE, WORKSPACE_ID, "b");
     expect(onLastClose).not.toHaveBeenCalled();
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(remaining);
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBe(remaining);
   });
 
   it("closePage fires onLastClose and drops the scope's set when closing the last page", async () => {
-    usePreviewTabsStore.getState().setTabSet(SCOPE, set("a", [page("a")]));
+    usePreviewTabsStore.getState().setTabSet(WORKSPACE_ID, SCOPE, set("a", [page("a")]));
     const { close, closeScope } = mockBridge({});
-    usePreviewTabsStore.getState().setLiveChrome(SCOPE, { title: "A", url: null, favicon: null });
+    usePreviewTabsStore.getState().setLiveChrome(WORKSPACE_ID, SCOPE, { title: "A", url: null, favicon: null });
     useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, SCOPE, "a");
     const onLastClose = vi.fn();
     onLastClose.mockImplementation(() => {
-      expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
-      expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]).toBeNull();
+      expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBeNull();
+      expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE_KEY]).toBeNull();
     });
     await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, "a", { onLastClose });
     expect(onLastClose).toHaveBeenCalledTimes(1);
-    expect(closeScope).toHaveBeenCalledWith(SCOPE);
+    expect(closeScope).toHaveBeenCalledWith(SCOPE, WORKSPACE_ID);
     expect(close).not.toHaveBeenCalled();
     expect(browserTargetRegistry.get(WORKSPACE_ID, SCOPE, "a")).toBeNull();
     // The Browser tab is gone; the scope's set must clear rather than retain
     // a phantom page.
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBeNull();
   });
 
   it("clearScope releases every target after a successful scope close", async () => {
@@ -225,7 +258,7 @@ describe("previewTabsStore", () => {
 
     await usePreviewTabsStore.getState().clearScope(WORKSPACE_ID, SCOPE);
 
-    expect(closeScope).toHaveBeenCalledWith(SCOPE);
+    expect(closeScope).toHaveBeenCalledWith(SCOPE, WORKSPACE_ID);
     expect(browserTargetRegistry.get(WORKSPACE_ID, SCOPE, "a")).toBeNull();
     expect(browserTargetRegistry.get(WORKSPACE_ID, SCOPE, "b")).toBeNull();
     expect(browserTargetRegistry.get(WORKSPACE_ID, "thread-2", "other")).not.toBeNull();
@@ -242,8 +275,8 @@ describe("previewTabsStore", () => {
 
   it("retains final-page UI state and automation targets when the physical scope close fails", async () => {
     const finalTabSet = set("a", [page("a")]);
-    usePreviewTabsStore.getState().setTabSet(SCOPE, finalTabSet);
-    usePreviewTabsStore.getState().setLiveChrome(SCOPE, { title: "A", url: "https://example.test", favicon: null });
+    usePreviewTabsStore.getState().setTabSet(WORKSPACE_ID, SCOPE, finalTabSet);
+    usePreviewTabsStore.getState().setLiveChrome(WORKSPACE_ID, SCOPE, { title: "A", url: "https://example.test", favicon: null });
     const { close, closeScope } = mockBridge({});
     closeScope.mockResolvedValueOnce({ ok: false, error: "scope close failed" });
     useBrowserAutomationStore.getState().registerTarget(WORKSPACE_ID, SCOPE, "a");
@@ -254,8 +287,8 @@ describe("previewTabsStore", () => {
     expect(close).not.toHaveBeenCalled();
     expect(onLastClose).not.toHaveBeenCalled();
     expect(browserTargetRegistry.get(WORKSPACE_ID, SCOPE, "a")).not.toBeNull();
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(finalTabSet);
-    expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE]).toEqual({
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBe(finalTabSet);
+    expect(usePreviewTabsStore.getState().liveChromeByScope[SCOPE_KEY]).toEqual({
       title: "A",
       url: "https://example.test",
       favicon: null,
@@ -264,18 +297,19 @@ describe("previewTabsStore", () => {
 
   it("setLiveChrome keeps the same reference when the chrome is unchanged", () => {
     const { setLiveChrome } = usePreviewTabsStore.getState();
-    setLiveChrome(SCOPE, { title: "T", url: "u", favicon: "f" });
+    setLiveChrome(WORKSPACE_ID, SCOPE, { title: "T", url: "u", favicon: "f" });
     const first = usePreviewTabsStore.getState().liveChromeByScope;
-    setLiveChrome(SCOPE, { title: "T", url: "u", favicon: "f" });
+    setLiveChrome(WORKSPACE_ID, SCOPE, { title: "T", url: "u", favicon: "f" });
     // An identical tick must not notify subscribers (re-render storm guard).
     expect(usePreviewTabsStore.getState().liveChromeByScope).toBe(first);
-    setLiveChrome(SCOPE, { title: "Changed", url: "u", favicon: "f" });
+    setLiveChrome(WORKSPACE_ID, SCOPE, { title: "Changed", url: "u", favicon: "f" });
     expect(usePreviewTabsStore.getState().liveChromeByScope).not.toBe(first);
   });
 
   it("updateTabChrome persists renderer-observed favicon for inactive tabs", () => {
     const { setTabSet, updateTabChrome } = usePreviewTabsStore.getState();
     setTabSet(
+      WORKSPACE_ID,
       SCOPE,
       set("a", [
         page("a", { title: "A", faviconUrl: "https://a.test/favicon.ico" }),
@@ -283,13 +317,13 @@ describe("previewTabsStore", () => {
       ]),
     );
 
-    updateTabChrome(SCOPE, "b", {
+    updateTabChrome(WORKSPACE_ID, SCOPE, "b", {
       title: "B updated",
       url: "https://b.test/path",
       favicon: "https://b.test/favicon.ico",
     });
 
-    const tabSet = usePreviewTabsStore.getState().tabSetByScope[SCOPE]!;
+    const tabSet = usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]!;
     expect(tabSet.tabs[0]!.faviconUrl).toBe("https://a.test/favicon.ico");
     expect(tabSet.tabs[1]).toMatchObject({
       title: "B updated",
@@ -307,15 +341,15 @@ describe("previewTabsStore", () => {
         faviconUrl: "https://a.test/favicon.ico",
       }),
     ]);
-    setTabSet(SCOPE, tabSet);
+    setTabSet(WORKSPACE_ID, SCOPE, tabSet);
 
-    updateTabChrome(SCOPE, "a", {
+    updateTabChrome(WORKSPACE_ID, SCOPE, "a", {
       title: "A",
       url: "https://a.test",
       favicon: "https://a.test/favicon.ico",
     });
 
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBe(tabSet);
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBe(tabSet);
   });
 
   it("page actions are no-ops without a desktop bridge", async () => {
@@ -326,7 +360,7 @@ describe("previewTabsStore", () => {
     await usePreviewTabsStore.getState().activatePage(WORKSPACE_ID, SCOPE, "a");
     await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, "a", { onLastClose });
     expect(onLastClose).not.toHaveBeenCalled();
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeUndefined();
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBeUndefined();
   });
 
   it("closes persistent web tabs with bridge-equivalent last-close behavior", async () => {
@@ -338,24 +372,24 @@ describe("previewTabsStore", () => {
       title: null,
       url: "https://example.test/second",
     });
-    usePreviewTabsStore.getState().upsertPersistentTab(SCOPE, persistent);
-    usePreviewTabsStore.getState().upsertPersistentTab(SCOPE, second);
+    usePreviewTabsStore.getState().upsertPersistentTab(WORKSPACE_ID, SCOPE, persistent);
+    usePreviewTabsStore.getState().upsertPersistentTab(WORKSPACE_ID, SCOPE, second);
 
     await usePreviewTabsStore.getState().activatePage(WORKSPACE_ID, SCOPE, persistent.id);
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]?.activeTabId).toBe(persistent.id);
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]?.tabs[0]?.active).toBe(true);
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]?.activeTabId).toBe(persistent.id);
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]?.tabs[0]?.active).toBe(true);
 
     const onLastClose = vi.fn();
     await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, second.id, { onLastClose });
     expect(onLastClose).not.toHaveBeenCalled();
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toMatchObject({
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toMatchObject({
       activeTabId: persistent.id,
       tabs: [{ ...persistent, active: true }],
     });
 
     await usePreviewTabsStore.getState().closePage(WORKSPACE_ID, SCOPE, persistent.id, { onLastClose });
     expect(onLastClose).toHaveBeenCalledOnce();
-    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE]).toBeNull();
-    expect(usePreviewTabsStore.getState().persistentTabIdsByScope[SCOPE]).toBeUndefined();
+    expect(usePreviewTabsStore.getState().tabSetByScope[SCOPE_KEY]).toBeNull();
+    expect(usePreviewTabsStore.getState().persistentTabIdsByScope[SCOPE_KEY]).toBeUndefined();
   });
 });

--- a/apps/web/src/stores/browserAutomationStore.ts
+++ b/apps/web/src/stores/browserAutomationStore.ts
@@ -54,14 +54,15 @@ interface BrowserAutomationState {
   readonly viewportCoordinators: ReadonlyMap<string, ViewportCoordinator>;
   readonly hostedScopeIds: ReadonlySet<string>;
   registerTarget: (workspaceId: string, threadId: string, tabId: string) => void;
-  refreshTarget: (threadId: string, tabId: string) => void;
-  detachTarget: (threadId: string, tabId: string) => void;
-  unregisterTarget: (threadId: string, tabId: string) => void;
+  refreshTarget: (workspaceId: string, threadId: string, tabId: string) => void;
+  detachTarget: (workspaceId: string, threadId: string, tabId: string) => void;
+  unregisterTarget: (workspaceId: string, threadId: string, tabId: string) => void;
   setLifecycleTabs: (tabs: readonly BrowserSessionLifecycleTab[]) => void;
-  releaseThreadTargets: (threadId: string) => void;
+  releaseThreadTargets: (workspaceId: string, threadId: string) => void;
   releaseWorkspaceTargets: (workspaceId: string) => void;
   setController: (state: BrowserAutomationControllerState) => void;
   setControllerForTarget: (
+    workspaceId: string,
     threadId: string,
     tabId: string,
     state: BrowserAutomationControllerState,
@@ -76,8 +77,9 @@ interface BrowserAutomationState {
   clearPendingAgentOpen: (requestId: string, sequence: number) => void;
   setRegistered: (registered: boolean) => void;
   setStatus: (status: BrowserAutomationHostStatus) => void;
-  setViewport: (threadId: string, tabId: string, width: number, height: number) => void;
+  setViewport: (workspaceId: string, threadId: string, tabId: string, width: number, height: number) => void;
   applyViewportIfCurrent: (
+    workspaceId: string,
     threadId: string,
     tabId: string,
     coordinator: ViewportCoordinator,
@@ -85,25 +87,32 @@ interface BrowserAutomationState {
     size: { readonly width: number; readonly height: number },
   ) => boolean;
   resetViewportIfCurrent: (
+    workspaceId: string,
     threadId: string,
     tabId: string,
     coordinator: ViewportCoordinator,
     targetGeneration: number,
   ) => boolean;
   setViewportState: (
+    workspaceId: string,
     threadId: string,
     tabId: string,
     state: ViewportCoordinatorState,
     coordinator?: ViewportCoordinator,
   ) => void;
-  setViewportCoordinator: (threadId: string, tabId: string, coordinator: ViewportCoordinator) => void;
-  clearViewportCoordinator: (threadId: string, tabId: string) => void;
+  setViewportCoordinator: (workspaceId: string, threadId: string, tabId: string, coordinator: ViewportCoordinator) => void;
+  clearViewportCoordinator: (workspaceId: string, threadId: string, tabId: string) => void;
   setHostedScopeIds: (scopeIds: ReadonlySet<string>) => void;
 }
 
 /** Stable key for an exact renderer-owned Browser tab. */
-export function browserAutomationTargetKey(threadId: string, tabId: string): string {
-  return JSON.stringify([threadId, tabId]);
+export function browserAutomationTargetKey(workspaceId: string, threadId: string, tabId: string): string {
+  return JSON.stringify([workspaceId, threadId, tabId]);
+}
+
+/** Stable key for one workspace and Browser scope lease. */
+export function browserAutomationScopeKey(workspaceId: string, scopeId: string): string {
+  return JSON.stringify([workspaceId, scopeId]);
 }
 
 /** Stable key for one lifecycle-backed tab across workspace and thread scopes. */
@@ -123,15 +132,15 @@ export function browserAutomationRequestKey(requestId: string, sequence: number)
 /** Returns the pending agent open for one exact Browser target, if any. */
 export function findPendingBrowserAutomationOpen(
   pendingAgentOpens: ReadonlyMap<string, BrowserAutomationPendingAgentOpen>,
+  workspaceId: string,
   threadId: string,
   tabId: string,
-  workspaceId?: string | null,
 ): BrowserAutomationPendingAgentOpen | null {
   for (const pending of pendingAgentOpens.values()) {
     if (
       pending.threadId === threadId &&
       pending.tabId === tabId &&
-      (!workspaceId || pending.workspaceId === workspaceId)
+      pending.workspaceId === workspaceId
     ) return pending;
   }
   return null;
@@ -140,18 +149,18 @@ export function findPendingBrowserAutomationOpen(
 /** Whether an agent controls or is opening one exact Browser target. */
 export function isBrowserAutomationAgentControlled(
   state: Pick<BrowserAutomationState, "controllers" | "pendingAgentOpens">,
+  workspaceId: string,
   threadId: string,
   tabId: string,
-  workspaceId?: string | null,
 ): boolean {
-  if (state.controllers.get(browserAutomationTargetKey(threadId, tabId))?.controller === "agent") {
+  if (state.controllers.get(browserAutomationTargetKey(workspaceId, threadId, tabId))?.controller === "agent") {
     return true;
   }
   return findPendingBrowserAutomationOpen(
     state.pendingAgentOpens,
+    workspaceId,
     threadId,
     tabId,
-    workspaceId,
   ) !== null;
 }
 
@@ -183,14 +192,14 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
   hostedScopeIds: new Set(),
   registerTarget: (workspaceId, threadId, tabId) =>
     set((state) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
-      const previous = browserTargetRegistry.get(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
+      const previous = browserTargetRegistry.get(workspaceId, threadId, tabId);
       if (previous?.attached && !state.liveTargets.has(key)) {
-        browserTargetRegistry.releaseTarget(threadId, tabId);
+        browserTargetRegistry.releaseTarget(workspaceId, threadId, tabId);
       }
       const currentRecord = browserTargetRegistry.register(workspaceId, threadId, tabId);
       const current = previous?.attached === false
-        ? browserTargetRegistry.refresh(threadId, tabId) ?? currentRecord
+        ? browserTargetRegistry.refresh(workspaceId, threadId, tabId) ?? currentRecord
         : currentRecord;
       const liveTargets = new Map(state.liveTargets);
       liveTargets.set(key, {
@@ -206,11 +215,11 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
       viewportCoordinators.delete(key);
       return { liveTargets, viewportCoordinators };
     }),
-  refreshTarget: (threadId, tabId) =>
+  refreshTarget: (workspaceId, threadId, tabId) =>
     set((state) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
       if (!state.liveTargets.has(key)) return state;
-      const current = browserTargetRegistry.refresh(threadId, tabId);
+      const current = browserTargetRegistry.refresh(workspaceId, threadId, tabId);
       if (!current) return state;
       const liveTargets = new Map(state.liveTargets);
       liveTargets.set(key, {
@@ -220,11 +229,11 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
       });
       return { liveTargets };
     }),
-  detachTarget: (threadId, tabId) => {
-    const key = browserAutomationTargetKey(threadId, tabId);
+  detachTarget: (workspaceId, threadId, tabId) => {
+    const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
     const coordinator = useBrowserAutomationStore.getState().viewportCoordinators.get(key);
     interruptViewportCoordinator(coordinator);
-    browserTargetRegistry.detach(threadId, tabId);
+    browserTargetRegistry.detach(workspaceId, threadId, tabId);
     set((state) => {
       if (!state.liveTargets.has(key)) return state;
       const liveTargets = new Map(state.liveTargets);
@@ -245,10 +254,10 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
       return { liveTargets, controllers, viewportByTarget, viewportStateByTarget, viewportCoordinators };
     });
   },
-  unregisterTarget: (threadId, tabId) => {
-    const key = browserAutomationTargetKey(threadId, tabId);
+  unregisterTarget: (workspaceId, threadId, tabId) => {
+    const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
     interruptViewportCoordinator(useBrowserAutomationStore.getState().viewportCoordinators.get(key));
-    browserTargetRegistry.releaseTarget(threadId, tabId);
+    browserTargetRegistry.releaseTarget(workspaceId, threadId, tabId);
     set((state) => {
       if (!state.liveTargets.has(key)) return state;
       const liveTargets = new Map(state.liveTargets);
@@ -287,16 +296,16 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
       }
       return { lifecycleTabs };
     }),
-  releaseThreadTargets: (threadId) => {
+  releaseThreadTargets: (workspaceId, threadId) => {
     const current = useBrowserAutomationStore.getState();
     for (const target of current.liveTargets.values()) {
-      if (target.threadId === threadId) {
+      if (target.workspaceId === workspaceId && target.threadId === threadId) {
         interruptViewportCoordinator(current.viewportCoordinators.get(
-          browserAutomationTargetKey(target.threadId, target.tabId),
+          browserAutomationTargetKey(target.workspaceId, target.threadId, target.tabId),
         ));
       }
     }
-    browserTargetRegistry.releaseThread(threadId);
+    browserTargetRegistry.releaseThread(workspaceId, threadId);
     set((state) => {
       const liveTargets = new Map(state.liveTargets);
       const controllers = new Map(state.controllers);
@@ -305,8 +314,8 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
       const viewportCoordinators = new Map(state.viewportCoordinators);
       const lifecycleTabs = new Map(state.lifecycleTabs);
       for (const target of state.liveTargets.values()) {
-        if (target.threadId !== threadId) continue;
-        const key = browserAutomationTargetKey(target.threadId, target.tabId);
+        if (target.workspaceId !== workspaceId || target.threadId !== threadId) continue;
+        const key = browserAutomationTargetKey(target.workspaceId, target.threadId, target.tabId);
         liveTargets.delete(key);
         controllers.delete(key);
         viewportByTarget.delete(key);
@@ -314,7 +323,7 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
         viewportCoordinators.delete(key);
       }
       for (const [lifecycleKey, tab] of lifecycleTabs) {
-        if (tab.threadId === threadId) lifecycleTabs.delete(lifecycleKey);
+        if (tab.workspaceId === workspaceId && tab.threadId === threadId) lifecycleTabs.delete(lifecycleKey);
       }
       return {
         liveTargets,
@@ -331,7 +340,7 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
     for (const target of current.liveTargets.values()) {
       if (target.workspaceId === workspaceId) {
         interruptViewportCoordinator(current.viewportCoordinators.get(
-          browserAutomationTargetKey(target.threadId, target.tabId),
+          browserAutomationTargetKey(target.workspaceId, target.threadId, target.tabId),
         ));
       }
     }
@@ -345,7 +354,7 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
       const lifecycleTabs = new Map(state.lifecycleTabs);
       for (const target of state.liveTargets.values()) {
         if (target.workspaceId !== workspaceId) continue;
-        const key = browserAutomationTargetKey(target.threadId, target.tabId);
+        const key = browserAutomationTargetKey(target.workspaceId, target.threadId, target.tabId);
         liveTargets.delete(key);
         controllers.delete(key);
         viewportByTarget.delete(key);
@@ -368,17 +377,17 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
   setController: (controller) => {
     const target = resolveBrowserAutomationControllerTarget(get().liveTargets.values(), controller);
     if (!target) return;
-    get().setControllerForTarget(target.threadId, target.tabId, controller);
+    get().setControllerForTarget(target.workspaceId, target.threadId, target.tabId, controller);
   },
-  setControllerForTarget: (threadId, tabId, controller) =>
+  setControllerForTarget: (workspaceId, threadId, tabId, controller) =>
     set((state) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
       if (!state.liveTargets.has(key)) return state;
       const controllers = new Map(state.controllers);
       if (controller.controller === "agent") {
         for (const target of state.liveTargets.values()) {
-          if (target.threadId !== threadId || target.tabId === tabId) continue;
-          const otherKey = browserAutomationTargetKey(target.threadId, target.tabId);
+          if (target.workspaceId !== workspaceId || target.threadId !== threadId || target.tabId === tabId) continue;
+          const otherKey = browserAutomationTargetKey(target.workspaceId, target.threadId, target.tabId);
           const other = controllers.get(otherKey);
           if (other?.controller !== "agent") continue;
           controllers.set(otherKey, {
@@ -433,18 +442,18 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
   setRegistered: (registered) => set({ registered }),
   setStatus: (status) => set({ status }),
   setHostedScopeIds: (hostedScopeIds) => set({ hostedScopeIds: new Set([...hostedScopeIds].slice(0, 5)) }),
-  setViewport: (threadId, tabId, width, height) =>
+  setViewport: (workspaceId, threadId, tabId, width, height) =>
     set((state) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
       if (!state.liveTargets.has(key)) return state;
       const viewportByTarget = new Map(state.viewportByTarget);
       viewportByTarget.set(key, { width, height });
       return { viewportByTarget };
     }),
-  applyViewportIfCurrent: (threadId, tabId, coordinator, targetGeneration, size) => {
+  applyViewportIfCurrent: (workspaceId, threadId, tabId, coordinator, targetGeneration, size) => {
     let applied = false;
     set((state) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
       const liveTarget = state.liveTargets.get(key);
       if (
         !liveTarget ||
@@ -458,10 +467,10 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
     });
     return applied;
   },
-  resetViewportIfCurrent: (threadId, tabId, coordinator, targetGeneration) => {
+  resetViewportIfCurrent: (workspaceId, threadId, tabId, coordinator, targetGeneration) => {
     let reset = false;
     set((state) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
       const liveTarget = state.liveTargets.get(key);
       if (
         !liveTarget ||
@@ -475,9 +484,9 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
     });
     return reset;
   },
-  setViewportState: (threadId, tabId, viewportState, coordinator) =>
+  setViewportState: (workspaceId, threadId, tabId, viewportState, coordinator) =>
     set((state) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
       if (!state.liveTargets.has(key)) return state;
       if (
         coordinator &&
@@ -492,9 +501,9 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
       }
       return { viewportStateByTarget, viewportByTarget };
     }),
-  setViewportCoordinator: (threadId, tabId, coordinator) =>
+  setViewportCoordinator: (workspaceId, threadId, tabId, coordinator) =>
     set((state) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
       if (!state.liveTargets.has(key)) return state;
       const viewportCoordinators = new Map(state.viewportCoordinators);
       viewportCoordinators.set(key, coordinator);
@@ -507,9 +516,9 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
       }
       return { viewportCoordinators, viewportStateByTarget, viewportByTarget };
     }),
-  clearViewportCoordinator: (threadId, tabId) =>
+  clearViewportCoordinator: (workspaceId, threadId, tabId) =>
     set((state) => {
-      const key = browserAutomationTargetKey(threadId, tabId);
+      const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
       if (!state.viewportCoordinators.has(key)) return state;
       interruptViewportCoordinator(state.viewportCoordinators.get(key));
       const viewportCoordinators = new Map(state.viewportCoordinators);
@@ -522,13 +531,14 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
 
 type BrowserAutomationInterruptionReason = "human-interrupted" | "user-stopped";
 type InterruptionListener = (
+  workspaceId: string,
   threadId: string,
   tabId: string,
   reason: BrowserAutomationInterruptionReason,
 ) => void;
 const interruptionListeners = new Set<InterruptionListener>();
 const pendingInterruptions = new Map<string, Promise<boolean>>();
-type ObservationInvalidationListener = (threadId: string, tabId: string) => void;
+type ObservationInvalidationListener = (workspaceId: string, threadId: string, tabId: string) => void;
 const observationInvalidationListeners = new Set<ObservationInvalidationListener>();
 
 /** Subscribe to trusted human input without changing Browser controller state. */
@@ -541,15 +551,16 @@ export function onBrowserAutomationObservationInvalidation(
 
 /** Notify Browser automation listeners that one target received trusted human input. */
 export function invalidateBrowserAutomationTargetObservation(
+  workspaceId: string,
   threadId: string,
   tabId: string,
 ): void {
-  for (const listener of observationInvalidationListeners) listener(threadId, tabId);
+  for (const listener of observationInvalidationListeners) listener(workspaceId, threadId, tabId);
 }
 
 /** Identifies persistent automation surfaces that must be released. */
 export type BrowserAutomationScopeRelease =
-  | { readonly threadId: string; readonly workspaceId?: never }
+  | { readonly workspaceId: string; readonly threadId: string }
   | { readonly workspaceId: string; readonly threadId?: never };
 
 type ScopeReleaseListener = (release: BrowserAutomationScopeRelease) => void;
@@ -562,9 +573,9 @@ export function onBrowserAutomationScopeRelease(listener: ScopeReleaseListener):
 }
 
 /** Release the persistent Browser surface owned by one deleted thread. */
-export function releaseBrowserAutomationThreadScope(threadId: string): void {
-  useBrowserAutomationStore.getState().releaseThreadTargets(threadId);
-  for (const listener of scopeReleaseListeners) listener({ threadId });
+export function releaseBrowserAutomationThreadScope(workspaceId: string, threadId: string): void {
+  useBrowserAutomationStore.getState().releaseThreadTargets(workspaceId, threadId);
+  for (const listener of scopeReleaseListeners) listener({ workspaceId, threadId });
 }
 
 /** Release all persistent Browser surfaces owned by one deleted workspace. */
@@ -581,49 +592,56 @@ export function onBrowserAutomationInterruption(listener: InterruptionListener):
 
 /** Transfer one exact target to the human after desktop-main accepts takeover. */
 export function interruptBrowserAutomationTarget(
+  workspaceId: string,
   threadId: string,
   tabId: string,
   reason: BrowserAutomationInterruptionReason,
 ): void {
   const bridge = window.desktopBridge?.preview?.automation;
   if (!bridge) {
-    for (const listener of interruptionListeners) listener(threadId, tabId, reason);
+    for (const listener of interruptionListeners) listener(workspaceId, threadId, tabId, reason);
     return;
   }
-  const key = browserAutomationTargetKey(threadId, tabId);
+  const key = browserAutomationTargetKey(workspaceId, threadId, tabId);
   if (pendingInterruptions.has(key)) return;
   const interruption = bridge.interrupt({ threadId, tabId });
   pendingInterruptions.set(key, interruption);
   void interruption.then((accepted) => {
     if (!accepted) return;
-    for (const listener of interruptionListeners) listener(threadId, tabId, reason);
+    for (const listener of interruptionListeners) listener(workspaceId, threadId, tabId, reason);
   }).catch(() => undefined).finally(() => {
     if (pendingInterruptions.get(key) === interruption) pendingInterruptions.delete(key);
   });
 }
 
 /** Return whether an exact target currently has an executing browser request. */
-export function isBrowserAutomationTargetBusy(threadId: string, tabId: string): boolean {
+export function isBrowserAutomationTargetBusy(workspaceId: string, threadId: string, tabId: string): boolean {
   return [...useBrowserAutomationStore.getState().activeRequests.values()].some(
-    ({ dispatch }) => dispatch.target.threadId === threadId && dispatch.target.tabId === tabId,
+    ({ dispatch }) =>
+      dispatch.request.workspaceId === workspaceId &&
+      dispatch.target.threadId === threadId &&
+      dispatch.target.tabId === tabId,
   );
 }
 
 /** Select active and busy tabs first, then fill the bounded pool by recency. */
 export function selectWarmBrowserTabIds(
   tabs: readonly { id: string }[],
+  workspaceId: string,
   threadId: string,
   activeTabId: string,
 ): ReadonlySet<string> {
   const state = useBrowserAutomationStore.getState();
   const byRecency = [...tabs].sort((left, right) => {
-    const leftTarget = state.liveTargets.get(browserAutomationTargetKey(threadId, left.id));
-    const rightTarget = state.liveTargets.get(browserAutomationTargetKey(threadId, right.id));
+    const leftTarget = state.liveTargets.get(browserAutomationTargetKey(workspaceId, threadId, left.id));
+    const rightTarget = state.liveTargets.get(browserAutomationTargetKey(workspaceId, threadId, right.id));
     return (rightTarget?.lastUsedAt ?? 0) - (leftTarget?.lastUsedAt ?? 0);
   });
   const selected = new Set<string>([activeTabId]);
   for (const { dispatch } of state.activeRequests.values()) {
-    if (dispatch.target.threadId === threadId) selected.add(dispatch.target.tabId);
+    if (dispatch.request.workspaceId === workspaceId && dispatch.target.threadId === threadId) {
+      selected.add(dispatch.target.tabId);
+    }
   }
   for (const tab of byRecency) {
     if (selected.size >= BROWSER_AUTOMATION_WARM_TARGET_LIMIT) break;

--- a/apps/web/src/stores/browserAutomationStore.ts
+++ b/apps/web/src/stores/browserAutomationStore.ts
@@ -272,7 +272,11 @@ export const useBrowserAutomationStore = create<BrowserAutomationState>((set, ge
       viewportCoordinators.delete(key);
       const lifecycleTabs = new Map(state.lifecycleTabs);
       for (const [lifecycleKey, tab] of lifecycleTabs) {
-        if (tab.threadId === threadId && tab.tabId === tabId) lifecycleTabs.delete(lifecycleKey);
+        if (
+          tab.workspaceId === workspaceId &&
+          tab.threadId === threadId &&
+          tab.tabId === tabId
+        ) lifecycleTabs.delete(lifecycleKey);
       }
       return {
         liveTargets,

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -129,7 +129,7 @@ interface PreviewTabsState {
   updateTabChrome: (scopeId: string, tabId: string, chrome: PreviewLiveChrome) => void;
 
   /** Open a new page or continue an exact existing page by id. */
-  openPage: (scopeId: string, options?: {
+  openPage: (workspaceId: string, scopeId: string, options?: {
     readonly focusOmnibox?: boolean;
     readonly activate?: boolean;
     readonly tabId?: string;
@@ -137,16 +137,16 @@ interface PreviewTabsState {
     readonly initialAddress?: string;
   }) => Promise<string | null>;
   /** Activate (switch to) a page within the scope's browser. */
-  activatePage: (scopeId: string, tabId: string) => Promise<void>;
+  activatePage: (workspaceId: string, scopeId: string, tabId: string) => Promise<void>;
   /**
    * Close a page. When it is the scope's last page, {@link ClosePageOptions.onLastClose}
    * fires (the panel uses it to close the Browser tab) before the bridge call,
    * so the tab collapses immediately rather than flashing the host's
    * always-recreated empty fallback.
    */
-  closePage: (scopeId: string, tabId: string, opts?: ClosePageOptions) => Promise<void>;
+  closePage: (workspaceId: string, scopeId: string, tabId: string, opts?: ClosePageOptions) => Promise<void>;
   /** Close every host-owned browser page for a scope and clear renderer mirrors. */
-  clearScope: (scopeId: string) => Promise<void>;
+  clearScope: (workspaceId: string, scopeId: string) => Promise<void>;
 }
 
 /** Hooks the store offers callers when a page close empties the browser. */
@@ -296,7 +296,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
       };
     }),
 
-  openPage: async (scopeId, options) => {
+  openPage: async (workspaceId, scopeId, options) => {
     const tabs = bridgeTabs();
     if (!tabs) return null;
     const activate = options?.activate ?? true;
@@ -308,7 +308,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     });
     if (r.ok) {
       get().setTabSet(scopeId, r.data.tabs);
-      useBrowserAutomationStore.getState().refreshTarget(scopeId, r.data.tabId);
+      useBrowserAutomationStore.getState().refreshTarget(workspaceId, scopeId, r.data.tabId);
       // A user-created page is empty; drop the cursor into the URL field so the
       // user can type immediately (matches the panel-open shortcut's UX).
       if (!options?.tabId && options?.focusOmnibox !== false && (options?.activate ?? true)) {
@@ -319,7 +319,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     return null;
   },
 
-  activatePage: async (scopeId, tabId) => {
+  activatePage: async (workspaceId, scopeId, tabId) => {
     const tabs = bridgeTabs();
     if (!tabs) {
       if (!get().persistentTabIdsByScope[scopeId]?.has(tabId)) return;
@@ -338,7 +338,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
           },
         };
       });
-      useBrowserAutomationStore.getState().refreshTarget(scopeId, tabId);
+      useBrowserAutomationStore.getState().refreshTarget(workspaceId, scopeId, tabId);
       return;
     }
     // The newly-active page has not emitted its live chrome yet; clear the
@@ -347,11 +347,11 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     const r = await tabs.activate(scopeId, tabId);
     if (r.ok) {
       get().setTabSet(scopeId, r.data);
-      useBrowserAutomationStore.getState().refreshTarget(scopeId, tabId);
+      useBrowserAutomationStore.getState().refreshTarget(workspaceId, scopeId, tabId);
     }
   },
 
-  closePage: async (scopeId, tabId, opts) => {
+  closePage: async (workspaceId, scopeId, tabId, opts) => {
     const tabs = bridgeTabs();
     const current = get().tabSetByScope[scopeId];
     const isLast = !!current && current.tabs.length <= 1;
@@ -363,12 +363,12 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
       if (isLast) {
         clearLastScopeState();
         opts?.onLastClose?.();
-        useBrowserAutomationStore.getState().releaseThreadTargets(scopeId);
+        useBrowserAutomationStore.getState().releaseThreadTargets(workspaceId, scopeId);
         return;
       }
       get().setLiveChrome(scopeId, null);
       get().removePersistentTab(scopeId, tabId);
-      useBrowserAutomationStore.getState().unregisterTarget(scopeId, tabId);
+      useBrowserAutomationStore.getState().unregisterTarget(workspaceId, scopeId, tabId);
       return;
     }
     if (isLast) {
@@ -377,14 +377,14 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
         : await tabs.close(scopeId, tabId);
       if (!r.ok) return;
       clearLastScopeState();
-      useBrowserAutomationStore.getState().releaseThreadTargets(scopeId);
+      useBrowserAutomationStore.getState().releaseThreadTargets(workspaceId, scopeId);
       opts?.onLastClose?.();
       return;
     }
     get().setLiveChrome(scopeId, null);
     const r = await tabs.close(scopeId, tabId);
     if (!r.ok) return;
-    useBrowserAutomationStore.getState().unregisterTarget(scopeId, tabId);
+    useBrowserAutomationStore.getState().unregisterTarget(workspaceId, scopeId, tabId);
     // Closing the last page collapses the Browser tab. The host always recreates
     // a blank fallback page in its returned set, but the tab is gone from the
     // rail, so drop the scope's set rather than leave that fallback as a phantom
@@ -392,11 +392,11 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     get().setTabSet(scopeId, isLast ? null : r.data);
   },
 
-  clearScope: async (scopeId) => {
+  clearScope: async (workspaceId, scopeId) => {
     const tabs = bridgeTabs();
     const r = await tabs?.closeScope?.(scopeId);
     if (r && !r.ok) throw new Error(r.error);
-    useBrowserAutomationStore.getState().releaseThreadTargets(scopeId);
+    useBrowserAutomationStore.getState().releaseThreadTargets(workspaceId, scopeId);
     set((s) => clearPreviewScopeState(s, scopeId, false));
   },
 }));

--- a/apps/web/src/stores/previewTabsStore.ts
+++ b/apps/web/src/stores/previewTabsStore.ts
@@ -7,7 +7,12 @@ import {
   type PreviewRenderingHost,
 } from "@mcode/contracts";
 import { usePreviewFocusStore } from "./previewFocusStore";
-import { useBrowserAutomationStore } from "./browserAutomationStore";
+import { browserAutomationScopeKey, useBrowserAutomationStore } from "./browserAutomationStore";
+
+/** Stable key for one workspace and preview scope. */
+export function previewTabsScopeKey(workspaceId: string, scopeId: string): string {
+  return browserAutomationScopeKey(workspaceId, scopeId);
+}
 
 /**
  * Live chrome for the active preview page, sourced from `preview:page-status`.
@@ -55,6 +60,7 @@ function sameBrowserTabSet(a: BrowserTabSet | null, b: BrowserTabSet | null): bo
 interface PreviewTabsBridgeLike {
   open(
     threadId: string,
+    workspaceId: string,
     options?: {
       readonly activate?: boolean;
       readonly tabId?: string;
@@ -64,14 +70,17 @@ interface PreviewTabsBridgeLike {
   ): Promise<{ ok: true; data: { tabId: string; tabs: BrowserTabSet } } | { ok: false; error: string }>;
   activate(
     threadId: string,
+    workspaceId: string,
     tabId: string,
   ): Promise<{ ok: true; data: BrowserTabSet } | { ok: false; error: string }>;
   close(
     threadId: string,
+    workspaceId: string,
     tabId: string,
   ): Promise<{ ok: true; data: BrowserTabSet } | { ok: false; error: string }>;
   closeScope?(
     threadId: string,
+    workspaceId: string,
   ): Promise<{ ok: true; data: BrowserTabSet } | { ok: false; error: string }>;
 }
 
@@ -118,15 +127,15 @@ interface PreviewTabsState {
   readonly persistentTabIdsByScope: Record<string, ReadonlySet<string>>;
 
   /** Reconcile a scope's tab set against a host snapshot (list / tabs-updated / mutation result). */
-  setTabSet: (scopeId: string, set: BrowserTabSet | null) => void;
+  setTabSet: (workspaceId: string, scopeId: string, set: BrowserTabSet | null) => void;
   /** Add or update one bounded renderer-owned web tab without activating it. */
-  upsertPersistentTab: (scopeId: string, tab: BrowserTabInfo) => void;
+  upsertPersistentTab: (workspaceId: string, scopeId: string, tab: BrowserTabInfo) => void;
   /** Remove one renderer-owned web tab from its scope projection. */
-  removePersistentTab: (scopeId: string, tabId: string) => void;
+  removePersistentTab: (workspaceId: string, scopeId: string, tabId: string) => void;
   /** Publish (or clear) the active page's live chrome for a scope. */
-  setLiveChrome: (scopeId: string, chrome: PreviewLiveChrome | null) => void;
+  setLiveChrome: (workspaceId: string, scopeId: string, chrome: PreviewLiveChrome | null) => void;
   /** Merge renderer-observed chrome into one tab's persisted renderer mirror. */
-  updateTabChrome: (scopeId: string, tabId: string, chrome: PreviewLiveChrome) => void;
+  updateTabChrome: (workspaceId: string, scopeId: string, tabId: string, chrome: PreviewLiveChrome) => void;
 
   /** Open a new page or continue an exact existing page by id. */
   openPage: (workspaceId: string, scopeId: string, options?: {
@@ -157,20 +166,20 @@ export interface ClosePageOptions {
 
 function clearPreviewScopeState(
   state: Pick<PreviewTabsState, "tabSetByScope" | "liveChromeByScope" | "persistentTabIdsByScope">,
-  scopeId: string,
+  scopeKey: string,
   preserveEmptyState: boolean,
 ): Pick<PreviewTabsState, "tabSetByScope" | "liveChromeByScope" | "persistentTabIdsByScope"> {
   const tabSetByScope = { ...state.tabSetByScope };
   const liveChromeByScope = { ...state.liveChromeByScope };
   const persistentTabIdsByScope = { ...state.persistentTabIdsByScope };
   if (preserveEmptyState) {
-    tabSetByScope[scopeId] = null;
-    liveChromeByScope[scopeId] = null;
+    tabSetByScope[scopeKey] = null;
+    liveChromeByScope[scopeKey] = null;
   } else {
-    delete tabSetByScope[scopeId];
-    delete liveChromeByScope[scopeId];
+    delete tabSetByScope[scopeKey];
+    delete liveChromeByScope[scopeKey];
   }
-  delete persistentTabIdsByScope[scopeId];
+  delete persistentTabIdsByScope[scopeKey];
   return { tabSetByScope, liveChromeByScope, persistentTabIdsByScope };
 }
 
@@ -187,25 +196,27 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
   liveChromeByScope: {},
   persistentTabIdsByScope: {},
 
-  setTabSet: (scopeId, value) =>
+  setTabSet: (workspaceId, scopeId, value) =>
     set((s) => {
-      const previous = s.tabSetByScope[scopeId] ?? null;
+      const scopeKey = previewTabsScopeKey(workspaceId, scopeId);
+      const previous = s.tabSetByScope[scopeKey] ?? null;
       if (sameBrowserTabSet(previous, value)) return s;
       return {
-        tabSetByScope: { ...s.tabSetByScope, [scopeId]: value },
+        tabSetByScope: { ...s.tabSetByScope, [scopeKey]: value },
       };
     }),
 
-  upsertPersistentTab: (scopeId, tab) =>
+  upsertPersistentTab: (workspaceId, scopeId, tab) =>
     set((s) => {
+      const scopeKey = previewTabsScopeKey(workspaceId, scopeId);
       if (
         tab.id.length > BROWSER_TAB_INFO_STRING_MAX.id ||
         tab.threadId.length > BROWSER_TAB_INFO_STRING_MAX.threadId
       ) return s;
-      const persistentIds = new Set(s.persistentTabIdsByScope[scopeId] ?? []);
+      const persistentIds = new Set(s.persistentTabIdsByScope[scopeKey] ?? []);
       if (!persistentIds.has(tab.id) && persistentIds.size >= MAX_PERSISTENT_WEB_TABS_PER_SCOPE) return s;
       persistentIds.add(tab.id);
-      const current = s.tabSetByScope[scopeId] ?? {
+      const current = s.tabSetByScope[scopeKey] ?? {
         threadId: scopeId,
         activeTabId: null,
         tabs: [],
@@ -223,25 +234,26 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
       return {
         tabSetByScope: {
           ...s.tabSetByScope,
-          [scopeId]: { ...current, tabs },
+          [scopeKey]: { ...current, tabs },
         },
         persistentTabIdsByScope: {
           ...s.persistentTabIdsByScope,
-          [scopeId]: persistentIds,
+          [scopeKey]: persistentIds,
         },
       };
     }),
 
-  removePersistentTab: (scopeId, tabId) =>
+  removePersistentTab: (workspaceId, scopeId, tabId) =>
     set((s) => {
-      const currentIds = s.persistentTabIdsByScope[scopeId];
+      const scopeKey = previewTabsScopeKey(workspaceId, scopeId);
+      const currentIds = s.persistentTabIdsByScope[scopeKey];
       if (!currentIds?.has(tabId)) return s;
       const persistentIds = new Set(currentIds);
       persistentIds.delete(tabId);
       const persistentTabIdsByScope = { ...s.persistentTabIdsByScope };
-      if (persistentIds.size > 0) persistentTabIdsByScope[scopeId] = persistentIds;
-      else delete persistentTabIdsByScope[scopeId];
-      const current = s.tabSetByScope[scopeId];
+      if (persistentIds.size > 0) persistentTabIdsByScope[scopeKey] = persistentIds;
+      else delete persistentTabIdsByScope[scopeKey];
+      const current = s.tabSetByScope[scopeKey];
       if (!current) return { persistentTabIdsByScope };
       const tabs = current.tabs.filter((tab) => tab.id !== tabId);
       const activeTabId = current.activeTabId === tabId ? tabs[0]?.id ?? null : current.activeTabId;
@@ -249,7 +261,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
         persistentTabIdsByScope,
         tabSetByScope: {
           ...s.tabSetByScope,
-          [scopeId]: {
+          [scopeKey]: {
             ...current,
             activeTabId,
             tabs: tabs.map((tab) => ({ ...tab, active: tab.id === activeTabId })),
@@ -258,19 +270,21 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
       };
     }),
 
-  setLiveChrome: (scopeId, chrome) =>
+  setLiveChrome: (workspaceId, scopeId, chrome) =>
     set((s) => {
       // The host re-emits page-status many times per second during a load.
       // Bail when the chrome is unchanged so unchanged ticks don't notify
       // subscribers (the rail glyph and the whole RightPanel tree subscribe).
-      const prev = s.liveChromeByScope[scopeId] ?? null;
+      const scopeKey = previewTabsScopeKey(workspaceId, scopeId);
+      const prev = s.liveChromeByScope[scopeKey] ?? null;
       if (sameLiveChrome(prev, chrome)) return s;
-      return { liveChromeByScope: { ...s.liveChromeByScope, [scopeId]: chrome } };
+      return { liveChromeByScope: { ...s.liveChromeByScope, [scopeKey]: chrome } };
     }),
 
-  updateTabChrome: (scopeId, tabId, chrome) =>
+  updateTabChrome: (workspaceId, scopeId, tabId, chrome) =>
     set((s) => {
-      const tabSet = s.tabSetByScope[scopeId] ?? null;
+      const scopeKey = previewTabsScopeKey(workspaceId, scopeId);
+      const tabSet = s.tabSetByScope[scopeKey] ?? null;
       if (!tabSet) return s;
       let changed = false;
       const tabs = tabSet.tabs.map((tab) => {
@@ -291,7 +305,7 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
       return {
         tabSetByScope: {
           ...s.tabSetByScope,
-          [scopeId]: { ...tabSet, tabs },
+          [scopeKey]: { ...tabSet, tabs },
         },
       };
     }),
@@ -300,14 +314,14 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     const tabs = bridgeTabs();
     if (!tabs) return null;
     const activate = options?.activate ?? true;
-    const r = await tabs.open(scopeId, {
+    const r = await tabs.open(scopeId, workspaceId, {
       activate,
       ...(options?.tabId ? { tabId: options.tabId } : {}),
       ...(options?.renderingHost ? { renderingHost: options.renderingHost } : {}),
       ...(options?.initialAddress ? { initialAddress: options.initialAddress } : {}),
     });
     if (r.ok) {
-      get().setTabSet(scopeId, r.data.tabs);
+      get().setTabSet(workspaceId, scopeId, r.data.tabs);
       useBrowserAutomationStore.getState().refreshTarget(workspaceId, scopeId, r.data.tabId);
       // A user-created page is empty; drop the cursor into the URL field so the
       // user can type immediately (matches the panel-open shortcut's UX).
@@ -322,15 +336,16 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
   activatePage: async (workspaceId, scopeId, tabId) => {
     const tabs = bridgeTabs();
     if (!tabs) {
-      if (!get().persistentTabIdsByScope[scopeId]?.has(tabId)) return;
-      get().setLiveChrome(scopeId, null);
+      const scopeKey = previewTabsScopeKey(workspaceId, scopeId);
+      if (!get().persistentTabIdsByScope[scopeKey]?.has(tabId)) return;
+      get().setLiveChrome(workspaceId, scopeId, null);
       set((s) => {
-        const tabSet = s.tabSetByScope[scopeId];
+        const tabSet = s.tabSetByScope[scopeKey];
         if (!tabSet || !tabSet.tabs.some((tab) => tab.id === tabId)) return s;
         return {
           tabSetByScope: {
             ...s.tabSetByScope,
-            [scopeId]: {
+            [scopeKey]: {
               ...tabSet,
               activeTabId: tabId,
               tabs: tabSet.tabs.map((tab) => ({ ...tab, active: tab.id === tabId })),
@@ -343,61 +358,62 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
     }
     // The newly-active page has not emitted its live chrome yet; clear the
     // stale overlay so it does not paint the prior page's favicon onto it.
-    get().setLiveChrome(scopeId, null);
-    const r = await tabs.activate(scopeId, tabId);
+    get().setLiveChrome(workspaceId, scopeId, null);
+    const r = await tabs.activate(scopeId, workspaceId, tabId);
     if (r.ok) {
-      get().setTabSet(scopeId, r.data);
+      get().setTabSet(workspaceId, scopeId, r.data);
       useBrowserAutomationStore.getState().refreshTarget(workspaceId, scopeId, tabId);
     }
   },
 
   closePage: async (workspaceId, scopeId, tabId, opts) => {
     const tabs = bridgeTabs();
-    const current = get().tabSetByScope[scopeId];
+    const scopeKey = previewTabsScopeKey(workspaceId, scopeId);
+    const current = get().tabSetByScope[scopeKey];
     const isLast = !!current && current.tabs.length <= 1;
     const clearLastScopeState = () => {
-      set((s) => clearPreviewScopeState(s, scopeId, true));
+      set((s) => clearPreviewScopeState(s, scopeKey, true));
     };
     if (!tabs) {
-      if (!get().persistentTabIdsByScope[scopeId]?.has(tabId)) return;
+      if (!get().persistentTabIdsByScope[scopeKey]?.has(tabId)) return;
       if (isLast) {
         clearLastScopeState();
         opts?.onLastClose?.();
         useBrowserAutomationStore.getState().releaseThreadTargets(workspaceId, scopeId);
         return;
       }
-      get().setLiveChrome(scopeId, null);
-      get().removePersistentTab(scopeId, tabId);
+      get().setLiveChrome(workspaceId, scopeId, null);
+      get().removePersistentTab(workspaceId, scopeId, tabId);
       useBrowserAutomationStore.getState().unregisterTarget(workspaceId, scopeId, tabId);
       return;
     }
     if (isLast) {
       const r = tabs.closeScope
-        ? await tabs.closeScope(scopeId)
-        : await tabs.close(scopeId, tabId);
+        ? await tabs.closeScope(scopeId, workspaceId)
+        : await tabs.close(scopeId, workspaceId, tabId);
       if (!r.ok) return;
       clearLastScopeState();
       useBrowserAutomationStore.getState().releaseThreadTargets(workspaceId, scopeId);
       opts?.onLastClose?.();
       return;
     }
-    get().setLiveChrome(scopeId, null);
-    const r = await tabs.close(scopeId, tabId);
+    get().setLiveChrome(workspaceId, scopeId, null);
+    const r = await tabs.close(scopeId, workspaceId, tabId);
     if (!r.ok) return;
     useBrowserAutomationStore.getState().unregisterTarget(workspaceId, scopeId, tabId);
     // Closing the last page collapses the Browser tab. The host always recreates
     // a blank fallback page in its returned set, but the tab is gone from the
     // rail, so drop the scope's set rather than leave that fallback as a phantom
     // page; reopening Browser re-seeds it via `list`.
-    get().setTabSet(scopeId, isLast ? null : r.data);
+    get().setTabSet(workspaceId, scopeId, isLast ? null : r.data);
   },
 
   clearScope: async (workspaceId, scopeId) => {
     const tabs = bridgeTabs();
-    const r = await tabs?.closeScope?.(scopeId);
+    const r = await tabs?.closeScope?.(scopeId, workspaceId);
     if (r && !r.ok) throw new Error(r.error);
     useBrowserAutomationStore.getState().releaseThreadTargets(workspaceId, scopeId);
-    set((s) => clearPreviewScopeState(s, scopeId, false));
+    set((s) => clearPreviewScopeState(s, previewTabsScopeKey(workspaceId, scopeId), false));
   },
 }));
 
@@ -408,9 +424,12 @@ export const usePreviewTabsStore = create<PreviewTabsState>((set, get) => ({
  */
 export function usePreviewDisplayTabSet(
   scopeId: string | null | undefined,
+  workspaceId?: string | null,
 ): BrowserTabSet | null {
-  const tabSet = usePreviewTabsStore((s) => (scopeId ? s.tabSetByScope[scopeId] ?? null : null));
-  const live = usePreviewTabsStore((s) => (scopeId ? s.liveChromeByScope[scopeId] ?? null : null));
+  const exactWorkspaceId = workspaceId ?? scopeId;
+  const scopeKey = scopeId && exactWorkspaceId ? previewTabsScopeKey(exactWorkspaceId, scopeId) : null;
+  const tabSet = usePreviewTabsStore((s) => (scopeKey ? s.tabSetByScope[scopeKey] ?? null : null));
+  const live = usePreviewTabsStore((s) => (scopeKey ? s.liveChromeByScope[scopeKey] ?? null : null));
   // overlayDisplaySet allocates a fresh set when live chrome is present; memoize
   // on the source references so an unchanged tick yields a stable reference and
   // does not defeat downstream memoization of the rail.

--- a/apps/web/src/stores/workspaceStore.ts
+++ b/apps/web/src/stores/workspaceStore.ts
@@ -43,8 +43,8 @@ const SYNC_THROTTLE_MS = 30_000;
 /** Tracks the last syncThreadPrs request time per workspace. */
 const lastSyncTime = new Map<string, number>();
 
-async function clearPreviewResources(threadId: string): Promise<void> {
-  await usePreviewTabsStore.getState().clearScope(threadId);
+async function clearPreviewResources(workspaceId: string, threadId: string): Promise<void> {
+  await usePreviewTabsStore.getState().clearScope(workspaceId, threadId);
   usePreviewReferenceQueueStore.getState().clearThread(threadId);
 }
 
@@ -528,7 +528,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       const deletedThreadIds = get()
         .threads.filter((t) => t.workspace_id === id)
         .map((t) => t.id);
-      await Promise.all(deletedThreadIds.map((tid) => clearPreviewResources(tid)));
+      await Promise.all(deletedThreadIds.map((tid) => clearPreviewResources(id, tid)));
       await getTransport().deleteWorkspace(id);
       releaseBrowserAutomationWorkspaceScopes(id);
       bumpThreadListMutationEpoch(id);
@@ -1099,7 +1099,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
   },
 
   dismissPreparingThread: (placeholderId) => {
-    releaseBrowserAutomationThreadScope(placeholderId);
+    const workspaceId = pendingThreadCreationByPlaceholderId.get(placeholderId)?.workspaceId ??
+      get().threads.find((thread) => thread.id === placeholderId)?.workspace_id;
+    if (workspaceId) releaseBrowserAutomationThreadScope(workspaceId, placeholderId);
     pendingThreadCreationByPlaceholderId.delete(placeholderId);
     useThreadStore.getState().clearThreadState(placeholderId);
     const didClearActiveThread = get().activeThreadId === placeholderId;
@@ -1125,8 +1127,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       const isClientOnly = !!(row?.clientPreparing || row?.clientError);
 
       if (isClientOnly) {
-        releaseBrowserAutomationThreadScope(threadId);
-        await clearPreviewResources(threadId);
+        if (workspaceIdForEpoch) releaseBrowserAutomationThreadScope(workspaceIdForEpoch, threadId);
+        if (workspaceIdForEpoch) await clearPreviewResources(workspaceIdForEpoch, threadId);
         if (workspaceIdForEpoch) {
           bumpThreadListMutationEpoch(workspaceIdForEpoch);
         }
@@ -1155,9 +1157,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         return;
       }
 
-      await clearPreviewResources(threadId);
+      if (workspaceIdForEpoch) await clearPreviewResources(workspaceIdForEpoch, threadId);
       await getTransport().deleteThread(threadId, cleanupWorktree);
-      releaseBrowserAutomationThreadScope(threadId);
+      if (workspaceIdForEpoch) releaseBrowserAutomationThreadScope(workspaceIdForEpoch, threadId);
       if (workspaceIdForEpoch) {
         bumpThreadListMutationEpoch(workspaceIdForEpoch);
       }

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -352,6 +352,7 @@ interface PreviewTabsBridge {
   ): Promise<PreviewTabIpcResult<BrowserTabSet>>;
   open(
     threadId: string,
+    workspaceId: string,
     options?: {
       readonly activate?: boolean;
       readonly tabId?: string;
@@ -361,13 +362,15 @@ interface PreviewTabsBridge {
   ): Promise<PreviewTabIpcResult<PreviewTabOpenData>>;
   activate(
     threadId: string,
+    workspaceId: string,
     tabId: string,
   ): Promise<PreviewTabIpcResult<BrowserTabSet>>;
   close(
     threadId: string,
+    workspaceId: string,
     tabId: string,
   ): Promise<PreviewTabIpcResult<BrowserTabSet>>;
-  closeScope(threadId: string): Promise<PreviewTabIpcResult<BrowserTabSet>>;
+  closeScope(threadId: string, workspaceId: string): Promise<PreviewTabIpcResult<BrowserTabSet>>;
   /** Subscribe to push-style tab set updates emitted on navigation/favicon/close. */
   onUpdated(callback: (payload: BrowserTabSet) => void): () => void;
 }


### PR DESCRIPTION
## What
Keep every warm Browser surface alive while its panel, tab, thread, workspace, docking mode, geometry, or React presentation changes.

## Why
Presentation changes must not dispose, reload, or replace Browser state. Hidden surfaces must retain exact workspace, scope, and tab identity so automation and capture can continue safely.

## Key Changes
- Keep renderer and Electron surfaces mounted when their presentation hides.
- Qualify preview, automation, lifecycle, and session state by workspace, scope, and tab.
- Bound preview IPC identifiers and reject invalid workspace identity.
- Add continuity, cross-workspace isolation, adoption, and automation regression coverage.
- Verify continuity with Playwright in the web runtime and real Electron.

Closes #1185

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788753495&installation_model_id=20477&pr_number=1197&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1197&signature=ce7b5b7dc750c957bce9c6c19f26d5f1c0d157e1e0253e45a0a3a961022ed518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->