### PR TITLE
feat(browser): add discard, re-warm, recovery, and final disposal

### DIFF
--- a/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
@@ -110,8 +110,9 @@ import {
   _resetAdoptionRegistryForTests,
   findAdoptedWebContentsForWindow,
   registerPreviewSurfaceHandlers,
+  requestRendererSurfaceDiscard,
 } from "../preview/preview-webview-adopt.js";
-import { getSession, previewTabScopeKey, sessions } from "../preview/preview-session.js";
+import { getSession, previewTabScopeKey, sessions, toBrowserTabSet } from "../preview/preview-session.js";
 
 const surface = (generation = 1) => ({
   identity: {
@@ -154,6 +155,7 @@ describe("preview typed surface bridge", () => {
     expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
     expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 1)).toBe(guest);
     expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 2)).toBeNull();
+    expect(toBrowserTabSet(getSession(allWindows[0] as never), "thread-A").tabs[0]?.warm).toBe(true);
   });
 
   it("rejects hostile sender, incomplete identity, mismatched owner, type, partition, and non-blank guests", () => {
@@ -218,8 +220,39 @@ describe("preview typed surface bridge", () => {
     expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
     getSession(allWindows[0] as never).tabsByThread.clear();
 
-    expect(invoke("preview.surface.release", { surface: surface() })).toEqual({ ok: true });
+    expect(invoke("preview.surface.release", {
+      surface: surface(),
+      reason: "dispose",
+    })).toEqual({ ok: true });
     expect(findAdoptedWebContentsForWindow(1, "thread-A", "tab-1", 1)).toBeNull();
+  });
+
+  it("marks renderer residency cold on release and requests policy-selected discard by exact generation", () => {
+    makeGuest(allWindows[0]!);
+    expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+    expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
+
+    expect(requestRendererSurfaceDiscard(allWindows[0] as never, "thread-A", "tab-1")).toBe(true);
+    expect(allWindows[0]!.webContents.send).toHaveBeenCalledWith(
+      "preview.surface.discard-requested",
+      surface(),
+    );
+    expect(invoke("preview.surface.release", {
+      surface: surface(),
+      reason: "attacker-controlled",
+    })).toMatchObject({ ok: false, error: "invalid-release-reason" });
+
+    expect(invoke("preview.surface.release", {
+      surface: surface(),
+      reason: "discard",
+    })).toEqual({ ok: true });
+    expect(toBrowserTabSet(getSession(allWindows[0] as never), "thread-A").tabs[0]?.warm).toBe(false);
+    expect(allWindows[0]!.webContents.send).toHaveBeenCalledWith(
+      "preview:tabs-updated",
+      expect.objectContaining({
+        tabs: [expect.objectContaining({ id: "tab-1", warm: false })],
+      }),
+    );
   });
 
   it("revalidates exact generation for address, history, reload, and force reload", async () => {

--- a/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
@@ -232,7 +232,8 @@ describe("preview typed surface bridge", () => {
     expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
     expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });
 
-    expect(requestRendererSurfaceDiscard(allWindows[0] as never, "thread-A", "tab-1")).toBe(true);
+    expect(requestRendererSurfaceDiscard(allWindows[0] as never, "workspace-other", "thread-A", "tab-1")).toBe(false);
+    expect(requestRendererSurfaceDiscard(allWindows[0] as never, "workspace-A", "thread-A", "tab-1")).toBe(true);
     expect(allWindows[0]!.webContents.send).toHaveBeenCalledWith(
       "preview.surface.discard-requested",
       surface(),

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -19,6 +19,10 @@ import {
   PREVIEW_POPUP_REQUESTED_CHANNEL,
   type PreviewPopupRequest,
 } from "./preview/preview-popup-contract.js";
+import {
+  PREVIEW_SURFACE_DISCARD_REQUESTED_CHANNEL,
+  type PreviewSurfaceDiscardRequest,
+} from "./preview/preview-surface-lifecycle-contract.js";
 
 contextBridge.exposeInMainWorld("desktopBridge", {
   /** Platform facts and allowlisted native window actions for the custom title bar. */
@@ -369,6 +373,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
           };
           generation: number;
         };
+        reason: "discard" | "replace" | "dispose" | "loss";
       }): Promise<{ ok: true } | { ok: false; error: string }> {
         return ipcRenderer.invoke("preview.surface.release", payload);
       },
@@ -393,6 +398,12 @@ contextBridge.exposeInMainWorld("desktopBridge", {
         const listener = (_event: unknown, request: PreviewPopupRequest) => callback(request);
         ipcRenderer.on(PREVIEW_POPUP_REQUESTED_CHANNEL, listener);
         return () => ipcRenderer.removeListener(PREVIEW_POPUP_REQUESTED_CHANNEL, listener);
+      },
+      /** Subscribes to exact-generation Memory Saver discard requests. */
+      onDiscardRequested(callback: (request: PreviewSurfaceDiscardRequest) => void): () => void {
+        const listener = (_event: unknown, request: PreviewSurfaceDiscardRequest) => callback(request);
+        ipcRenderer.on(PREVIEW_SURFACE_DISCARD_REQUESTED_CHANNEL, listener);
+        return () => ipcRenderer.removeListener(PREVIEW_SURFACE_DISCARD_REQUESTED_CHANNEL, listener);
       },
     },
     /** Bounded provider-neutral browser operations. Raw CDP is intentionally not exposed. */

--- a/apps/desktop/src/main/preview/preview-discard-scheduler.ts
+++ b/apps/desktop/src/main/preview/preview-discard-scheduler.ts
@@ -153,7 +153,7 @@ export async function runDiscardSweep(
       if (win.isDestroyed()) return;
 
       if (tab.rendererSurfaceGeneration != null) {
-        requestRendererSurfaceDiscard(win, tab.threadId, tab.id);
+        requestRendererSurfaceDiscard(win, s.workspaceId ?? tab.threadId, tab.threadId, tab.id);
         continue;
       }
       disposeTabView(win, s, tab);

--- a/apps/desktop/src/main/preview/preview-discard-scheduler.ts
+++ b/apps/desktop/src/main/preview/preview-discard-scheduler.ts
@@ -28,6 +28,10 @@ import {
   type ThreadTabSet,
 } from "./preview-session.js";
 import { disposeTabView } from "./preview-lifecycle.js";
+import {
+  findAdoptedWebContentsForWindow,
+  requestRendererSurfaceDiscard,
+} from "./preview-webview-adopt.js";
 import { validateResumeUrl } from "./preview-local-file.js";
 import { bumpPerf, setPerf } from "./preview-perf.js";
 
@@ -65,7 +69,10 @@ function collectWarmTabs(s: PreviewSession): WarmTabRef[] {
   const out: WarmTabRef[] = [];
   for (const set of s.tabsByThread.values()) {
     for (const tab of set.tabs) {
-      if (tab.view && !tab.view.webContents.isDestroyed()) {
+      if (
+        tab.view && !tab.view.webContents.isDestroyed() ||
+        tab.rendererSurfaceGeneration != null
+      ) {
         out.push({ tabId: tab.id, threadId: tab.threadId, lastActiveAt: tab.lastActiveAt });
       }
     }
@@ -123,9 +130,20 @@ export async function runDiscardSweep(
       const { set, tab } = located;
 
       // Persist the validated current URL before disposing (ADR 0002).
-      if (tab.view && !tab.view.webContents.isDestroyed()) {
+      const rendererGuest = tab.rendererSurfaceGeneration == null
+        ? null
+        : findAdoptedWebContentsForWindow(
+            win.id,
+            tab.threadId,
+            tab.id,
+            tab.rendererSurfaceGeneration,
+          );
+      const liveGuest = tab.view && !tab.view.webContents.isDestroyed()
+        ? tab.view.webContents
+        : rendererGuest;
+      if (liveGuest) {
         try {
-          const live = tab.view.webContents.getURL();
+          const live = liveGuest.getURL();
           const safe = await validateResumeUrl(isAllowedPreviewUrl(live) ? live : null);
           if (safe) tab.resumeUrl = safe;
         } catch {
@@ -134,14 +152,17 @@ export async function runDiscardSweep(
       }
       if (win.isDestroyed()) return;
 
-      const wasActiveTab =
-        tab.threadId === s.lastPreviewThreadId && set.activeTabId === tab.id;
-
+      if (tab.rendererSurfaceGeneration != null) {
+        requestRendererSurfaceDiscard(win, tab.threadId, tab.id);
+        continue;
+      }
       disposeTabView(win, s, tab);
       bumpPerf("inactiveTabBudgetEvictions");
 
       // The active tab can only be dropped when hidden; surface it through the
       // single page-status channel so the reducer records phase: 'discarded'.
+      const wasActiveTab =
+        tab.threadId === s.lastPreviewThreadId && set.activeTabId === tab.id;
       if (wasActiveTab) applyPageStatus(win, s, { type: "discard" });
       if (tab.threadId === s.lastPreviewThreadId) activeThreadTouched = true;
     }

--- a/apps/desktop/src/main/preview/preview-session.ts
+++ b/apps/desktop/src/main/preview/preview-session.ts
@@ -61,6 +61,8 @@ export interface TabState {
   viewportTargetGeneration: number | null;
   /** Latest viewport operation generation admitted for the current target generation. */
   viewportOperationGeneration: number | null;
+  /** Current renderer-owned guest generation, or null while the tab is cold. */
+  rendererSurfaceGeneration?: number | null;
   /**
    * True for a page the user explicitly opened as a new, blank tab. Such a tab
    * must stay on its empty "Enter a URL" state and must NOT adopt the thread's
@@ -399,7 +401,7 @@ export function toBrowserTabSet(s: PreviewSession, threadId: string): BrowserTab
     title: t.title,
     url: t.resumeUrl,
     faviconUrl: t.faviconUrl,
-    warm: t.view !== null && !t.view.webContents.isDestroyed(),
+    warm: (t.view !== null && !t.view.webContents.isDestroyed()) || t.rendererSurfaceGeneration != null,
     active: t.id === set.activeTabId,
   }));
   return {

--- a/apps/desktop/src/main/preview/preview-surface-lifecycle-contract.ts
+++ b/apps/desktop/src/main/preview/preview-surface-lifecycle-contract.ts
@@ -1,0 +1,12 @@
+/** Renderer channel for a Memory Saver discard request on one exact surface. */
+export const PREVIEW_SURFACE_DISCARD_REQUESTED_CHANNEL = "preview.surface.discard-requested" as const;
+
+/** Complete identity and generation selected for renderer-side discard. */
+export interface PreviewSurfaceDiscardRequest {
+  readonly identity: {
+    readonly workspaceId: string;
+    readonly scope: { readonly kind: "thread" | "workspace"; readonly id: string };
+    readonly tabId: string;
+  };
+  readonly generation: number;
+}

--- a/apps/desktop/src/main/preview/preview-webview-adopt.ts
+++ b/apps/desktop/src/main/preview/preview-webview-adopt.ts
@@ -5,7 +5,13 @@ import {
 } from "electron";
 import type { IpcMainInvokeEvent, WebContents } from "electron";
 import { logger } from "@mcode/shared";
-import { getSession, getThreadTabSet } from "./preview-session.js";
+import {
+  applyPageStatus,
+  emitTabsUpdated,
+  getSession,
+  getThreadTabSet,
+  type TabState,
+} from "./preview-session.js";
 import { resolvePreviewNavigationTarget } from "./preview-navigation.js";
 import { trustMainProcessFileNavigation } from "./preview-local-file.js";
 import {
@@ -16,6 +22,8 @@ import { previewSessionAdapter } from "./preview-session-adapter.js";
 import { PREVIEW_POPUP_REQUESTED_CHANNEL } from "./preview-popup-contract.js";
 import type { PreviewPopupSurfaceRef } from "./preview-popup-contract.js";
 import { isBrowserAutomationAgentOperationActive } from "../browser-automation/active-operation.js";
+import { PREVIEW_SURFACE_DISCARD_REQUESTED_CHANNEL } from "./preview-surface-lifecycle-contract.js";
+import { bumpPerf } from "./preview-perf.js";
 
 const MAX_SURFACE_ID_LENGTH = 256;
 const MAX_ADOPTION_TOKEN_LENGTH = 128;
@@ -69,6 +77,7 @@ export interface PreviewSurfaceAdoptInput extends PreviewSurfacePrepareInput {}
 /** Input accepted by preview.surface.release. */
 export interface PreviewSurfaceReleaseInput {
   readonly surface: PreviewSurfaceRef;
+  readonly reason: "discard" | "replace" | "dispose" | "loss";
 }
 
 /** Input accepted by preview.surface.navigate. */
@@ -140,20 +149,22 @@ function windowMap<T>(maps: Map<number, Map<string, T>>, windowId: number): Map<
 function findOwnedTab(
   win: BrowserWindow,
   identity: PreviewSurfaceIdentity,
-): { threadId: string; tabId: string } | null {
+): { threadId: string; tabId: string; tab: TabState } | null {
   const session = getSession(win);
   if (session.workspaceId !== identity.workspaceId) return null;
   if (identity.scope.kind === "thread") {
     const tab = getThreadTabSet(session, identity.scope.id, identity.workspaceId)?.tabs.find((candidate) => candidate.id === identity.tabId);
-    return tab?.threadId === identity.scope.id ? { threadId: identity.scope.id, tabId: tab.id } : null;
+    return tab?.threadId === identity.scope.id
+      ? { threadId: identity.scope.id, tabId: tab.id, tab }
+      : null;
   }
   if (identity.scope.id !== identity.workspaceId) return null;
-  let found: { threadId: string; tabId: string } | null = null;
+  let found: { threadId: string; tabId: string; tab: TabState } | null = null;
   for (const tabSet of session.tabsByThread.values()) {
     const tab = tabSet.tabs.find((candidate) => candidate.id === identity.tabId);
     if (!tab) continue;
     if (found) return null;
-    found = { threadId: tab.threadId, tabId: tab.id };
+    found = { threadId: tab.threadId, tabId: tab.id, tab };
   }
   return found;
 }
@@ -199,7 +210,11 @@ function errorResult(error: string): PreviewSurfaceResult {
 function validateSenderAndSurface(
   event: IpcMainInvokeEvent,
   surfaceValue: unknown,
-): { win: BrowserWindow; surface: PreviewSurfaceRef; owner: { threadId: string; tabId: string } } | PreviewSurfaceResult {
+): {
+  win: BrowserWindow;
+  surface: PreviewSurfaceRef;
+  owner: { threadId: string; tabId: string; tab: TabState };
+} | PreviewSurfaceResult {
   const win = BrowserWindow.fromWebContents(event.sender);
   if (!win || win.isDestroyed()) return errorResult("no-window");
   const surface = validateSurface(surfaceValue);
@@ -227,6 +242,20 @@ function dropPending(windowId: number, key: string): void {
   const map = pendingByWindow.get(windowId);
   map?.delete(key);
   if (map && map.size === 0) pendingByWindow.delete(windowId);
+}
+
+function validReleaseReason(value: unknown): value is PreviewSurfaceReleaseInput["reason"] {
+  return value === "discard" || value === "replace" || value === "dispose" || value === "loss";
+}
+
+function setRendererResidency(
+  win: BrowserWindow,
+  owner: { threadId: string; tabId: string; tab: TabState },
+  generation: number | null,
+): void {
+  if (owner.tab.rendererSurfaceGeneration === generation) return;
+  owner.tab.rendererSurfaceGeneration = generation;
+  emitTabsUpdated(win, getSession(win), owner.threadId);
 }
 
 /** Resolves the adopted guest for an exact identity and generation. */
@@ -259,6 +288,23 @@ export function findAdoptedWebContentsForWindow(
     ) return record.webContents;
   }
   return null;
+}
+
+/** Requests renderer-side discard for one adopted surface selected by Memory Saver. */
+export function requestRendererSurfaceDiscard(
+  win: BrowserWindow,
+  threadId: string,
+  tabId: string,
+): boolean {
+  const records = adoptedByWindow.get(win.id);
+  const record = [...(records?.values() ?? [])].find((candidate) =>
+    candidate.surface.identity.scope.kind === "thread" &&
+    candidate.surface.identity.scope.id === threadId &&
+    candidate.surface.identity.tabId === tabId &&
+    !candidate.webContents.isDestroyed());
+  if (!record || win.isDestroyed() || win.webContents.isDestroyed()) return false;
+  win.webContents.send(PREVIEW_SURFACE_DISCARD_REQUESTED_CHANNEL, record.surface);
+  return true;
 }
 
 function prepareSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSurfaceResult {
@@ -298,7 +344,7 @@ function adoptSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSu
   if (!validAdoptionToken(input.adoptionToken)) return errorResult("invalid-adoption-token");
   const validated = validateSenderAndSurface(event, input.surface);
   if ("ok" in validated) return validated;
-  const { win, surface } = validated;
+  const { win, surface, owner } = validated;
   const key = surfaceKey(surface.identity);
   const currentGeneration = generationByWindow.get(win.id)?.get(key);
   if (currentGeneration !== surface.generation) return errorResult("stale-generation");
@@ -311,7 +357,10 @@ function adoptSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSu
       candidate.getURL() === `about:blank#${input.adoptionToken}` && candidate.hostWebContents === event.sender);
     return errorResult(matches.length > 1 ? "non-unique-adoption" : "guest-not-found");
   }
-  const onDestroyed = () => dropAdoption(win.id, key);
+  const onDestroyed = () => {
+    dropAdoption(win.id, key);
+    setRendererResidency(win, owner, null);
+  };
   guest.once("destroyed", onDestroyed);
   const disposePopup = previewSessionAdapter.bindGuestPopup(guest, {
     sourceSurface: surface,
@@ -333,6 +382,7 @@ function adoptSurface(event: IpcMainInvokeEvent, inputValue: unknown): PreviewSu
   };
   windowMap(adoptedByWindow, win.id).set(key, { surface, adoptionToken: input.adoptionToken, webContents: guest, dispose });
   dropPending(win.id, key);
+  setRendererResidency(win, owner, surface.generation);
   logger.info("Preview: adopted typed webview surface", {
     workspaceId: surface.identity.workspaceId,
     scope: surface.identity.scope,
@@ -348,7 +398,9 @@ function releaseSurface(event: IpcMainInvokeEvent, inputValue: unknown): Preview
   if (!win || win.isDestroyed()) return errorResult("no-window");
   const surface = validateSurface(input.surface);
   if (!surface) return errorResult("invalid-surface");
+  if (!validReleaseReason(input.reason)) return errorResult("invalid-release-reason");
   const key = surfaceKey(surface.identity);
+  const owner = findOwnedTab(win, surface.identity);
   const currentGeneration = generationByWindow.get(win.id)?.get(key);
   if (currentGeneration !== surface.generation) return errorResult("stale-generation");
   const record = adoptedByWindow.get(win.id)?.get(key);
@@ -357,6 +409,21 @@ function releaseSurface(event: IpcMainInvokeEvent, inputValue: unknown): Preview
     dropAdoption(win.id, key);
   }
   dropPending(win.id, key);
+  if (owner) {
+    setRendererResidency(win, owner, null);
+    if (input.reason === "discard") {
+      const session = getSession(win);
+      const activeTabId = getThreadTabSet(
+        session,
+        owner.threadId,
+        surface.identity.workspaceId,
+      )?.activeTabId;
+      if (session.lastPreviewThreadId === owner.threadId && activeTabId === owner.tabId) {
+        applyPageStatus(win, session, { type: "discard" });
+      }
+      bumpPerf("inactiveTabBudgetEvictions");
+    }
+  }
   return { ok: true };
 }
 

--- a/apps/desktop/src/main/preview/preview-webview-adopt.ts
+++ b/apps/desktop/src/main/preview/preview-webview-adopt.ts
@@ -293,11 +293,13 @@ export function findAdoptedWebContentsForWindow(
 /** Requests renderer-side discard for one adopted surface selected by Memory Saver. */
 export function requestRendererSurfaceDiscard(
   win: BrowserWindow,
+  workspaceId: string,
   threadId: string,
   tabId: string,
 ): boolean {
   const records = adoptedByWindow.get(win.id);
   const record = [...(records?.values() ?? [])].find((candidate) =>
+    candidate.surface.identity.workspaceId === workspaceId &&
     candidate.surface.identity.scope.kind === "thread" &&
     candidate.surface.identity.scope.id === threadId &&
     candidate.surface.identity.tabId === tabId &&

--- a/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
+++ b/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
@@ -8,44 +8,13 @@ import {
 } from "@/services/browser-surfaces";
 import {
   invalidateBrowserAutomationTargetObservation,
+  parseBrowserAutomationScopeKey,
+  parseBrowserAutomationTargetKey,
   useBrowserAutomationStore,
 } from "@/stores/browserAutomationStore";
 import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 
 let surfaceRoot: HTMLDivElement | null = null;
-
-function parsePreviewScopeKey(scopeKey: string): { workspaceId: string; scopeId: string } | null {
-  try {
-    const parsed = JSON.parse(scopeKey) as unknown;
-    if (
-      !Array.isArray(parsed) ||
-      parsed.length !== 2 ||
-      typeof parsed[0] !== "string" ||
-      typeof parsed[1] !== "string"
-    ) return null;
-    return { workspaceId: parsed[0], scopeId: parsed[1] };
-  } catch {
-    return null;
-  }
-}
-
-function parseBrowserTargetKey(targetKey: string): BrowserSurfaceIdentity | null {
-  try {
-    const parsed = JSON.parse(targetKey) as unknown;
-    if (
-      !Array.isArray(parsed) ||
-      parsed.length !== 3 ||
-      parsed.some((value) => typeof value !== "string")
-    ) return null;
-    return {
-      workspaceId: parsed[0] as string,
-      scope: { kind: "thread", id: parsed[1] as string },
-      tabId: parsed[2] as string,
-    };
-  } catch {
-    return null;
-  }
-}
 
 /** Renderer-window Browser surface host used by the web iframe adapter. */
 export const browserSurfaceHost = new BrowserSurfaceHost({
@@ -119,7 +88,7 @@ export function BrowserSurfaceHostRoot() {
       if (!previousSet) continue;
       const currentSet = state.tabSetByScope[scopeKey];
       const currentIds = new Set(currentSet?.tabs.map((tab) => tab.id) ?? []);
-      const scope = parsePreviewScopeKey(scopeKey);
+      const scope = parseBrowserAutomationScopeKey(scopeKey);
       if (!scope) continue;
       for (const tab of previousSet.tabs) {
         if (currentIds.has(tab.id)) continue;
@@ -142,8 +111,13 @@ export function BrowserSurfaceHostRoot() {
         ...(previous?.controllers.keys() ?? []),
       ]);
       for (const targetKey of targetKeys) {
-        const identity = parseBrowserTargetKey(targetKey);
-        if (!identity) continue;
+        const target = parseBrowserAutomationTargetKey(targetKey);
+        if (!target) continue;
+        const identity: BrowserSurfaceIdentity = {
+          workspaceId: target.workspaceId,
+          scope: { kind: "thread", id: target.threadId },
+          tabId: target.tabId,
+        };
         browserSurfaceHost.setControlled(
           identity,
           state.controllers.get(targetKey)?.controller === "agent",
@@ -177,8 +151,10 @@ export function BrowserSurfaceHostRoot() {
           scope: { kind: "thread", id: active.dispatch.target.threadId },
           tabId: active.dispatch.target.tabId,
         };
-        const generation = browserSurfaceHost.getSnapshot(identity)?.generation;
-        if (generation === undefined) continue;
+        const metadata = browserSurfaceHost.inspect(identity);
+        if (!metadata) continue;
+        const generation = browserSurfaceHost.getSnapshot(identity)?.generation ??
+          browserSurfaceHost.ensure(identity).generation;
         const existing = releases.get(requestKey);
         if (existing?.generation === generation) continue;
         existing?.release();
@@ -204,9 +180,12 @@ export function BrowserSurfaceHostRoot() {
   }, []);
 
   useEffect(() => {
-    const dispose = (): void => browserSurfaceHost.disposeHost();
-    window.addEventListener("beforeunload", dispose);
-    return () => window.removeEventListener("beforeunload", dispose);
+    const dispose = (event: PageTransitionEvent): void => {
+      if (event.persisted) return;
+      browserSurfaceHost.disposeHost();
+    };
+    window.addEventListener("pagehide", dispose);
+    return () => window.removeEventListener("pagehide", dispose);
   }, []);
 
   return (

--- a/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
+++ b/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from "react";
 import {
   BrowserSurfaceHost,
+  type BrowserSurfaceIdentity,
   ElectronWebviewBrowserSurfaceAdapter,
   normalizeElectronWebviewSurfaceAddress,
   WebIframeBrowserSurfaceAdapter,
@@ -12,6 +13,39 @@ import {
 import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 
 let surfaceRoot: HTMLDivElement | null = null;
+
+function parsePreviewScopeKey(scopeKey: string): { workspaceId: string; scopeId: string } | null {
+  try {
+    const parsed = JSON.parse(scopeKey) as unknown;
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length !== 2 ||
+      typeof parsed[0] !== "string" ||
+      typeof parsed[1] !== "string"
+    ) return null;
+    return { workspaceId: parsed[0], scopeId: parsed[1] };
+  } catch {
+    return null;
+  }
+}
+
+function parseBrowserTargetKey(targetKey: string): BrowserSurfaceIdentity | null {
+  try {
+    const parsed = JSON.parse(targetKey) as unknown;
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length !== 3 ||
+      parsed.some((value) => typeof value !== "string")
+    ) return null;
+    return {
+      workspaceId: parsed[0] as string,
+      scope: { kind: "thread", id: parsed[1] as string },
+      tabId: parsed[2] as string,
+    };
+  } catch {
+    return null;
+  }
+}
 
 /** Renderer-window Browser surface host used by the web iframe adapter. */
 export const browserSurfaceHost = new BrowserSurfaceHost({
@@ -57,7 +91,7 @@ export function BrowserSurfaceHostRoot() {
   useEffect(() => {
     const surfaceBridge = window.desktopBridge?.preview?.surface;
     if (!surfaceBridge) return;
-    return surfaceBridge.onPopupRequested((request) => {
+    const stopPopups = surfaceBridge.onPopupRequested((request) => {
       const source = browserSurfaceHost.getSnapshot(request.sourceSurface.identity);
       if (!source || source.generation !== request.sourceSurface.generation) return;
       void usePreviewTabsStore.getState().openPage(
@@ -71,6 +105,97 @@ export function BrowserSurfaceHostRoot() {
         },
       );
     });
+    const stopDiscards = surfaceBridge.onDiscardRequested((request) => {
+      browserSurfaceHost.discard(request.identity, request.generation);
+    });
+    return () => {
+      stopPopups();
+      stopDiscards();
+    };
+  }, []);
+
+  useEffect(() => usePreviewTabsStore.subscribe((state, previous) => {
+    for (const [scopeKey, previousSet] of Object.entries(previous.tabSetByScope)) {
+      if (!previousSet) continue;
+      const currentSet = state.tabSetByScope[scopeKey];
+      const currentIds = new Set(currentSet?.tabs.map((tab) => tab.id) ?? []);
+      const scope = parsePreviewScopeKey(scopeKey);
+      if (!scope) continue;
+      for (const tab of previousSet.tabs) {
+        if (currentIds.has(tab.id)) continue;
+        browserSurfaceHost.dispose({
+          workspaceId: scope.workspaceId,
+          scope: { kind: "thread", id: scope.scopeId },
+          tabId: tab.id,
+        });
+      }
+    }
+  }), []);
+
+  useEffect(() => {
+    const synchronizeControllers = (
+      state: ReturnType<typeof useBrowserAutomationStore.getState>,
+      previous?: ReturnType<typeof useBrowserAutomationStore.getState>,
+    ): void => {
+      const targetKeys = new Set([
+        ...state.controllers.keys(),
+        ...(previous?.controllers.keys() ?? []),
+      ]);
+      for (const targetKey of targetKeys) {
+        const identity = parseBrowserTargetKey(targetKey);
+        if (!identity) continue;
+        browserSurfaceHost.setControlled(
+          identity,
+          state.controllers.get(targetKey)?.controller === "agent",
+        );
+      }
+    };
+    synchronizeControllers(useBrowserAutomationStore.getState());
+    return useBrowserAutomationStore.subscribe(synchronizeControllers);
+  }, []);
+
+  useEffect(() => {
+    const releases = new Map<string, () => void>();
+    const synchronizeOperations = (
+      state: ReturnType<typeof useBrowserAutomationStore.getState>,
+    ): void => {
+      for (const [requestKey, release] of releases) {
+        if (state.activeRequests.has(requestKey)) continue;
+        release();
+        releases.delete(requestKey);
+      }
+      for (const [requestKey, active] of state.activeRequests) {
+        if (releases.has(requestKey)) continue;
+        const identity: BrowserSurfaceIdentity = {
+          workspaceId: active.dispatch.scope.workspaceId,
+          scope: { kind: "thread", id: active.dispatch.target.threadId },
+          tabId: active.dispatch.target.tabId,
+        };
+        const generation = browserSurfaceHost.getSnapshot(identity)?.generation;
+        if (generation === undefined) continue;
+        const operation = active.dispatch.request.operation;
+        const capturesSurface = operation === "snapshot" || operation === "screenshot" ||
+          operation === "inspect" && active.dispatch.request.args.includeScreenshot;
+        releases.set(
+          requestKey,
+          capturesSurface
+            ? browserSurfaceHost.pinCapture(identity, generation)
+            : browserSurfaceHost.pinOperation(identity, generation),
+        );
+      }
+    };
+    synchronizeOperations(useBrowserAutomationStore.getState());
+    const unsubscribe = useBrowserAutomationStore.subscribe(synchronizeOperations);
+    return () => {
+      unsubscribe();
+      for (const release of releases.values()) release();
+    };
+  }, []);
+
+  useEffect(() => {
+    const dispose = (): void => browserSurfaceHost.disposeHost();
+    window.addEventListener("beforeunload", dispose);
+    return () => window.removeEventListener("beforeunload", dispose);
   }, []);
 
   return (

--- a/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
+++ b/apps/web/src/components/panels/BrowserSurfaceHostRoot.tsx
@@ -151,21 +151,27 @@ export function BrowserSurfaceHostRoot() {
       }
     };
     synchronizeControllers(useBrowserAutomationStore.getState());
-    return useBrowserAutomationStore.subscribe(synchronizeControllers);
+    const unsubscribeStore = useBrowserAutomationStore.subscribe(synchronizeControllers);
+    const unsubscribeSurfaces = browserSurfaceHost.subscribeMaterialized(() => {
+      synchronizeControllers(useBrowserAutomationStore.getState());
+    });
+    return () => {
+      unsubscribeStore();
+      unsubscribeSurfaces();
+    };
   }, []);
 
   useEffect(() => {
-    const releases = new Map<string, () => void>();
+    const releases = new Map<string, { generation: number; release: () => void }>();
     const synchronizeOperations = (
       state: ReturnType<typeof useBrowserAutomationStore.getState>,
     ): void => {
-      for (const [requestKey, release] of releases) {
+      for (const [requestKey, pinned] of releases) {
         if (state.activeRequests.has(requestKey)) continue;
-        release();
+        pinned.release();
         releases.delete(requestKey);
       }
       for (const [requestKey, active] of state.activeRequests) {
-        if (releases.has(requestKey)) continue;
         const identity: BrowserSurfaceIdentity = {
           workspaceId: active.dispatch.scope.workspaceId,
           scope: { kind: "thread", id: active.dispatch.target.threadId },
@@ -173,22 +179,27 @@ export function BrowserSurfaceHostRoot() {
         };
         const generation = browserSurfaceHost.getSnapshot(identity)?.generation;
         if (generation === undefined) continue;
+        const existing = releases.get(requestKey);
+        if (existing?.generation === generation) continue;
+        existing?.release();
         const operation = active.dispatch.request.operation;
         const capturesSurface = operation === "snapshot" || operation === "screenshot" ||
           operation === "inspect" && active.dispatch.request.args.includeScreenshot;
-        releases.set(
-          requestKey,
-          capturesSurface
-            ? browserSurfaceHost.pinCapture(identity, generation)
-            : browserSurfaceHost.pinOperation(identity, generation),
-        );
+        const release = capturesSurface
+          ? browserSurfaceHost.pinCapture(identity, generation)
+          : browserSurfaceHost.pinOperation(identity, generation);
+        releases.set(requestKey, { generation, release });
       }
     };
     synchronizeOperations(useBrowserAutomationStore.getState());
-    const unsubscribe = useBrowserAutomationStore.subscribe(synchronizeOperations);
+    const unsubscribeStore = useBrowserAutomationStore.subscribe(synchronizeOperations);
+    const unsubscribeSurfaces = browserSurfaceHost.subscribeMaterialized(() => {
+      synchronizeOperations(useBrowserAutomationStore.getState());
+    });
     return () => {
-      unsubscribe();
-      for (const release of releases.values()) release();
+      unsubscribeStore();
+      unsubscribeSurfaces();
+      for (const pinned of releases.values()) pinned.release();
     };
   }, []);
 

--- a/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
@@ -7,7 +7,10 @@ import {
 import type { BrowserSurfaceIdentity } from "@/services/browser-surfaces";
 import { usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { useBrowserAutomationStore } from "@/stores/browserAutomationStore";
-import type { PreviewPopupRequest, PreviewSurfaceRef } from "@/transport/desktop-bridge";
+import type {
+  PreviewPopupRequest,
+  PreviewSurfaceDiscardRequest,
+} from "@/transport/desktop-bridge";
 
 const IDENTITY: BrowserSurfaceIdentity = {
   workspaceId: "workspace-1",
@@ -31,7 +34,7 @@ describe("BrowserSurfaceHostRoot", () => {
   });
 
   it("discards only the exact current generation selected by Memory Saver", () => {
-    let onDiscardRequested: ((request: PreviewSurfaceRef) => void) | null = null;
+    let onDiscardRequested: ((request: PreviewSurfaceDiscardRequest) => void) | null = null;
     const stopDiscardRequests = vi.fn();
     const first = browserSurfaceHost.create(IDENTITY, {
       generation: 7,
@@ -41,7 +44,7 @@ describe("BrowserSurfaceHostRoot", () => {
       preview: {
         surface: {
           onPopupRequested: vi.fn(() => () => undefined),
-          onDiscardRequested: vi.fn((listener: (request: PreviewSurfaceRef) => void) => {
+          onDiscardRequested: vi.fn((listener: (request: PreviewSurfaceDiscardRequest) => void) => {
             onDiscardRequested = listener;
             return stopDiscardRequests;
           }),
@@ -118,6 +121,48 @@ describe("BrowserSurfaceHostRoot", () => {
 
     act(() => useBrowserAutomationStore.setState({ activeRequests: new Map() }));
     expect(browserSurfaceHost.discard(IDENTITY, first.generation)).toBe(true);
+    view.unmount();
+  });
+
+  it("re-warms and pins a cold surface when an operation starts", () => {
+    const view = render(<BrowserSurfaceHostRoot />);
+    const first = browserSurfaceHost.create(IDENTITY, { address: "https://example.test/recovery" });
+    expect(browserSurfaceHost.discard(IDENTITY, first.generation)).toBe(true);
+
+    act(() => useBrowserAutomationStore.setState({
+      activeRequests: new Map([[
+        "request-cold:1",
+        {
+          dispatch: {
+            scope: { workspaceId: "workspace-1" },
+            target: { threadId: "thread-1", tabId: "web-preview" },
+            request: { requestId: "request-cold", sequence: 1, operation: "navigate", args: {} },
+          },
+          startedAt: 1,
+        } as never,
+      ]]),
+    }));
+
+    const rewarmed = browserSurfaceHost.getSnapshot(IDENTITY);
+    expect(rewarmed?.generation).toBe(first.generation + 1);
+    expect(browserSurfaceHost.discard(IDENTITY, rewarmed?.generation)).toBe(false);
+    act(() => useBrowserAutomationStore.setState({ activeRequests: new Map() }));
+    expect(browserSurfaceHost.discard(IDENTITY, rewarmed?.generation)).toBe(true);
+    view.unmount();
+  });
+
+  it("keeps the host for cancelled or cached unloads and disposes on committed pagehide", () => {
+    const view = render(<BrowserSurfaceHostRoot />);
+    const first = browserSurfaceHost.create(IDENTITY);
+
+    act(() => window.dispatchEvent(new Event("beforeunload", { cancelable: true })));
+    expect(browserSurfaceHost.getSnapshot(IDENTITY)).toBe(first);
+
+    act(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+    expect(browserSurfaceHost.getSnapshot(IDENTITY)).toBe(first);
+
+    act(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: false })));
+    expect(browserSurfaceHost.getSnapshot(IDENTITY)).toBeNull();
     view.unmount();
   });
 

--- a/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
@@ -81,6 +81,46 @@ describe("BrowserSurfaceHostRoot", () => {
     expect(stopDiscardRequests).toHaveBeenCalledTimes(1);
   });
 
+  it("applies controller and operation protection when their surface materializes later", () => {
+    useBrowserAutomationStore.getState().registerTarget("workspace-1", "thread-1", "web-preview");
+    useBrowserAutomationStore.getState().setControllerForTarget(
+      "workspace-1",
+      "thread-1",
+      "web-preview",
+      { tabId: "web-preview", controller: "agent", controlEpoch: 1 },
+    );
+    useBrowserAutomationStore.setState({
+      activeRequests: new Map([[
+        "request-1:1",
+        {
+          dispatch: {
+            scope: { workspaceId: "workspace-1" },
+            target: { threadId: "thread-1", tabId: "web-preview" },
+            request: { requestId: "request-1", sequence: 1, operation: "navigate", args: {} },
+          },
+          startedAt: 1,
+        } as never,
+      ]]),
+    });
+    const view = render(<BrowserSurfaceHostRoot />);
+    const first = browserSurfaceHost.create(IDENTITY);
+
+    expect(browserSurfaceHost.discard(IDENTITY, first.generation)).toBe(false);
+    act(() => {
+      useBrowserAutomationStore.getState().setControllerForTarget(
+        "workspace-1",
+        "thread-1",
+        "web-preview",
+        { tabId: "web-preview", controller: "none", controlEpoch: 1 },
+      );
+    });
+    expect(browserSurfaceHost.discard(IDENTITY, first.generation)).toBe(false);
+
+    act(() => useBrowserAutomationStore.setState({ activeRequests: new Map() }));
+    expect(browserSurfaceHost.discard(IDENTITY, first.generation)).toBe(true);
+    view.unmount();
+  });
+
   it("disposes a surface when canonical tab membership removes it", () => {
     const view = render(<BrowserSurfaceHostRoot />);
     browserSurfaceHost.create(IDENTITY);

--- a/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
@@ -6,7 +6,8 @@ import {
 } from "../BrowserSurfaceHostRoot";
 import type { BrowserSurfaceIdentity } from "@/services/browser-surfaces";
 import { usePreviewTabsStore } from "@/stores/previewTabsStore";
-import type { PreviewPopupRequest } from "@/transport/desktop-bridge";
+import { useBrowserAutomationStore } from "@/stores/browserAutomationStore";
+import type { PreviewPopupRequest, PreviewSurfaceRef } from "@/transport/desktop-bridge";
 
 const IDENTITY: BrowserSurfaceIdentity = {
   workspaceId: "workspace-1",
@@ -19,8 +20,88 @@ describe("BrowserSurfaceHostRoot", () => {
 
   afterEach(() => {
     browserSurfaceHost.dispose(IDENTITY);
-    usePreviewTabsStore.setState({ openPage: originalOpenPage });
+    usePreviewTabsStore.setState({
+      openPage: originalOpenPage,
+      tabSetByScope: {},
+      liveChromeByScope: {},
+      persistentTabIdsByScope: {},
+    });
+    useBrowserAutomationStore.getState().releaseWorkspaceTargets("workspace-1");
     delete window.desktopBridge;
+  });
+
+  it("discards only the exact current generation selected by Memory Saver", () => {
+    let onDiscardRequested: ((request: PreviewSurfaceRef) => void) | null = null;
+    const stopDiscardRequests = vi.fn();
+    const first = browserSurfaceHost.create(IDENTITY, {
+      generation: 7,
+      address: "https://example.test/recovery",
+    });
+    window.desktopBridge = {
+      preview: {
+        surface: {
+          onPopupRequested: vi.fn(() => () => undefined),
+          onDiscardRequested: vi.fn((listener: (request: PreviewSurfaceRef) => void) => {
+            onDiscardRequested = listener;
+            return stopDiscardRequests;
+          }),
+        },
+      },
+    } as never;
+    const view = render(<BrowserSurfaceHostRoot />);
+
+    act(() => onDiscardRequested?.({ identity: IDENTITY, generation: 6 }));
+    expect(browserSurfaceHost.getSnapshot(IDENTITY)).toBe(first);
+
+    act(() => {
+      useBrowserAutomationStore.getState().registerTarget("workspace-1", "thread-1", "web-preview");
+      useBrowserAutomationStore.getState().setControllerForTarget(
+        "workspace-1",
+        "thread-1",
+        "web-preview",
+        { tabId: "web-preview", controller: "agent", controlEpoch: 1 },
+      );
+      onDiscardRequested?.({ identity: IDENTITY, generation: 7 });
+    });
+    expect(browserSurfaceHost.getSnapshot(IDENTITY)).toBe(first);
+
+    act(() => {
+      useBrowserAutomationStore.getState().setControllerForTarget(
+        "workspace-1",
+        "thread-1",
+        "web-preview",
+        { tabId: "web-preview", controller: "none", controlEpoch: 1 },
+      );
+      onDiscardRequested?.({ identity: IDENTITY, generation: 7 });
+    });
+    expect(browserSurfaceHost.getSnapshot(IDENTITY)).toBeNull();
+    expect(browserSurfaceHost.inspect(IDENTITY)?.residency).toBe("cold");
+
+    view.unmount();
+    expect(stopDiscardRequests).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes a surface when canonical tab membership removes it", () => {
+    const view = render(<BrowserSurfaceHostRoot />);
+    browserSurfaceHost.create(IDENTITY);
+    usePreviewTabsStore.getState().setTabSet("workspace-1", "thread-1", {
+      threadId: "thread-1",
+      activeTabId: "web-preview",
+      tabs: [{
+        id: "web-preview",
+        threadId: "thread-1",
+        title: null,
+        url: null,
+        faviconUrl: null,
+        warm: true,
+        active: true,
+      }],
+    });
+
+    act(() => usePreviewTabsStore.getState().setTabSet("workspace-1", "thread-1", null));
+
+    expect(browserSurfaceHost.inspect(IDENTITY)).toBeNull();
+    view.unmount();
   });
 
   it("mounts a hosted iframe outside the panel tree", () => {
@@ -49,6 +130,7 @@ describe("BrowserSurfaceHostRoot", () => {
             onPopupRequested = listener;
             return stopPopupRequests;
           }),
+          onDiscardRequested: vi.fn(() => () => undefined),
         },
       },
     } as never;

--- a/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
+++ b/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
@@ -148,6 +148,12 @@ export interface BrowserSurfaceMetadata {
 /** Listener invoked when a generation's canonical state is published. */
 export type BrowserSurfaceListener = (snapshot: BrowserSurfacePageState) => void;
 
+/** Listener invoked whenever a warm generation is materialized. */
+export type BrowserSurfaceMaterializedListener = (
+  identity: BrowserSurfaceIdentity,
+  generation: number,
+) => void;
+
 const MAX_ADDRESS = BROWSER_TAB_INFO_STRING_MAX.url;
 const MAX_TITLE = BROWSER_TAB_INFO_STRING_MAX.title;
 const MAX_FAVICON = BROWSER_TAB_INFO_STRING_MAX.faviconUrl;
@@ -256,6 +262,7 @@ function sameStateValue(left: unknown, right: unknown): boolean {
  */
 export class BrowserSurfaceHost {
   private readonly records = new Map<string, SurfaceRecord>();
+  private readonly materializedListeners = new Set<BrowserSurfaceMaterializedListener>();
   private readonly scheduling: BrowserSurfaceScheduling;
   private readonly visibility: BrowserSurfaceVisibility;
   private readonly normalizeAddress: (address: string) => string;
@@ -317,6 +324,7 @@ export class BrowserSurfaceHost {
     };
     this.records.set(key, record);
     record.stopAdapter = adapter.subscribe((event) => this.handleEvent(event));
+    for (const listener of [...this.materializedListeners]) listener(identity, generation);
     adapter.create?.();
     if (address !== undefined) void adapter.navigate(address);
     if (record.publicationPending) this.schedulePublication(record);
@@ -381,6 +389,7 @@ export class BrowserSurfaceHost {
     const record = this.records.get(surfaceKey(event.identity));
     if (!record || record.disposed || record.generation !== event.generation || !sameIdentity(record.identity, event.identity)) return;
     if (event.type === "surface-lost") {
+      if (!record.state) return;
       this.handleUnexpectedLoss(record);
       return;
     }
@@ -411,6 +420,12 @@ export class BrowserSurfaceHost {
     if (!record || !sameIdentity(record.identity, identity)) return () => undefined;
     record.listeners.add(listener);
     return () => record.listeners.delete(listener);
+  }
+
+  /** Subscribes to warm generation materialization across this host. */
+  public subscribeMaterialized(listener: BrowserSurfaceMaterializedListener): () => void {
+    this.materializedListeners.add(listener);
+    return () => this.materializedListeners.delete(listener);
   }
 
   /** Discards one unprotected warm generation and retains bounded recovery metadata. */
@@ -474,6 +489,7 @@ export class BrowserSurfaceHost {
   public disposeHost(): void {
     this.stopVisibility();
     this.disposeAll();
+    this.materializedListeners.clear();
   }
 
   /** Disposes every surface while retaining host-level visibility resources. */

--- a/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
+++ b/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
@@ -63,6 +63,7 @@ export type BrowserSurfaceAdapterEvent = BrowserSurfaceAdapterEventBase & (
   | { readonly type: "favicon-updated"; readonly favicon: string | null }
   | { readonly type: "navigation-state"; readonly navigation: BrowserSurfaceNavigationState | null }
   | { readonly type: "document-access"; readonly access: BrowserSurfaceDocumentAccess }
+  | { readonly type: "surface-lost" }
 );
 
 /** Event payload accepted by adapter test doubles before identity is attached. */
@@ -85,8 +86,11 @@ export interface BrowserSurfaceAdapter {
   /** Subscribes to semantic adapter events. */
   subscribe(listener: (event: BrowserSurfaceAdapterEvent) => void): () => void;
   /** Releases the adapter's resource and listeners. */
-  dispose(): void;
+  dispose(reason?: BrowserSurfaceDisposalReason): void;
 }
+
+/** Why a generation-bound adapter stopped owning its surface. */
+export type BrowserSurfaceDisposalReason = "discard" | "replace" | "dispose" | "loss";
 
 /** Bounded viewport placement supplied by the root host for presentation. */
 export interface BrowserSurfacePresentation {
@@ -129,6 +133,16 @@ export interface BrowserSurfaceHostOptions {
 export interface BrowserSurfaceCreateOptions {
   readonly address?: string;
   readonly generation?: number;
+}
+
+/** Bounded lifecycle metadata retained while a Browser tab is cold. */
+export interface BrowserSurfaceMetadata {
+  readonly identity: BrowserSurfaceIdentity;
+  readonly residency: "warm" | "cold";
+  readonly generation: number;
+  readonly recoveryAddress: string | null;
+  readonly title: string;
+  readonly favicon: string | null;
 }
 
 /** Listener invoked when a generation's canonical state is published. */
@@ -184,16 +198,21 @@ function defaultVisibility(): BrowserSurfaceVisibility {
   };
 }
 
-function initialPageState(identity: BrowserSurfaceIdentity, generation: number, address?: string): BrowserSurfacePageState {
+function initialPageState(
+  identity: BrowserSurfaceIdentity,
+  generation: number,
+  address?: string,
+  metadata?: Pick<BrowserSurfaceMetadata, "recoveryAddress" | "title" | "favicon">,
+): BrowserSurfacePageState {
   const pendingAddress = boundString(address, MAX_ADDRESS);
   return {
     identity,
     generation,
     pendingAddress,
     committedAddress: null,
-    recoveryAddress: null,
-    title: "",
-    favicon: null,
+    recoveryAddress: metadata?.recoveryAddress ?? pendingAddress,
+    title: metadata?.title ?? "",
+    favicon: metadata?.favicon ?? null,
     phase: "loading",
     mainFrameError: null,
     navigation: null,
@@ -268,33 +287,49 @@ export class BrowserSurfaceHost {
       ? undefined
       : this.normalizeAddress(options.address);
     const generation = options.generation ?? (prior ? prior.generation + 1 : this.nextGeneration++);
-    if (prior && options.generation !== undefined && generation <= prior.generation) return prior.state;
+    if (prior && options.generation !== undefined && generation <= prior.generation) {
+      if (prior.state) return prior.state;
+      throw new RangeError("Cannot create a Browser surface from a retired generation");
+    }
     if (generation >= this.nextGeneration) this.nextGeneration = generation + 1;
+    const retainedMetadata = prior ? this.metadataFor(prior) : undefined;
     if (prior) this.disposeRecord(key, prior, false);
     const adapter = this.adapterFactory(identity, generation);
+    const state = initialPageState(identity, generation, address, retainedMetadata);
     const record: SurfaceRecord = {
       identity,
       generation,
       adapter,
-      state: initialPageState(identity, generation, address),
+      state,
+      recoveryAddress: state.recoveryAddress,
+      title: retainedMetadata?.title ?? "",
+      favicon: retainedMetadata?.favicon ?? null,
       listeners: prior?.listeners ?? new Set(),
       stopAdapter: () => undefined,
       frameHandle: null,
       publicationPending: prior !== undefined,
       disposed: false,
+      visible: prior?.visible ?? false,
+      controlled: prior?.controlled ?? false,
+      operationPins: 0,
+      capturePins: 0,
+      presentation: prior?.presentation ?? null,
     };
     this.records.set(key, record);
     record.stopAdapter = adapter.subscribe((event) => this.handleEvent(event));
     adapter.create?.();
     if (address !== undefined) void adapter.navigate(address);
     if (record.publicationPending) this.schedulePublication(record);
-    return record.state;
+    return state;
   }
 
   /** Returns an identity's warm surface, or creates it when it does not exist. */
   public ensure(identity: BrowserSurfaceIdentity, options: BrowserSurfaceCreateOptions = {}): BrowserSurfacePageState {
     const current = this.records.get(surfaceKey(identity));
-    if (current && sameIdentity(current.identity, identity)) return current.state;
+    if (current && sameIdentity(current.identity, identity)) {
+      if (current.state) return current.state;
+      return this.rewarmRecord(current, options.address);
+    }
     return this.create(identity, options);
   }
 
@@ -307,23 +342,33 @@ export class BrowserSurfaceHost {
   }): void {
     const record = this.records.get(surfaceKey(identity));
     if (!record || !sameIdentity(record.identity, identity)) return;
-    record.adapter.present(boundPresentation(presentation));
+    const bounded = boundPresentation(presentation);
+    const state = record.state ?? this.rewarmRecord(record);
+    const current = this.records.get(surfaceKey(identity));
+    if (!current || current.state !== state || !current.adapter) return;
+    current.visible = true;
+    current.presentation = bounded;
+    current.adapter.present(bounded);
   }
 
   /** Hides an identity's current surface while retaining the live adapter. */
   public hide(identity: BrowserSurfaceIdentity): void {
     const record = this.records.get(surfaceKey(identity));
     if (!record || !sameIdentity(record.identity, identity)) return;
-    record.adapter.hide();
+    record.visible = false;
+    record.adapter?.hide();
   }
 
   /** Requests navigation and synchronously enters the loading phase. */
   public navigate(identity: BrowserSurfaceIdentity, address: string): void {
     const record = this.records.get(surfaceKey(identity));
     if (!record || !sameIdentity(record.identity, identity)) return;
+    if (!record.state) this.rewarmRecord(record, address);
+    const current = this.records.get(surfaceKey(identity));
+    if (!current?.state || !current.adapter) return;
     const normalized = this.normalizeAddress(address);
-    this.reduce(record, { type: "navigation-started", identity, generation: record.generation, mainFrame: true, address: normalized });
-    void record.adapter.navigate(normalized);
+    this.reduce(current, { type: "navigation-started", identity, generation: current.generation, mainFrame: true, address: normalized });
+    void current.adapter.navigate(normalized);
   }
 
   /** Alias for callers that name the operation as a navigation request. */
@@ -335,12 +380,29 @@ export class BrowserSurfaceHost {
   public handleEvent(event: BrowserSurfaceAdapterEvent): void {
     const record = this.records.get(surfaceKey(event.identity));
     if (!record || record.disposed || record.generation !== event.generation || !sameIdentity(record.identity, event.identity)) return;
+    if (event.type === "surface-lost") {
+      this.handleUnexpectedLoss(record);
+      return;
+    }
+    if (!record.state) return;
     this.reduce(record, event);
   }
 
   /** Reads the current canonical snapshot for one identity. */
   public getSnapshot(identity: BrowserSurfaceIdentity): BrowserSurfacePageState | null {
     return this.records.get(surfaceKey(identity))?.state ?? null;
+  }
+
+  /** Reads warm or cold metadata without materializing a cold surface. */
+  public inspect(identity: BrowserSurfaceIdentity): BrowserSurfaceMetadata | null {
+    const record = this.records.get(surfaceKey(identity));
+    if (!record || !sameIdentity(record.identity, identity)) return null;
+    return {
+      identity: record.identity,
+      residency: record.state ? "warm" : "cold",
+      generation: record.generation,
+      ...this.metadataFor(record),
+    };
   }
 
   /** Subscribes to one identity; listeners never receive another identity's state. */
@@ -351,12 +413,61 @@ export class BrowserSurfaceHost {
     return () => record.listeners.delete(listener);
   }
 
+  /** Discards one unprotected warm generation and retains bounded recovery metadata. */
+  public discard(identity: BrowserSurfaceIdentity, expectedGeneration?: number): boolean {
+    const record = this.records.get(surfaceKey(identity));
+    if (
+      !record ||
+      !record.state ||
+      !sameIdentity(record.identity, identity) ||
+      expectedGeneration !== undefined && record.generation !== expectedGeneration ||
+      this.isProtected(record)
+    ) return false;
+    this.retireToCold(record);
+    return true;
+  }
+
+  /** Changes agent-control protection without changing residency or generation. */
+  public setControlled(identity: BrowserSurfaceIdentity, controlled: boolean): void {
+    const record = this.records.get(surfaceKey(identity));
+    if (!record || !sameIdentity(record.identity, identity)) return;
+    record.controlled = controlled;
+  }
+
+  /** Pins a generation while an automation operation is in flight. */
+  public pinOperation(identity: BrowserSurfaceIdentity, generation: number): () => void {
+    return this.pin(identity, generation, "operationPins");
+  }
+
+  /** Pins a generation while capture is in flight. */
+  public pinCapture(identity: BrowserSurfaceIdentity, generation: number): () => void {
+    return this.pin(identity, generation, "capturePins");
+  }
+
   /** Disposes an identity and cancels any queued publication for its generation. */
   public dispose(identity: BrowserSurfaceIdentity): void {
     const key = surfaceKey(identity);
     const record = this.records.get(key);
     if (!record || !sameIdentity(record.identity, identity)) return;
     this.disposeRecord(key, record, true);
+  }
+
+  /** Disposes every surface in one exact workspace-qualified scope. */
+  public disposeScope(workspaceId: string, scope: BrowserSurfaceIdentity["scope"]): void {
+    for (const [key, record] of this.records) {
+      if (
+        record.identity.workspaceId === workspaceId &&
+        record.identity.scope.kind === scope.kind &&
+        record.identity.scope.id === scope.id
+      ) this.disposeRecord(key, record, true);
+    }
+  }
+
+  /** Disposes every surface owned by one workspace. */
+  public disposeWorkspace(workspaceId: string): void {
+    for (const [key, record] of this.records) {
+      if (record.identity.workspaceId === workspaceId) this.disposeRecord(key, record, true);
+    }
   }
 
   /** Stops host visibility and disposes every registered surface. */
@@ -376,16 +487,22 @@ export class BrowserSurfaceHost {
     record.frameHandle = null;
     record.publicationPending = false;
     record.stopAdapter();
-    record.adapter.dispose();
+    record.adapter?.dispose(remove ? "dispose" : "replace");
+    record.adapter = null;
+    record.state = null;
     if (remove) record.listeners.clear();
     if (remove && this.records.get(key) === record) this.records.delete(key);
   }
 
   private reduce(record: SurfaceRecord, event: BrowserSurfaceAdapterEvent): void {
     const previous = record.state;
+    if (!previous || event.type === "surface-lost") return;
     const next = this.nextState(previous, event);
     if (next === previous) return;
     record.state = next;
+    record.recoveryAddress = next.recoveryAddress;
+    record.title = next.title;
+    record.favicon = next.favicon;
     record.publicationPending = true;
     this.schedulePublication(record);
   }
@@ -438,6 +555,8 @@ export class BrowserSurfaceHost {
         return this.mergeState(state, { navigation: event.navigation });
       case "document-access":
         return this.mergeState(state, { documentAccess: event.access });
+      case "surface-lost":
+        return state;
     }
   }
 
@@ -455,12 +574,13 @@ export class BrowserSurfaceHost {
   }
 
   private schedulePublication(record: SurfaceRecord): void {
-    if (record.frameHandle !== null || this.visibility.isHidden()) return;
+    if (!record.state || record.frameHandle !== null || this.visibility.isHidden()) return;
     record.frameHandle = this.scheduling.requestAnimationFrame(() => {
       record.frameHandle = null;
       if (record.disposed || this.visibility.isHidden()) return;
       if (!record.publicationPending) return;
       record.publicationPending = false;
+      if (!record.state) return;
       for (const listener of [...record.listeners]) listener(record.state);
     });
   }
@@ -472,16 +592,90 @@ export class BrowserSurfaceHost {
       this.schedulePublication(record);
     }
   }
+
+  private metadataFor(record: SurfaceRecord): Pick<BrowserSurfaceMetadata, "recoveryAddress" | "title" | "favicon"> {
+    return {
+      recoveryAddress: record.state?.recoveryAddress ?? record.recoveryAddress,
+      title: record.state?.title ?? record.title,
+      favicon: record.state?.favicon ?? record.favicon,
+    };
+  }
+
+  private isProtected(record: SurfaceRecord): boolean {
+    return record.visible || record.controlled || record.operationPins > 0 || record.capturePins > 0;
+  }
+
+  private retireToCold(record: SurfaceRecord, reason: BrowserSurfaceDisposalReason = "discard"): void {
+    const metadata = this.metadataFor(record);
+    record.recoveryAddress = metadata.recoveryAddress;
+    record.title = metadata.title;
+    record.favicon = metadata.favicon;
+    record.visible = false;
+    record.presentation = null;
+    if (record.frameHandle !== null) this.scheduling.cancelAnimationFrame(record.frameHandle);
+    record.frameHandle = null;
+    record.publicationPending = false;
+    record.stopAdapter();
+    record.stopAdapter = () => undefined;
+    record.adapter?.dispose(reason);
+    record.adapter = null;
+    record.state = null;
+  }
+
+  private rewarmRecord(record: SurfaceRecord, requestedAddress?: string): BrowserSurfacePageState {
+    const recoveryAddress = requestedAddress ?? record.recoveryAddress ?? undefined;
+    return this.create(record.identity, {
+      generation: record.generation + 1,
+      ...(recoveryAddress === undefined ? {} : { address: recoveryAddress }),
+    });
+  }
+
+  private handleUnexpectedLoss(record: SurfaceRecord): void {
+    const shouldRestore = this.isProtected(record);
+    const presentation = record.presentation;
+    this.retireToCold(record, "loss");
+    if (!shouldRestore) return;
+    this.rewarmRecord(record);
+    if (presentation) this.present(record.identity, presentation);
+  }
+
+  private pin(
+    identity: BrowserSurfaceIdentity,
+    generation: number,
+    field: "operationPins" | "capturePins",
+  ): () => void {
+    const record = this.records.get(surfaceKey(identity));
+    if (!record || !record.state || record.generation !== generation || !sameIdentity(record.identity, identity)) {
+      return () => undefined;
+    }
+    record[field] += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const current = this.records.get(surfaceKey(identity));
+      if (current !== record) return;
+      current[field] = Math.max(0, current[field] - 1);
+    };
+  }
 }
 
 interface SurfaceRecord {
   readonly identity: BrowserSurfaceIdentity;
   readonly generation: number;
-  readonly adapter: BrowserSurfaceAdapter;
+  adapter: BrowserSurfaceAdapter | null;
   readonly listeners: Set<BrowserSurfaceListener>;
-  state: BrowserSurfacePageState;
+  state: BrowserSurfacePageState | null;
+  recoveryAddress: string | null;
+  title: string;
+  favicon: string | null;
   stopAdapter: () => void;
   frameHandle: number | null;
   publicationPending: boolean;
   disposed: boolean;
+  visible: boolean;
+  controlled: boolean;
+  operationPins: number;
+  capturePins: number;
+  presentation: BrowserSurfacePresentation | null;
 }

--- a/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
+++ b/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
@@ -327,6 +327,7 @@ export class BrowserSurfaceHost {
     for (const listener of [...this.materializedListeners]) listener(identity, generation);
     adapter.create?.();
     if (address !== undefined) void adapter.navigate(address);
+    if (record.visible && record.presentation) adapter.present(record.presentation);
     if (record.publicationPending) this.schedulePublication(record);
     return state;
   }
@@ -371,7 +372,10 @@ export class BrowserSurfaceHost {
   public navigate(identity: BrowserSurfaceIdentity, address: string): void {
     const record = this.records.get(surfaceKey(identity));
     if (!record || !sameIdentity(record.identity, identity)) return;
-    if (!record.state) this.rewarmRecord(record, address);
+    if (!record.state) {
+      this.rewarmRecord(record, address);
+      return;
+    }
     const current = this.records.get(surfaceKey(identity));
     if (!current?.state || !current.adapter) return;
     const normalized = this.normalizeAddress(address);

--- a/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
+++ b/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
@@ -10,6 +10,7 @@ import type {
   BrowserSurfaceAdapterEvent,
   BrowserSurfaceAdapterEventPayload,
   BrowserSurfaceAdapterFactory,
+  BrowserSurfaceDisposalReason,
   BrowserSurfaceIdentity,
   BrowserSurfacePresentation,
 } from "./BrowserSurfaceHost";
@@ -161,6 +162,7 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
     this.frame.addEventListener("page-favicon-updated", this.onFaviconUpdated);
     this.frame.addEventListener("dom-ready", this.onDomReady);
     this.frame.addEventListener("ipc-message", this.onIpcMessage);
+    this.frame.addEventListener("render-process-gone", this.onRenderProcessGone);
     this.preparePromise = Promise.resolve(this.bridge.prepare({
       surface: this.surface,
       adoptionToken: this.adoptionToken,
@@ -222,7 +224,7 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
   }
 
   /** Removes native listeners, releases the exact surface generation, and detaches the webview. */
-  public dispose(): void {
+  public dispose(reason: BrowserSurfaceDisposalReason = "dispose"): void {
     if (this.disposed) return;
     this.disposed = true;
     this.resolveAdoptionWaiters(false);
@@ -236,8 +238,9 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
     this.frame.removeEventListener("page-favicon-updated", this.onFaviconUpdated);
     this.frame.removeEventListener("dom-ready", this.onDomReady);
     this.frame.removeEventListener("ipc-message", this.onIpcMessage);
+    this.frame.removeEventListener("render-process-gone", this.onRenderProcessGone);
     this.listeners.clear();
-    void Promise.resolve(this.bridge.release({ surface: this.surface })).catch(() => undefined);
+    void Promise.resolve(this.bridge.release({ surface: this.surface, reason })).catch(() => undefined);
     this.frame.remove();
   }
 
@@ -367,6 +370,10 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
     const kind = (message as { readonly kind?: unknown }).kind;
     if (typeof kind !== "string" || !HUMAN_INPUT_KINDS.has(kind)) return;
     this.onHumanInput?.(this.identity, this.generation);
+  };
+
+  private readonly onRenderProcessGone = (): void => {
+    this.emit({ type: "surface-lost" });
   };
 }
 

--- a/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
@@ -338,6 +338,27 @@ describe("BrowserSurfaceHost", () => {
     host.disposeHost();
   });
 
+  it("ignores a late loss event after a generation is already cold", () => {
+    const adapters: TestAdapter[] = [];
+    const host = new BrowserSurfaceHost({
+      adapterFactory: () => {
+        const adapter = new TestAdapter();
+        adapters.push(adapter);
+        return adapter;
+      },
+    });
+    const first = host.create(IDENTITY, { address: "https://example.test/recovery" });
+    expect(host.discard(IDENTITY, first.generation)).toBe(true);
+    host.setControlled(IDENTITY, true);
+
+    host.handleEvent({ type: "surface-lost", identity: IDENTITY, generation: first.generation });
+
+    expect(host.getSnapshot(IDENTITY)).toBeNull();
+    expect(host.inspect(IDENTITY)?.residency).toBe("cold");
+    expect(adapters).toHaveLength(1);
+    host.disposeHost();
+  });
+
   it("changes control ownership without changing the surface or generation", () => {
     const { host, adapter } = testHost();
     const snapshot = host.getSnapshot(IDENTITY)!;

--- a/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
@@ -245,6 +245,43 @@ describe("BrowserSurfaceHost", () => {
     host.disposeHost();
   });
 
+  it("restores presentation when a visible surface generation is replaced", () => {
+    const adapters: TestAdapter[] = [];
+    const host = new BrowserSurfaceHost({
+      adapterFactory: () => {
+        const adapter = new TestAdapter();
+        adapters.push(adapter);
+        return adapter;
+      },
+    });
+    host.create(IDENTITY);
+    host.present(IDENTITY, { left: 10, top: 20, width: 640, height: 480 });
+
+    host.create(IDENTITY);
+
+    expect(adapters).toHaveLength(2);
+    expect(adapters[1]?.presented).toBe(1);
+    host.disposeHost();
+  });
+
+  it("navigates only once when navigation re-warms a cold surface", () => {
+    const adapters: TestAdapter[] = [];
+    const host = new BrowserSurfaceHost({
+      adapterFactory: () => {
+        const adapter = new TestAdapter();
+        adapters.push(adapter);
+        return adapter;
+      },
+    });
+    const first = host.create(IDENTITY, { address: "https://example.test/start" });
+    expect(host.discard(IDENTITY, first.generation)).toBe(true);
+
+    host.navigate(IDENTITY, "https://example.test/next");
+
+    expect(adapters[1]?.navigations).toEqual(["https://example.test/next"]);
+    host.disposeHost();
+  });
+
   it("discards to bounded cold metadata and re-warms the recovery address in a new generation", () => {
     const adapters: TestAdapter[] = [];
     const host = new BrowserSurfaceHost({

--- a/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
@@ -244,4 +244,144 @@ describe("BrowserSurfaceHost", () => {
     expect(host.getSnapshot(IDENTITY)?.generation).toBe(4);
     host.disposeHost();
   });
+
+  it("discards to bounded cold metadata and re-warms the recovery address in a new generation", () => {
+    const adapters: TestAdapter[] = [];
+    const host = new BrowserSurfaceHost({
+      adapterFactory: () => {
+        const adapter = new TestAdapter();
+        adapters.push(adapter);
+        return adapter;
+      },
+    });
+    const first = host.create(IDENTITY, { address: "https://example.test/start" });
+    adapters[0]!.emit({
+      type: "navigation-committed",
+      mainFrame: true,
+      address: "https://example.test/recovery",
+    });
+    adapters[0]!.emit({ type: "title-updated", title: "Recovery title" });
+    adapters[0]!.emit({ type: "favicon-updated", favicon: "https://example.test/icon.png" });
+
+    expect(host.discard(IDENTITY, first.generation)).toBe(true);
+    expect(adapters[0]!.disposed).toBe(1);
+    expect(host.getSnapshot(IDENTITY)).toBeNull();
+    expect(host.inspect(IDENTITY)).toEqual({
+      identity: IDENTITY,
+      residency: "cold",
+      generation: first.generation,
+      recoveryAddress: "https://example.test/recovery",
+      title: "Recovery title",
+      favicon: "https://example.test/icon.png",
+    });
+    expect(adapters).toHaveLength(1);
+
+    const rewarmed = host.ensure(IDENTITY);
+    expect(rewarmed.generation).toBe(first.generation + 1);
+    expect(rewarmed.pendingAddress).toBe("https://example.test/recovery");
+    expect(adapters).toHaveLength(2);
+    expect(adapters[1]!.navigations).toEqual(["https://example.test/recovery"]);
+    expect(host.inspect(IDENTITY)?.residency).toBe("warm");
+    host.disposeHost();
+  });
+
+  it("protects visible, controlled, operation-pinned, and capture-pinned surfaces from discard", () => {
+    const { host } = testHost();
+    const generation = host.getSnapshot(IDENTITY)!.generation;
+
+    host.present(IDENTITY);
+    expect(host.discard(IDENTITY, generation)).toBe(false);
+    host.hide(IDENTITY);
+
+    host.setControlled(IDENTITY, true);
+    expect(host.discard(IDENTITY, generation)).toBe(false);
+    host.setControlled(IDENTITY, false);
+
+    const releaseOperation = host.pinOperation(IDENTITY, generation);
+    expect(host.discard(IDENTITY, generation)).toBe(false);
+    releaseOperation();
+
+    const releaseCapture = host.pinCapture(IDENTITY, generation);
+    expect(host.discard(IDENTITY, generation)).toBe(false);
+    releaseCapture();
+
+    expect(host.discard(IDENTITY, generation)).toBe(true);
+    host.disposeHost();
+  });
+
+  it("restores a protected unexpected loss and leaves an inactive loss cold", () => {
+    const adapters: TestAdapter[] = [];
+    const host = new BrowserSurfaceHost({
+      adapterFactory: () => {
+        const adapter = new TestAdapter();
+        adapters.push(adapter);
+        return adapter;
+      },
+    });
+    const first = host.create(IDENTITY, { address: "https://example.test/start" });
+    adapters[0]!.emit({
+      type: "navigation-committed",
+      mainFrame: true,
+      address: "https://example.test/recovery",
+    });
+    host.setControlled(IDENTITY, true);
+
+    adapters[0]!.emit({ type: "surface-lost" });
+
+    expect(host.getSnapshot(IDENTITY)?.generation).toBe(first.generation + 1);
+    expect(adapters[1]!.navigations).toEqual(["https://example.test/recovery"]);
+    host.setControlled(IDENTITY, false);
+    adapters[1]!.emit({ type: "surface-lost" }, IDENTITY, first.generation + 1);
+    expect(host.getSnapshot(IDENTITY)).toBeNull();
+    expect(host.inspect(IDENTITY)?.residency).toBe("cold");
+    expect(adapters).toHaveLength(2);
+    host.disposeHost();
+  });
+
+  it("changes control ownership without changing the surface or generation", () => {
+    const { host, adapter } = testHost();
+    const snapshot = host.getSnapshot(IDENTITY)!;
+
+    host.setControlled(IDENTITY, true);
+    host.setControlled(IDENTITY, false);
+
+    expect(host.getSnapshot(IDENTITY)).toBe(snapshot);
+    expect(adapter.disposed).toBe(0);
+    host.disposeHost();
+  });
+
+  it("disposes exact scopes and workspaces without allowing late resurrection", () => {
+    const adapters: TestAdapter[] = [];
+    const host = new BrowserSurfaceHost({
+      adapterFactory: () => {
+        const adapter = new TestAdapter();
+        adapters.push(adapter);
+        return adapter;
+      },
+    });
+    const sibling: BrowserSurfaceIdentity = {
+      workspaceId: IDENTITY.workspaceId,
+      scope: { kind: "thread", id: "thread-b" },
+      tabId: "tab-b",
+    };
+    const otherWorkspace: BrowserSurfaceIdentity = {
+      workspaceId: "workspace-b",
+      scope: { kind: "thread", id: "thread-c" },
+      tabId: "tab-c",
+    };
+    host.create(IDENTITY);
+    host.create(sibling);
+    host.create(otherWorkspace);
+
+    host.disposeScope(IDENTITY.workspaceId, IDENTITY.scope);
+    adapters[0]!.emit({ type: "surface-lost" });
+    expect(host.inspect(IDENTITY)).toBeNull();
+    expect(host.getSnapshot(sibling)).not.toBeNull();
+
+    host.disposeWorkspace(IDENTITY.workspaceId);
+    expect(host.inspect(sibling)).toBeNull();
+    expect(host.getSnapshot(otherWorkspace)).not.toBeNull();
+    host.disposeHost();
+    expect(host.inspect(otherWorkspace)).toBeNull();
+  });
 });

--- a/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
@@ -28,6 +28,7 @@ function bridge(): PreviewSurfaceBridge & {
     navigate: vi.fn().mockResolvedValue({ ok: true }),
     release: vi.fn().mockResolvedValue({ ok: true }),
     onPopupRequested: vi.fn(() => () => undefined),
+    onDiscardRequested: vi.fn(() => () => undefined),
   };
 }
 
@@ -99,14 +100,19 @@ describe("ElectronWebviewBrowserSurfaceAdapter", () => {
     }));
     adapter.element.dispatchEvent(Object.assign(new Event("page-title-updated"), { title: "Example" }));
     adapter.element.dispatchEvent(Object.assign(new Event("page-favicon-updated"), { favicons: ["https://example.test/icon.png"] }));
+    adapter.element.dispatchEvent(new Event("render-process-gone"));
     expect(events).toEqual(expect.arrayContaining([
       expect.objectContaining({ type: "load-started", identity: IDENTITY, generation: 3 }),
       expect.objectContaining({ type: "navigation-committed", address: "https://example.test/loaded", identity: IDENTITY, generation: 3 }),
       expect.objectContaining({ type: "title-updated", title: "Example", identity: IDENTITY, generation: 3 }),
       expect.objectContaining({ type: "favicon-updated", favicon: "https://example.test/icon.png", identity: IDENTITY, generation: 3 }),
+      expect.objectContaining({ type: "surface-lost", identity: IDENTITY, generation: 3 }),
     ]));
     adapter.dispose();
-    expect(surfaceBridge.release).toHaveBeenCalledWith({ surface: { identity: IDENTITY, generation: 3 } });
+    expect(surfaceBridge.release).toHaveBeenCalledWith({
+      surface: { identity: IDENTITY, generation: 3 },
+      reason: "dispose",
+    });
     expect(document.body.contains(adapter.element)).toBe(false);
     expect(() => adapter.element.dispatchEvent(new Event("did-navigate"))).not.toThrow();
   });

--- a/apps/web/src/services/browser-surfaces/__tests__/browserSurfaceContract.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/browserSurfaceContract.ts
@@ -47,5 +47,19 @@ export function runBrowserSurfaceContract(name: string, adapterFactory: BrowserS
       expect(host.getSnapshot(IDENTITY)).toBe(snapshot);
       host.disposeHost();
     });
+
+    it("discards and re-warms through a new adapter generation", () => {
+      const host = new BrowserSurfaceHost({ adapterFactory });
+      const first = host.create(IDENTITY, { address: "https://example.test/recovery" });
+      expect(host.discard(IDENTITY, first.generation)).toBe(true);
+      expect(host.getSnapshot(IDENTITY)).toBeNull();
+      expect(host.inspect(IDENTITY)?.residency).toBe("cold");
+
+      const second = host.ensure(IDENTITY);
+      expect(second.generation).toBe(first.generation + 1);
+      expect(second.pendingAddress).toBe("https://example.test/recovery");
+      expect(host.inspect(IDENTITY)?.residency).toBe("warm");
+      host.disposeHost();
+    });
   });
 }

--- a/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
+++ b/apps/web/src/stores/__tests__/browserAutomationStore.test.ts
@@ -5,6 +5,8 @@ import {
   browserAutomationRequestKey,
   browserAutomationScopeKey,
   browserAutomationTargetKey,
+  parseBrowserAutomationScopeKey,
+  parseBrowserAutomationTargetKey,
   onBrowserAutomationScopeRelease,
   invalidateBrowserAutomationTargetObservation,
   onBrowserAutomationObservationInvalidation,
@@ -109,6 +111,21 @@ describe("browser automation renderer scope", () => {
     expect(browserAutomationRequestKey("request\u00001", 2)).not.toBe(
       browserAutomationRequestKey("request", 12),
     );
+  });
+
+  it("decodes only valid scope and target tuple keys", () => {
+    expect(parseBrowserAutomationScopeKey(browserAutomationScopeKey("workspace-a", "thread-a"))).toEqual({
+      workspaceId: "workspace-a",
+      scopeId: "thread-a",
+    });
+    expect(parseBrowserAutomationTargetKey(browserAutomationTargetKey("workspace-a", "thread-a", "tab-a"))).toEqual({
+      workspaceId: "workspace-a",
+      threadId: "thread-a",
+      tabId: "tab-a",
+    });
+    expect(parseBrowserAutomationScopeKey('["workspace-a"]')).toBeNull();
+    expect(parseBrowserAutomationTargetKey('["workspace-a","thread-a",1]')).toBeNull();
+    expect(parseBrowserAutomationTargetKey("not-json")).toBeNull();
   });
 
   it("does not resolve a controller event when duplicate tab ids span threads", () => {

--- a/apps/web/src/stores/browserAutomationStore.ts
+++ b/apps/web/src/stores/browserAutomationStore.ts
@@ -110,9 +110,43 @@ export function browserAutomationTargetKey(workspaceId: string, threadId: string
   return JSON.stringify([workspaceId, threadId, tabId]);
 }
 
+/** Decodes one exact renderer-owned Browser tab key. */
+export function parseBrowserAutomationTargetKey(
+  value: string,
+): { workspaceId: string; threadId: string; tabId: string } | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length !== 3 ||
+      parsed.some((item) => typeof item !== "string")
+    ) return null;
+    return { workspaceId: parsed[0], threadId: parsed[1], tabId: parsed[2] };
+  } catch {
+    return null;
+  }
+}
+
 /** Stable key for one workspace and Browser scope lease. */
 export function browserAutomationScopeKey(workspaceId: string, scopeId: string): string {
   return JSON.stringify([workspaceId, scopeId]);
+}
+
+/** Decodes one workspace-qualified Browser scope key. */
+export function parseBrowserAutomationScopeKey(
+  value: string,
+): { workspaceId: string; scopeId: string } | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length !== 2 ||
+      parsed.some((item) => typeof item !== "string")
+    ) return null;
+    return { workspaceId: parsed[0], scopeId: parsed[1] };
+  } catch {
+    return null;
+  }
 }
 
 /** Stable key for one lifecycle-backed tab across workspace and thread scopes. */

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -120,6 +120,9 @@ export interface PreviewSurfaceRef {
   readonly generation: number;
 }
 
+/** Exact renderer surface selected for a Memory Saver discard request. */
+export type PreviewSurfaceDiscardRequest = PreviewSurfaceRef;
+
 /** Opener-free popup request for one exact Browser surface generation. */
 export interface PreviewPopupRequest {
   readonly sourceSurface: PreviewSurfaceRef;
@@ -168,7 +171,7 @@ export interface PreviewSurfaceBridge {
   /** Subscribe to popup requests that Electron main denied and mediated. */
   onPopupRequested(callback: (request: PreviewPopupRequest) => void): () => void;
   /** Subscribe to exact-generation Memory Saver discard requests. */
-  onDiscardRequested(callback: (request: PreviewSurfaceRef) => void): () => void;
+  onDiscardRequested(callback: (request: PreviewSurfaceDiscardRequest) => void): () => void;
 }
 
 /**

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -156,7 +156,10 @@ export interface PreviewSurfaceBridge {
     readonly initialAddress?: string;
   }): Promise<PreviewSurfaceBridgeResult>;
   /** Releases one exact surface generation. */
-  release(payload: { readonly surface: PreviewSurfaceRef }): Promise<PreviewSurfaceBridgeResult>;
+  release(payload: {
+    readonly surface: PreviewSurfaceRef;
+    readonly reason: "discard" | "replace" | "dispose" | "loss";
+  }): Promise<PreviewSurfaceBridgeResult>;
   /** Executes one validated navigation operation against one exact surface generation. */
   navigate(payload: {
     readonly surface: PreviewSurfaceRef;
@@ -164,6 +167,8 @@ export interface PreviewSurfaceBridge {
   }): Promise<PreviewSurfaceBridgeResult>;
   /** Subscribe to popup requests that Electron main denied and mediated. */
   onPopupRequested(callback: (request: PreviewPopupRequest) => void): () => void;
+  /** Subscribe to exact-generation Memory Saver discard requests. */
+  onDiscardRequested(callback: (request: PreviewSurfaceRef) => void): () => void;
 }
 
 /**


### PR DESCRIPTION
## What

Add the complete lifecycle for hosted Browser surfaces. Warm surfaces can become cold, re-warm with a new generation, recover from guest loss, and release their resources.

## Why

Persistent hosted surfaces need bounded memory use without loss of tab identity, ownership, or the last allowed recovery address.

## Key Changes

- Connect renderer-owned surfaces to the existing Memory Saver policy.
- Protect visible, agent-controlled, operation-pinned, and capture-pinned surfaces from discard.
- Keep bounded metadata for cold tabs and re-warm them with a new guest generation.
- Reject stale generation events and dispose exact tab, scope, workspace, provider, and shutdown resources.
- Add focused lifecycle coverage and a live Playwright web check. The full repository gate passed.

Closes #1186

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788778292&installation_model_id=20477&pr_number=1198&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1198&signature=ff59230c7ec1e2d7b44f47a17ab6db0fac75053e6414c916be24d316efa5aee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Memory Saver support for browser preview surfaces, including generation-specific discard and recovery.
  * Discarded previews can be re-created while preserving their pending address and metadata.
  * Added protection for active automation and controlled surfaces during memory cleanup.
  * Added recovery when a browser surface unexpectedly loses its renderer.

* **Bug Fixes**
  * Improved cleanup when preview tabs, scopes, workspaces, or windows are removed.
  * Added explicit release reasons for safer surface lifecycle handling.

* **Tests**
  * Expanded coverage for discarding, rewarming, protection, recovery, and scoped disposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->