### PR TITLE
test(browser): prove BrowserSurfaceHost cutover

### DIFF
--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -2953,6 +2953,7 @@ export function PreviewPanel({
     return (
       <PreviewWebview
         key={tab.id}
+        active={tab.id === activeWebviewTabId}
         ref={(handle) => {
           webviewRefs.current[tab.id] = handle;
         }}

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -25,6 +25,7 @@ import {
 
 /** Properties for one hosted renderer Browser surface. */
 export interface PreviewWebviewProps {
+  readonly active?: boolean;
   readonly workspaceId?: string;
   readonly threadId: string;
   readonly tabId: string;
@@ -86,6 +87,7 @@ function supportedInitialAddress(address: string): string | undefined {
 export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewProps>(
   function PreviewWebview(
     {
+      active = true,
       threadId,
       workspaceId = threadId,
       tabId,
@@ -250,6 +252,10 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
     useLayoutEffect(() => {
       const placement = placementRef.current;
       if (!placement) return;
+      if (!active) {
+        browserSurfaceHost.hide(identity);
+        return;
+      }
       const update = (): void => {
         const bounds = placement.getBoundingClientRect();
         if (
@@ -280,7 +286,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         window.removeEventListener("resize", update);
         browserSurfaceHost.hide(identity);
       };
-    }, [identity, viewport]);
+    }, [active, identity, viewport]);
 
     return (
       <div

--- a/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserSurfaceHostRoot.test.tsx
@@ -1,11 +1,12 @@
 import { act, render, screen } from "@testing-library/react";
+import { Profiler, type ProfilerOnRenderCallback, useSyncExternalStore } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BrowserSurfaceHostRoot,
   browserSurfaceHost,
 } from "../BrowserSurfaceHostRoot";
 import type { BrowserSurfaceIdentity } from "@/services/browser-surfaces";
-import { usePreviewTabsStore } from "@/stores/previewTabsStore";
+import { previewTabsScopeKey, usePreviewTabsStore } from "@/stores/previewTabsStore";
 import { useBrowserAutomationStore } from "@/stores/browserAutomationStore";
 import type {
   PreviewPopupRequest,
@@ -18,11 +19,49 @@ const IDENTITY: BrowserSurfaceIdentity = {
   tabId: "web-preview",
 };
 
+const UNRELATED_IDENTITY: BrowserSurfaceIdentity = {
+  workspaceId: "workspace-1",
+  scope: { kind: "thread", id: "thread-2" },
+  tabId: "web-preview-other",
+};
+
+const UNRELATED_SCOPE_KEY = previewTabsScopeKey("workspace-1", "thread-2");
+
+function SurfaceSnapshotProbe({ identity }: { identity: BrowserSurfaceIdentity }) {
+  const subscribe = (listener: () => void): (() => void) =>
+    browserSurfaceHost.subscribe(identity, () => listener());
+  const getSnapshot = (): ReturnType<typeof browserSurfaceHost.getSnapshot> =>
+    browserSurfaceHost.getSnapshot(identity);
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, () => null);
+
+  return <output data-testid={`surface-title-${identity.tabId}`}>{snapshot?.title ?? ""}</output>;
+}
+
+function PanelStoreRerenderHarness() {
+  usePreviewTabsStore((state) => state.liveChromeByScope[UNRELATED_SCOPE_KEY]);
+  useBrowserAutomationStore((state) => state.status);
+  return <BrowserSurfaceHostRoot />;
+}
+
+async function flushSurfaceFrame(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      if (typeof window.requestAnimationFrame === "function") {
+        window.requestAnimationFrame(() => resolve());
+        return;
+      }
+      window.setTimeout(resolve, 0);
+    });
+  });
+}
+
 describe("BrowserSurfaceHostRoot", () => {
   const originalOpenPage = usePreviewTabsStore.getState().openPage;
+  const originalAutomationStatus = useBrowserAutomationStore.getState().status;
 
   afterEach(() => {
     browserSurfaceHost.dispose(IDENTITY);
+    browserSurfaceHost.dispose(UNRELATED_IDENTITY);
     usePreviewTabsStore.setState({
       openPage: originalOpenPage,
       tabSetByScope: {},
@@ -30,6 +69,7 @@ describe("BrowserSurfaceHostRoot", () => {
       persistentTabIdsByScope: {},
     });
     useBrowserAutomationStore.getState().releaseWorkspaceTargets("workspace-1");
+    useBrowserAutomationStore.getState().setStatus(originalAutomationStatus);
     delete window.desktopBridge;
   });
 
@@ -82,6 +122,107 @@ describe("BrowserSurfaceHostRoot", () => {
 
     view.unmount();
     expect(stopDiscardRequests).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the root host mounted across unrelated panel and store updates", () => {
+    const phases: Parameters<ProfilerOnRenderCallback>[1][] = [];
+    const view = render(
+      <Profiler id="browser-surface-host-root" onRender={(_id, phase) => phases.push(phase)}>
+        <PanelStoreRerenderHarness />
+      </Profiler>,
+    );
+    const rootBefore = document.querySelector("[data-browser-surface-host]");
+    expect(rootBefore).not.toBeNull();
+
+    act(() => {
+      usePreviewTabsStore.getState().setLiveChrome("workspace-1", "thread-2", {
+        title: "Unrelated panel update",
+        url: "https://other.example.test",
+        favicon: null,
+      });
+      useBrowserAutomationStore.getState().setStatus("registered");
+    });
+
+    expect(document.querySelector("[data-browser-surface-host]")).toBe(rootBefore);
+    expect(phases.filter((phase) => phase === "mount")).toHaveLength(1);
+    view.unmount();
+  });
+
+  it("does not commit for a semantic no-op surface event", async () => {
+    browserSurfaceHost.create(IDENTITY, { address: "https://example.test/profiler-no-op" });
+    await flushSurfaceFrame();
+    const commits: Parameters<ProfilerOnRenderCallback>[1][] = [];
+    const view = render(
+      <Profiler id="observed-surface" onRender={(_id, phase) => commits.push(phase)}>
+        <SurfaceSnapshotProbe identity={IDENTITY} />
+      </Profiler>,
+    );
+
+    act(() => browserSurfaceHost.handleEvent({
+      type: "title-updated",
+      identity: IDENTITY,
+      generation: browserSurfaceHost.getSnapshot(IDENTITY)!.generation,
+      title: "",
+    }));
+    await flushSurfaceFrame();
+
+    expect(screen.getByTestId("surface-title-web-preview")).toHaveTextContent("");
+    expect(commits).toEqual(["mount"]);
+    view.unmount();
+  });
+
+  it("publishes changed surface state at most once per frame", async () => {
+    browserSurfaceHost.create(IDENTITY, { address: "https://example.test/profiler-frame" });
+    await flushSurfaceFrame();
+    const commits: Parameters<ProfilerOnRenderCallback>[1][] = [];
+    const view = render(
+      <Profiler id="observed-surface" onRender={(_id, phase) => commits.push(phase)}>
+        <SurfaceSnapshotProbe identity={IDENTITY} />
+      </Profiler>,
+    );
+    const generation = browserSurfaceHost.getSnapshot(IDENTITY)!.generation;
+
+    act(() => {
+      browserSurfaceHost.handleEvent({ type: "title-updated", identity: IDENTITY, generation, title: "A" });
+      browserSurfaceHost.handleEvent({ type: "title-updated", identity: IDENTITY, generation, title: "B" });
+    });
+    await flushSurfaceFrame();
+    const firstFrameCommits = commits.length - 1;
+    expect(screen.getByTestId("surface-title-web-preview")).toHaveTextContent("B");
+
+    act(() => browserSurfaceHost.handleEvent({ type: "title-updated", identity: IDENTITY, generation, title: "C" }));
+    await flushSurfaceFrame();
+    const secondFrameCommits = commits.length - 1 - firstFrameCommits;
+
+    expect(screen.getByTestId("surface-title-web-preview")).toHaveTextContent("C");
+    expect(firstFrameCommits).toBe(1);
+    expect(secondFrameCommits).toBe(1);
+    view.unmount();
+  });
+
+  it("does not commit the observed identity for an unrelated complete surface identity", async () => {
+    browserSurfaceHost.create(IDENTITY, { address: "https://example.test/profiler-observed" });
+    browserSurfaceHost.create(UNRELATED_IDENTITY, { address: "https://example.test/profiler-unrelated" });
+    await flushSurfaceFrame();
+    const commits: Parameters<ProfilerOnRenderCallback>[1][] = [];
+    const view = render(
+      <Profiler id="observed-surface" onRender={(_id, phase) => commits.push(phase)}>
+        <SurfaceSnapshotProbe identity={IDENTITY} />
+      </Profiler>,
+    );
+    const generation = browserSurfaceHost.getSnapshot(UNRELATED_IDENTITY)!.generation;
+
+    act(() => browserSurfaceHost.handleEvent({
+      type: "title-updated",
+      identity: UNRELATED_IDENTITY,
+      generation,
+      title: "Unrelated surface",
+    }));
+    await flushSurfaceFrame();
+
+    expect(screen.getByTestId("surface-title-web-preview")).toHaveTextContent("");
+    expect(commits).toEqual(["mount"]);
+    view.unmount();
   });
 
   it("applies controller and operation protection when their surface materializes later", () => {

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -231,4 +231,39 @@ describe("PreviewWebview", () => {
       height: "768px",
     });
   });
+
+  it("hides a warm inactive surface and presents it when selected", () => {
+    const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(10, 20, 640, 480),
+    );
+    const { rerender } = render(
+      <PreviewWebview
+        active={false}
+        threadId="thread-switch"
+        tabId="tab-switch"
+        src="https://example.com"
+      />,
+    );
+    const surface = screen.getByTestId("web-runtime-preview-iframe");
+    expect(surface).toHaveStyle({ visibility: "hidden", pointerEvents: "none" });
+
+    rerender(
+      <PreviewWebview
+        active
+        threadId="thread-switch"
+        tabId="tab-switch"
+        src="https://example.com"
+      />,
+    );
+
+    expect(surface).toHaveStyle({
+      left: "10px",
+      top: "20px",
+      width: "640px",
+      height: "480px",
+      visibility: "visible",
+      pointerEvents: "auto",
+    });
+    rect.mockRestore();
+  });
 });

--- a/apps/web/src/services/browser-surfaces/__tests__/browserSurfaceContract.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/browserSurfaceContract.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   BrowserSurfaceHost,
+  type BrowserSurfaceAdapterEvent,
+  type BrowserSurfaceAdapterEventPayload,
   type BrowserSurfaceAdapterFactory,
   type BrowserSurfaceIdentity,
+  type BrowserSurfaceScheduling,
 } from "../BrowserSurfaceHost";
 
 const IDENTITY: BrowserSurfaceIdentity = {
@@ -11,54 +14,325 @@ const IDENTITY: BrowserSurfaceIdentity = {
   tabId: "contract-tab",
 };
 
+class TestScheduling implements BrowserSurfaceScheduling {
+  private nextHandle = 1;
+  readonly frames = new Map<number, () => void>();
+
+  requestAnimationFrame(callback: () => void): number {
+    const handle = this.nextHandle++;
+    this.frames.set(handle, callback);
+    return handle;
+  }
+
+  cancelAnimationFrame(handle: number): void {
+    this.frames.delete(handle);
+  }
+
+  flush(): void {
+    const queued = [...this.frames.values()];
+    this.frames.clear();
+    for (const callback of queued) callback();
+  }
+}
+
+interface AdapterGenerationRecord {
+  readonly identity: BrowserSurfaceIdentity;
+  readonly generation: number;
+  subscribeCalls: number;
+}
+
+interface ContractFixture {
+  readonly host: BrowserSurfaceHost;
+  readonly scheduling: TestScheduling;
+  readonly records: AdapterGenerationRecord[];
+  readonly activeAdapterCount: () => number;
+  readonly activeSubscriptionCount: () => number;
+}
+
+function trackedFactory(adapterFactory: BrowserSurfaceAdapterFactory): {
+  factory: BrowserSurfaceAdapterFactory;
+  records: AdapterGenerationRecord[];
+  activeAdapterCount: () => number;
+  activeSubscriptionCount: () => number;
+} {
+  const records: AdapterGenerationRecord[] = [];
+  let activeAdapters = 0;
+  let activeSubscriptions = 0;
+
+  const factory: BrowserSurfaceAdapterFactory = (identity, generation) => {
+    const adapter = adapterFactory(identity, generation);
+    const record: AdapterGenerationRecord = { identity, generation, subscribeCalls: 0 };
+    records.push(record);
+    activeAdapters += 1;
+
+    const subscribe = adapter.subscribe.bind(adapter);
+    adapter.subscribe = (listener) => {
+      record.subscribeCalls += 1;
+      activeSubscriptions += 1;
+      const stop = subscribe(listener);
+      let stopped = false;
+      return () => {
+        if (stopped) return;
+        stopped = true;
+        activeSubscriptions -= 1;
+        stop();
+      };
+    };
+
+    const dispose = adapter.dispose.bind(adapter);
+    let disposed = false;
+    adapter.dispose = (reason) => {
+      if (!disposed) {
+        disposed = true;
+        activeAdapters -= 1;
+      }
+      dispose(reason);
+    };
+    return adapter;
+  };
+
+  return {
+    factory,
+    records,
+    activeAdapterCount: () => activeAdapters,
+    activeSubscriptionCount: () => activeSubscriptions,
+  };
+}
+
+function contractFixture(adapterFactory: BrowserSurfaceAdapterFactory): ContractFixture {
+  const tracked = trackedFactory(adapterFactory);
+  const scheduling = new TestScheduling();
+  return {
+    host: new BrowserSurfaceHost({ adapterFactory: tracked.factory, scheduling }),
+    scheduling,
+    records: tracked.records,
+    activeAdapterCount: tracked.activeAdapterCount,
+    activeSubscriptionCount: tracked.activeSubscriptionCount,
+  };
+}
+
+function eventFor(
+  identity: BrowserSurfaceIdentity,
+  generation: number,
+  event: BrowserSurfaceAdapterEventPayload,
+): BrowserSurfaceAdapterEvent {
+  return { ...event, identity, generation } as BrowserSurfaceAdapterEvent;
+}
+
+function identityKey(identity: BrowserSurfaceIdentity): string {
+  return JSON.stringify([identity.workspaceId, identity.scope.kind, identity.scope.id, identity.tabId]);
+}
+
 /** Runs the durable lifecycle contract against any Browser surface adapter. */
 export function runBrowserSurfaceContract(name: string, adapterFactory: BrowserSurfaceAdapterFactory): void {
   describe(name, () => {
-    it("creates, presents, hides, and disposes one exact identity", () => {
-      const host = new BrowserSurfaceHost({ adapterFactory });
+    it("isolates every identity field", () => {
+      const fixture = contractFixture(adapterFactory);
+      const { host, scheduling } = fixture;
+      const variants: BrowserSurfaceIdentity[] = [
+        { ...IDENTITY, workspaceId: "other-workspace" },
+        { ...IDENTITY, scope: { kind: "workspace", id: IDENTITY.scope.id } },
+        { ...IDENTITY, scope: { kind: "thread", id: "other-thread" } },
+        { ...IDENTITY, tabId: "other-tab" },
+      ];
+      const identities = [IDENTITY, ...variants];
+      const snapshots = new Map(identities.map((identity) => [identityKey(identity), host.create(identity)]));
+      const publications = new Map<string, number>();
+      for (const identity of identities) {
+        publications.set(identityKey(identity), 0);
+        host.subscribe(identity, () => {
+          publications.set(identityKey(identity), publications.get(identityKey(identity))! + 1);
+        });
+      }
+
+      const primary = snapshots.get(identityKey(IDENTITY))!;
+      host.handleEvent(eventFor(IDENTITY, primary.generation, { type: "title-updated", title: "primary" }));
+      scheduling.flush();
+
+      expect(host.getSnapshot(IDENTITY)?.title).toBe("primary");
+      expect(publications.get(identityKey(IDENTITY))).toBe(1);
+      for (const identity of variants) {
+        expect(host.getSnapshot(identity)).toBe(snapshots.get(identityKey(identity)));
+        expect(publications.get(identityKey(identity))).toBe(0);
+      }
+      fixture.records.forEach((record) => expect(record.subscribeCalls).toBe(1));
+      host.disposeHost();
+    });
+
+    it("creates, presents, and hides without remounting", () => {
+      const baselineChildren = document.body.childElementCount;
+      const fixture = contractFixture(adapterFactory);
+      const { host } = fixture;
       const snapshot = host.create(IDENTITY);
-      expect(snapshot.identity).toEqual(IDENTITY);
+
       host.present(IDENTITY, { left: 0, top: 0, width: 640, height: 480 });
       host.hide(IDENTITY);
+
       expect(host.ensure(IDENTITY)).toBe(snapshot);
-      expect(host.getSnapshot(IDENTITY)?.generation).toBe(snapshot.generation);
+      expect(fixture.records).toHaveLength(1);
+      expect(fixture.records[0]?.subscribeCalls).toBe(1);
+      expect(fixture.activeAdapterCount()).toBe(1);
+      expect(fixture.activeSubscriptionCount()).toBe(1);
+      expect(document.body.childElementCount).toBe(baselineChildren + 1);
+
       host.dispose(IDENTITY);
-      expect(host.getSnapshot(IDENTITY)).toBeNull();
+      expect(fixture.activeAdapterCount()).toBe(0);
+      expect(fixture.activeSubscriptionCount()).toBe(0);
+      expect(document.body.childElementCount).toBe(baselineChildren);
       host.disposeHost();
     });
 
-    it("isolates complete identity and rejects stale generation events", () => {
-      const host = new BrowserSurfaceHost({ adapterFactory });
-      const other: BrowserSurfaceIdentity = { ...IDENTITY, workspaceId: "other-workspace" };
-      host.create(IDENTITY);
-      host.create(other);
-      const before = host.getSnapshot(other);
-      host.handleEvent({ type: "title-updated", identity: IDENTITY, generation: 999, title: "stale" });
-      expect(host.getSnapshot(other)).toBe(before);
+    it("does not publish no-op state changes and preserves the snapshot object", () => {
+      const fixture = contractFixture(adapterFactory);
+      const { host, scheduling } = fixture;
+      const initial = host.create(IDENTITY);
+      const publications: string[] = [];
+      host.subscribe(IDENTITY, (snapshot) => publications.push(snapshot.title));
+
+      host.handleEvent(eventFor(IDENTITY, initial.generation, {
+        type: "navigation-state",
+        navigation: { canGoBack: false, canGoForward: false },
+      }));
+      scheduling.flush();
+      publications.length = 0;
+      const knownNavigation = host.getSnapshot(IDENTITY)!;
+
+      host.handleEvent(eventFor(IDENTITY, initial.generation, {
+        type: "navigation-state",
+        navigation: { canGoBack: false, canGoForward: false },
+      }));
+      scheduling.flush();
+
+      expect(host.getSnapshot(IDENTITY)).toBe(knownNavigation);
+      expect(publications).toEqual([]);
       host.disposeHost();
     });
 
-    it("preserves state object identity for semantic navigation no-ops", () => {
-      const host = new BrowserSurfaceHost({ adapterFactory });
-      host.create(IDENTITY);
-      host.handleEvent({ type: "navigation-state", identity: IDENTITY, generation: 1, navigation: { canGoBack: false, canGoForward: false } });
-      const snapshot = host.getSnapshot(IDENTITY);
-      host.handleEvent({ type: "navigation-state", identity: IDENTITY, generation: 1, navigation: { canGoBack: false, canGoForward: false } });
-      expect(host.getSnapshot(IDENTITY)).toBe(snapshot);
+    it("publishes changed state at most once per frame", () => {
+      const fixture = contractFixture(adapterFactory);
+      const { host, scheduling } = fixture;
+      const initial = host.create(IDENTITY);
+      const publications: string[] = [];
+      host.subscribe(IDENTITY, (snapshot) => publications.push(snapshot.title));
+
+      host.handleEvent(eventFor(IDENTITY, initial.generation, { type: "title-updated", title: "A" }));
+      host.handleEvent(eventFor(IDENTITY, initial.generation, { type: "title-updated", title: "B" }));
+      expect(scheduling.frames.size).toBe(1);
+      scheduling.flush();
+      expect(publications).toEqual(["B"]);
+
+      host.handleEvent(eventFor(IDENTITY, initial.generation, { type: "title-updated", title: "C" }));
+      scheduling.flush();
+      expect(publications).toEqual(["B", "C"]);
       host.disposeHost();
     });
 
-    it("discards and re-warms through a new adapter generation", () => {
-      const host = new BrowserSurfaceHost({ adapterFactory });
+    it("does not publish an unrelated identity", () => {
+      const fixture = contractFixture(adapterFactory);
+      const { host, scheduling } = fixture;
+      const other: BrowserSurfaceIdentity = { ...IDENTITY, tabId: "other-tab" };
+      const primary = host.create(IDENTITY);
+      const otherSnapshot = host.create(other);
+      const primaryPublications: string[] = [];
+      const otherPublications: string[] = [];
+      host.subscribe(IDENTITY, (snapshot) => primaryPublications.push(snapshot.title));
+      host.subscribe(other, (snapshot) => otherPublications.push(snapshot.title));
+
+      host.handleEvent(eventFor(IDENTITY, primary.generation, { type: "title-updated", title: "primary" }));
+      scheduling.flush();
+
+      expect(primaryPublications).toEqual(["primary"]);
+      expect(otherPublications).toEqual([]);
+      expect(host.getSnapshot(other)).toBe(otherSnapshot);
+      host.disposeHost();
+    });
+
+    it("advances generation on discard and rejects late old events", () => {
+      const fixture = contractFixture(adapterFactory);
+      const { host, scheduling } = fixture;
       const first = host.create(IDENTITY, { address: "https://example.test/recovery" });
+      const publications: string[] = [];
+      host.subscribe(IDENTITY, (snapshot) => publications.push(snapshot.title));
+
       expect(host.discard(IDENTITY, first.generation)).toBe(true);
       expect(host.getSnapshot(IDENTITY)).toBeNull();
-      expect(host.inspect(IDENTITY)?.residency).toBe("cold");
-
       const second = host.ensure(IDENTITY);
       expect(second.generation).toBe(first.generation + 1);
-      expect(second.pendingAddress).toBe("https://example.test/recovery");
-      expect(host.inspect(IDENTITY)?.residency).toBe("warm");
+      expect(fixture.records).toHaveLength(2);
+      expect(fixture.records.every((record) => record.subscribeCalls === 1)).toBe(true);
+      scheduling.flush();
+      publications.length = 0;
+
+      host.handleEvent(eventFor(IDENTITY, first.generation, { type: "title-updated", title: "old" }));
+      scheduling.flush();
+
+      expect(host.getSnapshot(IDENTITY)).toBe(second);
+      expect(second.title).toBe("");
+      expect(publications).toEqual([]);
+      host.disposeHost();
+    });
+
+    it("disposes exact identities, scopes, and workspaces", () => {
+      const baselineChildren = document.body.childElementCount;
+      const fixture = contractFixture(adapterFactory);
+      const { host } = fixture;
+      const sibling: BrowserSurfaceIdentity = {
+        ...IDENTITY,
+        tabId: "sibling-tab",
+      };
+      const otherScope: BrowserSurfaceIdentity = {
+        ...IDENTITY,
+        scope: { kind: "thread", id: "other-scope" },
+        tabId: "other-scope-tab",
+      };
+      const otherWorkspace: BrowserSurfaceIdentity = {
+        ...IDENTITY,
+        workspaceId: "other-workspace",
+        tabId: "other-workspace-tab",
+      };
+      for (const identity of [IDENTITY, sibling, otherScope, otherWorkspace]) host.create(identity);
+
+      host.dispose(IDENTITY);
+      expect(host.getSnapshot(IDENTITY)).toBeNull();
+      expect(host.getSnapshot(sibling)).not.toBeNull();
+
+      host.disposeScope(IDENTITY.workspaceId, IDENTITY.scope);
+      expect(host.getSnapshot(sibling)).toBeNull();
+      expect(host.getSnapshot(otherScope)).not.toBeNull();
+      expect(host.getSnapshot(otherWorkspace)).not.toBeNull();
+
+      host.disposeWorkspace(IDENTITY.workspaceId);
+      expect(host.getSnapshot(otherScope)).toBeNull();
+      expect(host.getSnapshot(otherWorkspace)).not.toBeNull();
+
+      host.disposeWorkspace(otherWorkspace.workspaceId);
+      expect(host.getSnapshot(otherWorkspace)).toBeNull();
+      expect(fixture.activeAdapterCount()).toBe(0);
+      expect(fixture.activeSubscriptionCount()).toBe(0);
+      expect(document.body.childElementCount).toBe(baselineChildren);
+      host.disposeHost();
+    });
+
+    it("returns fixture resources to baseline after 25 lifecycle cycles", () => {
+      const baselineChildren = document.body.childElementCount;
+      const fixture = contractFixture(adapterFactory);
+      const { host } = fixture;
+      const identity: BrowserSurfaceIdentity = { ...IDENTITY, tabId: "cycle-tab" };
+
+      for (let cycle = 0; cycle < 25; cycle += 1) {
+        const first = host.create(identity);
+        host.hide(identity);
+        expect(host.discard(identity, first.generation)).toBe(true);
+        const rewarmed = host.ensure(identity);
+        expect(rewarmed.generation).toBe(first.generation + 1);
+        host.dispose(identity);
+      }
+
+      expect(fixture.records).toHaveLength(50);
+      expect(fixture.records.every((record) => record.subscribeCalls === 1)).toBe(true);
+      expect(fixture.activeAdapterCount()).toBe(0);
+      expect(fixture.activeSubscriptionCount()).toBe(0);
+      expect(document.body.childElementCount).toBe(baselineChildren);
       host.disposeHost();
     });
   });

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -1,7 +1,39 @@
 import "@testing-library/jest-dom/vitest";
 
+function createTestStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key) {
+      return values.get(String(key)) ?? null;
+    },
+    key(index) {
+      return [...values.keys()][index] ?? null;
+    },
+    removeItem(key) {
+      values.delete(String(key));
+    },
+    setItem(key, value) {
+      values.set(String(key), String(value));
+    },
+  };
+}
+
 // Polyfill window.matchMedia for jsdom (skip in node environment)
 if (typeof window !== "undefined") {
+  // Node 26 exposes a localStorage getter that returns undefined without a
+  // persistence flag, which prevents Vitest's jsdom environment from installing storage.
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: createTestStorage(),
+  });
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: (query: string) => ({


### PR DESCRIPTION
## What
Prove the BrowserSurfaceHost cutover across web and Electron adapters, and keep inactive warm Electron surfaces hidden.

## Why
Issue #1189 requires adapter-neutral lifecycle coverage, resource bounds, and live Electron evidence before the legacy Browser surface path can be removed. The full verification gate also exposed a Node 26 jsdom storage incompatibility that prevented unrelated web tests from running.

## Key Changes
- Add a shared Browser surface contract for lifecycle, identity, generation, and 25-cycle resource-bound behavior.
- Add React Profiler coverage for host and webview lifecycle behavior.
- Hide inactive warm Electron webviews so only the active page is visible.
- Install isolated test storage when Node 26 masks jsdom localStorage.
- Verify the fixed flow in the Electron app and pass the full and changed verification gates.

Closes #1189

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788800351&installation_model_id=20477&pr_number=1200&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1200&signature=664dc9ed814f0386d3b1bbc15f82418bb4fe68c50954c374d058d0595ef9ba08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inactive preview tabs are now hidden and non-interactive, while active tabs correctly display their content and position.

* **Tests**
  * Expanded coverage for preview visibility, browser surface stability, event handling, update batching, lifecycle cleanup, and isolation.
  * Improved browser-like test setup with local storage support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->