### PR TITLE
fix(browser): harden automation across live tabs

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-automation-kernel.test.ts
@@ -584,6 +584,25 @@ describe("BrowserAutomationKernel", () => {
     unsubscribe();
   });
 
+  it("scrolls an off-screen semantic target into view before clicking", async () => {
+    currentWebContents!.semanticElements.set("offscreen-button", { attached: true, visible: true, x: 25, y: 40 });
+
+    await kernel.execute(event(), payload(request("click", {
+      target: { semanticId: "offscreen-button" },
+      button: "left",
+      clickCount: 1,
+      timeoutMs: 1_000,
+    }, { requestId: "offscreen-semantic-target" })));
+
+    const targetResolution = currentWebContents!.debugger.commands.findLast(
+      ({ method, params }) => method === "Runtime.callFunctionOn" &&
+        (params as { functionDeclaration?: string }).functionDeclaration?.includes("inspectPageTarget"),
+    );
+    expect(targetResolution?.params).toMatchObject({
+      arguments: [{ value: { target: { semanticId: "offscreen-button" }, scrollIntoView: true } }],
+    });
+  });
+
   it("retains agent control between Browser calls until the renderer releases the turn", async () => {
     await expect(kernel.execute(event(), payload(request("press", {
       key: "A",

--- a/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
+++ b/apps/desktop/src/main/__tests__/preview-webview-adopt.test.ts
@@ -193,6 +193,16 @@ describe("preview typed surface bridge", () => {
     expect(invoke("preview.surface.adopt", { surface: surface(), adoptionToken: "token-1234" })).toMatchObject({ ok: false, error: "non-unique-adoption" });
   });
 
+  it("returns the next valid generation when renderer state restarts after reload", () => {
+    expect(invoke("preview.surface.prepare", { surface: surface(7), adoptionToken: "token-1234" })).toEqual({ ok: true });
+
+    expect(invoke("preview.surface.prepare", { surface: surface(1), adoptionToken: "token-5678" })).toEqual({
+      ok: false,
+      error: "stale-generation",
+      nextGeneration: 8,
+    });
+  });
+
   it("retires the adopted guest when the owner advances to a new generation", () => {
     const firstGuest = makeGuest(allWindows[0]!);
     expect(invoke("preview.surface.prepare", { surface: surface(), adoptionToken: "token-1234" })).toEqual({ ok: true });

--- a/apps/desktop/src/main/browser-automation/kernel.ts
+++ b/apps/desktop/src/main/browser-automation/kernel.ts
@@ -340,7 +340,7 @@ export function snapshotPage(argument: { semanticGeneration: number; maxElements
 }
 
 /** Resolves one target to attachment, visibility, and action-point state inside the isolated world. */
-export function inspectPageTarget(argument: { target: BrowserAutomationTarget }) {
+export function inspectPageTarget(argument: { target: BrowserAutomationTarget; scrollIntoView?: boolean }) {
   const nodeList = document.querySelectorAll("a[href],button,input,textarea,select,[role],[tabindex]");
   const candidates: Element[] = [];
   for (let index = 0; index < Math.min(nodeList.length, 2_000); index += 1) {
@@ -415,17 +415,31 @@ export function inspectPageTarget(argument: { target: BrowserAutomationTarget })
     };
   }
   if (!found) return { attached: false, visible: false };
-  const rect = found.getBoundingClientRect();
+  let rect = found.getBoundingClientRect();
+  if (
+    argument.scrollIntoView &&
+    (rect.left < 0 || rect.top < 0 || rect.right > innerWidth || rect.bottom > innerHeight)
+  ) {
+    found.scrollIntoView({ block: "center", inline: "center" });
+    rect = found.getBoundingClientRect();
+  }
   const style = getComputedStyle(found);
+  const point = { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
   const isVisible =
     rect.width > 0 &&
     rect.height > 0 &&
     style.visibility !== "hidden" &&
-    style.display !== "none";
+    style.display !== "none" &&
+    (!argument.scrollIntoView || (
+      point.x >= 0 &&
+      point.y >= 0 &&
+      point.x <= innerWidth &&
+      point.y <= innerHeight
+    ));
   return {
     attached: true,
     visible: isVisible,
-    ...(isVisible ? { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 } : {}),
+    ...(isVisible ? point : {}),
   };
 }
 
@@ -1613,7 +1627,7 @@ export class BrowserAutomationKernel {
   }
 
   private async resolvePoint(resolved: ResolvedTarget, target: BrowserAutomationTarget): Promise<{ x: number; y: number }> {
-    const value = await this.callIsolatedFunction(resolved.state, inspectPageTarget, { target });
+    const value = await this.callIsolatedFunction(resolved.state, inspectPageTarget, { target, scrollIntoView: true });
     const record = asRecord(value);
     if (!record.attached || !record.visible || !Number.isFinite(record.x) || !Number.isFinite(record.y)) {
       throw new KernelError("TARGET_NOT_FOUND", "Browser target did not resolve to one visible element", true);

--- a/apps/desktop/src/main/preview/preview-webview-adopt.ts
+++ b/apps/desktop/src/main/preview/preview-webview-adopt.ts
@@ -52,7 +52,7 @@ export type PreviewSurfaceNavigation =
 /** Result returned by a typed Preview surface operation. */
 export type PreviewSurfaceResult =
   | { readonly ok: true }
-  | { readonly ok: false; readonly error: string };
+  | { readonly ok: false; readonly error: string; readonly nextGeneration?: number };
 
 /** Pending or adopted exact Preview guest held by Electron main. */
 export interface AdoptedPreviewSurface {
@@ -207,6 +207,10 @@ function errorResult(error: string): PreviewSurfaceResult {
   return { ok: false, error };
 }
 
+function staleGenerationResult(currentGeneration: number): PreviewSurfaceResult {
+  return { ok: false, error: "stale-generation", nextGeneration: currentGeneration + 1 };
+}
+
 function validateSenderAndSurface(
   event: IpcMainInvokeEvent,
   surfaceValue: unknown,
@@ -328,12 +332,12 @@ function prepareSurface(event: IpcMainInvokeEvent, inputValue: unknown): Preview
   const key = surfaceKey(surface.identity);
   const adopted = adoptedByWindow.get(win.id)?.get(key);
   if (adopted?.surface.generation === surface.generation) return errorResult("duplicate-adoption");
-  if (adopted && surface.generation < adopted.surface.generation) return errorResult("stale-generation");
   const pending = pendingByWindow.get(win.id)?.get(key);
   if (pending?.surface.generation === surface.generation) return errorResult("duplicate-adoption");
-  if (pending && surface.generation < pending.surface.generation) return errorResult("stale-generation");
-  const generations = generationByWindow.get(win.id)?.get(key);
-  if (generations !== undefined && surface.generation <= generations) return errorResult("stale-generation");
+  const currentGeneration = generationByWindow.get(win.id)?.get(key);
+  if (currentGeneration !== undefined && surface.generation <= currentGeneration) {
+    return staleGenerationResult(currentGeneration);
+  }
   for (const records of pendingByWindow.values()) {
     for (const candidate of records.values()) {
       if (candidate.adoptionToken === input.adoptionToken) return errorResult("duplicate-adoption-token");

--- a/apps/web/src/components/panels/BrowserAutomationHost.tsx
+++ b/apps/web/src/components/panels/BrowserAutomationHost.tsx
@@ -57,6 +57,8 @@ import {
 } from "@/services/browser-automation/viewportCoordinatorFactory";
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
+const TARGET_DISCOVERY_RETRY_MS = 50;
+const TARGET_DISCOVERY_MAX_ATTEMPTS = 40;
 const WEB_AUTOMATION_UNAVAILABLE_REASON = "Web automation executor is unavailable";
 const viewportCoordinatorDispatches = new WeakMap<object, BrowserAutomationHostDispatch>();
 
@@ -479,6 +481,34 @@ function waitForLiveTarget(
     });
     signal.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+async function waitForDesktopTarget(
+  bridge: PreviewAutomationBridge,
+  threadId: string,
+  tabId: string,
+  deadline: number,
+  signal: AbortSignal,
+): Promise<Extract<Awaited<ReturnType<PreviewAutomationBridge["describeTarget"]>>, { ok: true }>["target"]> {
+  while (true) {
+    if (signal.aborted) throw signal.reason;
+    const described = await bridge.describeTarget({ threadId, tabId });
+    if (described.ok) return described.target;
+    if (described.error !== "TAB_UNAVAILABLE") throw new Error("Browser target could not be described");
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw new Error("Browser target could not be described before the request deadline");
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        window.clearTimeout(timer);
+        reject(signal.reason);
+      };
+      const timer = window.setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, Math.min(TARGET_DISCOVERY_RETRY_MS, remaining));
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
 }
 
 function webPreviewIframe(
@@ -1040,6 +1070,7 @@ export function BrowserAutomationHost() {
     const lease = leaseRef.current;
     if (!lease || connectionStatus !== "connected") return;
     let cancelled = false;
+    let retryTimer: number | null = null;
     const bridge = window.desktopBridge?.preview?.automation;
     if (!bridge && !isBrowserAutomationWebRuntimeEnabled()) return;
     if (!bridge) {
@@ -1070,32 +1101,41 @@ export function BrowserAutomationHost() {
       return;
     }
     const targets = [...liveTargets.values()].slice(0, 64);
-    void Promise.all(targets.map(async (candidate) => {
-      const described = await bridge.describeTarget({
-        threadId: candidate.threadId,
-        tabId: candidate.tabId,
-      });
-      if (!described.ok) return null;
-      const controller = useBrowserAutomationStore.getState().controllers.get(browserAutomationTargetKey(candidate.workspaceId, candidate.threadId, candidate.tabId));
-      return {
-        ...described.target,
-        desktopInstanceId: lease.desktopInstanceId,
-        connectionGeneration: lease.generation,
-        ...(controller ? { controller } : {}),
-      } satisfies BrowserAutomationHostDispatchTarget;
-    })).then((resolved) => {
+    const publishTargets = async (attempt: number): Promise<void> => {
+      const resolved = await Promise.all(targets.map(async (candidate) => {
+        const described = await bridge.describeTarget({
+          threadId: candidate.threadId,
+          tabId: candidate.tabId,
+        });
+        if (!described.ok) return null;
+        const controller = useBrowserAutomationStore.getState().controllers.get(browserAutomationTargetKey(candidate.workspaceId, candidate.threadId, candidate.tabId));
+        return {
+          ...described.target,
+          desktopInstanceId: lease.desktopInstanceId,
+          connectionGeneration: lease.generation,
+          ...(controller ? { controller } : {}),
+        } satisfies BrowserAutomationHostDispatchTarget;
+      }));
       if (cancelled || leaseRef.current !== lease) return;
-      return getTransport().updateBrowserAutomationHostTargets(
+      await getTransport().updateBrowserAutomationHostTargets(
         lease.hostId,
         lease.generation,
         resolved.filter((target): target is BrowserAutomationHostDispatchTarget => target !== null),
       );
-    }).catch(() => {
-      // A replacement or release can race target discovery. The next registry
-      // revision retries with desktop-main identity as the source of truth.
+      if (resolved.some((target) => target === null) && attempt < TARGET_DISCOVERY_MAX_ATTEMPTS) {
+        retryTimer = window.setTimeout(() => {
+          retryTimer = null;
+          void publishTargets(attempt + 1).catch(() => undefined);
+        }, TARGET_DISCOVERY_RETRY_MS);
+      }
+    };
+    void publishTargets(1).catch(() => {
+      // A replacement or release can race publication. Registry changes retry
+      // with desktop-main identity as the source of truth.
     });
     return () => {
       cancelled = true;
+      if (retryTimer !== null) window.clearTimeout(retryTimer);
     };
   }, [cancelHostedRequest, connectionStatus, liveTargets, registered]);
 
@@ -1609,7 +1649,16 @@ export function BrowserAutomationHost() {
         await waitForLiveTarget(request.workspaceId, request.threadId, tabId, request.deadline, controller.signal);
         ensureActive();
         const described = bridge
-          ? await bridge.describeTarget({ threadId: request.threadId, tabId })
+          ? {
+              ok: true as const,
+              target: await waitForDesktopTarget(
+                bridge,
+                request.threadId,
+                tabId,
+                request.deadline,
+                controller.signal,
+              ),
+            }
           : {
               ok: true as const,
               target: {
@@ -1624,7 +1673,6 @@ export function BrowserAutomationHost() {
                 lastUsedAt: Date.now(),
               },
             };
-        if (!described.ok) throw new Error("Browser target could not be described");
         ensureActive();
         const target: BrowserAutomationHostDispatchTarget = {
           ...described.target,

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -2966,7 +2966,7 @@ export function PreviewPanel({
     return (
       <PreviewWebview
         key={tab.id}
-        active={tab.id === activeWebviewTabId}
+        active={automationOnly || tab.id === activeWebviewTabId}
         ref={(handle) => {
           webviewRefs.current[tab.id] = handle;
         }}
@@ -2974,6 +2974,7 @@ export function PreviewPanel({
         workspaceId={workspaceId ?? threadId}
         tabId={tab.id}
         src={tab.src}
+        allowHiddenPresentation={automationOnly}
         viewport={tabViewportState?.mode === "responsive" ? tabViewport : undefined}
         className={cn(
           responsiveViewportSize

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -31,6 +31,8 @@ export interface PreviewWebviewProps {
   readonly tabId: string;
   readonly src: string;
   readonly className?: string;
+  /** Keep an off-screen automation surface presented inside its dedicated inert host. */
+  readonly allowHiddenPresentation?: boolean;
   readonly viewport?: { readonly width: number; readonly height: number };
   readonly onPageStatus?: (status: PreviewPageStatus) => void;
   readonly onNavigationStateChange?: (state: {
@@ -93,6 +95,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       tabId,
       src,
       className,
+      allowHiddenPresentation = false,
       viewport,
       onPageStatus,
       onNavigationStateChange,
@@ -260,7 +263,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         if (
           bounds.width <= 0 ||
           bounds.height <= 0 ||
-          placement.closest("[inert], [aria-hidden='true']")
+          (!allowHiddenPresentation && placement.closest("[inert], [aria-hidden='true']"))
         ) {
           browserSurfaceHost.hide(identity);
           return;
@@ -285,7 +288,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         window.removeEventListener("resize", update);
         browserSurfaceHost.hide(identity);
       };
-    }, [active, identity, viewport]);
+    }, [active, allowHiddenPresentation, identity, viewport]);
 
     return (
       <div

--- a/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
+++ b/apps/web/src/components/panels/__tests__/BrowserAutomationHost.test.tsx
@@ -1255,6 +1255,19 @@ describe("BrowserAutomationHost", () => {
     view.unmount();
   });
 
+  it("retries target publication while an adopted desktop guest is still becoming discoverable", async () => {
+    describeTarget.mockResolvedValueOnce({ ok: false, error: "TAB_UNAVAILABLE" });
+    const view = render(<BrowserAutomationHost />);
+
+    await waitFor(() => expect(harness.transport.updateBrowserAutomationHostTargets).toHaveBeenCalledTimes(2));
+    expect(harness.transport.updateBrowserAutomationHostTargets.mock.calls[0]?.[2]).toEqual([]);
+    expect(harness.transport.updateBrowserAutomationHostTargets.mock.calls[1]?.[2]).toEqual([
+      expect.objectContaining({ threadId: "thread-1", tabId: "tab-1", targetGeneration: 3 }),
+    ]);
+
+    view.unmount();
+  });
+
   it("keeps duplicate bookkeeping stable and correlates cancel by request id plus sequence", async () => {
     const first = deferred<BrowserAutomationResponse>();
     const second = deferred<BrowserAutomationResponse>();
@@ -1562,18 +1575,24 @@ describe("BrowserAutomationHost", () => {
       };
       return { ok: true, data: { tabId: agentTab.id, tabs: tabSet } };
     });
-    describeTarget.mockImplementation(async ({ tabId }: { tabId: string }) => ({
-      ok: true,
-      target: {
-        windowId: 7,
-        threadId: "thread-1",
-        tabId,
-        targetGeneration: 1,
-        active: tabId === userTab.id,
-        focused: tabId === userTab.id,
-        lastUsedAt: tabId === userTab.id ? 100 : 50,
-      },
-    }));
+    let agentTargetDiscoveryAttempts = 0;
+    describeTarget.mockImplementation(async ({ tabId }: { tabId: string }) => {
+      if (tabId === agentTab.id && agentTargetDiscoveryAttempts++ === 0) {
+        return { ok: false as const, error: "TAB_UNAVAILABLE" };
+      }
+      return {
+        ok: true as const,
+        target: {
+          windowId: 7,
+          threadId: "thread-1",
+          tabId,
+          targetGeneration: 1,
+          active: tabId === userTab.id,
+          focused: tabId === userTab.id,
+          lastUsedAt: tabId === userTab.id ? 100 : 50,
+        },
+      };
+    });
     execute.mockResolvedValue({
       contractVersion: BROWSER_AUTOMATION_CONTRACT_VERSION,
       requestId: "request-1192",
@@ -1604,6 +1623,7 @@ describe("BrowserAutomationHost", () => {
     act(() => harness.emit("browserAutomation.bootstrap", { hostId, generation: 1, request: openRequest }));
     await waitFor(() => expect(harness.transport.respondToBrowserAutomationRequest).toHaveBeenCalledOnce());
     expect(createTab).toHaveBeenCalledOnce();
+    expect(agentTargetDiscoveryAttempts).toBeGreaterThanOrEqual(2);
     expect(createTab).toHaveBeenCalledWith("thread-1", "workspace-1", { activate: false });
     expect(execute).toHaveBeenCalledOnce();
     expect(execute).toHaveBeenCalledWith(expect.objectContaining({

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -1039,6 +1039,43 @@ describe("PreviewPanel: full panel state", () => {
     expect(omnibox).toHaveValue("https://b.example");
   });
 
+  it("presents every warm tab in the hidden automation host", async () => {
+    const bounds = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 1280,
+      bottom: 720,
+      left: 0,
+      width: 1280,
+      height: 720,
+      toJSON: () => ({}),
+    });
+    mockUsePreviewBridge.mockReturnValue(mockBridgeState({ storedUrl: "https://a.example" }));
+    mockUsePreviewTabs.mockReturnValue({
+      tabSet: {
+        threadId: "thread-1",
+        activeTabId: "tab-a",
+        tabs: [
+          { id: "tab-a", threadId: "thread-1", title: "A", url: "https://a.example", faviconUrl: null, warm: true, active: true },
+          { id: "tab-b", threadId: "thread-1", title: "B", url: "https://b.example", faviconUrl: null, warm: true, active: false },
+        ],
+      },
+      newTab: vi.fn(),
+      activateTab: vi.fn(),
+      closeTab: vi.fn(),
+    });
+
+    render(<PreviewPanel threadId="thread-1" workspaceId="workspace-1" automationOnly />);
+
+    await waitFor(() => expect(screen.getAllByTestId("electron-browser-surface-webview")).toHaveLength(2));
+    expect(screen.getAllByTestId("electron-browser-surface-webview")).toEqual([
+      expect.objectContaining({ style: expect.objectContaining({ visibility: "visible" }) }),
+      expect.objectContaining({ style: expect.objectContaining({ visibility: "visible" }) }),
+    ]);
+    bounds.mockRestore();
+  });
+
   it("persists favicon updates from inactive warm webview pages", async () => {
     const tabSet = {
       threadId: "thread-1",

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -266,4 +266,40 @@ describe("PreviewWebview", () => {
     });
     rect.mockRestore();
   });
+
+  it("presents an active automation surface inside its dedicated hidden host", () => {
+    const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(-20_000, 0, 1280, 720),
+    );
+    const { rerender } = render(
+      <div aria-hidden="true" inert>
+        <PreviewWebview
+          threadId="thread-background"
+          tabId="tab-background"
+          src="https://example.com"
+        />
+      </div>,
+    );
+    const surface = screen.getByTestId("web-runtime-preview-iframe");
+    expect(surface).toHaveStyle({ visibility: "hidden", width: "1px", height: "1px" });
+
+    rerender(
+      <div aria-hidden="true" inert>
+        <PreviewWebview
+          allowHiddenPresentation
+          threadId="thread-background"
+          tabId="tab-background"
+          src="https://example.com"
+        />
+      </div>,
+    );
+
+    expect(surface).toHaveStyle({
+      left: "-20000px",
+      width: "1280px",
+      height: "720px",
+      visibility: "visible",
+    });
+    rect.mockRestore();
+  });
 });

--- a/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.test.ts
@@ -441,6 +441,39 @@ describe("BrowserSessionDriver", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
+  it("executes an assert step through bounded wait conditions", async () => {
+    const execute = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => ({
+      ok: true,
+      result: { operation: dispatch.request.operation },
+    }) as unknown as BrowserAutomationResponse);
+    const driver = new BrowserSessionDriver({
+      web: { execute },
+      electron: { execute },
+      isElectron: () => false,
+      supportedActOperations: ["click"],
+    });
+    const inspect = await driver.execute(inspectDispatch(), new AbortController().signal);
+    const observationRef = (inspect as { result: { observationRef: string } }).result.observationRef;
+
+    const result = await driver.execute(actDispatch(observationRef, [{
+      operation: "assert",
+      target: { cssSelector: "#status" },
+      text: "Action status: complete",
+    }]), new AbortController().signal);
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: { receipts: [{ operation: "assert", status: "satisfied" }] },
+    });
+    expect(execute.mock.calls.slice(1).map(([dispatch]) => ({
+      operation: dispatch.request.operation,
+      args: dispatch.request.args,
+    }))).toEqual([
+      expect.objectContaining({ operation: "waitFor", args: expect.objectContaining({ target: { cssSelector: "#status" }, state: "visible" }) }),
+      expect.objectContaining({ operation: "waitFor", args: expect.objectContaining({ text: "Action status: complete" }) }),
+    ]);
+  });
+
   it("stops before the next effect when control revision changes", async () => {
     let controlRevision = 0;
     const execute = vi.fn(async (dispatch: BrowserAutomationHostDispatch) => {

--- a/apps/web/src/services/browser-automation/browserSessionDriver.ts
+++ b/apps/web/src/services/browser-automation/browserSessionDriver.ts
@@ -447,7 +447,8 @@ export class BrowserSessionDriver {
     const observation = this.observations.get(request.args.observationRef);
     const capabilityRevision = this.options.getCapabilityRevision?.() ?? dispatch.connection?.capabilityRevision ?? 1;
     const supported = typeof this.options.supportedActOperations === "function" ? this.options.supportedActOperations() : this.options.supportedActOperations;
-    if (supported && request.args.steps.some((step: BrowserAutomationActStep) => !supported.includes(step.operation))) {
+    if (supported && request.args.steps.some((step: BrowserAutomationActStep) =>
+      step.operation !== "assert" && !supported.includes(step.operation))) {
       return Promise.resolve(this.actFailure(dispatch, "UNSUPPORTED_OPERATION", "Browser runtime cannot execute every browser_act step"));
     }
     const currentBinding = this.currentObservationBinding(dispatch, capabilityRevision);
@@ -493,7 +494,9 @@ export class BrowserSessionDriver {
           break;
         }
         const stepDispatch = this.stepDispatch(dispatch, step, deadline, index);
-        const response = await this.executeAdapter(stepDispatch, signal, { implicitClaim: false });
+        const response = step.operation === "assert"
+          ? await this.executeAssertStep(stepDispatch, step, signal, deadline)
+          : await this.executeAdapter(stepDispatch, signal, { implicitClaim: false });
         if (!response.ok) {
           outcome = response.error.code === "OPERATION_CANCELLED" || response.error.code === "HUMAN_INTERRUPTED" || response.error.code === "DEADLINE_EXCEEDED" ? "interrupted" : "failed";
           stoppingPosition = index;
@@ -1091,6 +1094,34 @@ export class BrowserSessionDriver {
         args,
       },
     } as unknown as BrowserAutomationHostDispatch;
+  }
+
+  private async executeAssertStep(
+    dispatch: BrowserAutomationHostDispatch,
+    step: Extract<BrowserAutomationActStep, { operation: "assert" }>,
+    signal: AbortSignal,
+    deadline: number,
+  ): Promise<BrowserAutomationResponse> {
+    const conditions: Array<Record<string, unknown>> = [];
+    if (step.target) conditions.push({ target: step.target, state: "visible" });
+    if (step.text) conditions.push({ text: step.text });
+    if (step.url) conditions.push({ url: step.url });
+    let response: BrowserAutomationResponse | null = null;
+    for (let index = 0; index < conditions.length; index += 1) {
+      const timeoutMs = Math.max(1, deadline - Date.now());
+      const waitDispatch = {
+        ...dispatch,
+        request: {
+          ...dispatch.request,
+          requestId: `${dispatch.request.requestId}:assert:${index}`,
+          operation: "waitFor",
+          args: { ...conditions[index], timeoutMs },
+        },
+      } as BrowserAutomationHostDispatch;
+      response = await this.executeAdapter(waitDispatch, signal, { implicitClaim: false });
+      if (!response.ok) return response;
+    }
+    return response!;
   }
 
   private actFailure(dispatch: BrowserAutomationHostDispatch, code: "STALE_TARGET_GENERATION" | "CAPABILITY_CHANGED" | "UNSUPPORTED_OPERATION", message: string): BrowserAutomationResponse {

--- a/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
+++ b/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
@@ -63,7 +63,7 @@ export type BrowserSurfaceAdapterEvent = BrowserSurfaceAdapterEventBase & (
   | { readonly type: "favicon-updated"; readonly favicon: string | null }
   | { readonly type: "navigation-state"; readonly navigation: BrowserSurfaceNavigationState | null }
   | { readonly type: "document-access"; readonly access: BrowserSurfaceDocumentAccess }
-  | { readonly type: "surface-lost" }
+  | { readonly type: "surface-lost"; readonly nextGeneration?: number }
 );
 
 /** Event payload accepted by adapter test doubles before identity is attached. */
@@ -394,7 +394,7 @@ export class BrowserSurfaceHost {
     if (!record || record.disposed || record.generation !== event.generation || !sameIdentity(record.identity, event.identity)) return;
     if (event.type === "surface-lost") {
       if (!record.state) return;
-      this.handleUnexpectedLoss(record);
+      this.handleUnexpectedLoss(record, event.nextGeneration);
       return;
     }
     if (!record.state) return;
@@ -642,20 +642,23 @@ export class BrowserSurfaceHost {
     record.state = null;
   }
 
-  private rewarmRecord(record: SurfaceRecord, requestedAddress?: string): BrowserSurfacePageState {
+  private rewarmRecord(record: SurfaceRecord, requestedAddress?: string, requestedGeneration?: number): BrowserSurfacePageState {
     const recoveryAddress = requestedAddress ?? record.recoveryAddress ?? undefined;
     return this.create(record.identity, {
-      generation: record.generation + 1,
+      generation: requestedGeneration ?? record.generation + 1,
       ...(recoveryAddress === undefined ? {} : { address: recoveryAddress }),
     });
   }
 
-  private handleUnexpectedLoss(record: SurfaceRecord): void {
-    const shouldRestore = this.isProtected(record);
+  private handleUnexpectedLoss(record: SurfaceRecord, requestedGeneration?: number): void {
+    const validRequestedGeneration = Number.isSafeInteger(requestedGeneration) && requestedGeneration! > record.generation
+      ? requestedGeneration
+      : undefined;
+    const shouldRestore = validRequestedGeneration !== undefined || this.isProtected(record);
     const presentation = record.presentation;
     this.retireToCold(record, "loss");
     if (!shouldRestore) return;
-    this.rewarmRecord(record);
+    this.rewarmRecord(record, undefined, validRequestedGeneration);
     if (presentation) this.present(record.identity, presentation);
   }
 

--- a/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
+++ b/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
@@ -108,7 +108,7 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
   private readonly bridge: PreviewSurfaceBridge;
   private readonly surface: PreviewSurfaceRef;
   private readonly adoptionToken: string;
-  private readonly preparePromise: Promise<boolean>;
+  private readonly preparePromise: Promise<PreviewSurfaceBridgeResult>;
   private adoptionPromise: Promise<boolean> | null = null;
   private readonly adoptionWaiters = new Set<(adopted: boolean) => void>();
   private pendingAddress: string | null = null;
@@ -166,7 +166,7 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
     this.preparePromise = Promise.resolve(this.bridge.prepare({
       surface: this.surface,
       adoptionToken: this.adoptionToken,
-    })).then(asResult, () => false);
+    })).catch(() => ({ ok: false as const, error: "Surface preparation failed" }));
     (options.root ?? this.documentRef.body)?.appendChild(this.frame);
   }
 
@@ -178,6 +178,16 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
   /** Materializes this adapter; construction already owns and attaches its webview. */
   public create(): void {
     if (this.disposed) return;
+    void this.preparePromise.then((result) => {
+      if (
+        !result.ok &&
+        result.error === "stale-generation" &&
+        Number.isSafeInteger(result.nextGeneration) &&
+        result.nextGeneration! > this.generation
+      ) {
+        this.emit({ type: "surface-lost", nextGeneration: result.nextGeneration });
+      }
+    });
   }
 
   /** Presents the webview at bounded host coordinates. */
@@ -260,7 +270,7 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
   };
 
   private async adoptAfterPreparation(): Promise<boolean> {
-    if (!(await this.preparePromise) || this.disposed) {
+    if (!asResult(await this.preparePromise) || this.disposed) {
       this.resolveAdoptionWaiters(false);
       return false;
     }

--- a/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/BrowserSurfaceHost.test.ts
@@ -375,6 +375,24 @@ describe("BrowserSurfaceHost", () => {
     host.disposeHost();
   });
 
+  it("uses the main process generation after renderer state restarts", () => {
+    const adapters: TestAdapter[] = [];
+    const host = new BrowserSurfaceHost({
+      adapterFactory: () => {
+        const adapter = new TestAdapter();
+        adapters.push(adapter);
+        return adapter;
+      },
+    });
+    host.create(IDENTITY, { address: "https://example.test/recovery" });
+
+    adapters[0]!.emit({ type: "surface-lost", nextGeneration: 8 });
+
+    expect(host.getSnapshot(IDENTITY)?.generation).toBe(8);
+    expect(adapters[1]!.navigations).toEqual(["https://example.test/recovery"]);
+    host.disposeHost();
+  });
+
   it("ignores a late loss event after a generation is already cold", () => {
     const adapters: TestAdapter[] = [];
     const host = new BrowserSurfaceHost({

--- a/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
@@ -132,4 +132,29 @@ describe("ElectronWebviewBrowserSurfaceAdapter", () => {
     await vi.waitFor(() => expect(surfaceBridge.adopt).toHaveBeenCalledTimes(2));
     adapter.dispose();
   });
+
+  it("reports the next valid generation when preparation finds stale renderer state", async () => {
+    const surfaceBridge = bridge();
+    surfaceBridge.prepare.mockResolvedValue({
+      ok: false,
+      error: "stale-generation",
+      nextGeneration: 12,
+    });
+    const adapter = new ElectronWebviewBrowserSurfaceAdapter(IDENTITY, 1, {
+      root: document.body,
+      bridge: surfaceBridge,
+    });
+    const events: BrowserSurfaceAdapterEvent[] = [];
+    adapter.subscribe((event) => events.push(event));
+
+    adapter.create();
+
+    await vi.waitFor(() => expect(events).toContainEqual({
+      type: "surface-lost",
+      identity: IDENTITY,
+      generation: 1,
+      nextGeneration: 12,
+    }));
+    adapter.dispose();
+  });
 });

--- a/apps/web/src/transport/desktop-bridge.d.ts
+++ b/apps/web/src/transport/desktop-bridge.d.ts
@@ -136,7 +136,7 @@ export type PreviewSurfaceNavigation =
 /** Result returned by a typed Electron Browser surface operation. */
 export type PreviewSurfaceBridgeResult =
   | { readonly ok: true }
-  | { readonly ok: false; readonly error: string };
+  | { readonly ok: false; readonly error: string; readonly nextGeneration?: number };
 
 /** Opaque Electron surface operations exposed to the renderer. */
 export interface PreviewSurfaceBridge {


### PR DESCRIPTION
## What
Harden Mcode Browser automation across empty, existing-tab, and multi-tab Electron sessions.

## Why
Live Playwright testing exposed failures that prevented agents from reliably adopting, presenting, and operating Browser tabs across reloads and background states.

## Key Changes
- Recover from stale Browser surface generations after renderer reloads.
- Retry target publication while Electron adopts an existing tab.
- Present every warm automation tab at a usable size.
- Scroll semantic click targets into view before interaction.
- Support bounded assert steps inside action batches.
- Add focused regression coverage for each failure.

## Verification
- Live Electron Playwright: zero-tab, one-existing-tab, and two-tab workflows passed.
- Focused web tests: 218 passed.
- Focused desktop tests: 57 passed.
- `bun run verify`: typecheck, lint, and unit tests passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788857954&installation_model_id=20477&pr_number=1204&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1204&signature=89d3a33bc15b4c23f2e738ea8275c24b118c38e42a32af49d7b4cc04cacdd27f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser automation can now assert target visibility, text, and URL conditions with bounded waiting.
  * Off-screen automation targets are brought into view before actions are performed.
  * Automation-only previews remain available even when their tabs are hidden or inactive.
  * Target discovery retries automatically when a desktop tab is temporarily unavailable.

* **Bug Fixes**
  * Improved recovery of preview surfaces after stale-generation or surface-loss events.
  * Prevented outdated preview operations from replacing newer rendered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->