### PR TITLE
fix(browser): float activity rail over Browser

### DIFF
--- a/apps/web/src/components/panels/ActivityRail.test.tsx
+++ b/apps/web/src/components/panels/ActivityRail.test.tsx
@@ -92,7 +92,7 @@ describe("ActivityRail expansion", () => {
     expect(rail).toHaveAttribute("data-expanded", "false");
   });
 
-  it("publishes expansion changes so renderer guests can yield the floating overlap", () => {
+  it("publishes expansion changes for Browser surface coverage", () => {
     const onExpandedChange = vi.fn();
     render(
       <ActivityRail

--- a/apps/web/src/components/panels/ActivityRail.tsx
+++ b/apps/web/src/components/panels/ActivityRail.tsx
@@ -654,7 +654,7 @@ export function ActivityRail({
   readonly terminalLabels?: Readonly<Record<string, string>>;
   onSelectBrowserPage: (instanceId: string, pageId: string) => void;
   onCloseBrowserPage: (pageId: string) => void;
-  /** Publishes the floating state so renderer guests can yield the overlap region. */
+  /** Publishes the floating state so Browser surfaces exclude the covered edge. */
   readonly onExpandedChange?: (expanded: boolean) => void;
 }) {
   const openTabs = tabInstances.map((instance) => instance.type);

--- a/apps/web/src/components/panels/PreviewPanel.tsx
+++ b/apps/web/src/components/panels/PreviewPanel.tsx
@@ -1559,8 +1559,8 @@ export interface PreviewPanelProps {
   readonly workspaceId?: string | null;
   /** Mount only automation webviews without visible panel chrome. */
   readonly automationOnly?: boolean;
-  /** Left edge hidden beneath floating renderer chrome while the remaining guest stays interactive. */
-  readonly rendererOccludedLeft?: number;
+  /** Width covered by floating panel chrome at the left edge. */
+  readonly coveredLeft?: number;
 }
 
 function useLiveViewportCoordinatorState(
@@ -1855,7 +1855,7 @@ export function PreviewPanel({
   threadId,
   workspaceId,
   automationOnly = false,
-  rendererOccludedLeft = 0,
+  coveredLeft = 0,
 }: PreviewPanelProps) {
   const surfaceRef = useRef<HTMLDivElement>(null);
   const webviewRefs = useRef<Record<string, PreviewWebviewHandle | null>>({});
@@ -2975,6 +2975,7 @@ export function PreviewPanel({
         tabId={tab.id}
         src={tab.src}
         allowHiddenPresentation={automationOnly}
+        coveredLeft={coveredLeft}
         viewport={tabViewportState?.mode === "responsive" ? tabViewport : undefined}
         className={cn(
           responsiveViewportSize
@@ -3175,11 +3176,6 @@ export function PreviewPanel({
         {hasWebviewLayer ? (
           <div
             data-testid="preview-webview-surface"
-            style={
-              rendererOccludedLeft > 0
-                ? { left: rendererOccludedLeft }
-                : undefined
-            }
             className={cn(
               "absolute inset-0 z-0 overflow-hidden rounded-tl-md",
               !webviewLayerInteractive && "pointer-events-none",

--- a/apps/web/src/components/panels/PreviewWebview.tsx
+++ b/apps/web/src/components/panels/PreviewWebview.tsx
@@ -33,6 +33,8 @@ export interface PreviewWebviewProps {
   readonly className?: string;
   /** Keep an off-screen automation surface presented inside its dedicated inert host. */
   readonly allowHiddenPresentation?: boolean;
+  /** Width covered by floating panel chrome at the left edge. */
+  readonly coveredLeft?: number;
   readonly viewport?: { readonly width: number; readonly height: number };
   readonly onPageStatus?: (status: PreviewPageStatus) => void;
   readonly onNavigationStateChange?: (state: {
@@ -96,6 +98,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
       src,
       className,
       allowHiddenPresentation = false,
+      coveredLeft = 0,
       viewport,
       onPageStatus,
       onNavigationStateChange,
@@ -277,6 +280,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
           height: intrinsicHeight,
           scale: viewport ? Math.min(bounds.width / intrinsicWidth, bounds.height / intrinsicHeight) : 1,
           zIndex: 31,
+          coveredLeft,
         });
       };
       const observer = typeof ResizeObserver === "function" ? new ResizeObserver(update) : null;
@@ -288,7 +292,7 @@ export const PreviewWebview = forwardRef<PreviewWebviewHandle, PreviewWebviewPro
         window.removeEventListener("resize", update);
         browserSurfaceHost.hide(identity);
       };
-    }, [active, allowHiddenPresentation, identity, viewport]);
+    }, [active, allowHiddenPresentation, coveredLeft, identity, viewport]);
 
     return (
       <div

--- a/apps/web/src/components/panels/RightPanel.test.tsx
+++ b/apps/web/src/components/panels/RightPanel.test.tsx
@@ -90,9 +90,9 @@ vi.mock("./CoordinationPanel", () => ({
 vi.mock("./plan", () => ({ PlanPanel: () => <div /> }));
 vi.mock("@/components/diff", () => ({ DiffPanel: () => <div /> }));
 vi.mock("@/components/panels/PreviewPanel", () => ({
-  PreviewPanel: ({ rendererOccludedLeft = 0 }: { rendererOccludedLeft?: number }) => {
-    previewPanelRender();
-    return <div data-testid="preview-panel" data-renderer-occluded-left={rendererOccludedLeft} />;
+  PreviewPanel: (props: Record<string, unknown>) => {
+    previewPanelRender(props);
+    return <div data-testid="preview-panel" data-covered-left={props.coveredLeft ?? 0} />;
   },
 }));
 vi.mock("@/components/terminal/TerminalPoolSlotContext", () => ({
@@ -466,7 +466,7 @@ describe("RightPanel", () => {
     expect(activatePreviewPage).not.toHaveBeenCalled();
   });
 
-  it("passes the floating rail overlap to the visible renderer Browser", () => {
+  it("covers the visible Browser edge without changing its layout geometry", () => {
     previewTabSet.current = {
       threadId: "workspace-1",
       activeTabId: "browser-tab-1",
@@ -493,14 +493,14 @@ describe("RightPanel", () => {
 
     render(<RightPanel />);
     expect(screen.getByTestId("preview-panel")).toHaveAttribute(
-      "data-renderer-occluded-left",
+      "data-covered-left",
       "0",
     );
 
     fireEvent.click(screen.getByTestId("expand-activity-rail"));
 
     expect(screen.getByTestId("preview-panel")).toHaveAttribute(
-      "data-renderer-occluded-left",
+      "data-covered-left",
       "112",
     );
   });

--- a/apps/web/src/components/panels/RightPanel.tsx
+++ b/apps/web/src/components/panels/RightPanel.tsx
@@ -89,13 +89,13 @@ const EMPTY_SCOPE_TERMINALS: readonly TerminalInstance[] = [];
 interface WarmPreviewSurfaceProps {
   readonly scope: WarmPreviewScope;
   readonly visible: boolean;
-  readonly rendererOccludedLeft: number;
+  readonly coveredLeft: number;
 }
 
 const WarmPreviewSurface = memo(function WarmPreviewSurface({
   scope,
   visible,
-  rendererOccludedLeft,
+  coveredLeft,
 }: WarmPreviewSurfaceProps) {
   const automationHosted = useBrowserAutomationStore((state) =>
     state.hostedScopeIds.has(warmPreviewScopeKey(scope)),
@@ -117,7 +117,7 @@ const WarmPreviewSurface = memo(function WarmPreviewSurface({
         <PreviewPanel
           threadId={scope.scopeId}
           workspaceId={scope.workspaceId}
-          rendererOccludedLeft={rendererOccludedLeft}
+          coveredLeft={coveredLeft}
         />
       )}
     </div>
@@ -692,7 +692,7 @@ export function RightPanel() {
                 key={warmPreviewScopeKey(scope)}
                 scope={scope}
                 visible={visible}
-                rendererOccludedLeft={
+                coveredLeft={
                   visible && activityRailExpanded
                     ? ACTIVITY_RAIL_FLOATING_OVERLAP_PX
                     : 0

--- a/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewPanel.test.tsx
@@ -858,20 +858,6 @@ describe("PreviewPanel: full panel state", () => {
     );
   });
 
-  it("removes the floating rail overlap from the renderer webview hit area", () => {
-    mockUsePreviewBridge.mockReturnValue(
-      mockBridgeState({ storedUrl: "https://example.com" }),
-    );
-
-    render(<PreviewPanel threadId="thread-1" rendererOccludedLeft={112} />);
-
-    expect(screen.getByTestId("preview-webview-surface")).toHaveStyle({ left: "112px" });
-    expect(screen.getByTestId("preview-webview-surface")).not.toHaveStyle({
-      clipPath: "inset(0px 0px 0px 112px)",
-    });
-    expect(screen.getByTestId("preview-webview")).not.toHaveClass("pointer-events-none");
-  });
-
   it("keeps an about:blank live tab stable while the persisted URL is empty", async () => {
     mockUsePreviewBridge.mockReturnValue(mockBridgeState({ storedUrl: "" }));
     mockUsePreviewTabs.mockReturnValue({

--- a/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
+++ b/apps/web/src/components/panels/__tests__/PreviewWebview.test.tsx
@@ -267,6 +267,38 @@ describe("PreviewWebview", () => {
     rect.mockRestore();
   });
 
+  it("clips the covered edge without changing the Browser viewport geometry", () => {
+    const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(10, 20, 640, 480),
+    );
+    const { rerender } = render(
+      <PreviewWebview
+        coveredLeft={112}
+        threadId="thread-covered"
+        tabId="tab-covered"
+        src="https://example.com"
+      />,
+    );
+    const surface = screen.getByTestId("web-runtime-preview-iframe");
+
+    expect(surface).toHaveStyle({
+      left: "10px",
+      width: "640px",
+      clipPath: "inset(0px 0px 0px 112px)",
+    });
+
+    rerender(
+      <PreviewWebview
+        coveredLeft={0}
+        threadId="thread-covered"
+        tabId="tab-covered"
+        src="https://example.com"
+      />,
+    );
+    expect(surface.style.clipPath).toBe("");
+    rect.mockRestore();
+  });
+
   it("presents an active automation surface inside its dedicated hidden host", () => {
     const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(
       new DOMRect(-20_000, 0, 1280, 720),

--- a/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
+++ b/apps/web/src/services/browser-surfaces/BrowserSurfaceHost.ts
@@ -100,6 +100,8 @@ export interface BrowserSurfacePresentation {
   readonly height: number;
   readonly scale?: number;
   readonly zIndex?: number;
+  /** Width hidden at the left edge while the full Browser viewport remains unchanged. */
+  readonly coveredLeft?: number;
 }
 
 /** Factory that creates the adapter for one complete identity and generation. */
@@ -235,13 +237,17 @@ function boundedNumber(value: number, fallback: number, minimum: number, maximum
 }
 
 function boundPresentation(presentation: BrowserSurfacePresentation): BrowserSurfacePresentation {
+  const width = boundedNumber(presentation.width, 1, 1, 10_000);
   return {
     left: boundedNumber(presentation.left, 0, -100_000, 100_000),
     top: boundedNumber(presentation.top, 0, -100_000, 100_000),
-    width: boundedNumber(presentation.width, 1, 1, 10_000),
+    width,
     height: boundedNumber(presentation.height, 1, 1, 10_000),
     ...(presentation.scale === undefined ? {} : { scale: boundedNumber(presentation.scale, 1, 0.1, 10) }),
     ...(presentation.zIndex === undefined ? {} : { zIndex: Math.round(boundedNumber(presentation.zIndex, 0, -2_147_483_648, 2_147_483_647)) }),
+    ...(presentation.coveredLeft === undefined
+      ? {}
+      : { coveredLeft: boundedNumber(presentation.coveredLeft, 0, 0, width) }),
   };
 }
 

--- a/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
+++ b/apps/web/src/services/browser-surfaces/ElectronWebviewBrowserSurfaceAdapter.ts
@@ -200,6 +200,9 @@ export class ElectronWebviewBrowserSurfaceAdapter implements BrowserSurfaceAdapt
     this.frame.style.transformOrigin = "top left";
     this.frame.style.transform = presentation.scale === undefined ? "" : `scale(${presentation.scale})`;
     this.frame.style.zIndex = presentation.zIndex === undefined ? "" : String(presentation.zIndex);
+    this.frame.style.clipPath = presentation.coveredLeft
+      ? `inset(0px 0px 0px ${presentation.coveredLeft}px)`
+      : "";
     this.frame.style.visibility = "visible";
     this.frame.style.pointerEvents = "auto";
     this.frame.setAttribute("aria-hidden", "false");

--- a/apps/web/src/services/browser-surfaces/WebIframeBrowserSurfaceAdapter.ts
+++ b/apps/web/src/services/browser-surfaces/WebIframeBrowserSurfaceAdapter.ts
@@ -123,6 +123,9 @@ export class WebIframeBrowserSurfaceAdapter implements BrowserSurfaceAdapter {
     this.frame.style.transformOrigin = "top left";
     this.frame.style.transform = presentation.scale === undefined ? "" : `scale(${presentation.scale})`;
     this.frame.style.zIndex = presentation.zIndex === undefined ? "" : String(presentation.zIndex);
+    this.frame.style.clipPath = presentation.coveredLeft
+      ? `inset(0px 0px 0px ${presentation.coveredLeft}px)`
+      : "";
     this.frame.style.visibility = "visible";
     this.frame.style.pointerEvents = "auto";
     this.frame.setAttribute("aria-hidden", "false");

--- a/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/ElectronWebviewBrowserSurfaceAdapter.test.ts
@@ -83,10 +83,13 @@ describe("ElectronWebviewBrowserSurfaceAdapter", () => {
     });
     const events: BrowserSurfaceAdapterEvent[] = [];
     adapter.subscribe((event) => events.push(event));
-    adapter.present({ left: 10, top: 20, width: 640, height: 480, scale: 1.25, zIndex: 42 });
+    adapter.present({ left: 10, top: 20, width: 640, height: 480, scale: 1.25, zIndex: 42, coveredLeft: 112 });
     expect(adapter.element.style.left).toBe("10px");
     expect(adapter.element.style.width).toBe("640px");
     expect(adapter.element.style.zIndex).toBe("42");
+    expect(adapter.element.style.clipPath).toBe("inset(0px 0px 0px 112px)");
+    adapter.present({ left: 10, top: 20, width: 640, height: 480, coveredLeft: 0 });
+    expect(adapter.element.style.clipPath).toBe("");
     adapter.hide();
     expect(adapter.element.style.visibility).toBe("hidden");
 

--- a/apps/web/src/services/browser-surfaces/__tests__/WebIframeBrowserSurfaceAdapter.test.ts
+++ b/apps/web/src/services/browser-surfaces/__tests__/WebIframeBrowserSurfaceAdapter.test.ts
@@ -29,10 +29,11 @@ describe("WebIframeBrowserSurfaceAdapter", () => {
       generation: "7",
     });
     expect(adapter.element.title).toBe("Preview");
-    adapter.present({ left: 10, top: 20, width: 640, height: 480, scale: 1.25, zIndex: 42 });
+    adapter.present({ left: 10, top: 20, width: 640, height: 480, scale: 1.25, zIndex: 42, coveredLeft: 112 });
     expect(adapter.element.style.left).toBe("10px");
     expect(adapter.element.style.width).toBe("640px");
     expect(adapter.element.style.zIndex).toBe("42");
+    expect(adapter.element.style.clipPath).toBe("inset(0px 0px 0px 112px)");
     adapter.dispose();
     expect(document.body.contains(adapter.element)).toBe(false);
   });


### PR DESCRIPTION
## What

Make the expanded activity rail float over Browser content without moving or resizing the Browser viewport.

## Why

The Browser surface uses a separate renderer host that painted above the expanded rail. The fallback shifted the Browser by 112 pixels, unlike Review and Terminal.

## Key Changes

- Add bounded left-edge coverage to Browser surface presentation.
- Clip the covered edge on Electron webviews and web iframes without changing viewport geometry.
- Connect activity rail expansion to Browser presentation and add regression coverage.

## Verification

- `bun run verify`
- Live Electron: the expanded rail painted and received pointer hits above Browser content while Browser position, width, and inner viewport stayed unchanged.
- Live Electron: Browser fixture interaction completed with zero console errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mzeey-Empire/codesmith/mcode/pr/1205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788880095&installation_model_id=20477&pr_number=1205&repository=Mzeey-Empire%2Fmcode&return_to=https%3A%2F%2Fgithub.com%2FMzeey-Empire%2Fmcode%2Fpull%2F1205&signature=a66c9790a11d45f3b731fb4bc62b1295052658e3e0067ef00da66f4aaa79eda4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Browser surface handling when the left edge is partially covered.
  - Preserved viewport position and width while visually clipping covered content.
  - Coverage is cleared correctly when the obstruction is removed.
  - Coverage values are safely constrained to the available surface width.

- **Tests**
  - Expanded coverage for left-edge clipping across preview, iframe, and webview surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->